### PR TITLE
fix: revert @xmldom/xmldom resolution to ^0.8.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "resolutions": {
     "serialize-javascript": "^7.0.5",
-    "@xmldom/xmldom": "^0.9.9",
+    "@xmldom/xmldom": "^0.8.10",
     "hono": "^4.12.12",
     "@hono/node-server": "^1.19.13",
     "lodash": "^4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,10 +4526,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmldom/xmldom@npm:^0.9.9":
-  version: 0.9.9
-  resolution: "@xmldom/xmldom@npm:0.9.9"
-  checksum: 10c0/f1ecf6cd6926651a752d578fe662c10c47b8f8d98abe646f3318998283ac4a0e591161f89c8d1fc1822ae2524b82f8ff3de4ab396fba7ad7988f508cd5118e89
+"@xmldom/xmldom@npm:^0.8.10":
+  version: 0.8.12
+  resolution: "@xmldom/xmldom@npm:0.8.12"
+  checksum: 10c0/b733c84292d1bee32ef21a05aba8f9063456b51a54068d0b4a1abf5545156ee0b9894b7ae23775b5881b11c35a8a03871d1b514fb7e1b11654cdbee57e1c2707
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Reverts `@xmldom/xmldom` resolution from `^0.9.9` to `^0.8.10`
- v0.9.x requires a `mimeType` argument in `DOMParser.parseFromString()` which breaks `plist` (used by electron-builder for macOS/Windows builds)
- This was causing the v0.1.1-beta.1 release to fail on both macOS and Windows

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` — 61 suites, 658 tests pass
- Release pipeline should succeed after this merges