### PR TITLE
fix: server crash on startup from import.meta.url in CJS bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,29 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      - name: Verify server CJS bundle
+        run: |
+          yarn workspace @vibegrid/server build
+          # Fail if import.meta snuck into CJS bundle (causes runtime crash in Electron)
+          if grep -q 'import_meta' packages/server/dist/index.cjs; then
+            echo "ERROR: import_meta found in CJS bundle — will crash at runtime"
+            exit 1
+          fi
+          # Smoke-test: require the bundle — fails immediately if module-level code crashes
+          node -e "
+            process.on('uncaughtException', (e) => {
+              if (e.code === 'ERR_INVALID_ARG_TYPE' || e.code === 'ERR_INVALID_URL') {
+                console.error('Server bundle crash:', e.message);
+                process.exit(1);
+              }
+              // Ignore other async errors (missing workers, etc.)
+            });
+            try { require('./packages/server/dist/index.cjs'); } catch(e) {
+              if (e.code === 'ERR_INVALID_ARG_TYPE' || e.code === 'ERR_INVALID_URL') {
+                console.error('Server bundle crash:', e.message);
+                process.exit(1);
+              }
+            }
+            setTimeout(() => process.exit(0), 2000);
+          "

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import Fastify from 'fastify'
 import websocket from '@fastify/websocket'
 import fastifyStatic from '@fastify/static'
@@ -14,8 +13,6 @@ import { scheduler } from './scheduler'
 import { setDataDir, getTaskImagePath as resolveTaskImagePath } from './task-images'
 import { getTailscaleStatus } from './tailscale'
 import log from './logger'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export async function startServer(
   options: { host?: string; port?: number; dataDir?: string } = {}


### PR DESCRIPTION
## Summary
- **Root cause**: `import.meta.url` is `undefined` in CJS bundles (tsup output), causing `fileURLToPath(undefined)` to throw `ERR_INVALID_ARG_TYPE` and crash the server on startup in the packaged Electron app
- Removed the unused `_serverDir` variable and `fileURLToPath` import — the CJS global `__dirname` already works correctly at the only usage site (line 94)
- Added a CI step that builds the server bundle and verifies it: greps for `import_meta` references, then smoke-tests `require()` to catch module-level crashes

## Test plan
- [x] `yarn workspace @vibegrid/server build` — no `import.meta` warnings
- [x] `grep import_meta packages/server/dist/index.cjs` — zero matches
- [x] `yarn build` + `yarn test` — all pass
- [x] Built unpacked app with `electron-builder --mac --dir`
- [x] Launched packaged app — server starts, bridge connects, no crash
- [x] CI smoke-test catches the old bug (verified with simulated broken code)