### PR TITLE
fix: use @vibegrid/mcp@latest in MCP setup commands

### DIFF
--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -11,23 +11,23 @@ interface AgentMcpSetup {
 const AGENT_SETUPS: AgentMcpSetup[] = [
   {
     agentType: 'claude',
-    command: 'claude mcp add vibegrid -- npx -y @vibegrid/mcp'
+    command: 'claude mcp add vibegrid -- npx -y @vibegrid/mcp@latest'
   },
   {
     agentType: 'copilot',
-    command: 'copilot mcp add vibegrid -- npx -y @vibegrid/mcp'
+    command: 'copilot mcp add vibegrid -- npx -y @vibegrid/mcp@latest'
   },
   {
     agentType: 'codex',
-    command: 'codex mcp add vibegrid -- npx -y @vibegrid/mcp'
+    command: 'codex mcp add vibegrid -- npx -y @vibegrid/mcp@latest'
   },
   {
     agentType: 'opencode',
-    command: 'opencode mcp add vibegrid -- npx -y @vibegrid/mcp'
+    command: 'opencode mcp add vibegrid -- npx -y @vibegrid/mcp@latest'
   },
   {
     agentType: 'gemini',
-    command: 'gemini mcp add vibegrid -- npx -y @vibegrid/mcp'
+    command: 'gemini mcp add vibegrid -- npx -y @vibegrid/mcp@latest'
   }
 ]
 


### PR DESCRIPTION
## Summary
- Update all MCP setup commands in settings to use `@vibegrid/mcp@latest`
- Prevents npx from resolving the local workspace package instead of the published npm version when running inside worktrees

## Test plan
- [ ] Settings page shows updated commands with `@latest`
- [ ] MCP connects successfully in worktrees