### PR TITLE
fix: update yarn.lock for mcp bin alias

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,6 +4129,7 @@ __metadata:
     ws: "npm:^8.18.0"
     zod: "npm:^4.3.6"
   bin:
+    mcp: dist/index.js
     vibegrid-mcp: dist/index.js
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- Update yarn.lock to include the new `mcp` bin entry from #85
- CI was failing because the lockfile was stale