### PR TITLE
feat: surface main branch in grid right-click worktree submenu

### DIFF
--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Play, FolderGit2, Plus, ChevronRight } from 'lucide-react'
+import { Play, FolderGit2, GitBranch, Plus, ChevronRight } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { type ProjectConfig } from '../../shared/types'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
@@ -105,27 +105,45 @@ export function GridContextMenu({ position, onClose }: Props) {
   }
 
   // Returns null for non-git projects (whose worktreeCache entry is never
-  // populated because listWorktrees fails). The main worktree is filtered out
-  // because plain sessions are reachable by clicking the parent project item.
+  // populated because listWorktrees fails). The main worktree is surfaced as
+  // its own entry (with a GitBranch icon) so users don't have to know they
+  // can click the parent project row to launch on main.
   const buildWorktreeSubmenu = (p: ProjectConfig): SubmenuItem[] | null => {
     const worktrees = worktreeCache.get(p.path)
     if (!worktrees || worktrees.length === 0) return null
+    const mainWt = worktrees.find((wt) => wt.isMain)
     const nonMain = worktrees.filter((wt) => !wt.isMain)
     const sessionCountByPath = new Map<string, number>()
     for (const [, t] of terminals) {
       const wtPath = t.session.worktreePath
       if (wtPath) sessionCountByPath.set(wtPath, (sessionCountByPath.get(wtPath) ?? 0) + 1)
     }
-    const subs: SubmenuItem[] = nonMain.map((wt) => {
-      const count = sessionCountByPath.get(wt.path) ?? 0
-      const label = wt.name === wt.branch ? wt.name : `${wt.name} (${wt.branch})`
-      return {
+    const formatDetail = (path: string): string => {
+      const count = sessionCountByPath.get(path) ?? 0
+      return count > 0 ? `${count} session${count > 1 ? 's' : ''}` : 'idle'
+    }
+    const formatLabel = (wt: { name: string; branch: string }): string =>
+      wt.name === wt.branch ? wt.name : `${wt.name} (${wt.branch})`
+
+    const subs: SubmenuItem[] = []
+    if (mainWt) {
+      subs.push({
+        iconElement: <GitBranch size={12} className="text-gray-400" />,
+        label: mainWt.branch,
+        detail: formatDetail(mainWt.path),
+        onClick: () =>
+          createSession(p, { branch: mainWt.branch, existingWorktreePath: mainWt.path })
+      })
+    }
+    for (const wt of nonMain) {
+      subs.push({
         iconElement: <FolderGit2 size={12} className="text-amber-400/70" />,
-        label,
-        detail: count > 0 ? `${count} session${count > 1 ? 's' : ''}` : 'idle',
+        label: formatLabel(wt),
+        detail: formatDetail(wt.path),
         onClick: () => createSession(p, { branch: wt.branch, existingWorktreePath: wt.path })
-      }
-    })
+      })
+    }
+    if (mainWt && nonMain.length > 0) subs[1].separator = true
     subs.push({
       iconElement: <Plus size={12} className="text-amber-400/70" />,
       label: 'New worktree',

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -135,15 +135,15 @@ export function GridContextMenu({ position, onClose }: Props) {
           createSession(p, { branch: mainWt.branch, existingWorktreePath: mainWt.path })
       })
     }
-    for (const wt of nonMain) {
+    nonMain.forEach((wt, i) => {
       subs.push({
         iconElement: <FolderGit2 size={12} className="text-amber-400/70" />,
         label: formatLabel(wt),
         detail: formatDetail(wt.path),
-        onClick: () => createSession(p, { branch: wt.branch, existingWorktreePath: wt.path })
+        onClick: () => createSession(p, { branch: wt.branch, existingWorktreePath: wt.path }),
+        separator: i === 0 && mainWt !== undefined
       })
-    }
-    if (mainWt && nonMain.length > 0) subs[1].separator = true
+    })
     subs.push({
       iconElement: <Plus size={12} className="text-amber-400/70" />,
       label: 'New worktree',

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -139,6 +139,63 @@ describe('GridContextMenu', () => {
     expect(screen.getByText('experiment')).toBeInTheDocument()
   })
 
+  it('shows the main branch as a first entry in the worktree submenu', () => {
+    const cache = new Map()
+    cache.set('/tmp/vorn', [
+      { path: '/tmp/vorn', branch: 'main', isMain: true, name: 'vorn' },
+      { path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false, name: 'feat-a' }
+    ])
+    useAppStore.setState({ worktreeCache: cache })
+
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+
+    fireEvent.mouseEnter(screen.getByText('Vorn').closest('button')!)
+
+    expect(screen.getByText('main')).toBeInTheDocument()
+    expect(screen.getByText('feat-a')).toBeInTheDocument()
+    expect(screen.getByText('New worktree')).toBeInTheDocument()
+  })
+
+  it('clicking the main branch entry creates a terminal pinned to the main worktree', async () => {
+    const cache = new Map()
+    cache.set('/tmp/vorn', [
+      { path: '/tmp/vorn', branch: 'main', isMain: true, name: 'vorn' },
+      { path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false, name: 'feat-a' }
+    ])
+    useAppStore.setState({ worktreeCache: cache })
+
+    mockCreateTerminal.mockResolvedValue({
+      id: 'main-term',
+      session: {
+        id: 'main-term',
+        agentType: 'claude',
+        projectName: 'Vorn',
+        projectPath: '/tmp/vorn',
+        branch: 'main',
+        worktreePath: '/tmp/vorn'
+      },
+      status: 'idle',
+      lastOutputTimestamp: Date.now()
+    })
+
+    const onClose = vi.fn()
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={onClose} />)
+
+    fireEvent.mouseEnter(screen.getByText('Vorn').closest('button')!)
+    fireEvent.click(screen.getByText('main'))
+
+    expect(onClose).toHaveBeenCalled()
+    expect(mockCreateTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentType: 'claude',
+        projectName: 'Vorn',
+        projectPath: '/tmp/vorn',
+        branch: 'main',
+        existingWorktreePath: '/tmp/vorn'
+      })
+    )
+  })
+
   it('clicking a worktree in the submenu creates terminal on that worktree', async () => {
     const cache = new Map()
     cache.set('/tmp/vorn', [


### PR DESCRIPTION
## Summary

- Adds an explicit main-branch entry at the top of the grid right-click context-menu worktree submenu, using a `GitBranch` icon so it reads distinctly from the amber `FolderGit2` worktree rows.
- Previously users had to know they could click the parent project row to launch a session on main; the submenu only listed non-main worktrees and a `New worktree` action, making the main-branch affordance invisible.
- Clicking the new entry launches a session pinned to the main worktree (`branch` + `existingWorktreePath`), matching how worktree rows launch.

## Layout

```
[GitBranch]  main                        idle
             ─────────────────────────
[FolderGit2] feat-a                      1 session
[FolderGit2] feat-b                      idle
             ─────────────────────────
[Plus]       New worktree
```

## Test plan

- [x] `yarn typecheck`
- [x] `yarn test tests/grid-context-menu.test.tsx` — 15/15 pass (2 new tests cover the main-branch entry + its click handler payload)
- [x] `yarn eslint` on touched files clean
- [x] Manual: right-click the grid, hover a project, confirm the main-branch row renders with a `GitBranch` icon, a separator divides it from worktrees, and clicking it opens a session on the main worktree path
- [x] Non-git project hover still suppresses the submenu entirely (null-return gate preserved)