### PR TITLE
feat: auto-detect OS and add direct download buttons to landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -899,8 +899,12 @@
       .os-btn svg {
         flex-shrink: 0;
       }
-      .install-download .install-alt {
+      .install-download > .install-alt {
         margin-top: 16px;
+      }
+      .install-download > .install-alt:first-child {
+        margin-top: 0;
+        margin-bottom: 16px;
       }
 
       /* ========== FOOTER ========== */


### PR DESCRIPTION
## Summary
- Auto-detect visitor OS (macOS/Windows/Linux) via `navigator.userAgent` and pre-select the correct install tab
- Replace generic "GitHub Releases" link with styled OS buttons (Apple, Windows, Linux icons) that link directly to the latest platform artifact
- Fetch latest release version from GitHub API to construct direct download URLs with graceful fallback to releases page