### PR TITLE
chore: release v0.3.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibegrid",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",


### PR DESCRIPTION
## Summary
Bump version to v0.3.0-beta.3.

### Changes since v0.3.0-beta.2
- fix: Windows terminal copy/paste, right-click menu, and clickable links (#81)
- fix: prefer NSIS installer for Windows download button (#79)
- fix: session restore and Recent Sessions resume (#77)
- fix: Windows installer places app in permanent location (#76)