### PR TITLE
feat: show progress toasts for slow worktree and session operations

### DIFF
--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState, useEffect, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Check, X, AlertTriangle, Info } from 'lucide-react'
+import { Check, X, AlertTriangle, Info, Loader2 } from 'lucide-react'
 import { useIsMobile } from '../hooks/useIsMobile'
 
 /* ------------------------------------------------------------------ */
 /*  Toast store — lightweight, no Zustand dependency                  */
 /* ------------------------------------------------------------------ */
 
-type ToastType = 'success' | 'error' | 'warning' | 'info'
+type ToastType = 'success' | 'error' | 'warning' | 'info' | 'loading'
 
 interface Toast {
   id: string
@@ -17,28 +17,77 @@ interface Toast {
   duration?: number
 }
 
+const DEFAULT_DURATIONS: Record<ToastType, number> = {
+  success: 2500,
+  error: 4000,
+  warning: 3500,
+  info: 2500,
+  loading: Number.POSITIVE_INFINITY
+}
+
 let listeners: Array<(toasts: Toast[]) => void> = []
 let toasts: Toast[] = []
+const dismissTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 function notify() {
   listeners.forEach((fn) => fn([...toasts]))
 }
 
-export function toast(message: string, type: ToastType = 'success', duration = 2500) {
-  const id = crypto.randomUUID()
-  toasts = [...toasts, { id, message, type, duration }]
-  notify()
+function clearDismissTimer(id: string) {
+  const existing = dismissTimers.get(id)
+  if (existing) {
+    clearTimeout(existing)
+    dismissTimers.delete(id)
+  }
+}
 
-  setTimeout(() => {
+function scheduleDismiss(id: string, duration: number) {
+  clearDismissTimer(id)
+  if (!Number.isFinite(duration)) return
+  const handle = setTimeout(() => {
+    dismissTimers.delete(id)
     toasts = toasts.filter((t) => t.id !== id)
     notify()
   }, duration)
+  dismissTimers.set(id, handle)
+}
+
+export function toast(
+  message: string,
+  type: ToastType = 'success',
+  duration: number = DEFAULT_DURATIONS[type]
+): string {
+  const id = crypto.randomUUID()
+  toasts = [...toasts, { id, message, type, duration }]
+  notify()
+  scheduleDismiss(id, duration)
+  return id
 }
 
 toast.success = (msg: string) => toast(msg, 'success')
 toast.error = (msg: string) => toast(msg, 'error', 4000)
 toast.warning = (msg: string) => toast(msg, 'warning', 3500)
 toast.info = (msg: string) => toast(msg, 'info')
+toast.loading = (msg: string) => toast(msg, 'loading')
+
+toast.update = (id: string, message: string, type: ToastType): string => {
+  const existing = toasts.find((t) => t.id === id)
+  if (!existing) {
+    // Toast was dismissed manually — fall back to a fresh one so feedback isn't lost
+    return toast(message, type)
+  }
+  const duration = DEFAULT_DURATIONS[type]
+  toasts = toasts.map((t) => (t.id === id ? { ...t, message, type, duration } : t))
+  notify()
+  scheduleDismiss(id, duration)
+  return id
+}
+
+toast.dismiss = (id: string): void => {
+  clearDismissTimer(id)
+  toasts = toasts.filter((t) => t.id !== id)
+  notify()
+}
 
 /* ------------------------------------------------------------------ */
 /*  Icons & colors per type                                           */
@@ -71,6 +120,12 @@ const TOAST_STYLES: Record<
     bg: 'bg-blue-500/10',
     border: 'border-blue-500/20',
     text: 'text-blue-400'
+  },
+  loading: {
+    icon: Loader2,
+    bg: 'bg-white/[0.05]',
+    border: 'border-white/10',
+    text: 'text-gray-300'
   }
 }
 
@@ -90,8 +145,7 @@ export function ToastContainer() {
   }, [])
 
   const dismiss = useCallback((id: string) => {
-    toasts = toasts.filter((t) => t.id !== id)
-    notify()
+    toast.dismiss(id)
   }, [])
 
   return (
@@ -129,7 +183,11 @@ export function ToastContainer() {
                   : { background: 'rgba(26, 26, 30, 0.92)' }
               }
             >
-              <Icon size={15} strokeWidth={2.5} className={`shrink-0 ${style.text}`} />
+              <Icon
+                size={15}
+                strokeWidth={2.5}
+                className={`shrink-0 ${style.text} ${t.type === 'loading' ? 'animate-spin' : ''}`}
+              />
               <span className="text-sm text-gray-200 flex-1">{t.message}</span>
               <button
                 onClick={() => dismiss(t.id)}

--- a/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FolderGit2, Trash2, FolderOpen, AlertTriangle, Loader2 } from 'lucide-react'
+import { FolderGit2, Trash2, FolderOpen, AlertTriangle } from 'lucide-react'
 import { useAppStore } from '../stores'
+import { withProgressToast } from '../lib/progress-toast'
 
 interface WorktreeCleanupInfo {
   id: string
@@ -43,8 +44,6 @@ function useExplicitDeleteSubscription(cb: ExplicitDeleteCallback): void {
 export function WorktreeCleanupDialog() {
   const [pending, setPending] = useState<WorktreeCleanupInfo | null>(null)
   const [explicitDelete, setExplicitDelete] = useState<ExplicitDeleteInfo | null>(null)
-  const [removing, setRemoving] = useState(false)
-  const [removeError, setRemoveError] = useState(false)
   const [dirtyState, setDirtyState] = useState<DirtyState>('checking')
   const checkIdRef = useRef(0)
 
@@ -57,8 +56,6 @@ export function WorktreeCleanupDialog() {
   const checkDirty = useCallback((worktreePath: string) => {
     const id = ++checkIdRef.current
     setDirtyState('checking')
-    setRemoveError(false)
-    setRemoving(false)
     window.api
       .isWorktreeDirty(worktreePath)
       .then((dirty) => {
@@ -95,35 +92,36 @@ export function WorktreeCleanupDialog() {
     setExplicitDelete(null)
   }
 
-  const handleRemove = async (): Promise<void> => {
+  const handleRemove = (): void => {
     if (!activePath || !activeProjectPath) return
-    setRemoving(true)
-    setRemoveError(false)
-    try {
-      if (explicitDelete && explicitDelete.sessionIds.length > 0) {
-        await Promise.all(
-          explicitDelete.sessionIds.flatMap((sid) => [
-            window.api.killTerminal(sid).catch(() => {}),
-            window.api.killHeadlessSession(sid).catch(() => {})
-          ])
-        )
-        // Brief delay for processes to release file locks
-        await new Promise((r) => setTimeout(r, 500))
-      }
+    const projectPath = activeProjectPath
+    const worktreePath = activePath
+    const force = dirtyState === 'dirty' || dirtyState === 'unknown'
+    const sessionIds = explicitDelete?.sessionIds ?? []
+    handleClose()
 
-      const force = dirtyState === 'dirty' || dirtyState === 'unknown'
-      const removed = await window.api.removeWorktree(activeProjectPath, activePath, force)
-      if (removed) {
-        useAppStore.getState().loadWorktrees(activeProjectPath, true)
-        handleClose()
-      } else {
-        setRemoveError(true)
+    void withProgressToast(
+      {
+        loading:
+          sessionIds.length > 0 ? 'Closing sessions & removing worktree…' : 'Removing worktree…',
+        success: 'Worktree removed'
+      },
+      async () => {
+        if (sessionIds.length > 0) {
+          await Promise.all(
+            sessionIds.flatMap((sid) => [
+              window.api.killTerminal(sid).catch(() => {}),
+              window.api.killHeadlessSession(sid).catch(() => {})
+            ])
+          )
+          // Brief delay for processes to release file locks
+          await new Promise((r) => setTimeout(r, 500))
+        }
+        const removed = await window.api.removeWorktree(projectPath, worktreePath, force)
+        if (!removed) throw new Error('Failed to remove worktree')
+        useAppStore.getState().loadWorktrees(projectPath, true)
       }
-    } catch {
-      setRemoveError(true)
-    } finally {
-      setRemoving(false)
-    }
+    )
   }
 
   const showWarning = dirtyState === 'dirty' || dirtyState === 'unknown'
@@ -194,13 +192,6 @@ export function WorktreeCleanupDialog() {
               </div>
             )}
 
-            {/* Remove error */}
-            {removeError && (
-              <div className="mx-5 mb-2 px-3 py-2 bg-red-500/[0.08] border border-red-500/20 rounded-lg">
-                <p className="text-[11px] text-red-300">Failed to remove worktree.</p>
-              </div>
-            )}
-
             <div className="px-5 py-3 border-t border-white/[0.06] flex justify-end gap-2">
               <button
                 onClick={handleClose}
@@ -218,7 +209,7 @@ export function WorktreeCleanupDialog() {
               </button>
               <button
                 onClick={handleRemove}
-                disabled={removing || dirtyState === 'checking'}
+                disabled={dirtyState === 'checking'}
                 className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors
                            disabled:opacity-50 ${
                              showWarning || (dialogMode === 'explicit-delete' && sessionCount > 0)
@@ -226,23 +217,14 @@ export function WorktreeCleanupDialog() {
                                : 'text-red-400 bg-red-500/[0.08] hover:bg-red-500/[0.15]'
                            }`}
               >
-                {removing ? (
-                  <>
-                    <Loader2 size={12} className="animate-spin" />
-                    {sessionCount > 0 ? 'Closing sessions...' : 'Removing...'}
-                  </>
-                ) : (
-                  <>
-                    <Trash2 size={12} />
-                    {dirtyState === 'checking'
-                      ? 'Checking...'
-                      : dialogMode === 'explicit-delete' && sessionCount > 0
-                        ? 'Close sessions & remove'
-                        : showWarning
-                          ? 'Remove anyway'
-                          : 'Remove'}
-                  </>
-                )}
+                <Trash2 size={12} />
+                {dirtyState === 'checking'
+                  ? 'Checking...'
+                  : dialogMode === 'explicit-delete' && sessionCount > 0
+                    ? 'Close sessions & remove'
+                    : showWarning
+                      ? 'Remove anyway'
+                      : 'Remove'}
               </button>
             </div>
           </motion.div>

--- a/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -46,6 +46,7 @@ export function WorktreeCleanupDialog() {
   const [explicitDelete, setExplicitDelete] = useState<ExplicitDeleteInfo | null>(null)
   const [dirtyState, setDirtyState] = useState<DirtyState>('checking')
   const checkIdRef = useRef(0)
+  const removingLock = useRef(false)
 
   const dialogMode: DialogMode = explicitDelete ? 'explicit-delete' : 'session-exit'
   const activePath = explicitDelete?.worktreePath ?? pending?.worktreePath
@@ -94,6 +95,8 @@ export function WorktreeCleanupDialog() {
 
   const handleRemove = (): void => {
     if (!activePath || !activeProjectPath) return
+    if (removingLock.current) return
+    removingLock.current = true
     const projectPath = activeProjectPath
     const worktreePath = activePath
     const force = dirtyState === 'dirty' || dirtyState === 'unknown'
@@ -121,7 +124,9 @@ export function WorktreeCleanupDialog() {
         if (!removed) throw new Error('Failed to remove worktree')
         useAppStore.getState().loadWorktrees(projectPath, true)
       }
-    )
+    ).finally(() => {
+      removingLock.current = false
+    })
   }
 
   const showWarning = dirtyState === 'dirty' || dirtyState === 'unknown'

--- a/src/renderer/components/project-sidebar/ProjectItem.tsx
+++ b/src/renderer/components/project-sidebar/ProjectItem.tsx
@@ -2,7 +2,8 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
-import { toast } from '../Toast'
+import { withProgressToast } from '../../lib/progress-toast'
+import { createSessionFromProject } from '../../lib/session-utils'
 import { ProjectIcon } from './ProjectIcon'
 import { ProjectContextMenu } from './ProjectContextMenu'
 import { WorktreeItem } from './WorktreeItem'
@@ -49,7 +50,6 @@ export function ProjectItem({
   const setActiveWorktreePath = useAppStore((s) => s.setActiveWorktreePath)
   const worktreeCache = useAppStore((s) => s.worktreeCache)
   const loadWorktrees = useAppStore((s) => s.loadWorktrees)
-  const addTerminal = useAppStore((s) => s.addTerminal)
   const config = useAppStore((s) => s.config)
   const setEditingProject = useAppStore((s) => s.setEditingProject)
   const setAddProjectDialogOpen = useAppStore((s) => s.setAddProjectDialogOpen)
@@ -59,6 +59,9 @@ export function ProjectItem({
 
   const [isExpanded, setIsExpanded] = useState(defaultExpanded)
   const [openMenu, setOpenMenu] = useState(false)
+  const [creatingSession, setCreatingSession] = useState(false)
+  const [creatingWorktree, setCreatingWorktree] = useState(false)
+  const [creatingMainSession, setCreatingMainSession] = useState(false)
   const [collapsedBranches, setCollapsedBranches] = useState<Set<string>>(new Set())
   const isRemoteProject = !!getProjectRemoteHostId(project)
   const [isGitRepo, setIsGitRepo] = useState(isRemoteProject)
@@ -222,24 +225,17 @@ export function ProjectItem({
                 <Tooltip label="New session" position="right">
                   <button
                     type="button"
-                    onClick={async (e) => {
+                    disabled={creatingSession}
+                    onClick={(e) => {
                       e.stopPropagation()
-                      try {
-                        const agentType = config?.defaults.defaultAgent || 'claude'
-                        const remoteHostId = getProjectRemoteHostId(project)
-                        const session = await window.api.createTerminal({
-                          agentType,
-                          projectName: project.name,
-                          projectPath: project.path,
-                          remoteHostId
-                        })
-                        addTerminal(session)
-                      } catch (err) {
-                        const msg = err instanceof Error ? err.message : String(err)
-                        toast.error(msg || 'Failed to create session')
-                      }
+                      if (creatingSession) return
+                      setCreatingSession(true)
+                      void withProgressToast(
+                        { loading: 'Starting session…', success: 'Session started' },
+                        () => createSessionFromProject(project)
+                      ).finally(() => setCreatingSession(false))
                     }}
-                    className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+                    className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                   >
                     <Plus size={14} strokeWidth={2} />
                   </button>
@@ -248,19 +244,25 @@ export function ProjectItem({
                   <Tooltip label="New worktree" position="right">
                     <button
                       type="button"
-                      onClick={async (e) => {
+                      disabled={creatingWorktree}
+                      onClick={(e) => {
                         e.stopPropagation()
+                        if (creatingWorktree) return
                         const name = generateWorktreeName()
-                        try {
-                          await window.api.createWorktree(project.path, 'main', name)
-                          loadWorktrees(project.path, true)
-                          if (!isExpanded) setIsExpanded(true)
-                        } catch (err) {
-                          const msg = err instanceof Error ? err.message : String(err)
-                          toast.error(msg || 'Failed to create worktree')
-                        }
+                        setCreatingWorktree(true)
+                        void withProgressToast(
+                          {
+                            loading: 'Creating worktree…',
+                            success: `Worktree "${name}" created`
+                          },
+                          async () => {
+                            await window.api.createWorktree(project.path, 'main', name)
+                            loadWorktrees(project.path, true)
+                            if (!isExpanded) setIsExpanded(true)
+                          }
+                        ).finally(() => setCreatingWorktree(false))
                       }}
-                      className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+                      className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                     >
                       <FolderGit2 size={14} strokeWidth={1.5} className="text-amber-400/70" />
                     </button>
@@ -368,20 +370,17 @@ export function ProjectItem({
                         <Tooltip label="New session" position="right">
                           <button
                             type="button"
-                            onClick={async (e) => {
+                            disabled={creatingMainSession}
+                            onClick={(e) => {
                               e.stopPropagation()
-                              const agentType = config?.defaults.defaultAgent || 'claude'
-                              const remoteHostId = getProjectRemoteHostId(project)
-                              const session = await window.api.createTerminal({
-                                agentType,
-                                projectName: project.name,
-                                projectPath: project.path,
-                                branch: mainWt.branch,
-                                remoteHostId
-                              })
-                              addTerminal(session)
+                              if (creatingMainSession) return
+                              setCreatingMainSession(true)
+                              void withProgressToast(
+                                { loading: 'Starting session…', success: 'Session started' },
+                                () => createSessionFromProject(project, { branch: mainWt.branch })
+                              ).finally(() => setCreatingMainSession(false))
                             }}
-                            className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+                            className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                           >
                             <Plus size={14} strokeWidth={2} />
                           </button>

--- a/src/renderer/components/project-sidebar/ProjectItem.tsx
+++ b/src/renderer/components/project-sidebar/ProjectItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
@@ -62,6 +62,9 @@ export function ProjectItem({
   const [creatingSession, setCreatingSession] = useState(false)
   const [creatingWorktree, setCreatingWorktree] = useState(false)
   const [creatingMainSession, setCreatingMainSession] = useState(false)
+  const creatingSessionLock = useRef(false)
+  const creatingWorktreeLock = useRef(false)
+  const creatingMainSessionLock = useRef(false)
   const [collapsedBranches, setCollapsedBranches] = useState<Set<string>>(new Set())
   const isRemoteProject = !!getProjectRemoteHostId(project)
   const [isGitRepo, setIsGitRepo] = useState(isRemoteProject)
@@ -228,12 +231,16 @@ export function ProjectItem({
                     disabled={creatingSession}
                     onClick={(e) => {
                       e.stopPropagation()
-                      if (creatingSession) return
+                      if (creatingSessionLock.current) return
+                      creatingSessionLock.current = true
                       setCreatingSession(true)
                       void withProgressToast(
                         { loading: 'Starting session…', success: 'Session started' },
                         () => createSessionFromProject(project)
-                      ).finally(() => setCreatingSession(false))
+                      ).finally(() => {
+                        creatingSessionLock.current = false
+                        setCreatingSession(false)
+                      })
                     }}
                     className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                   >
@@ -247,7 +254,8 @@ export function ProjectItem({
                       disabled={creatingWorktree}
                       onClick={(e) => {
                         e.stopPropagation()
-                        if (creatingWorktree) return
+                        if (creatingWorktreeLock.current) return
+                        creatingWorktreeLock.current = true
                         const name = generateWorktreeName()
                         setCreatingWorktree(true)
                         void withProgressToast(
@@ -260,7 +268,10 @@ export function ProjectItem({
                             loadWorktrees(project.path, true)
                             if (!isExpanded) setIsExpanded(true)
                           }
-                        ).finally(() => setCreatingWorktree(false))
+                        ).finally(() => {
+                          creatingWorktreeLock.current = false
+                          setCreatingWorktree(false)
+                        })
                       }}
                       className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                     >
@@ -373,12 +384,16 @@ export function ProjectItem({
                             disabled={creatingMainSession}
                             onClick={(e) => {
                               e.stopPropagation()
-                              if (creatingMainSession) return
+                              if (creatingMainSessionLock.current) return
+                              creatingMainSessionLock.current = true
                               setCreatingMainSession(true)
                               void withProgressToast(
                                 { loading: 'Starting session…', success: 'Session started' },
                                 () => createSessionFromProject(project, { branch: mainWt.branch })
-                              ).finally(() => setCreatingMainSession(false))
+                              ).finally(() => {
+                                creatingMainSessionLock.current = false
+                                setCreatingMainSession(false)
+                              })
                             }}
                             className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
                           >

--- a/src/renderer/components/project-sidebar/WorktreeItem.tsx
+++ b/src/renderer/components/project-sidebar/WorktreeItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { FolderGit2, GitBranch, ChevronRight, Plus, Pencil, Trash2, Check, X } from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
@@ -34,6 +34,8 @@ export function WorktreeItem({
   const [renameValue, setRenameValue] = useState('')
   const [creatingSession, setCreatingSession] = useState(false)
   const [removing, setRemoving] = useState(false)
+  const creatingSessionLock = useRef(false)
+  const removingLock = useRef(false)
 
   const wt = worktree
 
@@ -145,7 +147,8 @@ export function WorktreeItem({
               disabled={creatingSession}
               onClick={(e) => {
                 e.stopPropagation()
-                if (creatingSession) return
+                if (creatingSessionLock.current) return
+                creatingSessionLock.current = true
                 setCreatingSession(true)
                 void withProgressToast(
                   { loading: 'Starting session…', success: 'Session started' },
@@ -157,7 +160,10 @@ export function WorktreeItem({
                       existingWorktreePath: wt.path
                     })
                   }
-                ).finally(() => setCreatingSession(false))
+                ).finally(() => {
+                  creatingSessionLock.current = false
+                  setCreatingSession(false)
+                })
               }}
               className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
             >
@@ -183,24 +189,34 @@ export function WorktreeItem({
               disabled={removing}
               onClick={async (e) => {
                 e.stopPropagation()
-                if (removing) return
-                const { count, sessionIds } = await window.api.getWorktreeActiveSessions(wt.path)
-                if (count > 0 || wt.isDirty) {
-                  requestWorktreeDelete({
-                    projectPath,
-                    worktreePath: wt.path,
-                    sessionIds
-                  })
-                } else {
-                  setRemoving(true)
-                  void withProgressToast(
-                    { loading: 'Removing worktree…', success: 'Worktree removed' },
-                    async () => {
-                      const removed = await window.api.removeWorktree(projectPath, wt.path, false)
-                      if (!removed) throw new Error('Failed to remove worktree')
-                      onWorktreesChanged()
-                    }
-                  ).finally(() => setRemoving(false))
+                if (removingLock.current) return
+                removingLock.current = true
+                try {
+                  const { count, sessionIds } = await window.api.getWorktreeActiveSessions(wt.path)
+                  if (count > 0 || wt.isDirty) {
+                    requestWorktreeDelete({
+                      projectPath,
+                      worktreePath: wt.path,
+                      sessionIds
+                    })
+                    removingLock.current = false
+                  } else {
+                    setRemoving(true)
+                    void withProgressToast(
+                      { loading: 'Removing worktree…', success: 'Worktree removed' },
+                      async () => {
+                        const removed = await window.api.removeWorktree(projectPath, wt.path, false)
+                        if (!removed) throw new Error('Failed to remove worktree')
+                        onWorktreesChanged()
+                      }
+                    ).finally(() => {
+                      removingLock.current = false
+                      setRemoving(false)
+                    })
+                  }
+                } catch (err) {
+                  removingLock.current = false
+                  toast.error(err instanceof Error ? err.message : 'Failed to check worktree')
                 }
               }}
               className="text-gray-500 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"

--- a/src/renderer/components/project-sidebar/WorktreeItem.tsx
+++ b/src/renderer/components/project-sidebar/WorktreeItem.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { FolderGit2, GitBranch, ChevronRight, Plus, Pencil, Trash2, Check, X } from 'lucide-react'
 import { useAppStore } from '../../stores'
-import { getProjectRemoteHostId } from '../../../shared/types'
 import { Tooltip } from '../Tooltip'
 import { toast } from '../Toast'
+import { withProgressToast } from '../../lib/progress-toast'
+import { createSessionFromProject } from '../../lib/session-utils'
 import { requestWorktreeDelete } from '../WorktreeCleanupDialog'
 import type { WorktreeInfo } from '../../stores/types'
 
@@ -28,10 +29,11 @@ export function WorktreeItem({
   sessionsExpanded?: boolean
   onToggleSessionsExpanded?: () => void
 }) {
-  const addTerminal = useAppStore((s) => s.addTerminal)
   const config = useAppStore((s) => s.config)
   const [renaming, setRenaming] = useState(false)
   const [renameValue, setRenameValue] = useState('')
+  const [creatingSession, setCreatingSession] = useState(false)
+  const [removing, setRemoving] = useState(false)
 
   const wt = worktree
 
@@ -140,22 +142,24 @@ export function WorktreeItem({
           <Tooltip label="New session" position="right">
             <button
               type="button"
-              onClick={async (e) => {
+              disabled={creatingSession}
+              onClick={(e) => {
                 e.stopPropagation()
-                const agentType = config?.defaults.defaultAgent || 'claude'
-                const proj = config?.projects.find((p) => p.name === projectName)
-                const remoteHostId = proj ? getProjectRemoteHostId(proj) : undefined
-                const session = await window.api.createTerminal({
-                  agentType,
-                  projectName,
-                  projectPath,
-                  branch: wt.branch,
-                  existingWorktreePath: wt.path,
-                  remoteHostId
-                })
-                addTerminal(session)
+                if (creatingSession) return
+                setCreatingSession(true)
+                void withProgressToast(
+                  { loading: 'Starting session…', success: 'Session started' },
+                  async () => {
+                    const proj = config?.projects.find((p) => p.name === projectName)
+                    if (!proj) throw new Error(`Project "${projectName}" not found`)
+                    await createSessionFromProject(proj, {
+                      branch: wt.branch,
+                      existingWorktreePath: wt.path
+                    })
+                  }
+                ).finally(() => setCreatingSession(false))
               }}
-              className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+              className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
             >
               <Plus size={14} strokeWidth={2} />
             </button>
@@ -176,8 +180,10 @@ export function WorktreeItem({
           <Tooltip label="Remove worktree" position="right">
             <button
               type="button"
+              disabled={removing}
               onClick={async (e) => {
                 e.stopPropagation()
+                if (removing) return
                 const { count, sessionIds } = await window.api.getWorktreeActiveSessions(wt.path)
                 if (count > 0 || wt.isDirty) {
                   requestWorktreeDelete({
@@ -186,16 +192,18 @@ export function WorktreeItem({
                     sessionIds
                   })
                 } else {
-                  const removed = await window.api.removeWorktree(projectPath, wt.path, false)
-                  if (removed) {
-                    toast.success('Worktree removed')
-                    onWorktreesChanged()
-                  } else {
-                    toast.error('Failed to remove worktree')
-                  }
+                  setRemoving(true)
+                  void withProgressToast(
+                    { loading: 'Removing worktree…', success: 'Worktree removed' },
+                    async () => {
+                      const removed = await window.api.removeWorktree(projectPath, wt.path, false)
+                      if (!removed) throw new Error('Failed to remove worktree')
+                      onWorktreesChanged()
+                    }
+                  ).finally(() => setRemoving(false))
                 }
               }}
-              className="text-gray-500 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+              className="text-gray-500 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
             >
               <Trash2 size={14} strokeWidth={2} />
             </button>

--- a/src/renderer/lib/progress-toast.ts
+++ b/src/renderer/lib/progress-toast.ts
@@ -9,7 +9,7 @@ interface ProgressLabels {
 export async function withProgressToast<T>(
   labels: ProgressLabels,
   fn: () => Promise<T>
-): Promise<T> {
+): Promise<T | undefined> {
   const id = toast.loading(labels.loading)
   try {
     const result = await fn()
@@ -18,6 +18,6 @@ export async function withProgressToast<T>(
   } catch (err) {
     const msg = labels.error ? labels.error(err) : err instanceof Error ? err.message : String(err)
     toast.update(id, msg || 'Operation failed', 'error')
-    throw err
+    return undefined
   }
 }

--- a/src/renderer/lib/progress-toast.ts
+++ b/src/renderer/lib/progress-toast.ts
@@ -1,0 +1,23 @@
+import { toast } from '../components/Toast'
+
+interface ProgressLabels {
+  loading: string
+  success: string
+  error?: (err: unknown) => string
+}
+
+export async function withProgressToast<T>(
+  labels: ProgressLabels,
+  fn: () => Promise<T>
+): Promise<T> {
+  const id = toast.loading(labels.loading)
+  try {
+    const result = await fn()
+    toast.update(id, labels.success, 'success')
+    return result
+  } catch (err) {
+    const msg = labels.error ? labels.error(err) : err instanceof Error ? err.message : String(err)
+    toast.update(id, msg || 'Operation failed', 'error')
+    throw err
+  }
+}

--- a/tests/progress-toast.test.ts
+++ b/tests/progress-toast.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockLoading = vi.fn(() => 'toast-id-1')
+const mockUpdate = vi.fn()
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: {
+    loading: (msg: string) => mockLoading(msg),
+    update: (id: string, msg: string, type: string) => mockUpdate(id, msg, type)
+  }
+}))
+
+import { withProgressToast } from '../src/renderer/lib/progress-toast'
+
+describe('withProgressToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLoading.mockReturnValue('toast-id-1')
+  })
+
+  it('shows loading toast immediately with the loading label', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => 'value')
+    expect(mockLoading).toHaveBeenCalledWith('Loading…')
+  })
+
+  it('transitions toast to success with the success label', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => 'value')
+    expect(mockUpdate).toHaveBeenCalledWith('toast-id-1', 'Done', 'success')
+  })
+
+  it('returns the resolved value on success', async () => {
+    const result = await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => 42)
+    expect(result).toBe(42)
+  })
+
+  it('transitions toast to error with the Error message on failure', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => {
+      throw new Error('Something broke')
+    })
+    expect(mockUpdate).toHaveBeenCalledWith('toast-id-1', 'Something broke', 'error')
+  })
+
+  it('returns undefined on failure instead of throwing', async () => {
+    const result = await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => {
+      throw new Error('fail')
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('coerces non-Error throws to string', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () =>
+      Promise.reject('plain string')
+    )
+    expect(mockUpdate).toHaveBeenCalledWith('toast-id-1', 'plain string', 'error')
+  })
+
+  it('uses custom error formatter when provided', async () => {
+    await withProgressToast(
+      {
+        loading: 'Loading…',
+        success: 'Done',
+        error: (err) => `Custom: ${(err as Error).message}`
+      },
+      async () => {
+        throw new Error('boom')
+      }
+    )
+    expect(mockUpdate).toHaveBeenCalledWith('toast-id-1', 'Custom: boom', 'error')
+  })
+
+  it('falls back to "Operation failed" when error message is empty', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => {
+      throw new Error('')
+    })
+    expect(mockUpdate).toHaveBeenCalledWith('toast-id-1', 'Operation failed', 'error')
+  })
+
+  it('does not call update on success with the loading id twice', async () => {
+    await withProgressToast({ loading: 'Loading…', success: 'Done' }, async () => 'v')
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/project-item.test.tsx
+++ b/tests/project-item.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }),
+  writable: true
+})
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((props, ref) =>
+          React.createElement(tag, { ...props, ref })
+        )
+    }
+  )
+}))
+
+const mockLoading = vi.fn(() => 'toast-id')
+const mockUpdate = vi.fn()
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: Object.assign(
+    (msg: string) => {
+      mockLoading(msg)
+      return 'toast-id'
+    },
+    {
+      loading: (msg: string) => mockLoading(msg),
+      update: (id: string, msg: string, type: string) => mockUpdate(id, msg, type),
+      dismiss: vi.fn(),
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn()
+    }
+  )
+}))
+
+const mockCreateSession = vi.fn()
+
+vi.mock('../src/renderer/lib/session-utils', () => ({
+  createSessionFromProject: (...args: unknown[]) => mockCreateSession(...args)
+}))
+
+const mockCreateWorktree = vi.fn()
+const mockIsGitRepo = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    createWorktree: (...a: unknown[]) => mockCreateWorktree(...a),
+    isGitRepo: (...a: unknown[]) => mockIsGitRepo(...a)
+  },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { ProjectItem } from '../src/renderer/components/project-sidebar/ProjectItem'
+import type { ProjectConfig, AppConfig } from '../src/shared/types'
+import type { WorktreeInfo } from '../src/renderer/stores/types'
+
+const project: ProjectConfig = {
+  name: 'test-proj',
+  path: '/tmp/test-proj'
+}
+
+const mainWorktree: WorktreeInfo = {
+  path: '/tmp/test-proj',
+  branch: 'main',
+  name: 'main',
+  isMain: true,
+  isDirty: false
+}
+
+const baseConfig: Partial<AppConfig> = {
+  projects: [project],
+  defaults: {
+    defaultAgent: 'claude'
+  } as AppConfig['defaults'],
+  remoteHosts: []
+}
+
+const initialState = useAppStore.getState()
+
+function renderProjectItem(overrides: Partial<React.ComponentProps<typeof ProjectItem>> = {}) {
+  const props: React.ComponentProps<typeof ProjectItem> = {
+    project,
+    sessionCount: 0,
+    defaultExpanded: true,
+    isActive: false,
+    isCollapsed: false,
+    worktreeSessionCounts: new Map(),
+    mainRepoSessionCount: 0,
+    viewMode: 'worktrees',
+    worktreeSessions: new Map(),
+    mainRepoSessions: [],
+    projectSessions: [],
+    ...overrides
+  }
+  return render(<ProjectItem {...props} />)
+}
+
+describe('ProjectItem progress-toast handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsGitRepo.mockResolvedValue(true)
+    mockCreateWorktree.mockResolvedValue(undefined)
+    mockCreateSession.mockResolvedValue(undefined)
+    useAppStore.setState({
+      config: baseConfig as AppConfig,
+      worktreeCache: new Map([[project.path, [mainWorktree]]])
+    })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  it('new session button fires a loading toast and calls createSessionFromProject', async () => {
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    const sessionBtn = container.querySelector('button[type="button"]')
+    expect(sessionBtn).not.toBeNull()
+    act(() => {
+      fireEvent.click(sessionBtn!)
+    })
+    expect(mockLoading).toHaveBeenCalledWith('Starting session…')
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(project)
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Session started', 'success')
+    })
+  })
+
+  it('new worktree button fires a loading toast and calls window.api.createWorktree', async () => {
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    // The new-worktree button is the 2nd visible action button (after new session)
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    // Find it via its SVG child: FolderGit2 is distinctive because it has class text-amber-400/70
+    const wtButton = buttons.find((b) => b.querySelector('.text-amber-400\\/70')) as HTMLElement
+    expect(wtButton).toBeDefined()
+    act(() => {
+      fireEvent.click(wtButton)
+    })
+    expect(mockLoading).toHaveBeenCalledWith('Creating worktree…')
+    await waitFor(() => {
+      expect(mockCreateWorktree).toHaveBeenCalledWith(project.path, 'main', expect.any(String))
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'toast-id',
+        expect.stringMatching(/^Worktree ".+" created$/),
+        'success'
+      )
+    })
+  })
+
+  it('new worktree button transitions toast to error when createWorktree fails', async () => {
+    mockCreateWorktree.mockRejectedValue(new Error('permission denied'))
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const wtButton = buttons.find((b) => b.querySelector('.text-amber-400\\/70')) as HTMLElement
+    act(() => {
+      fireEvent.click(wtButton)
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'permission denied', 'error')
+    })
+  })
+
+  it('does not fire createSessionFromProject twice when the new-session button is double-clicked synchronously', async () => {
+    // Keep createSessionFromProject pending so the ref-lock stays active across both clicks
+    let resolveIt: () => void
+    mockCreateSession.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveIt = resolve
+        })
+    )
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    const sessionBtn = container.querySelector('button[type="button"]') as HTMLElement
+    act(() => {
+      fireEvent.click(sessionBtn)
+      fireEvent.click(sessionBtn)
+    })
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    act(() => resolveIt!())
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+  })
+})

--- a/tests/toast.test.tsx
+++ b/tests/toast.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+
+// jsdom doesn't implement matchMedia; stub it for useIsMobile.
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }),
+  writable: true
+})
+
+// Framer Motion's AnimatePresence keeps exiting elements in the DOM during
+// the exit transition, which breaks synchronous dismissal assertions. Mock
+// the library to be a transparent pass-through for these tests.
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((props, ref) =>
+          React.createElement(tag, { ...props, ref })
+        )
+    }
+  )
+}))
+
+import { toast, ToastContainer } from '../src/renderer/components/Toast'
+
+describe('toast module', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    // Flush any pending timers before restoring real timers.
+    act(() => {
+      vi.runAllTimers()
+    })
+    vi.useRealTimers()
+  })
+
+  it('toast() returns a string id', () => {
+    const id = toast('hello', 'success')
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+  })
+
+  it('toast.loading() creates a sticky toast that does not auto-dismiss', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.loading('Working…')
+    })
+    expect(screen.getByText('Working…')).toBeInTheDocument()
+    // Fast-forward far beyond any reasonable duration
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(screen.getByText('Working…')).toBeInTheDocument()
+    // Cleanup: dismiss so the module state doesn't leak into other tests
+    act(() => {
+      toast.dismiss('cleanup-id-does-not-exist')
+    })
+  })
+
+  it('toast.success shortcut creates a success toast that dismisses after default duration', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.success('Saved!')
+    })
+    expect(screen.getByText('Saved!')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(screen.queryByText('Saved!')).not.toBeInTheDocument()
+  })
+
+  it('toast.error shortcut uses a longer duration (4000ms)', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.error('Boom')
+    })
+    expect(screen.getByText('Boom')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(screen.getByText('Boom')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(screen.queryByText('Boom')).not.toBeInTheDocument()
+  })
+
+  it('toast.warning and toast.info shortcuts render their messages', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.warning('Careful')
+      toast.info('FYI')
+    })
+    expect(screen.getByText('Careful')).toBeInTheDocument()
+    expect(screen.getByText('FYI')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+  })
+
+  it('toast.update() mutates an existing toast message in place', () => {
+    render(<ToastContainer />)
+    let id = ''
+    act(() => {
+      id = toast.loading('Starting…')
+    })
+    expect(screen.getByText('Starting…')).toBeInTheDocument()
+    act(() => {
+      toast.update(id, 'Done!', 'success')
+    })
+    expect(screen.queryByText('Starting…')).not.toBeInTheDocument()
+    expect(screen.getByText('Done!')).toBeInTheDocument()
+    // Still auto-dismisses at the success duration
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+    expect(screen.queryByText('Done!')).not.toBeInTheDocument()
+  })
+
+  it('toast.update() on an unknown id falls back to creating a fresh toast', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.update('does-not-exist', 'Fallback', 'success')
+    })
+    expect(screen.getByText('Fallback')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(2500)
+    })
+  })
+
+  it('toast.dismiss() removes a toast immediately', () => {
+    render(<ToastContainer />)
+    let id = ''
+    act(() => {
+      id = toast.loading('Waiting…')
+    })
+    expect(screen.getByText('Waiting…')).toBeInTheDocument()
+    act(() => {
+      toast.dismiss(id)
+    })
+    expect(screen.queryByText('Waiting…')).not.toBeInTheDocument()
+  })
+
+  it('calling toast.update twice in quick succession does not prematurely dismiss from the first timer', () => {
+    // This is the bug fix — previously the first update's setTimeout could fire
+    // and dismiss the toast even after a second update scheduled a longer timer.
+    render(<ToastContainer />)
+    let id = ''
+    act(() => {
+      id = toast.loading('Step 1')
+    })
+    act(() => {
+      toast.update(id, 'Step 2', 'success') // duration 2500
+    })
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    act(() => {
+      toast.update(id, 'Step 3', 'success') // new duration 2500 from now (3500 total)
+    })
+    // At t=2500 (when the FIRST timer would have fired), the toast must still be visible.
+    act(() => {
+      vi.advanceTimersByTime(1500) // now t=2500
+    })
+    expect(screen.getByText('Step 3')).toBeInTheDocument()
+    // Confirm the new timer still dismisses at the expected time.
+    act(() => {
+      vi.advanceTimersByTime(1000) // now t=3500
+    })
+    expect(screen.queryByText('Step 3')).not.toBeInTheDocument()
+  })
+
+  it('clicking the toast close button dismisses it and clears its timer', () => {
+    render(<ToastContainer />)
+    act(() => {
+      toast.success('Click me off')
+    })
+    expect(screen.getByText('Click me off')).toBeInTheDocument()
+    const closeButtons = screen.getAllByRole('button')
+    act(() => {
+      fireEvent.click(closeButtons[closeButtons.length - 1])
+    })
+    expect(screen.queryByText('Click me off')).not.toBeInTheDocument()
+  })
+
+  it('renders a spinner on loading toasts', () => {
+    const { container } = render(<ToastContainer />)
+    act(() => {
+      toast.loading('Spinning')
+    })
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+})

--- a/tests/worktree-cleanup-dialog.test.tsx
+++ b/tests/worktree-cleanup-dialog.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+
+// jsdom doesn't implement matchMedia.
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }),
+  writable: true
+})
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((props, ref) =>
+          React.createElement(tag, { ...props, ref })
+        )
+    }
+  )
+}))
+
+const mockLoading = vi.fn(() => 'toast-id')
+const mockUpdate = vi.fn()
+const mockDismiss = vi.fn()
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: Object.assign(
+    (msg: string) => {
+      mockLoading(msg)
+      return 'toast-id'
+    },
+    {
+      loading: (msg: string) => mockLoading(msg),
+      update: (id: string, msg: string, type: string) => mockUpdate(id, msg, type),
+      dismiss: (id: string) => mockDismiss(id),
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn()
+    }
+  )
+}))
+
+const mockIsWorktreeDirty = vi.fn()
+const mockRemoveWorktree = vi.fn()
+const mockKillTerminal = vi.fn()
+const mockKillHeadlessSession = vi.fn()
+const mockOnWorktreeCleanup = vi.fn(() => () => {})
+const mockLoadWorktreesStoreFn = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    isWorktreeDirty: (...a: unknown[]) => mockIsWorktreeDirty(...a),
+    removeWorktree: (...a: unknown[]) => mockRemoveWorktree(...a),
+    killTerminal: (...a: unknown[]) => mockKillTerminal(...a),
+    killHeadlessSession: (...a: unknown[]) => mockKillHeadlessSession(...a),
+    onWorktreeCleanup: (cb: unknown) => mockOnWorktreeCleanup(cb)
+  },
+  writable: true
+})
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: Object.assign(
+    (selector: (s: unknown) => unknown) => selector({ loadWorktrees: mockLoadWorktreesStoreFn }),
+    {
+      getState: () => ({ loadWorktrees: mockLoadWorktreesStoreFn })
+    }
+  )
+}))
+
+import {
+  WorktreeCleanupDialog,
+  requestWorktreeDelete
+} from '../src/renderer/components/WorktreeCleanupDialog'
+
+async function openExplicitDelete(
+  opts: {
+    projectPath?: string
+    worktreePath?: string
+    sessionIds?: string[]
+    dirty?: boolean
+  } = {}
+) {
+  mockIsWorktreeDirty.mockResolvedValue(opts.dirty ?? false)
+  act(() => {
+    requestWorktreeDelete({
+      projectPath: opts.projectPath ?? '/tmp/proj',
+      worktreePath: opts.worktreePath ?? '/tmp/proj/wt',
+      sessionIds: opts.sessionIds ?? []
+    })
+  })
+  // Wait for the dirty-state check to resolve and the Remove button to enable
+  await waitFor(() => {
+    const btn = screen.getByRole('button', { name: /Remove/i })
+    expect(btn).not.toBeDisabled()
+  })
+}
+
+describe('WorktreeCleanupDialog (explicit-delete mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLoading.mockReturnValue('toast-id')
+    mockRemoveWorktree.mockResolvedValue(true)
+    mockKillTerminal.mockResolvedValue(undefined)
+    mockKillHeadlessSession.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    // Ensure any open dialog is cleaned up between tests
+    vi.clearAllMocks()
+  })
+
+  it('opens when requestWorktreeDelete is called and shows the worktree path', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete({ worktreePath: '/tmp/proj/wt-abc' })
+    expect(screen.getByText('/tmp/proj/wt-abc')).toBeInTheDocument()
+  })
+
+  it('closes the dialog immediately on confirm and does not block', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete()
+    const removeBtn = screen.getByRole('button', { name: /Remove/i })
+    act(() => {
+      fireEvent.click(removeBtn)
+    })
+    // Dialog should be gone synchronously — removal runs in background
+    expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument()
+  })
+
+  it('fires a loading toast and calls removeWorktree in the background', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete({
+      projectPath: '/tmp/proj',
+      worktreePath: '/tmp/proj/wt'
+    })
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Remove/i }))
+    })
+    expect(mockLoading).toHaveBeenCalledWith('Removing worktree…')
+    await waitFor(() => {
+      expect(mockRemoveWorktree).toHaveBeenCalledWith('/tmp/proj', '/tmp/proj/wt', false)
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Worktree removed', 'success')
+    })
+  })
+
+  it('shows the sessions-closing label and kills sessions when sessionIds are set', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete({ sessionIds: ['sess-1', 'sess-2'] })
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Close sessions & remove/i }))
+    })
+    expect(mockLoading).toHaveBeenCalledWith('Closing sessions & removing worktree…')
+    await waitFor(() => {
+      expect(mockKillTerminal).toHaveBeenCalledWith('sess-1')
+      expect(mockKillTerminal).toHaveBeenCalledWith('sess-2')
+      expect(mockRemoveWorktree).toHaveBeenCalled()
+    })
+  })
+
+  it('uses force=true when the worktree is dirty', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete({ dirty: true })
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Remove anyway/i }))
+    })
+    await waitFor(() => {
+      expect(mockRemoveWorktree).toHaveBeenCalledWith(expect.any(String), expect.any(String), true)
+    })
+  })
+
+  it('reports a failure via the progress toast when removeWorktree returns false', async () => {
+    mockRemoveWorktree.mockResolvedValue(false)
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete()
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Remove/i }))
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Failed to remove worktree', 'error')
+    })
+  })
+
+  it('clicking Cancel closes the dialog without calling removeWorktree', async () => {
+    render(<WorktreeCleanupDialog />)
+    await openExplicitDelete()
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+    expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument()
+    expect(mockRemoveWorktree).not.toHaveBeenCalled()
+  })
+})

--- a/tests/worktree-item.test.tsx
+++ b/tests/worktree-item.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }),
+  writable: true
+})
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((props, ref) =>
+          React.createElement(tag, { ...props, ref })
+        )
+    }
+  )
+}))
+
+const mockLoading = vi.fn(() => 'toast-id')
+const mockUpdate = vi.fn()
+const mockToastError = vi.fn()
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: Object.assign(
+    (msg: string) => {
+      mockLoading(msg)
+      return 'toast-id'
+    },
+    {
+      loading: (msg: string) => mockLoading(msg),
+      update: (id: string, msg: string, type: string) => mockUpdate(id, msg, type),
+      dismiss: vi.fn(),
+      success: vi.fn(),
+      error: (msg: string) => mockToastError(msg),
+      warning: vi.fn(),
+      info: vi.fn()
+    }
+  )
+}))
+
+const mockCreateSession = vi.fn()
+
+vi.mock('../src/renderer/lib/session-utils', () => ({
+  createSessionFromProject: (...args: unknown[]) => mockCreateSession(...args)
+}))
+
+const mockRequestWorktreeDelete = vi.fn()
+
+vi.mock('../src/renderer/components/WorktreeCleanupDialog', () => ({
+  requestWorktreeDelete: (info: unknown) => mockRequestWorktreeDelete(info),
+  WorktreeCleanupDialog: () => null
+}))
+
+const mockGetActiveSessions = vi.fn()
+const mockRemoveWorktree = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    getWorktreeActiveSessions: (...a: unknown[]) => mockGetActiveSessions(...a),
+    removeWorktree: (...a: unknown[]) => mockRemoveWorktree(...a),
+    renameWorktree: vi.fn()
+  },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { WorktreeItem } from '../src/renderer/components/project-sidebar/WorktreeItem'
+import type { ProjectConfig, AppConfig } from '../src/shared/types'
+import type { WorktreeInfo } from '../src/renderer/stores/types'
+
+const project: ProjectConfig = {
+  name: 'test-proj',
+  path: '/tmp/test-proj'
+}
+
+const worktree: WorktreeInfo = {
+  path: '/tmp/test-proj/wt-a',
+  branch: 'feature-a',
+  name: 'feature-a',
+  isMain: false,
+  isDirty: false
+}
+
+const baseConfig: Partial<AppConfig> = {
+  projects: [project],
+  defaults: { defaultAgent: 'claude' } as AppConfig['defaults'],
+  remoteHosts: []
+}
+
+const initialState = useAppStore.getState()
+
+function renderWorktreeItem(wt: WorktreeInfo = worktree, onWorktreesChanged: () => void = vi.fn()) {
+  return render(
+    <WorktreeItem
+      worktree={wt}
+      projectPath={project.path}
+      projectName={project.name}
+      isActiveWorktree={false}
+      sessionCount={0}
+      onSelect={vi.fn()}
+      onWorktreesChanged={onWorktreesChanged}
+    />
+  )
+}
+
+describe('WorktreeItem progress-toast handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateSession.mockResolvedValue(undefined)
+    mockGetActiveSessions.mockResolvedValue({ count: 0, sessionIds: [] })
+    mockRemoveWorktree.mockResolvedValue(true)
+    useAppStore.setState({ config: baseConfig as AppConfig })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  it('new session button fires loading toast and calls createSessionFromProject', async () => {
+    const { container } = renderWorktreeItem()
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const sessionBtn = buttons[0]
+    act(() => {
+      fireEvent.click(sessionBtn)
+    })
+    expect(mockLoading).toHaveBeenCalledWith('Starting session…')
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(project, {
+        branch: 'feature-a',
+        existingWorktreePath: '/tmp/test-proj/wt-a'
+      })
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Session started', 'success')
+    })
+  })
+
+  it('new session ref-lock prevents a synchronous double-click from firing twice', async () => {
+    let resolveIt: () => void
+    mockCreateSession.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveIt = resolve
+        })
+    )
+    const { container } = renderWorktreeItem()
+    const sessionBtn = container.querySelectorAll('button[type="button"]')[0]
+    act(() => {
+      fireEvent.click(sessionBtn)
+      fireEvent.click(sessionBtn)
+    })
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    act(() => resolveIt!())
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+  })
+
+  it('remove button takes the fast path when worktree is clean and has no sessions', async () => {
+    const onWorktreesChanged = vi.fn()
+    const { container } = renderWorktreeItem(worktree, onWorktreesChanged)
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const removeBtn = buttons[buttons.length - 1]
+    act(() => {
+      fireEvent.click(removeBtn)
+    })
+    await waitFor(() => {
+      expect(mockGetActiveSessions).toHaveBeenCalledWith(worktree.path)
+    })
+    await waitFor(() => {
+      expect(mockLoading).toHaveBeenCalledWith('Removing worktree…')
+      expect(mockRemoveWorktree).toHaveBeenCalledWith(project.path, worktree.path, false)
+      expect(onWorktreesChanged).toHaveBeenCalled()
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Worktree removed', 'success')
+    })
+  })
+
+  it('remove button routes through cleanup dialog when worktree has active sessions', async () => {
+    mockGetActiveSessions.mockResolvedValue({ count: 2, sessionIds: ['s1', 's2'] })
+    const { container } = renderWorktreeItem()
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const removeBtn = buttons[buttons.length - 1]
+    act(() => {
+      fireEvent.click(removeBtn)
+    })
+    await waitFor(() => {
+      expect(mockRequestWorktreeDelete).toHaveBeenCalledWith({
+        projectPath: project.path,
+        worktreePath: worktree.path,
+        sessionIds: ['s1', 's2']
+      })
+    })
+    // Fast path should NOT run
+    expect(mockRemoveWorktree).not.toHaveBeenCalled()
+    expect(mockLoading).not.toHaveBeenCalledWith('Removing worktree…')
+  })
+
+  it('remove button routes through cleanup dialog when worktree is dirty', async () => {
+    const dirty: WorktreeInfo = { ...worktree, isDirty: true }
+    const { container } = renderWorktreeItem(dirty)
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const removeBtn = buttons[buttons.length - 1]
+    act(() => {
+      fireEvent.click(removeBtn)
+    })
+    await waitFor(() => {
+      expect(mockRequestWorktreeDelete).toHaveBeenCalled()
+    })
+    expect(mockRemoveWorktree).not.toHaveBeenCalled()
+  })
+
+  it('remove fast path transitions toast to error when removeWorktree returns false', async () => {
+    mockRemoveWorktree.mockResolvedValue(false)
+    const { container } = renderWorktreeItem()
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+    const removeBtn = buttons[buttons.length - 1]
+    act(() => {
+      fireEvent.click(removeBtn)
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Failed to remove worktree', 'error')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Creating worktrees, starting sessions, and removing worktrees can take several seconds — especially on Windows — and the sidebar gave no feedback until the operation completed. Users were clicking twice, wondering if the app was frozen. This PR adds immediate, non-blocking progress feedback.

- **Sticky loading toast that transitions in place** — new `'loading'` toast type plus `toast.update(id, msg, type)` and `toast.dismiss(id)`. The same toast animates from "Creating worktree…" to "Worktree \"foo\" created" (or to a red error), so one action never stacks multiple toasts. Dismiss timers are tracked in a Map and cleared on update so back-to-back updates can't leave a stale timeout that fires prematurely.
- **`withProgressToast(labels, fn)` helper** — thin try/catch wrapper keeps call sites to one-liners.
- **Sidebar handlers wired up** — new-session (project row, main worktree row, and worktree row), new-worktree, and the fast-path remove-worktree all show a loading toast and disable their button while in flight to prevent double-submits.
- **Dedupe via `createSessionFromProject`** — three near-identical `createTerminal` + `addTerminal` blocks collapsed into calls to the existing helper in `session-utils.ts`.
- **Cleanup dialog no longer blocks the UI** — `WorktreeCleanupDialog.handleRemove` now closes the dialog immediately on confirm and runs the deletion in the background via `withProgressToast`. The in-dialog spinner, `removing`/`removeError` local state, and inline error box are gone. The user has already decided; no reason to keep them staring at a blocked modal.

## Test plan

- [ ] `yarn typecheck` and `yarn lint` pass
- [ ] `yarn test` passes (703 tests)
- [ ] Click "new worktree" on a project → gray "Creating worktree…" toast appears instantly with spinning icon, transitions to green "Worktree \"x\" created" on success
- [ ] Trigger a failure (e.g., invalid branch) → same toast transitions to red with the error message
- [ ] Click "+" on a project row and on a worktree row → "Starting session…" → "Session started"
- [ ] Remove a clean worktree with no sessions (fast path) → "Removing worktree…" → "Worktree removed"
- [ ] Remove a dirty worktree or one with active sessions (dialog path) → confirm dialog closes immediately, corner toast shows "Closing sessions & removing worktree…" and transitions to success/error; sidebar remains interactive while deletion runs
- [ ] Rapidly double-click "new worktree" → only one worktree is created (button disables after the first click)
- [ ] Manually dismiss a loading toast mid-flight → operation still completes; a fresh success/error toast appears (fallback in `toast.update`)