### PR TITLE
fix: inject git tag version into desktop builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,14 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Sync version from tag
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            npm pkg set version="$VERSION"
+            echo "Set version to $VERSION"
+          fi
+
       - name: Build
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -149,6 +157,14 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Sync version from tag
+        run: |
+          if ($env:GITHUB_REF -match '^refs/tags/') {
+            $version = $env:GITHUB_REF_NAME -replace '^v', ''
+            npm pkg set version="$version"
+            Write-Output "Set version to $version"
+          }
+
       - name: Build
         run: |
           yarn build
@@ -201,6 +217,14 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+
+      - name: Sync version from tag
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            npm pkg set version="$VERSION"
+            echo "Set version to $VERSION"
+          fi
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
- Adds a "Sync version from tag" step to macOS, Windows, and Linux build jobs
- Uses `npm pkg set version` to inject the tag version (e.g. `0.1.1-beta.3`) into `package.json` at build time — no commit created
- Same pattern already used by the `publish-mcp` job
- Now `app.getVersion()` will correctly return `0.1.1-beta.3` for beta builds

## How it works
1. Push tag `v0.1.1-beta.3`
2. CI checks out code (package.json says `0.1.1`)
3. New step runs `npm pkg set version="0.1.1-beta.3"` (working tree only)
4. Build runs with correct version baked in
5. No commit, no PR — clean

## Test plan
- Tag a new beta after merging to verify the app shows the beta version