### PR TITLE
fix: prefer NSIS installer for Windows download button

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1862,7 +1862,7 @@
       const REPO = 'jcanizalez/vibegrid'
       const ASSET_MATCH = {
         mac: (name) => name.endsWith('.dmg') && !name.endsWith('.blockmap'),
-        win: (name) => /Setup.*\.exe$/.test(name) && !name.endsWith('.blockmap'),
+        win: (name) => /-Setup-.*\.exe$/.test(name) && !name.endsWith('.blockmap'),
         linux: (name) => name.endsWith('.AppImage')
       }
       const osButtons = document.querySelectorAll('.os-btn')


### PR DESCRIPTION
## Summary
- The landing page Windows download button matched any `.exe` asset, which could link to the portable build instead of the installer
- Narrowed the asset matcher to `Setup*.exe` so it consistently serves the NSIS installer, matching the behavior of `install.ps1`

## Test plan
- [ ] Verify the Windows download button on the landing page links to the Setup `.exe`
- [ ] Confirm macOS and Linux download buttons are unaffected