### PR TITLE
chore: enforce vitest test-quality rules in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import vitest from '@vitest/eslint-plugin'
 import prettier from 'eslint-config-prettier'
 
 export default tseslint.config(
@@ -48,18 +49,23 @@ export default tseslint.config(
   },
 
   {
-    files: ['tests/**/*.test.ts'],
+    files: ['tests/**/*.test.{ts,tsx}'],
+    plugins: { vitest },
     languageOptions: {
       globals: {
-        describe: 'readonly',
-        it: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
-        vi: 'readonly'
+        ...vitest.environments.env.globals
       }
+    },
+    rules: {
+      // Core anti-fake-test guardrails. Keep these as errors so a PR can't
+      // merge a test that makes no assertions, a .only that silences the
+      // rest of the suite, a .skip, or two tests that shadow each other.
+      'vitest/expect-expect': 'error',
+      'vitest/no-focused-tests': 'error',
+      'vitest/no-disabled-tests': 'error',
+      'vitest/no-identical-title': 'error',
+      'vitest/no-commented-out-tests': 'error',
+      'vitest/valid-expect': 'error'
     }
   }
 )

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/coverage-v8": "4.1.4",
+    "@vitest/eslint-plugin": "^1.6.16",
     "electron": "^41.2.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",

--- a/tests/port-file-lifecycle.test.ts
+++ b/tests/port-file-lifecycle.test.ts
@@ -149,8 +149,7 @@ describe('port file delete (shutdown)', () => {
   })
 
   it('no-ops when file is already gone', () => {
-    // Should not throw
-    deletePortFileIfOwned(process.pid)
+    expect(() => deletePortFileIfOwned(process.pid)).not.toThrow()
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,6 +4232,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/project-service@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.58.2"
+    "@typescript-eslint/types": "npm:^8.58.2"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/57fa2a54452f9d9058781feb8d99d7a25096d55db15783a552b242d144992ccf893548672d3bc554c1bc0768cd8c80dbb467e9aff0db471ebcc876d4409cf75e
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/scope-manager@npm:8.58.1"
@@ -4242,12 +4255,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.58.2, @typescript-eslint/scope-manager@npm:^8.58.0":
+  version: 8.58.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+  checksum: 10c0/9bf17c32d99db840500dfa4f0504635f6422fa435e0d2f3c58c36a88434d7af7ffe7ba9a6b13bd105dfa0f36a74307955ef2837ec5f1855e34c3af1843c11d36
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.58.1, @typescript-eslint/tsconfig-utils@npm:^8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.1"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/dcccf8c64e3806e3bcac750f9746f852cbf36abb816afb3e3a825f7d0268eb0bf3aa97c019082d0976508b93d2f09ff21cdfffcbffdc3204db3cb98cd0aa33cc
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.58.2, @typescript-eslint/tsconfig-utils@npm:^8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.2"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d3dc874ab43af39245ee8383bb6d39c985e64c43b81a7bbf18b7982047473366c252e19a9fbfe38df30c677b42133aa43a1c0a75e92b8de5d2e64defd4b3a05e
   languageName: node
   linkType: hard
 
@@ -4274,6 +4306,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:8.58.2, @typescript-eslint/types@npm:^8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/types@npm:8.58.2"
+  checksum: 10c0/6707c1a2ec921b9ae441b35d9cb4e0af11673a67e332a366e3033f1d558ff5db4f39021872c207fb361841670e9ffcc4981f19eb21e4495a3a031d02015637a7
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.58.1"
@@ -4293,6 +4332,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.58.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/60a323f60eff9b4bb6eb3121c5f6292e7962517a329a8a9f828e8f07516de78e6a7c1b1b1cfd732f39edf184fe57828ca557fbc63b74c61b54bcb679a69e249c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/utils@npm:8.58.1"
@@ -4308,6 +4366,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.58.0":
+  version: 8.58.2
+  resolution: "@typescript-eslint/utils@npm:8.58.2"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/d83e6c7c1b01236d255cabe2a5dc5384eedebc9f9af6aa19cc2ab7d8b280f86912f2b1a87659b2754919afd2606820b4e53862ac91970794e2980bc97487537c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/visitor-keys@npm:8.58.1"
@@ -4315,6 +4388,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.58.1"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/d2709bfb63bd86eb7b28bc86c15d9b29a8cceb5e25843418b039f497a1007fc92fa02eef8a2cbfd9cdec47f490205a00eab7fb204fd14472cf31b8db0e2db963
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.58.2":
+  version: 8.58.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.58.2"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.2"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/6775a63dbafe7a305f0cf3f0c5eb077e30dba8a60022e4ce3220669c7f1e742c6ea2ebff8c6c0288dc17eeef8f4015089a23abbdc82a6a9382abe4a77950b695
   languageName: node
   linkType: hard
 
@@ -4362,6 +4445,28 @@ __metadata:
     "@vitest/browser":
       optional: true
   checksum: 10c0/e128a70b15eeee55ad201b9f2a9d88f3a2ccd630c1518ec8ab1d80a6e7b557d23d426244ce09748c8553a53725137d92696bd1be3bd9349863dd375749988a4a
+  languageName: node
+  linkType: hard
+
+"@vitest/eslint-plugin@npm:^1.6.16":
+  version: 1.6.16
+  resolution: "@vitest/eslint-plugin@npm:1.6.16"
+  dependencies:
+    "@typescript-eslint/scope-manager": "npm:^8.58.0"
+    "@typescript-eslint/utils": "npm:^8.58.0"
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": "*"
+    eslint: ">=8.57.0"
+    typescript: ">=5.0.0"
+    vitest: "*"
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+    typescript:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10c0/b2871ce12b831ea1e1ff8cf01d978d0746aaeac951830880ad966ad2783de4fbe835a1c74c44f5bccca73ca6007174cd0434c2725269cfafdcc6fbb43d4da495
   languageName: node
   linkType: hard
 
@@ -12729,6 +12834,7 @@ __metadata:
     "@types/react-dom": "npm:^19"
     "@vitejs/plugin-react": "npm:^5.2.0"
     "@vitest/coverage-v8": "npm:4.1.4"
+    "@vitest/eslint-plugin": "npm:^1.6.16"
     "@xterm/addon-canvas": "npm:^0.7.0"
     "@xterm/addon-fit": "npm:^0.11.0"
     "@xterm/addon-web-links": "npm:0.12.0"


### PR DESCRIPTION
## Summary
Adds `@vitest/eslint-plugin` as a dev dependency and enables six rules against `tests/**/*.test.{ts,tsx}`. They run as **errors**, so the existing `--max-warnings 0` pipeline (pre-commit + CI) blocks any PR that ships a test that doesn't assert.

| Rule | What it catches |
|---|---|
| `expect-expect` | Tests with zero `expect(...)` calls — the "I imported the function and called it" fake test |
| `no-focused-tests` | `it.only` / `describe.only` committed by accident, silencing the rest of the suite |
| `no-disabled-tests` | `it.skip` / `xit` committed as "temporary" and forgotten |
| `no-identical-title` | Two tests with the same name (the second shadows the first) |
| `no-commented-out-tests` | Dead tests left in the file masquerading as documentation |
| `valid-expect` | Unawaited async matchers (`expect(p).resolves.toBe(...)` without `await`) |

### Scope widened from `.ts` to `.ts,.tsx`
The pre-existing test-files glob was `tests/**/*.test.ts` — which silently skipped every `.test.tsx` component test in the repo (~15 files). Fixing that on its own would have been enough for a separate PR; bundled here because it's a precondition for the rules to cover component tests.

### Existing violation
The new rule caught exactly one existing weak spot: `tests/port-file-lifecycle.test.ts` had a test that relied on the implicit "if it throws the test fails" pattern with zero assertions. Replaced with `expect(() => ...).not.toThrow()` so a future refactor that silently swallows errors can't pass the test unnoticed.

### Sanity-checked
I temporarily added a fake test to confirm the rule fires:
\`\`\`
tests/_sanity_fake_test.test.ts
  4:3  error  Test has no assertions  vitest/expect-expect
✖ 1 problem (1 error, 0 warnings)
\`\`\`
(File deleted before committing.)

## Limitations
- **Doesn't catch "test asserts on a mock, never touches real code"** — only mutation testing (Stryker) can catch that. If you want, we can add a follow-up PR for Stryker on the diff.
- **Doesn't catch "test imports a locally-defined helper instead of the real function"** — code review still needed.

## Test plan
- [ ] `yarn typecheck && yarn lint && yarn format:check && yarn test` (all green locally — 662 tests pass)
- [ ] Confirm the rule fires on a test with no assertions
- [ ] Confirm existing `.tsx` component tests now get linted (previously excluded by the glob)