### PR TITLE
fix: persist view mode and layout across config reloads

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -379,10 +379,10 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
       mainViewMode: map.mainViewMode as AppConfig['defaults']['mainViewMode']
     }),
     ...(map.layoutMode !== undefined && {
-      layoutMode: map.layoutMode as 'grid' | 'tabs'
+      layoutMode: map.layoutMode as AppConfig['defaults']['layoutMode']
     }),
     ...(map.updateChannel !== undefined && {
-      updateChannel: map.updateChannel as 'stable' | 'beta'
+      updateChannel: map.updateChannel as AppConfig['defaults']['updateChannel']
     })
   }
 }


### PR DESCRIPTION
## Summary
- `loadDefaults()` was missing `mainViewMode`, `layoutMode`, and `updateChannel` — they were saved to DB but dropped on reload
- This caused the Tasks view to snap back to Sessions ~1s after switching (WAL watcher rebroadcasts config without these fields)

## Test plan
- [ ] Switch to Tasks view → stays on Tasks (no snap-back after ~1s)
- [ ] Switch layout mode → persists
- [ ] Set update channel to beta → persists