### PR TITLE
refactor: share SessionStatusBar between tab and focused grid views

### DIFF
--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -7,14 +7,15 @@ import { InlineRename } from './InlineRename'
 import { Tooltip } from './Tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
 import { SessionStatusBar } from './SessionStatusBar'
+import { StatusBadge } from './StatusBadge'
 import { MobileFontSizeControl } from './MobileFontSizeControl'
 import { MobileTerminalKeybar } from './MobileTerminalKeybar'
-import { getDisplayName } from '../lib/terminal-display'
+import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { useTerminalScrollButton } from '../hooks/useTerminalScrollButton'
 import { useTerminalPinchZoom } from '../hooks/useTerminalPinchZoom'
 import { useIsMobile } from '../hooks/useIsMobile'
-import { ArrowDown, Minimize2, X, Pencil } from 'lucide-react'
+import { ArrowDown, FolderGit2, GitBranch, Minimize2, X, Pencil } from 'lucide-react'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
 const MOD = isMac ? '⌘' : 'Ctrl+'
@@ -128,7 +129,25 @@ export function FocusedTerminal() {
                 </button>
               </span>
             )}
+            {isMobile && terminal.session.branch && (
+              <span className="flex items-center gap-1 mt-0.5">
+                {terminal.session.isWorktree ? (
+                  <FolderGit2 size={11} className="text-amber-500" strokeWidth={1.5} />
+                ) : (
+                  <GitBranch size={11} className="text-gray-600" strokeWidth={1.5} />
+                )}
+                <span
+                  className={`text-[11px] font-mono truncate ${
+                    terminal.session.isWorktree ? 'text-amber-400' : 'text-gray-500'
+                  }`}
+                >
+                  {getBranchLabel(terminal.session)}
+                </span>
+              </span>
+            )}
           </div>
+
+          {isMobile && <StatusBadge status={terminal.status} />}
 
           {/* Keyboard shortcut hints (desktop only) */}
           {!isMobile && (

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -143,6 +143,9 @@ export function FocusedTerminal() {
                 >
                   {getBranchLabel(terminal.session)}
                 </span>
+                {terminal.session.isWorktree && (
+                  <span className="text-[10px] text-amber-500/60">worktree</span>
+                )}
               </span>
             )}
           </div>

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -3,20 +3,18 @@ import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
 import { TerminalInstance } from './TerminalInstance'
 import { AgentIcon } from './AgentIcon'
-import { StatusBadge } from './StatusBadge'
 import { InlineRename } from './InlineRename'
-import { OpenInButton } from './OpenInButton'
 import { Tooltip } from './Tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
-import { GitChangesIndicator, BrowseFilesButton } from './GitChangesIndicator'
+import { SessionStatusBar } from './SessionStatusBar'
 import { MobileFontSizeControl } from './MobileFontSizeControl'
 import { MobileTerminalKeybar } from './MobileTerminalKeybar'
-import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
+import { getDisplayName } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { useTerminalScrollButton } from '../hooks/useTerminalScrollButton'
 import { useTerminalPinchZoom } from '../hooks/useTerminalPinchZoom'
 import { useIsMobile } from '../hooks/useIsMobile'
-import { GitBranch, FolderGit2, ArrowDown, Minimize2, X, Pencil } from 'lucide-react'
+import { ArrowDown, Minimize2, X, Pencil } from 'lucide-react'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
 const MOD = isMac ? '⌘' : 'Ctrl+'
@@ -130,29 +128,7 @@ export function FocusedTerminal() {
                 </button>
               </span>
             )}
-            {terminal.session.branch && (
-              <span className="flex items-center gap-1 ml-3">
-                {terminal.session.isWorktree ? (
-                  <FolderGit2 size={12} className="text-amber-500" strokeWidth={1.5} />
-                ) : (
-                  <GitBranch size={12} className="text-gray-600" strokeWidth={1.5} />
-                )}
-                <span
-                  className={`text-[12px] font-mono ${terminal.session.isWorktree ? 'text-amber-400' : 'text-gray-500'}`}
-                >
-                  {getBranchLabel(terminal.session)}
-                </span>
-                {terminal.session.isWorktree && (
-                  <span className="text-[11px] text-amber-500/60 ml-1">worktree</span>
-                )}
-              </span>
-            )}
           </div>
-
-          {!isMobile && <BrowseFilesButton terminalId={effectiveId} />}
-          {!isMobile && <GitChangesIndicator terminalId={effectiveId} />}
-
-          <StatusBadge status={terminal.status} />
 
           {/* Keyboard shortcut hints (desktop only) */}
           {!isMobile && (
@@ -175,7 +151,6 @@ export function FocusedTerminal() {
             </div>
           )}
 
-          {!isMobile && <OpenInButton projectPath={terminal.session.projectPath} />}
           {!isMobile && (
             <Tooltip label="Collapse to grid" position="bottom">
               <button
@@ -237,6 +212,8 @@ export function FocusedTerminal() {
             )}
           </div>
         </div>
+
+        {!isMobile && <SessionStatusBar terminalId={effectiveId} />}
 
         {/* Mobile: extended terminal keyboard bar (Termux-style) */}
         {isMobile && <MobileTerminalKeybar terminalId={effectiveId} />}

--- a/src/renderer/components/SessionStatusBar.tsx
+++ b/src/renderer/components/SessionStatusBar.tsx
@@ -10,7 +10,7 @@ interface Props {
   terminalId: string
 }
 
-export function TabStatusBar({ terminalId }: Props) {
+export function SessionStatusBar({ terminalId }: Props) {
   const { terminal, assignedTask } = useAppStore(
     useShallow((s) => ({
       terminal: s.terminals.get(terminalId),

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -11,7 +11,7 @@ import { PromptLauncher } from './PromptLauncher'
 import { InlineRename } from './InlineRename'
 import { CardContextMenu } from './CardContextMenu'
 import { BackgroundTray } from './BackgroundTray'
-import { TabStatusBar } from './TabStatusBar'
+import { SessionStatusBar } from './SessionStatusBar'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { resolveActiveProject } from '../lib/session-utils'
@@ -522,7 +522,7 @@ export function TabView() {
       </div>
 
       {/* Status bar */}
-      {activeTabId && activeTerminal && <TabStatusBar terminalId={activeTabId} />}
+      {activeTabId && activeTerminal && <SessionStatusBar terminalId={activeTabId} />}
 
       {/* Context menu */}
       {contextMenu && (

--- a/tests/session-status-bar.test.tsx
+++ b/tests/session-status-bar.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../src/renderer/components/TerminalInstance', () => ({
+  TerminalInstance: () => <div data-testid="terminal-instance" />
+}))
+vi.mock('../src/renderer/components/PromptLauncher', () => ({
+  PromptLauncher: () => null
+}))
+vi.mock('../src/renderer/components/CardContextMenu', () => ({
+  CardContextMenu: () => null
+}))
+vi.mock('../src/renderer/components/BackgroundTray', () => ({
+  BackgroundTray: () => null
+}))
+vi.mock('../src/renderer/components/MobileFontSizeControl', () => ({
+  MobileFontSizeControl: () => null
+}))
+vi.mock('../src/renderer/components/MobileTerminalKeybar', () => ({
+  MobileTerminalKeybar: () => null
+}))
+vi.mock('../src/renderer/components/OpenInButton', () => ({
+  OpenInButton: () => <div data-testid="open-in" />
+}))
+vi.mock('../src/renderer/components/GitChangesIndicator', () => ({
+  GitChangesIndicator: () => <div data-testid="git-changes" />,
+  BrowseFilesButton: () => <div data-testid="browse-files" />
+}))
+vi.mock('../src/renderer/components/GridContextMenu', () => ({
+  GridContextMenu: () => null
+}))
+vi.mock('../src/renderer/hooks/useIsMobile', () => ({
+  useIsMobile: () => false
+}))
+vi.mock('../src/renderer/hooks/useTerminalScrollButton', () => ({
+  useTerminalScrollButton: () => ({ showScrollBtn: false, handleScrollToBottom: vi.fn() })
+}))
+vi.mock('../src/renderer/hooks/useTerminalPinchZoom', () => ({
+  useTerminalPinchZoom: vi.fn()
+}))
+vi.mock('../src/renderer/hooks/useVisibleTerminals', () => ({
+  useVisibleTerminals: () => ({ orderedIds: ['term-1'], minimizedIds: [] })
+}))
+vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({
+  useFilteredHeadless: () => []
+}))
+vi.mock('../src/renderer/lib/terminal-close', () => ({
+  closeTerminalSession: vi.fn()
+}))
+vi.mock('../src/renderer/lib/session-utils', () => ({
+  resolveActiveProject: () => null
+}))
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('../src/renderer/components/ConfirmPopover', () => ({
+  ConfirmPopover: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+Object.defineProperty(window, 'api', {
+  value: {
+    killTerminal: vi.fn(),
+    saveConfig: vi.fn(),
+    notifyWidgetStatus: vi.fn(),
+    getGitDiffStat: vi.fn().mockResolvedValue(null),
+    createTerminal: vi.fn()
+  },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { SessionStatusBar } from '../src/renderer/components/SessionStatusBar'
+import { TabView } from '../src/renderer/components/TabView'
+import { FocusedTerminal } from '../src/renderer/components/FocusedTerminal'
+
+const mockTerminal = {
+  id: 'term-1',
+  session: {
+    id: 'term-1',
+    agentType: 'claude' as const,
+    projectName: 'Vorn',
+    projectPath: '/tmp/vorn',
+    status: 'running' as const,
+    createdAt: Date.now(),
+    pid: 1234,
+    branch: 'main',
+    isWorktree: false
+  },
+  status: 'running' as const,
+  lastOutputTimestamp: Date.now()
+}
+
+const initialState = useAppStore.getState()
+
+beforeEach(() => {
+  const terminals = new Map()
+  terminals.set('term-1', mockTerminal)
+  useAppStore.setState({
+    terminals,
+    activeTabId: 'term-1',
+    focusedTerminalId: null,
+    previewTerminalId: null,
+    statusFilter: 'all',
+    sortMode: 'manual',
+    renamingTerminalId: null
+  })
+})
+
+afterEach(() => {
+  useAppStore.setState(initialState)
+})
+
+describe('SessionStatusBar (homologated bottom bar)', () => {
+  it('renders the branch label for the given terminal', () => {
+    render(<SessionStatusBar terminalId="term-1" />)
+    expect(screen.getByText('main')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the terminal is missing', () => {
+    const { container } = render(<SessionStatusBar terminalId="nonexistent" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders worktree label for worktree sessions', () => {
+    const terminals = new Map()
+    terminals.set('wt-1', {
+      id: 'wt-1',
+      session: {
+        ...mockTerminal.session,
+        id: 'wt-1',
+        branch: 'feature-x',
+        isWorktree: true,
+        worktreePath: '/tmp/wt/feature-x'
+      },
+      status: 'running' as const,
+      lastOutputTimestamp: Date.now()
+    })
+    useAppStore.setState({ terminals })
+    render(<SessionStatusBar terminalId="wt-1" />)
+    expect(screen.getByText('worktree')).toBeInTheDocument()
+  })
+})
+
+describe('TabView mounts SessionStatusBar at the bottom', () => {
+  it('renders the shared status bar so branch appears below the terminal', () => {
+    const { container } = render(<TabView />)
+    // SessionStatusBar sits at the bottom and displays the branch label.
+    // Use within + the git-changes testid as an anchor to target the bar.
+    const gitChanges = screen.getByTestId('git-changes')
+    const bar = gitChanges.closest('div.border-t') as HTMLElement | null
+    expect(bar).not.toBeNull()
+    expect(within(bar!).getByText('main')).toBeInTheDocument()
+    // Sanity: terminal instance also mounted
+    expect(container.querySelector('[data-testid="terminal-instance"]')).toBeInTheDocument()
+  })
+})
+
+describe('FocusedTerminal mounts SessionStatusBar at the bottom on desktop', () => {
+  it('moves branch, git changes, and open-in into the shared bottom bar', () => {
+    useAppStore.setState({ focusedTerminalId: 'term-1' })
+    render(<FocusedTerminal />)
+    const gitChanges = screen.getByTestId('git-changes')
+    const bar = gitChanges.closest('div.border-t') as HTMLElement | null
+    expect(bar).not.toBeNull()
+    expect(within(bar!).getByText('main')).toBeInTheDocument()
+    expect(within(bar!).getByTestId('open-in')).toBeInTheDocument()
+    expect(within(bar!).getByTestId('browse-files')).toBeInTheDocument()
+  })
+})

--- a/tests/session-status-bar.test.tsx
+++ b/tests/session-status-bar.test.tsx
@@ -32,8 +32,9 @@ vi.mock('../src/renderer/components/GitChangesIndicator', () => ({
 vi.mock('../src/renderer/components/GridContextMenu', () => ({
   GridContextMenu: () => null
 }))
+let mockIsMobile = false
 vi.mock('../src/renderer/hooks/useIsMobile', () => ({
-  useIsMobile: () => false
+  useIsMobile: () => mockIsMobile
 }))
 vi.mock('../src/renderer/hooks/useTerminalScrollButton', () => ({
   useTerminalScrollButton: () => ({ showScrollBtn: false, handleScrollToBottom: vi.fn() })
@@ -99,6 +100,7 @@ const mockTerminal = {
 const initialState = useAppStore.getState()
 
 beforeEach(() => {
+  mockIsMobile = false
   const terminals = new Map()
   terminals.set('term-1', mockTerminal)
   act(() => {
@@ -179,5 +181,62 @@ describe('FocusedTerminal mounts SessionStatusBar at the bottom on desktop', () 
     expect(within(bar!).getByText('main')).toBeInTheDocument()
     expect(within(bar!).getByTestId('open-in')).toBeInTheDocument()
     expect(within(bar!).getByTestId('browse-files')).toBeInTheDocument()
+  })
+
+  it('renders the assigned-task pill inside the shared bar', () => {
+    const task = {
+      id: 'task-1',
+      title: 'Ship the homologation',
+      status: 'in_progress' as const,
+      assignedSessionId: 'term-1'
+    }
+    act(() => {
+      useAppStore.setState({
+        focusedTerminalId: 'term-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config: { tasks: [task] } as any
+      })
+    })
+    render(<FocusedTerminal />)
+    const pill = screen.getByRole('button', { name: /Ship the homologation/ })
+    expect(pill).toBeInTheDocument()
+    const bar = pill.closest('div.border-t')
+    expect(bar).not.toBeNull()
+  })
+})
+
+describe('FocusedTerminal on mobile keeps branch + StatusBadge in the title bar', () => {
+  it('renders branch label for a non-worktree session in the mobile title bar', () => {
+    mockIsMobile = true
+    act(() => {
+      useAppStore.setState({ focusedTerminalId: 'term-1' })
+    })
+    render(<FocusedTerminal />)
+    expect(screen.getByText('main')).toBeInTheDocument()
+    expect(screen.queryByText('worktree')).not.toBeInTheDocument()
+    // SessionStatusBar (desktop) should not be mounted
+    expect(screen.queryByTestId('git-changes')).not.toBeInTheDocument()
+  })
+
+  it('renders the "worktree" label on mobile for worktree sessions', () => {
+    mockIsMobile = true
+    const terminals = new Map()
+    terminals.set('wt-1', {
+      id: 'wt-1',
+      session: {
+        ...mockTerminal.session,
+        id: 'wt-1',
+        branch: 'feature-x',
+        isWorktree: true,
+        worktreePath: '/tmp/wt/feature-x'
+      },
+      status: 'running' as const,
+      lastOutputTimestamp: Date.now()
+    })
+    act(() => {
+      useAppStore.setState({ terminals, focusedTerminalId: 'wt-1' })
+    })
+    render(<FocusedTerminal />)
+    expect(screen.getByText('worktree')).toBeInTheDocument()
   })
 })

--- a/tests/session-status-bar.test.tsx
+++ b/tests/session-status-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { ReactNode } from 'react'
 
@@ -101,19 +101,23 @@ const initialState = useAppStore.getState()
 beforeEach(() => {
   const terminals = new Map()
   terminals.set('term-1', mockTerminal)
-  useAppStore.setState({
-    terminals,
-    activeTabId: 'term-1',
-    focusedTerminalId: null,
-    previewTerminalId: null,
-    statusFilter: 'all',
-    sortMode: 'manual',
-    renamingTerminalId: null
+  act(() => {
+    useAppStore.setState({
+      terminals,
+      activeTabId: 'term-1',
+      focusedTerminalId: null,
+      previewTerminalId: null,
+      statusFilter: 'all',
+      sortMode: 'manual',
+      renamingTerminalId: null
+    })
   })
 })
 
 afterEach(() => {
-  useAppStore.setState(initialState)
+  act(() => {
+    useAppStore.setState(initialState)
+  })
 })
 
 describe('SessionStatusBar (homologated bottom bar)', () => {
@@ -141,7 +145,9 @@ describe('SessionStatusBar (homologated bottom bar)', () => {
       status: 'running' as const,
       lastOutputTimestamp: Date.now()
     })
-    useAppStore.setState({ terminals })
+    act(() => {
+      useAppStore.setState({ terminals })
+    })
     render(<SessionStatusBar terminalId="wt-1" />)
     expect(screen.getByText('worktree')).toBeInTheDocument()
   })
@@ -163,7 +169,9 @@ describe('TabView mounts SessionStatusBar at the bottom', () => {
 
 describe('FocusedTerminal mounts SessionStatusBar at the bottom on desktop', () => {
   it('moves branch, git changes, and open-in into the shared bottom bar', () => {
-    useAppStore.setState({ focusedTerminalId: 'term-1' })
+    act(() => {
+      useAppStore.setState({ focusedTerminalId: 'term-1' })
+    })
     render(<FocusedTerminal />)
     const gitChanges = screen.getByTestId('git-changes')
     const bar = gitChanges.closest('div.border-t') as HTMLElement | null


### PR DESCRIPTION
## Summary

- Moves the branch / assigned-task / status / git-changes / browse-files / open-in toolbar in `FocusedTerminal` (grid-mode focused card) out of the **top title bar** and into a **bottom status bar**, matching the position it already has in tab mode.
- The two views now share the same component — `TabStatusBar` is renamed to `SessionStatusBar` since it's no longer tab-specific.
- Fixes a pre-existing gap: the **assigned-task pill** now appears in focused mode too (it was only rendered in tab mode).
- Mobile layout of `FocusedTerminal` is preserved (bar is gated `!isMobile`).

## Test plan

- [ ] `yarn dev`, open a worktree in **tab mode** — bottom status bar looks identical to before.
- [ ] Switch to **grid mode**, click a card to focus it — verify the same controls now live at the bottom (branch, task, status, git changes, browse files, open-in) in the same order.
- [ ] Top title bar of focused view only shows: agent icon, name + rename, keyboard hints, collapse, close.
- [ ] Assign a task to a session — pill shows in both tab and focused views.
- [ ] Worktree session shows the amber `FolderGit2` icon + "worktree" label in both views.
- [ ] `OpenInButton` dropdown opens upward in focused mode (`direction="up"`).
- [ ] Narrow the window — branch/task labels truncate gracefully.