### PR TITLE
fix: sessions created via MCP now appear in UI

### DIFF
--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -179,8 +179,10 @@ export function registerAllMethods(): void {
 
   // ─── Hook server integration ──────────────────────────────────
 
-  // Handle new terminal sessions (Copilot hook setup)
+  // Handle new terminal sessions: broadcast to UI + Copilot hook setup
   ptyManager.on('session-created', (session, payload) => {
+    clientRegistry.broadcast(IPC.SESSION_CREATED, session)
+
     if (payload.agentType === 'copilot') {
       const port = hookServer.getPort()
       if (port <= 0) return

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -143,6 +143,7 @@ export interface RequestMethods {
 export interface ServerNotifications {
   'terminal:data': { id: string; data: string }
   'terminal:exit': { id: string; exitCode: number }
+  'session:created': TerminalSession
   'headless:data': { id: string; data: string }
   'headless:exit': { id: string; exitCode: number }
   'config:changed': AppConfig

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -373,6 +373,7 @@ export const IPC = {
   TERMINAL_KILL: 'terminal:kill',
   TERMINAL_DATA: 'terminal:data',
   TERMINAL_EXIT: 'terminal:exit',
+  SESSION_CREATED: 'session:created',
   CONFIG_LOAD: 'config:load',
   CONFIG_SAVE: 'config:save',
   CONFIG_CHANGED: 'config:changed',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import {
   CreateTerminalPayload,
+  TerminalSession,
   ResizePayload,
   AppConfig,
   RecentSession,
@@ -47,6 +48,15 @@ const api = {
     ipcRenderer.on(IPC.TERMINAL_EXIT, listener)
     return () => {
       ipcRenderer.removeListener(IPC.TERMINAL_EXIT, listener)
+    }
+  },
+
+  onSessionCreated: (callback: (session: TerminalSession) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, session: TerminalSession): void =>
+      callback(session)
+    ipcRenderer.on(IPC.SESSION_CREATED, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.SESSION_CREATED, listener)
     }
   },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -200,6 +200,13 @@ export function App() {
       }
     })
 
+    const removeSessionCreatedListener = window.api.onSessionCreated((session) => {
+      const state = useAppStore.getState()
+      if (!state.terminals.has(session.id)) {
+        state.addTerminal(session)
+      }
+    })
+
     const removeConfigListener = window.api.onConfigChanged((config) => {
       useAppStore.getState().setConfig(config)
     })
@@ -227,6 +234,7 @@ export function App() {
 
     return () => {
       removeExitListener()
+      removeSessionCreatedListener()
       removeConfigListener()
       removeMenuListener()
       removeSchedulerListener()


### PR DESCRIPTION
## Summary
- Broadcast `SESSION_CREATED` event when `ptyManager.createPty()` runs
- Renderer listens and adds to Zustand store with dedup guard
- Sessions launched via MCP `launch_agent` tool now appear instantly in the UI

## Test plan
- [ ] Launch agent via MCP tool → session card appears in VibeGrid
- [ ] Launch agent via New Session button → still works, no duplicates
- [ ] Kill MCP-launched session → card disappears from UI