### PR TITLE
ci: fail PRs under 80% patch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
@@ -20,6 +22,9 @@ jobs:
 
       - name: Install Python setuptools
         run: pip install setuptools
+
+      - name: Install diff-cover
+        run: pip install diff-cover
 
       - uses: actions/setup-node@v6
         with:
@@ -41,7 +46,11 @@ jobs:
         run: yarn format:check
 
       - name: Test
-        run: yarn test
+        run: yarn test:coverage
+
+      - name: Enforce 80% patch coverage
+        if: github.event_name == 'pull_request'
+        run: diff-cover coverage/lcov.info --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
       - name: Verify server CJS bundle
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 out/
 dist/
+coverage/
 .DS_Store
 *.log
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- Run `yarn test:coverage` in CI and enforce 80% coverage on lines changed vs the PR base branch using `diff-cover` against `coverage/lcov.info`.
- `actions/checkout` now fetches full history so diff-cover can reach `origin/<base_ref>`.
- Gate runs only on `pull_request` events — pushes to `main` skip it.
- Adds `coverage/` to `.gitignore`.

## Test plan
- [ ] CI green on this PR (the diff only touches `.github/workflows/ci.yml` and `.gitignore`, so patch coverage has no covered lines to evaluate)
- [ ] Confirm the `Enforce 80% patch coverage` step runs on a follow-up PR that touches `.ts`/`.tsx` and fails when coverage is below 80%