### PR TITLE
feat: expose existing worktrees as palette quick-launch commands

### DIFF
--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -6,7 +6,11 @@ import { SortMode, StatusFilter } from '../stores/types'
 import { AGENT_DEFINITIONS, AGENT_LIST } from '../lib/agent-definitions'
 import { AgentIcon } from './AgentIcon'
 import { getDisplayName } from '../lib/terminal-display'
-import { formatRecentSessionActivity, resolveProjectName } from '../lib/session-utils'
+import {
+  formatRecentSessionActivity,
+  resolveProjectName,
+  createSessionFromProject
+} from '../lib/session-utils'
 import { executeWorkflow } from '../lib/workflow-execution'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import {
@@ -110,6 +114,7 @@ function useCommands(
 ): Command[] {
   const config = useAppStore((s) => s.config)
   const terminals = useAppStore((s) => s.terminals)
+  const worktreeCache = useAppStore((s) => s.worktreeCache)
   const addTerminal = useAppStore((s) => s.addTerminal)
   const setFocusedTerminal = useAppStore((s) => s.setFocusedTerminal)
   const setActiveProject = useAppStore((s) => s.setActiveProject)
@@ -358,42 +363,40 @@ function useCommands(
           category: 'quicklaunch',
           icon: <AgentIcon agentType={agent.type} size={14} />,
           keywords: ['launch', 'start', 'run'],
-          onExecute: async () => {
-            const remoteHostId = getProjectRemoteHostId(project)
-            const session = await window.api.createTerminal({
-              agentType: agent.type,
-              projectName: project.name,
-              projectPath: project.path,
-              remoteHostId
-            })
-            addTerminal(session)
-          }
+          onExecute: () => createSessionFromProject(project, { agentType: agent.type })
         })
-        // Worktree variant — only for confirmed git repos
-        if (gitRepoStatus[project.path] === true) {
+        if (gitRepoStatus[project.path] !== true) continue
+
+        // Existing worktrees — one command per cached worktree
+        const worktrees = (worktreeCache.get(project.path) ?? []).filter((wt) => !wt.isMain)
+        for (const wt of worktrees) {
           commands.push({
-            id: `quicklaunch:${agent.type}:${project.name}:worktree`,
-            label: `${agent.displayName} on ${project.name} (worktree)`,
-            sublabel: 'Isolated worktree from current branch',
+            id: `quicklaunch:${agent.type}:${project.name}:wt:${wt.path}`,
+            label: `${agent.displayName} on ${project.name} on ${wt.branch}`,
+            sublabel: 'Existing worktree',
             category: 'quicklaunch',
             icon: <AgentIcon agentType={agent.type} size={14} />,
-            keywords: ['launch', 'start', 'run', 'worktree', 'branch', 'isolated', 'fork'],
-            onExecute: async () => {
-              const remoteHostId = getProjectRemoteHostId(project)
-              const branchResult = await window.api.listBranches(project.path)
-              const branch = branchResult.current || 'main'
-              const session = await window.api.createTerminal({
+            keywords: ['launch', 'start', 'run', 'worktree', 'branch', wt.branch],
+            onExecute: () =>
+              createSessionFromProject(project, {
                 agentType: agent.type,
-                projectName: project.name,
-                projectPath: project.path,
-                branch,
-                useWorktree: true,
-                remoteHostId
+                branch: wt.branch,
+                existingWorktreePath: wt.path
               })
-              addTerminal(session)
-            }
           })
         }
+
+        // New worktree from current branch
+        commands.push({
+          id: `quicklaunch:${agent.type}:${project.name}:worktree`,
+          label: `${agent.displayName} on ${project.name} (new worktree)`,
+          sublabel: 'Isolated worktree from current branch',
+          category: 'quicklaunch',
+          icon: <AgentIcon agentType={agent.type} size={14} />,
+          keywords: ['launch', 'start', 'run', 'worktree', 'branch', 'isolated', 'fork', 'new'],
+          onExecute: () =>
+            createSessionFromProject(project, { agentType: agent.type, useWorktree: true })
+        })
       }
     }
 
@@ -439,6 +442,7 @@ function useCommands(
     recentSessions,
     installStatus,
     gitRepoStatus,
+    worktreeCache,
     addTerminal,
     setFocusedTerminal,
     setActiveProject,
@@ -463,6 +467,7 @@ export function CommandPalette() {
   const setOpen = useAppStore((s) => s.setCommandPaletteOpen)
 
   const config = useAppStore((s) => s.config)
+  const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
   const [recentSessions, setRecentSessions] = useState<RecentSession[]>([])
@@ -484,6 +489,7 @@ export function CommandPalette() {
       Promise.allSettled(
         localProjects.map(async (p) => {
           const isRepo = await window.api.isGitRepo(p.path)
+          if (isRepo) loadWorktrees(p.path)
           return [p.path, isRepo] as const
         })
       ).then((results) => {
@@ -493,7 +499,7 @@ export function CommandPalette() {
         setGitRepoStatus(Object.fromEntries(entries))
       })
     }
-  }, [isOpen, config?.projects])
+  }, [isOpen, config?.projects, loadWorktrees])
 
   const commands = useCommands(recentSessions, installStatus, gitRepoStatus)
 

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -372,11 +372,11 @@ function useCommands(
         for (const wt of worktrees) {
           commands.push({
             id: `quicklaunch:${agent.type}:${project.name}:wt:${wt.path}`,
-            label: `${agent.displayName} on ${project.name} on ${wt.branch}`,
-            sublabel: 'Existing worktree',
+            label: `${agent.displayName} on ${project.name} / ${wt.name}`,
+            sublabel: wt.branch === wt.name ? 'Existing worktree' : `Branch: ${wt.branch}`,
             category: 'quicklaunch',
             icon: <AgentIcon agentType={agent.type} size={14} />,
-            keywords: ['launch', 'start', 'run', 'worktree', 'branch', wt.branch],
+            keywords: ['launch', 'start', 'run', 'worktree', 'branch', wt.name, wt.branch],
             onExecute: () =>
               createSessionFromProject(project, {
                 agentType: agent.type,

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -3,9 +3,9 @@ import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Play, FolderGit2, Plus, ChevronRight } from 'lucide-react'
 import { useAppStore } from '../stores'
-import { getProjectRemoteHostId, type ProjectConfig } from '../../shared/types'
+import { type ProjectConfig } from '../../shared/types'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
-import { resolveActiveProject } from '../lib/session-utils'
+import { resolveActiveProject, createSessionFromProject } from '../lib/session-utils'
 import { useWorkspaceProjects } from '../hooks/useWorkspaceProjects'
 
 interface Props {
@@ -94,33 +94,16 @@ export function GridContextMenu({ position, onClose }: Props) {
     activeWorktreeBranch = activeWt?.branch
   }
 
-  const createSession = async (
+  const createSession = (
     p: ProjectConfig,
     opts: {
       branch?: string
       existingWorktreePath?: string
       useWorktree?: boolean
     } = {}
-  ) => {
+  ): Promise<void> => {
     onClose()
-    const state = useAppStore.getState()
-    const agentType = state.config?.defaults.defaultAgent || 'claude'
-    const remoteHostId = getProjectRemoteHostId(p)
-    let branch = opts.branch
-    if (opts.useWorktree && !branch) {
-      const branchResult = await window.api.listBranches(p.path)
-      branch = branchResult.current || 'main'
-    }
-    const session = await window.api.createTerminal({
-      agentType,
-      projectName: p.name,
-      projectPath: p.path,
-      branch,
-      existingWorktreePath: opts.existingWorktreePath,
-      useWorktree: opts.useWorktree,
-      remoteHostId
-    })
-    state.addTerminal(session)
+    return createSessionFromProject(p, opts)
   }
 
   // Returns null for non-git projects (whose worktreeCache entry is never

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -87,12 +87,10 @@ export function GridContextMenu({ position, onClose }: Props) {
   const project = resolveActiveProject()
   const terminals = useAppStore.getState().terminals
 
-  let activeWorktreeBranch: string | undefined
-  if (activeWorktreePath && project) {
-    const cachedWts = worktreeCache.get(project.path)
-    const activeWt = cachedWts?.find((wt) => wt.path === activeWorktreePath)
-    activeWorktreeBranch = activeWt?.branch
-  }
+  const activeWt =
+    activeWorktreePath && project
+      ? worktreeCache.get(project.path)?.find((wt) => wt.path === activeWorktreePath)
+      : undefined
 
   const createSession = (
     p: ProjectConfig,
@@ -120,9 +118,10 @@ export function GridContextMenu({ position, onClose }: Props) {
     }
     const subs: SubmenuItem[] = nonMain.map((wt) => {
       const count = sessionCountByPath.get(wt.path) ?? 0
+      const label = wt.name === wt.branch ? wt.name : `${wt.name} (${wt.branch})`
       return {
         iconElement: <FolderGit2 size={12} className="text-amber-400/70" />,
-        label: wt.branch,
+        label,
         detail: count > 0 ? `${count} session${count > 1 ? 's' : ''}` : 'idle',
         onClick: () => createSession(p, { branch: wt.branch, existingWorktreePath: wt.path })
       }
@@ -140,8 +139,8 @@ export function GridContextMenu({ position, onClose }: Props) {
 
   if (project) {
     const quickLabel = activeWorktreePath
-      ? activeWorktreeBranch
-        ? `New session in ${project.name} on ${activeWorktreeBranch}`
+      ? activeWt
+        ? `New session in ${project.name} / ${activeWt.name}`
         : `New session in ${project.name} (worktree)`
       : `New session in ${project.name}`
 
@@ -156,7 +155,7 @@ export function GridContextMenu({ position, onClose }: Props) {
       onClick: () =>
         activeWorktreePath
           ? createSession(project, {
-              branch: activeWorktreeBranch,
+              branch: activeWt?.branch,
               existingWorktreePath: activeWorktreePath
             })
           : createSession(project)

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -1,8 +1,11 @@
 import {
   supportsExactSessionResume,
+  getProjectRemoteHostId,
   type TerminalSession,
   type RecentSession,
-  type CreateTerminalPayload
+  type CreateTerminalPayload,
+  type ProjectConfig,
+  type AgentType
 } from '../../shared/types'
 import { useAppStore } from '../stores'
 
@@ -148,6 +151,40 @@ export function buildRestorePayload(
     remoteHostId: s.remoteHostId,
     resumeSessionId
   }
+}
+
+/**
+ * Create a terminal session in a project. Handles agent defaults, remote host
+ * resolution, and the worktree branch lookup so callers (grid context menu,
+ * command palette, project sidebar) share one code path.
+ */
+export async function createSessionFromProject(
+  p: ProjectConfig,
+  opts: {
+    agentType?: AgentType
+    branch?: string
+    existingWorktreePath?: string
+    useWorktree?: boolean
+  } = {}
+): Promise<void> {
+  const state = useAppStore.getState()
+  const agentType = opts.agentType ?? state.config?.defaults.defaultAgent ?? 'claude'
+  const remoteHostId = getProjectRemoteHostId(p)
+  let branch = opts.branch
+  if (opts.useWorktree && !branch) {
+    const branchResult = await window.api.listBranches(p.path)
+    branch = branchResult.current || 'main'
+  }
+  const session = await window.api.createTerminal({
+    agentType,
+    projectName: p.name,
+    projectPath: p.path,
+    branch,
+    existingWorktreePath: opts.existingWorktreePath,
+    useWorktree: opts.useWorktree,
+    remoteHostId
+  })
+  state.addTerminal(session)
 }
 
 /**

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -108,8 +108,8 @@ describe('GridContextMenu', () => {
   it('shows worktree submenu on hover over project item', () => {
     const cache = new Map()
     cache.set('/tmp/vorn', [
-      { path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false },
-      { path: '/tmp/wt/feat-b', branch: 'feat-b', isMain: false }
+      { path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false, name: 'feat-a' },
+      { path: '/tmp/wt/feat-b', branch: 'feat-b', isMain: false, name: 'feat-b' }
     ])
     useAppStore.setState({ worktreeCache: cache })
 
@@ -126,7 +126,7 @@ describe('GridContextMenu', () => {
   it('shows worktree submenu on hover over non-active project', () => {
     const cache = new Map()
     cache.set('/tmp/otherapp', [
-      { path: '/tmp/wt/experiment', branch: 'experiment', isMain: false }
+      { path: '/tmp/wt/experiment', branch: 'experiment', isMain: false, name: 'experiment' }
     ])
     useAppStore.setState({ worktreeCache: cache })
 
@@ -141,7 +141,9 @@ describe('GridContextMenu', () => {
 
   it('clicking a worktree in the submenu creates terminal on that worktree', async () => {
     const cache = new Map()
-    cache.set('/tmp/vorn', [{ path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false }])
+    cache.set('/tmp/vorn', [
+      { path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false, name: 'feat-a' }
+    ])
     useAppStore.setState({ worktreeCache: cache })
 
     mockCreateTerminal.mockResolvedValue({


### PR DESCRIPTION
Depends on #205 (shares the branch history). After #205 merges this will rebase cleanly onto main.

## Summary

- Adds one palette command per agent × local git project × existing worktree — `Claude on vorn on feat-a` — so you can launch a session on an existing worktree without ever leaving the keyboard.
- Keeps the existing \`(worktree)\` command for "new worktree from current branch" (relabeled to \`(new worktree)\` for clarity).
- Worktree cache is warmed when the palette opens (calls \`loadWorktrees(project.path)\` alongside the existing \`isGitRepo\` check; 5s TTL keeps re-opens cheap).
- Extracts \`createSessionFromProject(p, opts)\` in \`session-utils.ts\` so the palette and \`GridContextMenu\` share one code path for agent defaults, remote host resolution, and the worktree branch lookup.

## Test plan

- [x] \`yarn vitest run tests/grid-context-menu.test.tsx\` — 11 tests still pass (GridContextMenu now delegates to the shared helper)
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean (husky pre-commit hook)
- [ ] Manual: open the palette, type a worktree branch name → the quick-launch command for that worktree appears and creates a session on the right path
- [ ] Manual: worktrees show up on first palette open (no stale empty state)
- [ ] Manual: after closing + reopening the palette quickly, no extra \`listWorktrees\` IPC calls (5s cache)