### PR TITLE
fix: install script DMG mount parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ case "$OS" in
     curl -fSL --progress-bar -o "${TMPDIR_INSTALL}/${ARTIFACT}" "$URL"
 
     echo "Mounting DMG..."
-    MOUNT_POINT="$(hdiutil attach "${TMPDIR_INSTALL}/${ARTIFACT}" -nobrowse -quiet | grep '/Volumes/' | sed 's/.*\(\/Volumes\/.*\)/\1/' | head -1)"
+    MOUNT_POINT="$(hdiutil attach "${TMPDIR_INSTALL}/${ARTIFACT}" -nobrowse | tail -1 | sed 's/.*	//')"
 
     if [ -d "/Applications/${APP_NAME}.app" ]; then
       echo "Removing previous installation..."


### PR DESCRIPTION
## Summary
- Remove `-quiet` from `hdiutil attach` (it suppresses all stdout, making mount point unparseable)
- Use `tail -1 | sed 's/.*\t//'` to correctly extract the mount path from tab-separated hdiutil output
- Fixes install failure on volumes with spaces in their name (e.g. "VibeGrid 0.1.0-arm64")

## Test plan
- [x] Tested locally: `sh install.sh` successfully installs v0.1.0 to /Applications/VibeGrid.app