### PR TITLE
v0.7.1: server extraction, workspaces, kanban redesign, and landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibegrid",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",


### PR DESCRIPTION
## Summary

Version bump to v0.7.1.

- feat: extract standalone server for multi-client architecture (#18)
- feat: add workspaces to group projects (#17)
- feat: redesign kanban board cards and columns (#16)
- feat: add landing page with OS-detected download buttons (#14, #19)
- fix: mini-card close cleanup and confirm popover placement (#15)