### PR TITLE
feat: add agent assignment to task views

### DIFF
--- a/src/renderer/components/AddTaskDialog.tsx
+++ b/src/renderer/components/AddTaskDialog.tsx
@@ -10,7 +10,9 @@ import { toast } from './Toast'
 import { isWeb } from '../lib/platform'
 import { StatusPicker } from './StatusPicker'
 import { ProjectPicker } from './ProjectPicker'
-import type { TaskStatus } from '../../shared/types'
+import { AgentPicker } from './AgentPicker'
+import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
+import type { AgentType, TaskStatus } from '../../shared/types'
 
 export function AddTaskDialog() {
   const isOpen = useAppStore((s) => s.isTaskDialogOpen)
@@ -30,9 +32,11 @@ export function AddTaskDialog() {
   const [description, setDescription] = useState('')
   const [branch, setBranch] = useState('')
   const [useWorktree, setUseWorktree] = useState(false)
+  const [assignedAgent, setAssignedAgent] = useState<AgentType | null>(null)
   const [images, setImages] = useState<string[]>([])
   const [imagePaths, setImagePaths] = useState<Map<string, string>>(new Map())
   const taskIdRef = useRef<string>(crypto.randomUUID())
+  const { status: agentInstallStatus } = useAgentInstallStatus()
 
   const isEditMode = !!editingTask
 
@@ -43,6 +47,7 @@ export function AddTaskDialog() {
       setDescription(editing.description)
       setBranch(editing.branch || '')
       setUseWorktree(editing.useWorktree || false)
+      setAssignedAgent(editing.assignedAgent || null)
       setImages(editing.images || [])
       setStatus(editing.status)
       taskIdRef.current = editing.id
@@ -74,6 +79,7 @@ export function AddTaskDialog() {
     setDescription(TASK_TEMPLATE)
     setBranch('')
     setUseWorktree(false)
+    setAssignedAgent(null)
     setImages([])
     setImagePaths(new Map())
     setStatus('todo')
@@ -157,6 +163,7 @@ export function AddTaskDialog() {
         status,
         branch: branch.trim() || undefined,
         useWorktree: useWorktree || undefined,
+        assignedAgent: assignedAgent || undefined,
         images: images.length > 0 ? images : undefined
       })
       toast.success('Task updated')
@@ -173,6 +180,7 @@ export function AddTaskDialog() {
         order: existingTasks.length,
         branch: branch.trim() || undefined,
         useWorktree: useWorktree || undefined,
+        assignedAgent: assignedAgent || undefined,
         images: images.length > 0 ? images : undefined,
         createdAt: now,
         updatedAt: now
@@ -299,6 +307,14 @@ export function AddTaskDialog() {
                 currentProject={projectName}
                 projects={config?.projects || []}
                 onChange={setProjectName}
+              />
+
+              {/* Agent picker */}
+              <AgentPicker
+                currentAgent={assignedAgent}
+                onChange={setAssignedAgent}
+                installStatus={agentInstallStatus}
+                allowNone
               />
 
               {/* Branch pill */}

--- a/src/renderer/components/AgentPicker.tsx
+++ b/src/renderer/components/AgentPicker.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Check, ChevronDown } from 'lucide-react'
+import { Check, ChevronDown, Bot } from 'lucide-react'
 import { AgentType } from '../../shared/types'
 import { AgentIcon } from './AgentIcon'
 
@@ -17,12 +17,14 @@ export function AgentPicker({
   currentAgent,
   onChange,
   installStatus,
-  variant = 'compact'
+  variant = 'compact',
+  allowNone = false
 }: {
-  currentAgent: AgentType
-  onChange: (agent: AgentType) => void
+  currentAgent: AgentType | null
+  onChange: (agent: AgentType | null) => void
   installStatus: Record<AgentType, boolean>
   variant?: 'compact' | 'form'
+  allowNone?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -42,8 +44,8 @@ export function AgentPicker({
     setOpen(true)
   }
 
-  const handleSelect = (agent: AgentType) => {
-    if (!installStatus[agent]) return
+  const handleSelect = (agent: AgentType | null) => {
+    if (agent && !installStatus[agent]) return
     setOpen(false)
     if (agent !== currentAgent) {
       onChange(agent)
@@ -81,8 +83,14 @@ export function AgentPicker({
             : 'flex items-center gap-1.5 hover:bg-white/[0.04] rounded px-1.5 py-0.5 -mx-1.5 transition-colors text-[12px] text-gray-300'
         }
       >
-        <AgentIcon agentType={currentAgent} size={14} />
-        <span className="flex-1 text-left">{AGENT_LABELS[currentAgent]}</span>
+        {currentAgent ? (
+          <AgentIcon agentType={currentAgent} size={14} />
+        ) : (
+          <Bot size={14} className="text-gray-500" />
+        )}
+        <span className={`flex-1 text-left ${currentAgent ? '' : 'text-gray-600'}`}>
+          {currentAgent ? AGENT_LABELS[currentAgent] : 'Unassigned'}
+        </span>
         <ChevronDown size={11} className="text-gray-500" />
       </button>
 
@@ -103,6 +111,19 @@ export function AgentPicker({
                 background: '#1e1e22'
               }}
             >
+              {allowNone && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleSelect(null)
+                  }}
+                  className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-500 hover:bg-white/[0.06] transition-colors"
+                >
+                  <Bot size={14} className="text-gray-600" />
+                  <span className="flex-1 text-left italic">None</span>
+                  {!currentAgent && <Check size={13} className="text-gray-400" />}
+                </button>
+              )}
               {agents.map((agent) => {
                 const installed = installStatus[agent]
                 const isCurrent = agent === currentAgent

--- a/src/renderer/components/TaskDetailPanel.tsx
+++ b/src/renderer/components/TaskDetailPanel.tsx
@@ -6,7 +6,8 @@ import { TASK_TEMPLATE } from './MarkdownEditor'
 const RichMarkdownEditor = lazy(() =>
   import('./rich-editor/RichMarkdownEditor').then((m) => ({ default: m.RichMarkdownEditor }))
 )
-import { AgentIcon } from './AgentIcon'
+import { AgentPicker } from './AgentPicker'
+import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import { DiffFileList, DiffContent } from './DiffSidebar'
 import { CommitDialog } from './CommitDialog'
 import { StatusPicker } from './StatusPicker'
@@ -109,8 +110,10 @@ export function TaskDetailPanel() {
   const [formDescription, setFormDescription] = useState('')
   const [formBranch, setFormBranch] = useState('')
   const [formUseWorktree, setFormUseWorktree] = useState(false)
+  const [formAssignedAgent, setFormAssignedAgent] = useState<AgentType | null>(null)
   const [formImages, setFormImages] = useState<string[]>([])
   const [formImagePaths, setFormImagePaths] = useState<Map<string, string>>(new Map())
+  const { status: agentInstallStatus } = useAgentInstallStatus()
   const newTaskIdRef = useRef<string>(crypto.randomUUID())
   const initializedRef = useRef(false)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -164,6 +167,7 @@ export function TaskDetailPanel() {
       setFormDescription(task.description)
       setFormBranch(task.branch || '')
       setFormUseWorktree(task.useWorktree || false)
+      setFormAssignedAgent(task.assignedAgent || null)
       setFormImages(task.images || [])
       if (task.images?.length) {
         Promise.all(
@@ -193,6 +197,7 @@ export function TaskDetailPanel() {
       setFormDescription(TASK_TEMPLATE)
       setFormBranch('')
       setFormUseWorktree(false)
+      setFormAssignedAgent(null)
       setFormImages([])
       setFormImagePaths(new Map())
       requestAnimationFrame(() => {
@@ -213,6 +218,7 @@ export function TaskDetailPanel() {
         description: formDescription.trim(),
         branch: formBranch.trim() || undefined,
         useWorktree: formUseWorktree || undefined,
+        assignedAgent: formAssignedAgent || undefined,
         images: formImages.length > 0 ? formImages : undefined
       })
     }, 500)
@@ -221,7 +227,15 @@ export function TaskDetailPanel() {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formTitle, formProjectName, formDescription, formBranch, formUseWorktree, formImages])
+  }, [
+    formTitle,
+    formProjectName,
+    formDescription,
+    formBranch,
+    formUseWorktree,
+    formAssignedAgent,
+    formImages
+  ])
 
   // Flush pending save on unmount or task switch
   const formRef = useRef({
@@ -230,6 +244,7 @@ export function TaskDetailPanel() {
     formDescription,
     formBranch,
     formUseWorktree,
+    formAssignedAgent,
     formImages
   })
   formRef.current = {
@@ -238,6 +253,7 @@ export function TaskDetailPanel() {
     formDescription,
     formBranch,
     formUseWorktree,
+    formAssignedAgent,
     formImages
   }
 
@@ -256,6 +272,7 @@ export function TaskDetailPanel() {
             description: f.formDescription.trim(),
             branch: f.formBranch.trim() || undefined,
             useWorktree: f.formUseWorktree || undefined,
+            assignedAgent: f.formAssignedAgent || undefined,
             images: f.formImages.length > 0 ? f.formImages : undefined
           })
         }
@@ -483,6 +500,7 @@ export function TaskDetailPanel() {
       order: existingTasks.length,
       branch: formBranch.trim() || undefined,
       useWorktree: formUseWorktree || undefined,
+      assignedAgent: formAssignedAgent || undefined,
       images: formImages.length > 0 ? formImages : undefined,
       createdAt: now,
       updatedAt: now
@@ -621,15 +639,15 @@ export function TaskDetailPanel() {
           </div>
 
           {/* Agent */}
-          {!isCreateMode && task?.assignedAgent && (
-            <div className="flex items-center gap-2 text-[12px]">
-              <span className="text-gray-600 w-20 shrink-0">Agent</span>
-              <span className="flex items-center gap-1.5 text-gray-400">
-                <AgentIcon agentType={task.assignedAgent} size={12} />
-                {task.assignedAgent}
-              </span>
-            </div>
-          )}
+          <div className="flex items-center gap-2 text-[12px]">
+            <span className="text-gray-600 w-20 shrink-0">Agent</span>
+            <AgentPicker
+              currentAgent={formAssignedAgent}
+              onChange={setFormAssignedAgent}
+              installStatus={agentInstallStatus}
+              allowNone
+            />
+          </div>
 
           {/* Created */}
           {!isCreateMode && task && (

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -12,12 +12,7 @@ import {
   Server,
   Terminal
 } from 'lucide-react'
-import {
-  LaunchAgentConfig,
-  AgentType,
-  TriggerConfig,
-  getProjectHostIds
-} from '../../../../shared/types'
+import { LaunchAgentConfig, TriggerConfig, getProjectHostIds } from '../../../../shared/types'
 import { useAppStore } from '../../../stores'
 import { TEMPLATE_VARIABLES, StepVariableGroup } from '../../../lib/template-vars'
 import { useAgentInstallStatus } from '../../../hooks/useAgentInstallStatus'
@@ -79,7 +74,7 @@ export function LaunchAgentConfigForm({ config, onChange, triggerType, stepGroup
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Agent</label>
         <AgentPicker
           currentAgent={config.agentType}
-          onChange={(agent: AgentType) => onChange({ ...config, agentType: agent })}
+          onChange={(agent) => agent && onChange({ ...config, agentType: agent })}
           installStatus={installStatus}
           variant="form"
         />

--- a/tests/agent-picker-nullable.test.tsx
+++ b/tests/agent-picker-nullable.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { AgentPicker } from '../src/renderer/components/AgentPicker'
+import type { AgentType } from '../src/shared/types'
+
+// Mock createPortal to render inline
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node
+  }
+})
+
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const ALL_INSTALLED: Record<AgentType, boolean> = {
+  claude: true,
+  copilot: true,
+  codex: true,
+  opencode: true,
+  gemini: true
+}
+
+describe('AgentPicker with allowNone', () => {
+  let onChange: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    onChange = vi.fn()
+  })
+
+  it('renders "Unassigned" when currentAgent is null', () => {
+    const { getByText } = render(
+      <AgentPicker
+        currentAgent={null}
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    expect(getByText('Unassigned')).toBeInTheDocument()
+  })
+
+  it('renders agent label when currentAgent is set', () => {
+    const { getByText } = render(
+      <AgentPicker
+        currentAgent="claude"
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    expect(getByText('Claude')).toBeInTheDocument()
+  })
+
+  it('shows "None" option in dropdown when allowNone is true', () => {
+    const { getByText, getAllByRole } = render(
+      <AgentPicker
+        currentAgent="claude"
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    // Open dropdown
+    fireEvent.click(getAllByRole('button')[0])
+    expect(getByText('None')).toBeInTheDocument()
+  })
+
+  it('does not show "None" option when allowNone is false', () => {
+    const { queryByText, getAllByRole } = render(
+      <AgentPicker currentAgent="claude" onChange={onChange} installStatus={ALL_INSTALLED} />
+    )
+    fireEvent.click(getAllByRole('button')[0])
+    expect(queryByText('None')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange(null) when "None" is selected', () => {
+    const { getByText, getAllByRole } = render(
+      <AgentPicker
+        currentAgent="claude"
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    fireEvent.click(getAllByRole('button')[0])
+    fireEvent.click(getByText('None'))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('calls onChange with agent type when an agent is selected', () => {
+    const { getByText, getAllByRole } = render(
+      <AgentPicker
+        currentAgent={null}
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    fireEvent.click(getAllByRole('button')[0])
+    fireEvent.click(getByText('Copilot'))
+    expect(onChange).toHaveBeenCalledWith('copilot')
+  })
+
+  it('does not call onChange for uninstalled agents', () => {
+    const status = { ...ALL_INSTALLED, codex: false }
+    const { getByText, getAllByRole } = render(
+      <AgentPicker currentAgent="claude" onChange={onChange} installStatus={status} allowNone />
+    )
+    fireEvent.click(getAllByRole('button')[0])
+    fireEvent.click(getByText('Codex'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('shows check mark on "None" when currentAgent is null', () => {
+    const { container, getAllByRole } = render(
+      <AgentPicker
+        currentAgent={null}
+        onChange={onChange}
+        installStatus={ALL_INSTALLED}
+        allowNone
+      />
+    )
+    fireEvent.click(getAllByRole('button')[0])
+    // The None button should contain a Check icon (svg with lucide class)
+    const noneButton = container.querySelector('button .italic')?.closest('button')
+    const checkIcon = noneButton?.querySelector('svg:last-child')
+    expect(checkIcon).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Extend `AgentPicker` with `allowNone` prop for nullable agent selection (matches `ProjectPicker` pattern)
- Add agent picker to `AddTaskDialog` toolbar between project and branch pills
- Replace read-only agent display in `TaskDetailPanel` with editable `AgentPicker`, wired into auto-save
- 8 new tests for nullable agent picker behavior

Closes #95

## Test plan
- [x] 8 new tests pass (agent-picker-nullable.test.tsx)
- [x] Existing agent-icon tests still pass
- [x] ESLint + Prettier pass
- [ ] Manual: create task with agent assigned
- [ ] Manual: change agent on existing task in detail panel
- [ ] Manual: set agent to "None" / unassigned