### PR TITLE
fix: Windows installer places app in permanent location

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,7 +34,6 @@ nsis:
   perMachine: false
   createDesktopShortcut: true
   createStartMenuShortcut: true
-  shortcutName: VibeGrid
   artifactName: '${productName}-Setup-${version}.${ext}'
 
 portable:

--- a/install.ps1
+++ b/install.ps1
@@ -29,35 +29,44 @@ New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
 Write-Host "Downloading $Artifact..."
 Invoke-WebRequest -Uri $Url -OutFile $InstallerPath -UseBasicParsing
 
-Write-Host "Running installer..."
-$process = Start-Process -FilePath $InstallerPath -ArgumentList "/S" -Wait -PassThru
+try {
+    Write-Host "Running installer..."
+    $process = Start-Process -FilePath $InstallerPath -ArgumentList "/S" -Wait -PassThru
 
-if ($process.ExitCode -ne 0) {
-    Write-Error "Installer exited with code $($process.ExitCode)."
-    exit 1
+    if ($process.ExitCode -ne 0) {
+        Write-Error "Installer exited with code $($process.ExitCode)."
+        exit 1
+    }
+
+    # Verify installation at the default per-user location
+    $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\$AppName"
+    $ExePath = Join-Path $InstallDir "$AppName.exe"
+
+    if (-not (Test-Path $ExePath)) {
+        Write-Error "Installation could not be verified — $ExePath not found."
+        Write-Host "Try running the installer manually: $InstallerPath"
+        exit 1
+    }
+
+    # Add install directory to user PATH if not already present
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $pathEntries = @()
+    if ($UserPath) {
+        $pathEntries = $UserPath -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    }
+    if (-not ($pathEntries -contains $InstallDir)) {
+        $pathEntries += $InstallDir
+        $newPath = ($pathEntries -join ';')
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Host "Added $InstallDir to your PATH."
+    }
+
+    Write-Host ""
+    Write-Host "$AppName $Version installed to $InstallDir"
+    Write-Host "Launch from Start Menu, desktop shortcut, or run '$AppName' in a new terminal."
+} finally {
+    Write-Host "Cleaning up..."
+    Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
 }
 
-# Verify installation at the default per-user location
-$InstallDir = Join-Path $env:LOCALAPPDATA "Programs\$AppName"
-$ExePath = Join-Path $InstallDir "$AppName.exe"
-
-if (-not (Test-Path $ExePath)) {
-    Write-Error "Installation could not be verified — $ExePath not found."
-    Write-Host "Try running the installer manually: $InstallerPath"
-    exit 1
-}
-
-# Add install directory to user PATH if not already present
-$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($UserPath -notlike "*$InstallDir*") {
-    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
-    Write-Host "Added $InstallDir to your PATH."
-}
-
-Write-Host "Cleaning up..."
-Remove-Item -Recurse -Force $TempDir
-
-Write-Host ""
-Write-Host "$AppName $Version installed to $InstallDir"
-Write-Host "Launch from Start Menu, desktop shortcut, or run '$AppName' in a new terminal."
 Write-Host "Done!"


### PR DESCRIPTION
## Summary
- **Root cause:** `artifactName` was set at the `win` level in `electron-builder.yml`, applying to both `nsis` and `portable` targets. Both produced `VibeGrid-Setup-{version}.exe` — the portable exe overwrote the NSIS installer. The PS1 script downloaded a standalone portable exe instead of the actual installer, so nothing was registered.
- Moved `artifactName` to target-specific sections (`nsis` → `Setup`, `portable` → `Portable`)
- Added explicit NSIS config: install wizard, desktop + Start Menu shortcuts
- PS1 script now verifies installation at `%LOCALAPPDATA%\Programs\VibeGrid`, adds install dir to user PATH, and reports the install location

## Test plan
- [ ] Build Windows targets and verify two distinct artifacts: `VibeGrid-Setup-{v}.exe` and `VibeGrid-Portable-{v}.exe`
- [ ] Run `install.ps1` — app should install to `%LOCALAPPDATA%\Programs\VibeGrid`
- [ ] Verify Start Menu shortcut and desktop shortcut are created
- [ ] Close and relaunch from Start Menu or by running `VibeGrid` in a new terminal
- [ ] Verify temp files are cleaned up after install

Fixes #75