### PR TITLE
fix: enlarge hero title and vitruvian figure on mobile

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -423,17 +423,6 @@
         z-index: 0;
       }
 
-      @media (max-width: 768px) {
-        .hero-vitruvian {
-          top: 8%;
-          width: min(78vw, 440px);
-          opacity: 0.22;
-        }
-        .hero-title {
-          font-size: clamp(4.5rem, 19vw, 6.5rem);
-        }
-      }
-
       /* Golden ratio spiral — decorative background */
       .hero-spiral {
         position: absolute;
@@ -491,6 +480,17 @@
         line-height: 0.85;
         margin-bottom: 24px;
         text-indent: 0.25em;
+      }
+
+      @media (max-width: 768px) {
+        .hero-vitruvian {
+          top: 8%;
+          width: min(78vw, 440px);
+          opacity: 0.22;
+        }
+        .hero-title {
+          font-size: clamp(4.5rem, 19vw, 6.5rem);
+        }
       }
 
       .hero-subtitle {

--- a/website/index.html
+++ b/website/index.html
@@ -423,6 +423,17 @@
         z-index: 0;
       }
 
+      @media (max-width: 768px) {
+        .hero-vitruvian {
+          top: 8%;
+          width: min(78vw, 440px);
+          opacity: 0.22;
+        }
+        .hero-title {
+          font-size: clamp(4.5rem, 19vw, 6.5rem);
+        }
+      }
+
       /* Golden ratio spiral — decorative background */
       .hero-spiral {
         position: absolute;


### PR DESCRIPTION
## Summary
- On viewports ≤768px the hero title was pinned to its 2.5rem floor (the 9vw preferred value never cleared the minimum below ~445px), leaving "VORN" feeling small and the Vitruvian backdrop barely visible.
- Add a mobile override: title becomes `clamp(4.5rem, 19vw, 6.5rem)` (~+80% at a 390px viewport), and the figure is resized to `min(78vw, 440px)` with a slight opacity bump so it sits meaningfully behind the wordmark.
- Desktop layout is untouched.

## Test plan
- [ ] Open `website/index.html` in Safari, narrow to ~390px, confirm "VORN" fills the hero and the Vitruvian figure reads clearly behind it
- [ ] Check at 320px (small phones) — title should not overflow
- [ ] Check at ≥769px — desktop hero unchanged