### PR TITLE
fix: MCP bin alias for npx -y @vibegrid/mcp

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,7 +19,8 @@
     "task-management"
   ],
   "bin": {
-    "vibegrid-mcp": "dist/index.js"
+    "vibegrid-mcp": "dist/index.js",
+    "mcp": "dist/index.js"
   },
   "main": "./dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Add `mcp` bin alias to `@vibegrid/mcp` package so `npx -y @vibegrid/mcp` resolves correctly
- npx looks for a bin matching the unscoped package name (`mcp`), but only `vibegrid-mcp` existed
- Tested locally: both bin names create correct symlinks and the server initializes successfully

## Test plan
- [x] `yarn workspace @vibegrid/mcp build` succeeds
- [x] Local tarball install creates both `mcp` and `vibegrid-mcp` bin links
- [x] `npx mcp` starts the server and responds to JSON-RPC initialize