### PR TITLE
feat: pin copilot session IDs at launch instead of reading the DB

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -62,18 +62,19 @@ export function buildAgentLaunchLine(
   let launchLine = [cmd.command, ...effectiveArgs.map((a) => shellEscape(a))].join(' ')
 
   if (payload.resumeSessionId && supportsExactSessionResume(payload.agentType)) {
+    const escapedResumeId = shellEscape(payload.resumeSessionId)
     switch (payload.agentType) {
       case 'claude':
-        launchLine += ` --resume ${payload.resumeSessionId}`
+        launchLine += ` --resume ${escapedResumeId}`
         break
       case 'copilot':
-        launchLine += ` --resume ${payload.resumeSessionId}`
+        launchLine += ` --resume ${escapedResumeId}`
         break
       case 'codex':
-        launchLine = `${cmd.command} resume ${payload.resumeSessionId}`
+        launchLine = `${cmd.command} resume ${escapedResumeId}`
         break
       case 'opencode':
-        launchLine += ` --session ${payload.resumeSessionId}`
+        launchLine += ` --session ${escapedResumeId}`
         break
     }
   }
@@ -85,7 +86,7 @@ export function buildAgentLaunchLine(
     payload.sessionId &&
     supportsSessionIdPinning(payload.agentType)
   ) {
-    launchLine += ` ${getSessionIdPinningFlag(payload.agentType)} ${payload.sessionId}`
+    launchLine += ` ${getSessionIdPinningFlag(payload.agentType)} ${shellEscape(payload.sessionId)}`
   }
 
   if (payload.initialPrompt) {

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -4,7 +4,8 @@ import {
   AgentCommandConfig,
   CreateTerminalPayload,
   supportsExactSessionResume,
-  supportsSessionIdPinning
+  supportsSessionIdPinning,
+  getSessionIdPinningFlag
 } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { shellEscape } from './process-utils'
@@ -77,14 +78,14 @@ export function buildAgentLaunchLine(
     }
   }
 
-  // For agents that support session ID pinning, assign the ID on fresh launch
-  // so we can reliably --resume later
+  // Pin the pre-generated ID on fresh launch so we know what to --resume later
+  // without reading the agent's private session store.
   if (
     !payload.resumeSessionId &&
     payload.sessionId &&
     supportsSessionIdPinning(payload.agentType)
   ) {
-    launchLine += ` --session-id ${payload.sessionId}`
+    launchLine += ` ${getSessionIdPinningFlag(payload.agentType)} ${payload.sessionId}`
   }
 
   if (payload.initialPrompt) {

--- a/packages/server/src/agent-session-capture.ts
+++ b/packages/server/src/agent-session-capture.ts
@@ -7,8 +7,6 @@ import log from './logger'
 
 function getAgentDbPath(agentType: AgentType): string | undefined {
   switch (agentType) {
-    case 'copilot':
-      return path.join(os.homedir(), '.copilot', 'session-store.db')
     case 'codex':
       return path.join(os.homedir(), '.codex', 'state_5.sqlite')
     case 'opencode': {
@@ -55,16 +53,6 @@ export function captureAgentSessionId(
     let row: { id: string } | undefined
 
     switch (agentType) {
-      case 'copilot':
-        row = db
-          .prepare(
-            `SELECT id FROM sessions
-             WHERE rtrim(lower(replace(cwd, '\\', '/')), '/') = ?
-             ORDER BY updated_at DESC LIMIT 1`
-          )
-          .get(normalized) as typeof row
-        break
-
       case 'codex':
         row = db
           .prepare(

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -6,9 +6,22 @@ export function supportsExactSessionResume(agentType: AgentType): boolean {
   return agentType !== 'gemini'
 }
 
-/** Can we assign a session ID on fresh launch (e.g. --session-id)? */
+/** Can we pin a pre-generated session ID on fresh launch so we can --resume it later? */
 export function supportsSessionIdPinning(agentType: AgentType): boolean {
-  return agentType === 'claude'
+  return agentType === 'claude' || agentType === 'copilot'
+}
+
+/** CLI flag used to pin a pre-generated session ID on fresh launch. Only valid
+ *  when supportsSessionIdPinning(agentType) is true. */
+export function getSessionIdPinningFlag(agentType: AgentType): string {
+  switch (agentType) {
+    case 'claude':
+      return '--session-id'
+    case 'copilot':
+      return '--resume'
+    default:
+      throw new Error(`getSessionIdPinningFlag: ${agentType} does not support session ID pinning`)
+  }
 }
 
 export function getRecentSessionActivityLabel(agentType: AgentType): string {
@@ -425,7 +438,7 @@ export interface CreateTerminalPayload {
   projectName: string
   projectPath: string
   resumeSessionId?: string
-  /** Pre-generated agent session ID (used with --session-id for Claude) */
+  /** Pre-generated agent session ID to pin on fresh launch (claude, copilot) */
   sessionId?: string
   displayName?: string
   branch?: string

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -99,13 +99,33 @@ describe('buildAgentLaunchLine', () => {
     expect(result).not.toContain('--session-id')
   })
 
-  it('does not add --session-id for non-Claude agents', () => {
+  it('pins fresh copilot session via --resume', () => {
     const result = buildAgentLaunchLine(
       makePayload({ agentType: 'copilot', sessionId: 'uuid-123' }),
       cmds,
       env
     )
+    expect(result).toBe('copilot --resume uuid-123')
     expect(result).not.toContain('--session-id')
+  })
+
+  it('prefers resumeSessionId over pinned sessionId for copilot', () => {
+    const result = buildAgentLaunchLine(
+      makePayload({ agentType: 'copilot', resumeSessionId: 'sess-1', sessionId: 'uuid-123' }),
+      cmds,
+      env
+    )
+    expect(result).toBe('copilot --resume sess-1')
+  })
+
+  it('does not add --session-id for non-pinning agents', () => {
+    const result = buildAgentLaunchLine(
+      makePayload({ agentType: 'codex', sessionId: 'uuid-123' }),
+      cmds,
+      env
+    )
+    expect(result).not.toContain('--session-id')
+    expect(result).not.toContain('--resume')
   })
 })
 

--- a/tests/agent-session-capture.test.ts
+++ b/tests/agent-session-capture.test.ts
@@ -17,22 +17,6 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true })
 })
 
-function createCopilotDb(sessions: { id: string; cwd: string; updated_at: string }[]): string {
-  const dbPath = path.join(tmpDir, 'copilot-session-store.db')
-  const db = new Database(dbPath)
-  db.exec(`CREATE TABLE sessions (
-    id TEXT PRIMARY KEY,
-    cwd TEXT,
-    summary TEXT,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now'))
-  )`)
-  const insert = db.prepare('INSERT INTO sessions (id, cwd, updated_at) VALUES (?, ?, ?)')
-  for (const s of sessions) insert.run(s.id, s.cwd, s.updated_at)
-  db.close()
-  return dbPath
-}
-
 function createCodexDb(
   threads: { id: string; cwd: string; updated_at: number; archived?: number }[]
 ): string {
@@ -84,44 +68,18 @@ function createOpenCodeDb(
 describe('captureAgentSessionId', () => {
   it('returns undefined for unsupported agent types', () => {
     expect(captureAgentSessionId('claude', '/any/path')).toBeUndefined()
+    expect(captureAgentSessionId('copilot', '/any/path')).toBeUndefined()
     expect(captureAgentSessionId('gemini', '/any/path')).toBeUndefined()
   })
 
   it('returns undefined when DB does not exist', () => {
     const fakePath = path.join(tmpDir, 'nonexistent.db')
-    expect(captureAgentSessionId('copilot', '/any/path', fakePath)).toBeUndefined()
+    expect(captureAgentSessionId('codex', '/any/path', fakePath)).toBeUndefined()
   })
 
   it('returns undefined for non-matching cwd', () => {
-    const dbPath = createCopilotDb([
-      { id: 'some-session', cwd: '/other/project', updated_at: '2026-04-01T00:00:00Z' }
-    ])
-    expect(captureAgentSessionId('copilot', '/my/project', dbPath)).toBeUndefined()
-  })
-})
-
-describe('copilot DB via captureAgentSessionId', () => {
-  it('reads most recent session by cwd', () => {
-    const dbPath = createCopilotDb([
-      { id: 'old-session', cwd: '/my/project', updated_at: '2026-01-01T00:00:00Z' },
-      { id: 'new-session', cwd: '/my/project', updated_at: '2026-04-01T00:00:00Z' },
-      { id: 'other-project', cwd: '/other/path', updated_at: '2026-04-02T00:00:00Z' }
-    ])
-    expect(captureAgentSessionId('copilot', '/my/project', dbPath)).toBe('new-session')
-  })
-
-  it('handles Windows backslash paths', () => {
-    const dbPath = createCopilotDb([
-      { id: 'win-session', cwd: 'C:\\Users\\dev\\project', updated_at: '2026-04-01T00:00:00Z' }
-    ])
-    expect(captureAgentSessionId('copilot', 'C:/Users/dev/project', dbPath)).toBe('win-session')
-  })
-
-  it('handles trailing slashes in cwd', () => {
-    const dbPath = createCopilotDb([
-      { id: 'trailing-slash', cwd: '/my/project/', updated_at: '2026-04-01T00:00:00Z' }
-    ])
-    expect(captureAgentSessionId('copilot', '/my/project', dbPath)).toBe('trailing-slash')
+    const dbPath = createCodexDb([{ id: 'some-thread', cwd: '/other/project', updated_at: 1000 }])
+    expect(captureAgentSessionId('codex', '/my/project', dbPath)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- Promote copilot to the session-ID-pinning tier: pre-generate a UUID and pass `copilot --resume <uuid>` on fresh launch. Verified against `GitHub Copilot CLI 1.0.27` — its own `--help` documents this as a first-class use case ("Start a new session with a specific UUID: `copilot --resume=<uuid>`"), and tested end-to-end: fresh-launch with an unknown UUID creates a session persisted with that exact ID, and subsequent `--resume=<same-uuid>` correctly recovers prior context.
- Delete the now-dead 5-second-after-launch DB-read fallback path for copilot in `captureAgentSessionId` (and its tests). The fallback still runs for `codex` and `opencode`.
- Add `getSessionIdPinningFlag(agentType)` in `shared/types.ts` next to `supportsSessionIdPinning` with an exhaustive throwing switch, so the "can pin" predicate and the per-agent flag shape stay in sync as new agents are added.
- `copilotProvider.getRecentSessions()` in `agent-history.ts` is untouched — it powers the recent-sessions UI that lists copilot sessions launched outside vorn, a separate feature.

## Test plan
- [x] Full suite: 660/660 passing (`npx vitest run`)
- [x] New unit tests in `tests/agent-launch.test.ts` cover: fresh copilot pin via `--resume`, resumeSessionId taking precedence over pinned sessionId, and non-pinning agents (codex) getting no session flag
- [x] Live verification: `copilot --resume=<new-uuid> -p "say pong"` on a clean UUID created the session with that ID in `~/.copilot/session-store.db`, and `copilot --resume=<same-uuid>` on a follow-up turn recovered the prior context
- [x] Audited all `terminal:create` / `headless:create` call paths — no caller passes `sessionId` explicitly; `pty-manager.ts:216` generates it uniformly for any pinning-capable agent, so every PTY copilot launch gets pinned regardless of caller