### PR TITLE
fix: install script mount point parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ case "$OS" in
     curl -fSL --progress-bar -o "${TMPDIR_INSTALL}/${ARTIFACT}" "$URL"
 
     echo "Mounting DMG..."
-    MOUNT_POINT="$(hdiutil attach "${TMPDIR_INSTALL}/${ARTIFACT}" -nobrowse -quiet | tail -1 | awk '{print $NF}')"
+    MOUNT_POINT="$(hdiutil attach "${TMPDIR_INSTALL}/${ARTIFACT}" -nobrowse -quiet | grep '/Volumes/' | sed 's/.*\(\/Volumes\/.*\)/\1/' | head -1)"
 
     if [ -d "/Applications/${APP_NAME}.app" ]; then
       echo "Removing previous installation..."


### PR DESCRIPTION
## Summary
- Fix `hdiutil attach` output parsing that broke when DMG volume names contain spaces (e.g., "VibeGrid 0.1.0-arm64")
- Replace `awk '{print $NF}'` with `grep + sed` to capture the full `/Volumes/...` path

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/jcanizalez/vibegrid/main/install.sh | sh` on macOS arm64
- [ ] Verify DMG mounts and app copies to /Applications successfully