### PR TITLE
fix: add -y flag to npx in MCP setup commands

### DIFF
--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -11,23 +11,23 @@ interface AgentMcpSetup {
 const AGENT_SETUPS: AgentMcpSetup[] = [
   {
     agentType: 'claude',
-    command: 'claude mcp add vibegrid -- npx @vibegrid/mcp'
+    command: 'claude mcp add vibegrid -- npx -y @vibegrid/mcp'
   },
   {
     agentType: 'copilot',
-    command: 'copilot mcp add vibegrid -- npx @vibegrid/mcp'
+    command: 'copilot mcp add vibegrid -- npx -y @vibegrid/mcp'
   },
   {
     agentType: 'codex',
-    command: 'codex mcp add vibegrid -- npx @vibegrid/mcp'
+    command: 'codex mcp add vibegrid -- npx -y @vibegrid/mcp'
   },
   {
     agentType: 'opencode',
-    command: 'opencode mcp add vibegrid -- npx @vibegrid/mcp'
+    command: 'opencode mcp add vibegrid -- npx -y @vibegrid/mcp'
   },
   {
     agentType: 'gemini',
-    command: 'gemini mcp add vibegrid -- npx @vibegrid/mcp'
+    command: 'gemini mcp add vibegrid -- npx -y @vibegrid/mcp'
   }
 ]
 


### PR DESCRIPTION
## Summary
- Adds `-y` flag to all `npx @vibegrid/mcp` commands in the MCP settings page
- Without `-y`, npx prompts for install confirmation which fails in non-interactive contexts

## Test plan
- [ ] Open Settings > MCP and verify all agent setup commands include `npx -y`
- [ ] Copy a command and run it to confirm it installs without prompting