### PR TITLE
perf: snap grid on project switch, pause xterm renderers when detached

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -1,6 +1,5 @@
 import { useState, memo, forwardRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
 import { AgentIcon } from './AgentIcon'
 import { StatusBadge } from './StatusBadge'
@@ -134,10 +133,8 @@ export const AgentCard = memo(
     }
 
     return (
-      <motion.div
+      <div
         ref={ref}
-        layout={!flexible}
-        layoutId={flexible ? undefined : terminalId}
         className={`relative rounded-lg border overflow-hidden flex flex-col
                    transition-colors
                    ${flexible ? 'h-full' : ''}
@@ -154,7 +151,6 @@ export const AgentCard = memo(
           background: '#1a1a1e',
           ...(isIdlePinned ? { opacity: 0.55 } : {})
         }}
-        transition={{ type: 'spring', stiffness: 300, damping: 25 }}
         onPointerDown={() => {
           if (!isSelected && !isFocused) setSelected(terminalId)
         }}
@@ -419,7 +415,7 @@ export const AgentCard = memo(
             onClose={() => setContextMenu(null)}
           />
         )}
-      </motion.div>
+      </div>
     )
   })
 )

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -1,7 +1,7 @@
 import { memo, useRef, useState, useCallback, useMemo, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
-import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { GridLayout, noCompactor, type EventCallback, type Layout } from 'react-grid-layout'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
@@ -203,30 +203,26 @@ export const GridView = memo(function GridView() {
             onShowContextMenu={setGridContextMenu}
           />
         ) : (
-          <LayoutGroup>
-            <div
-              className="grid gap-4"
-              style={gridStyle}
-              onDoubleClick={handleGridDoubleClick}
-              onContextMenu={handleGridContextMenu}
-            >
-              <AnimatePresence>
-                {orderedIds.map((id, index) => (
-                  <AgentCard
-                    key={id}
-                    ref={(el) => {
-                      if (el) cardRefs.current.set(id, el)
-                      else cardRefs.current.delete(id)
-                    }}
-                    terminalId={id}
-                    index={index}
-                    isDragTarget={dragState?.isDragging === true && dropTargetIndex === index}
-                    onDragStart={sortMode === 'manual' ? handleDragStart : undefined}
-                  />
-                ))}
-              </AnimatePresence>
-            </div>
-          </LayoutGroup>
+          <div
+            className="grid gap-4"
+            style={gridStyle}
+            onDoubleClick={handleGridDoubleClick}
+            onContextMenu={handleGridContextMenu}
+          >
+            {orderedIds.map((id, index) => (
+              <AgentCard
+                key={id}
+                ref={(el) => {
+                  if (el) cardRefs.current.set(id, el)
+                  else cardRefs.current.delete(id)
+                }}
+                terminalId={id}
+                index={index}
+                isDragTarget={dragState?.isDragging === true && dropTargetIndex === index}
+                onDragStart={sortMode === 'manual' ? handleDragStart : undefined}
+              />
+            ))}
+          </div>
         )
       ) : null}
       {gridContextMenu && (

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -181,8 +181,14 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     e._gpuAddon = addon
     term.refresh(0, term.rows - 1)
   }
-  const loadCanvas = (): Promise<void> =>
-    import('@xterm/addon-canvas').then(({ CanvasAddon }) => mountAddon(() => new CanvasAddon()))
+  // Terminal fallback — if even canvas fails to load, there's no further
+  // fallback, so swallow the error here instead of propagating an unhandled
+  // rejection up through the WebGL error paths.
+  const loadCanvas = (): void => {
+    import('@xterm/addon-canvas')
+      .then(({ CanvasAddon }) => mountAddon(() => new CanvasAddon()))
+      .catch(() => {})
+  }
   const loadRenderer = (): void => {
     const current = registry.get(terminalId)
     if (!current || current._gpuAddon) return
@@ -262,9 +268,9 @@ export function attachTerminal(terminalId: string, container: HTMLDivElement): T
 /**
  * Detach a terminal from its current container (e.g. on component unmount).
  * Does NOT dispose the Terminal — it stays alive in the registry and its
- * buffer keeps receiving pty data. Releases the GPU renderer addon though,
- * since there's no visible canvas for it to draw to. The renderer is
- * rebuilt by attachTerminal on re-attach.
+ * buffer keeps receiving pty data. Releases the active renderer addon
+ * (WebGL or canvas fallback) since there's no visible surface for it to
+ * draw to. The renderer is rebuilt by attachTerminal on re-attach.
  */
 export function detachTerminal(terminalId: string, container: HTMLDivElement): void {
   const entry = registry.get(terminalId)

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -1,4 +1,4 @@
-import { Terminal } from '@xterm/xterm'
+import { Terminal, type ITerminalAddon } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
@@ -170,41 +170,32 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     return true
   })
 
-  // Try WebGL, fall back to canvas. Idempotent + detach-safe: bails if the
-  // terminal is destroyed, already has a live renderer, or has been detached
-  // while the dynamic import was in flight.
+  const mountAddon = (make: () => ITerminalAddon): void => {
+    // Re-check under the await — the terminal may have been destroyed or
+    // detached while the dynamic import was in flight, and a concurrent
+    // load may have already installed an addon.
+    const e = registry.get(terminalId)
+    if (!e || !e.currentContainer || e._gpuAddon) return
+    const addon = make()
+    term.loadAddon(addon)
+    e._gpuAddon = addon
+    term.refresh(0, term.rows - 1)
+  }
+  const loadCanvas = (): Promise<void> =>
+    import('@xterm/addon-canvas').then(({ CanvasAddon }) => mountAddon(() => new CanvasAddon()))
   const loadRenderer = (): void => {
     const current = registry.get(terminalId)
     if (!current || current._gpuAddon) return
     import('@xterm/addon-webgl')
       .then(({ WebglAddon }) => {
-        const e = registry.get(terminalId)
-        if (!e || !e.currentContainer || e._gpuAddon) return
         try {
-          const addon = new WebglAddon()
-          term.loadAddon(addon)
-          e._gpuAddon = addon
-          term.refresh(0, term.rows - 1)
+          mountAddon(() => new WebglAddon())
         } catch {
-          import('@xterm/addon-canvas').then(({ CanvasAddon }) => {
-            const e2 = registry.get(terminalId)
-            if (!e2 || !e2.currentContainer || e2._gpuAddon) return
-            const addon = new CanvasAddon()
-            term.loadAddon(addon)
-            e2._gpuAddon = addon
-            term.refresh(0, term.rows - 1)
-          })
+          loadCanvas()
         }
       })
       .catch(() => {
-        import('@xterm/addon-canvas').then(({ CanvasAddon }) => {
-          const e = registry.get(terminalId)
-          if (!e || !e.currentContainer || e._gpuAddon) return
-          const addon = new CanvasAddon()
-          term.loadAddon(addon)
-          e._gpuAddon = addon
-          term.refresh(0, term.rows - 1)
-        })
+        loadCanvas()
       })
   }
 
@@ -219,8 +210,6 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     currentContainer: null
   }
 
-  // Retained across pause/resume cycles — called whenever a detached
-  // terminal is re-attached so we can rebuild the GPU renderer.
   entry._loadRenderer = loadRenderer
 
   registry.set(terminalId, entry)
@@ -264,12 +253,9 @@ export function attachTerminal(terminalId: string, container: HTMLDivElement): T
     container.appendChild(termEl)
   }
   entry.currentContainer = container
-
-  // Resume the renderer if it was paused while detached.
   if (!entry._gpuAddon) {
     entry._loadRenderer?.()
   }
-
   return entry
 }
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -170,33 +170,40 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     return true
   })
 
-  // Try WebGL, fall back to canvas (loaded after open())
+  // Try WebGL, fall back to canvas. Idempotent + detach-safe: bails if the
+  // terminal is destroyed, already has a live renderer, or has been detached
+  // while the dynamic import was in flight.
   const loadRenderer = (): void => {
+    const current = registry.get(terminalId)
+    if (!current || current._gpuAddon) return
     import('@xterm/addon-webgl')
       .then(({ WebglAddon }) => {
-        if (!registry.has(terminalId)) return // terminal already destroyed
+        const e = registry.get(terminalId)
+        if (!e || !e.currentContainer || e._gpuAddon) return
         try {
           const addon = new WebglAddon()
           term.loadAddon(addon)
-          const e = registry.get(terminalId)
-          if (e) e._gpuAddon = addon
+          e._gpuAddon = addon
+          term.refresh(0, term.rows - 1)
         } catch {
           import('@xterm/addon-canvas').then(({ CanvasAddon }) => {
-            if (!registry.has(terminalId)) return
+            const e2 = registry.get(terminalId)
+            if (!e2 || !e2.currentContainer || e2._gpuAddon) return
             const addon = new CanvasAddon()
             term.loadAddon(addon)
-            const e = registry.get(terminalId)
-            if (e) e._gpuAddon = addon
+            e2._gpuAddon = addon
+            term.refresh(0, term.rows - 1)
           })
         }
       })
       .catch(() => {
         import('@xterm/addon-canvas').then(({ CanvasAddon }) => {
-          if (!registry.has(terminalId)) return
+          const e = registry.get(terminalId)
+          if (!e || !e.currentContainer || e._gpuAddon) return
           const addon = new CanvasAddon()
           term.loadAddon(addon)
-          const e = registry.get(terminalId)
-          if (e) e._gpuAddon = addon
+          e._gpuAddon = addon
+          term.refresh(0, term.rows - 1)
         })
       })
   }
@@ -212,7 +219,8 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     currentContainer: null
   }
 
-  // Store a flag so we only load renderer once after first open
+  // Retained across pause/resume cycles — called whenever a detached
+  // terminal is re-attached so we can rebuild the GPU renderer.
   entry._loadRenderer = loadRenderer
 
   registry.set(terminalId, entry)
@@ -240,7 +248,6 @@ export function attachTerminal(terminalId: string, container: HTMLDivElement): T
     entry.currentContainer = container
     // Load GPU renderer after open
     entry._loadRenderer?.()
-    entry._loadRenderer = null
     setTimeout(() => entry!.fitAddon.fit(), 0)
     return entry
   }
@@ -258,17 +265,32 @@ export function attachTerminal(terminalId: string, container: HTMLDivElement): T
   }
   entry.currentContainer = container
 
+  // Resume the renderer if it was paused while detached.
+  if (!entry._gpuAddon) {
+    entry._loadRenderer?.()
+  }
+
   return entry
 }
 
 /**
  * Detach a terminal from its current container (e.g. on component unmount).
- * Does NOT dispose — the terminal stays alive in the registry.
+ * Does NOT dispose the Terminal — it stays alive in the registry and its
+ * buffer keeps receiving pty data. Releases the GPU renderer addon though,
+ * since there's no visible canvas for it to draw to. The renderer is
+ * rebuilt by attachTerminal on re-attach.
  */
 export function detachTerminal(terminalId: string, container: HTMLDivElement): void {
   const entry = registry.get(terminalId)
-  if (entry && entry.currentContainer === container) {
-    entry.currentContainer = null
+  if (!entry || entry.currentContainer !== container) return
+  entry.currentContainer = null
+  if (entry._gpuAddon) {
+    try {
+      entry._gpuAddon.dispose()
+    } catch {
+      // GL context may already be lost
+    }
+    entry._gpuAddon = null
   }
 }
 

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { forwardRef } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+Object.defineProperty(window, 'api', {
+  value: {
+    isWorktreeDirty: vi.fn().mockResolvedValue(false),
+    getGitDiffStat: vi.fn().mockResolvedValue(null),
+    getGitBranch: vi.fn().mockResolvedValue(null),
+    notifyWidgetStatus: vi.fn()
+  },
+  writable: true
+})
+
+// Stub AgentCard with forwardRef so GridView's ref callback (which calls
+// cardRefs.current.set(id, el)) actually fires.
+vi.mock('../src/renderer/components/AgentCard', () => ({
+  AgentCard: forwardRef<
+    HTMLDivElement,
+    { terminalId: string; index: number; isDragTarget: boolean }
+  >(function MockAgentCard({ terminalId, index, isDragTarget }, ref) {
+    return (
+      <div
+        ref={ref}
+        data-testid={`card-${terminalId}`}
+        data-index={index}
+        data-drag-target={isDragTarget ? 'yes' : 'no'}
+      />
+    )
+  })
+}))
+
+vi.mock('../src/renderer/components/BackgroundTray', () => ({
+  BackgroundTray: () => null
+}))
+
+vi.mock('../src/renderer/components/PromptLauncher', () => ({
+  PromptLauncher: () => null
+}))
+
+vi.mock('../src/renderer/components/GridContextMenu', () => ({
+  GridContextMenu: () => null
+}))
+
+vi.mock('../src/renderer/hooks/useIsMobile', () => ({
+  useIsMobile: () => false
+}))
+
+vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({
+  useFilteredHeadless: () => []
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { GridView } from '../src/renderer/components/GridView'
+
+const mockConfig = {
+  projects: [
+    {
+      name: 'Vorn',
+      path: '/tmp/vorn',
+      icon: 'Rocket',
+      iconColor: '#ff0000',
+      preferredAgents: ['claude' as const]
+    }
+  ],
+  workflows: [],
+  defaults: { defaultAgent: 'claude' as const, rowHeight: 208 },
+  remoteHosts: [],
+  workspaces: []
+}
+
+function makeTerminal(id: string, status: 'idle' | 'running' = 'idle') {
+  return {
+    id,
+    session: {
+      id,
+      agentType: 'claude' as const,
+      projectName: 'Vorn',
+      projectPath: '/tmp/vorn',
+      isWorktree: false,
+      branch: 'main',
+      createdAt: Date.now()
+    },
+    status,
+    lastOutputTimestamp: Date.now()
+  }
+}
+
+beforeEach(() => {
+  const terminals = new Map()
+  terminals.set('term-a', makeTerminal('term-a'))
+  terminals.set('term-b', makeTerminal('term-b', 'running'))
+
+  useAppStore.setState({
+    terminals,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    config: mockConfig as any,
+    activeProject: 'Vorn',
+    activeWorktreePath: null,
+    activeWorkspace: 'personal',
+    gridColumns: 2,
+    sortMode: 'manual',
+    statusFilter: 'all',
+    focusedTerminalId: null,
+    previewTerminalId: null,
+    minimizedTerminals: new Set<string>(),
+    rowHeight: 208,
+    terminalOrder: ['term-a', 'term-b']
+  })
+})
+
+describe('GridView', () => {
+  it('renders an AgentCard for each terminal in the active project', () => {
+    render(<GridView />)
+    expect(screen.getByTestId('card-term-a')).toBeInTheDocument()
+    expect(screen.getByTestId('card-term-b')).toBeInTheDocument()
+  })
+
+  it('passes the card index in sort order', () => {
+    render(<GridView />)
+    expect(screen.getByTestId('card-term-a').dataset.index).toBe('0')
+    expect(screen.getByTestId('card-term-b').dataset.index).toBe('1')
+  })
+
+  it('omits the drag-start handler when sort mode is not manual', () => {
+    useAppStore.setState({ sortMode: 'created' })
+    render(<GridView />)
+    expect(screen.getByTestId('card-term-a').dataset.dragTarget).toBe('no')
+  })
+})


### PR DESCRIPTION
## Summary

Grid mode felt laggy in two specific interactions — project switching and minimizing a card. Root-caused to two compounding issues, both fixed here:

- **Framer-motion layout spring on every card.** `AgentCard` was a `motion.div` with `layout`/`layoutId` inside `<LayoutGroup>` + `<AnimatePresence>`, with `spring { stiffness: 300, damping: 25 }`. On project switch almost every `terminalId` changes, so the whole grid ran an exit/enter cascade (~400–600ms settling). On minimize, the card faded out via the default `AnimatePresence` exit while `MinimizedPill` mounted instantly — visible gap.
- **xterm.js never pauses.** Per [xtermjs/xterm.js#880](https://github.com/xtermjs/xterm.js/issues/880), the WebGL renderer keeps drawing every incoming byte regardless of visibility. Terminals in background projects and minimized cards were still burning GPU.

### Change 1 — fully instant grid
- `AgentCard.tsx`: `motion.div` → plain `div`, dropped `layout`/`layoutId`/`transition` props and the `framer-motion` import.
- `GridView.tsx`: removed `<LayoutGroup>` / `<AnimatePresence>` wrappers from the grid. Kept `motion` for the unrelated drag ghost.

Card churn now lands in a single React commit — project switch snaps, and minimize/pill transition happens same frame.

### Change 2 — pause WebGL renderer on detach
- `terminal-registry.ts`:
  - `detachTerminal` disposes `_gpuAddon` (wrapped in the same try/catch shape the existing teardown uses). Terminal instance + buffer stay alive, pty data still lands.
  - `_loadRenderer` is retained across pause/resume instead of nulled after first use.
  - `attachTerminal`'s re-attach branch calls the loader when `_gpuAddon` is absent.
  - `loadRenderer` is now idempotent and detach-safe (bails if the terminal was re-detached mid dynamic-import), and calls `term.refresh(0, term.rows - 1)` in each success branch so the canvas repaints the buffered content instantly on resume.

No new visibility predicate, no new hook — just tied to the existing attach/detach lifecycle.

## Test plan

- [x] `tsc --noEmit` on both `tsconfig.web.json` and `tsconfig.node.json` — clean
- [x] `vitest run` — 675/675 passing
- [x] `eslint` on touched files — clean
- [x] Manual dogfood: switch between projects with multiple agents — cards snap into place with no settling
- [x] Manual dogfood: minimize a card — pill appears same frame, no gap
- [ ] DevTools Performance trace on an inactive project shows GPU drop vs baseline
- [ ] Switch back to a previously inactive project — content repaints immediately (not blank, not stale)
- [ ] Close a paused terminal via context menu — no crash
- [ ] Force WebGL off in DevTools → confirm canvas fallback still works on resume