### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibegrid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",


### PR DESCRIPTION
## Summary
- Bump root package.json version to 0.3.1 so desktop artifacts match the release tag