### PR TITLE
fix: pin zod v3 in MCP package for SDK compatibility

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,8 +19,8 @@
     "task-management"
   ],
   "bin": {
-    "vibegrid-mcp": "dist/index.js",
-    "mcp": "dist/index.js"
+    "mcp": "dist/index.js",
+    "vibegrid-mcp": "dist/index.js"
   },
   "main": "./dist/index.js",
   "files": [
@@ -31,11 +31,11 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "libsql": "^0.5.22",
     "pino": "^9.6.0",
     "ws": "^8.18.0",
-    "zod": "^4.3.6"
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@vibegrid/server": "workspace:*",

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -140,7 +140,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.tool(
     'create_workflow',
     'Create a new workflow. Accepts either full nodes/edges or a convenience flat format (trigger + actions array).',
-    z.object({
+    {
       name: V.title.describe('Workflow name'),
       trigger: triggerConfigSchema
         .optional()
@@ -155,7 +155,7 @@ export function registerWorkflowTools(server: McpServer): void {
       icon_color: V.hexColor.optional().describe('Hex color (default: #6366f1)'),
       enabled: z.boolean().optional().describe('Whether workflow is enabled (default: true)'),
       stagger_delay_ms: z.number().optional().describe('Delay in ms between actions')
-    }),
+    },
     async (args) => {
       let nodes: WorkflowNode[]
       let edges: WorkflowEdge[]
@@ -192,7 +192,7 @@ export function registerWorkflowTools(server: McpServer): void {
   server.tool(
     'update_workflow',
     "Update a workflow's properties",
-    z.object({
+    {
       id: V.id.describe('Workflow ID'),
       name: V.title.optional(),
       nodes: z.array(nodeSchema).optional(),
@@ -201,7 +201,7 @@ export function registerWorkflowTools(server: McpServer): void {
       icon_color: V.hexColor.optional(),
       enabled: z.boolean().optional(),
       stagger_delay_ms: z.number().optional()
-    }),
+    },
     async (args) => {
       const workflows = dbListWorkflows()
       const workflow = workflows.find((w) => w.id === args.id)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2622,6 +2622,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@modelcontextprotocol/sdk@npm:^1.28.0":
+  version: 1.28.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.28.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/eff999884bea7302b42832b7fe172a53c83ee0afd6fa42dcda29dd503d72b6f67f3d45e9eebbcecbe52e1ee418c14574b6d30ce5a0b10f947a2a680f8bb8c8c3
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^1.1.1":
   version: 1.1.1
   resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
@@ -4118,7 +4151,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vibegrid/mcp@workspace:packages/mcp"
   dependencies:
-    "@modelcontextprotocol/sdk": "npm:^1.27.1"
+    "@modelcontextprotocol/sdk": "npm:^1.28.0"
     "@vibegrid/server": "workspace:*"
     "@vibegrid/shared": "workspace:*"
     libsql: "npm:^0.5.22"
@@ -4127,7 +4160,7 @@ __metadata:
     tsx: "npm:^4.19.4"
     typescript: "npm:^5.6.0"
     ws: "npm:^8.18.0"
-    zod: "npm:^4.3.6"
+    zod: "npm:^3.23.0"
   bin:
     mcp: dist/index.js
     vibegrid-mcp: dist/index.js
@@ -13178,6 +13211,13 @@ __metadata:
   peerDependencies:
     zod: ^3.25.0 || ^4.0.0
   checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.0":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Pin `zod@^3.23.0` in `@vibegrid/mcp` — Zod v4 schemas fail SDK introspection when bundled (different `_zod` vs `_def` instance check)
- Convert `create_workflow` and `update_workflow` from `z.object()` to plain object format
- Confirmed all 38 tools register and return valid JSON schemas

## Test plan
- [x] `yarn workspace @vibegrid/mcp build` succeeds
- [x] `tools/list` returns all 38 tools with valid inputSchema
- [x] `create_workflow` and `update_workflow` schemas serialize correctly
- [ ] MCP connects on Windows (where Zod v4 was being resolved by npx)