### PR TITLE
fix: reduce focused↔grid terminal flicker via sync fit on reparent

### DIFF
--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -101,7 +101,7 @@ const TERM_OPTIONS = {
     brightCyan: '#22d3ee',
     brightWhite: '#fafafa'
   },
-  scrollback: 5000,
+  scrollback: 2000,
   allowProposedApi: true
 }
 
@@ -262,6 +262,13 @@ export function attachTerminal(terminalId: string, container: HTMLDivElement): T
   if (!entry._gpuAddon) {
     entry._loadRenderer?.()
   }
+
+  // Fit synchronously so the terminal renders at the correct size on the very
+  // first paint in the new container. Without this, the caller's rAF-scheduled
+  // fit produces a visible frame at the old size before the resized frame lands,
+  // which shows up as a flicker when switching focused ↔ grid.
+  fitTerminal(terminalId)
+
   return entry
 }
 


### PR DESCRIPTION
## Summary

- On focused ↔ grid view switch, the xterm DOM element is moved into the new container. The caller's `rAF`-scheduled fit leaves a visible paint at the old size before the resized frame lands, which reads as a flicker.
- Fit synchronously inside `attachTerminal`'s reparent path so the terminal renders at the correct size on the very first paint in the new container. Delegates to the existing `fitTerminal` helper to avoid duplicating the fit/resize body.
- Drops default `scrollback` from 5000 → 2000. Lighter WebGL texture atlas and less work on reparent; still comfortable for typical agent output.

This is an incremental fix. The WebGL context still briefly blips on reparent — full elimination requires a persistent terminal host (no-reparent overlay), which will land in a follow-up.

## Test plan

- [ ] Open multiple agent cards in grid
- [ ] Click to expand one to focused view — flicker should be noticeably reduced
- [ ] Collapse back to grid — same
- [ ] Repeat rapidly — no stuck state / wrong-size frames
- [ ] Verify shell panel and tab-view terminals still resize correctly
- [ ] Window resize still refits all visible terminals