### PR TITLE
fix: remove .mcp.json from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 *.log
 *.tsbuildinfo
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "vibegrid": {
-      "type": "http",
-      "url": "http://localhost:56433/mcp"
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Remove tracked `.mcp.json` (HTTP transport) that breaks MCP in worktrees
- Add `.mcp.json` to `.gitignore` — MCP config lives in `~/.claude.json` (stdio)

## Test plan
- [ ] MCP connects in main repo via `~/.claude.json` stdio config
- [ ] New worktrees no longer get a broken `.mcp.json`