### PR TITLE
chore: release v0.3.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibegrid",
-  "version": "0.3.0-beta.0",
+  "version": "0.3.0-beta.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",


### PR DESCRIPTION
## Release v0.3.0-beta.1

### Fixes
- **Server crash on startup** — Removed `import.meta.url` usage in CJS bundle that caused `ERR_INVALID_ARG_TYPE` crash in packaged Electron app (#70)
- **CI: server bundle smoke-test** — New CI step verifies the CJS bundle loads without module-level crashes