### PR TITLE
Interactive branch switch in session status bar + header cleanup

### DIFF
--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -171,9 +171,13 @@ class PtyManager extends EventEmitter {
 
     if (payload.existingWorktreePath && fs.existsSync(payload.existingWorktreePath)) {
       effectivePath = payload.existingWorktreePath
-      worktreePath = payload.existingWorktreePath
-      worktreeName = payload.worktreeName || extractWorktreeName(payload.existingWorktreePath)
       effectiveBranch = payload.branch
+      const isMainWorktree =
+        normalizePath(payload.existingWorktreePath) === normalizePath(payload.projectPath)
+      if (!isMainWorktree) {
+        worktreePath = payload.existingWorktreePath
+        worktreeName = payload.worktreeName || extractWorktreeName(payload.existingWorktreePath)
+      }
     } else if ((payload.useWorktree || payload.existingWorktreePath) && payload.branch) {
       if (isGitRepo(payload.projectPath)) {
         if (payload.existingWorktreePath) {

--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -24,8 +24,8 @@ import {
 import { toast } from './Toast'
 import { Tooltip } from './Tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
+import { isMac, MOD } from '../lib/platform'
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
 // On touch devices, always show action buttons (no hover available)
 const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(hover: none)').matches
 
@@ -312,7 +312,7 @@ export const AgentCard = memo(
           {/* Expand + Minimize + Close — appear on hover, right of git */}
           {cardHovered && (
             <div className="flex items-center gap-0.5">
-              <Tooltip label="Expand" position="top">
+              <Tooltip label="Expand" shortcut={`${MOD}O`} position="top">
                 <button
                   onClick={(e) => {
                     e.stopPropagation()

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -16,9 +16,7 @@ import { useTerminalScrollButton } from '../hooks/useTerminalScrollButton'
 import { useTerminalPinchZoom } from '../hooks/useTerminalPinchZoom'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { ArrowDown, FolderGit2, GitBranch, Minimize2, X, Pencil } from 'lucide-react'
-
-const isMac = navigator.platform.toUpperCase().includes('MAC')
-const MOD = isMac ? '⌘' : 'Ctrl+'
+import { MOD } from '../lib/platform'
 
 export function FocusedTerminal() {
   const focusedId = useAppStore((s) => s.focusedTerminalId)
@@ -132,9 +130,9 @@ export function FocusedTerminal() {
             {isMobile && terminal.session.branch && (
               <span className="flex items-center gap-1 mt-0.5">
                 {terminal.session.isWorktree ? (
-                  <FolderGit2 size={11} className="text-amber-500" strokeWidth={1.5} />
+                  <FolderGit2 size={11} className="text-amber-500 shrink-0" strokeWidth={1.5} />
                 ) : (
-                  <GitBranch size={11} className="text-gray-600" strokeWidth={1.5} />
+                  <GitBranch size={11} className="text-gray-600 shrink-0" strokeWidth={1.5} />
                 )}
                 <span
                   className={`text-[11px] font-mono truncate ${
@@ -144,7 +142,12 @@ export function FocusedTerminal() {
                   {getBranchLabel(terminal.session)}
                 </span>
                 {terminal.session.isWorktree && (
-                  <span className="text-[10px] text-amber-500/60">worktree</span>
+                  <>
+                    <GitBranch size={10} className="text-gray-600 shrink-0" strokeWidth={1.5} />
+                    <span className="text-[10px] font-mono text-gray-500 truncate">
+                      {terminal.session.branch}
+                    </span>
+                  </>
                 )}
               </span>
             )}
@@ -152,29 +155,8 @@ export function FocusedTerminal() {
 
           {isMobile && <StatusBadge status={terminal.status} />}
 
-          {/* Keyboard shortcut hints (desktop only) */}
           {!isMobile && (
-            <div className="flex items-center gap-2 text-[10px] text-gray-600 mx-1">
-              <span className="flex items-center gap-0.5">
-                <kbd className="px-1 py-0.5 rounded bg-white/[0.06] text-gray-500 font-mono">
-                  {MOD}W
-                </kbd>
-                collapse
-              </span>
-              <span className="flex items-center gap-0.5">
-                <kbd className="px-1 py-0.5 rounded bg-white/[0.06] text-gray-500 font-mono">
-                  {MOD}[
-                </kbd>
-                <kbd className="px-1 py-0.5 rounded bg-white/[0.06] text-gray-500 font-mono">
-                  {MOD}]
-                </kbd>
-                cycle
-              </span>
-            </div>
-          )}
-
-          {!isMobile && (
-            <Tooltip label="Collapse to grid" position="bottom">
+            <Tooltip label="Collapse to grid" shortcut={`${MOD}W`} position="bottom">
               <button
                 type="button"
                 onClick={handleContract}

--- a/src/renderer/components/SessionStatusBar.tsx
+++ b/src/renderer/components/SessionStatusBar.tsx
@@ -3,8 +3,9 @@ import { useShallow } from 'zustand/react/shallow'
 import { StatusBadge } from './StatusBadge'
 import { GitChangesIndicator, BrowseFilesButton } from './GitChangesIndicator'
 import { OpenInButton } from './OpenInButton'
-import { GitBranch, FolderGit2, ListTodo } from 'lucide-react'
-import { getBranchLabel } from '../lib/terminal-display'
+import { BranchPicker } from './BranchPicker'
+import { useBranchSwitcher } from '../hooks/useBranchSwitcher'
+import { GitBranch, FolderGit2, ListTodo, ChevronDown } from 'lucide-react'
 
 interface Props {
   terminalId: string
@@ -20,7 +21,18 @@ export function SessionStatusBar({ terminalId }: Props) {
     }))
   )
 
-  if (!terminal) return null
+  const session = terminal?.session
+  const branchCwd = session && (session.worktreePath ?? session.projectPath)
+
+  const { showPicker, togglePicker, closePicker, isSwitching, selectBranch } = useBranchSwitcher({
+    projectPath: session?.projectPath,
+    branchCwd,
+    branchName: session?.branch
+  })
+
+  if (!terminal || !session) return null
+
+  const { projectPath, branch: branchName } = session
 
   const handleTaskClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
@@ -35,23 +47,41 @@ export function SessionStatusBar({ terminalId }: Props) {
       style={{ background: '#1a1a1e' }}
     >
       <div className="flex items-center gap-3 flex-1 min-w-0">
-        {terminal.session.branch && (
+        {branchName && (
           <div className="flex items-center gap-1 shrink-0">
-            {terminal.session.isWorktree ? (
-              <FolderGit2 size={11} className="text-amber-500 shrink-0" strokeWidth={1.5} />
-            ) : (
-              <GitBranch size={11} className="text-gray-500 shrink-0" strokeWidth={1.5} />
+            {session.isWorktree && session.worktreeName && (
+              <>
+                <FolderGit2 size={11} className="text-amber-500 shrink-0" strokeWidth={1.5} />
+                <span className="font-mono text-amber-400 truncate max-w-[140px]">
+                  {session.worktreeName}
+                </span>
+              </>
             )}
-            <span
-              className={`font-mono truncate max-w-[140px] ${
-                terminal.session.isWorktree ? 'text-amber-400' : 'text-gray-400'
-              }`}
-            >
-              {getBranchLabel(terminal.session)}
-            </span>
-            {terminal.session.isWorktree && (
-              <span className="text-[10px] text-amber-500/60">worktree</span>
-            )}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={togglePicker}
+                disabled={isSwitching}
+                className={`flex items-center gap-1 transition-colors rounded px-1 -mx-1 ${
+                  showPicker
+                    ? 'text-gray-200 bg-white/[0.08]'
+                    : 'text-gray-400 hover:text-gray-200 hover:bg-white/[0.06]'
+                } ${isSwitching ? 'opacity-50' : ''}`}
+              >
+                <GitBranch size={11} className="text-gray-500 shrink-0" strokeWidth={1.5} />
+                <span className="font-mono truncate max-w-[140px]">{branchName}</span>
+                <ChevronDown size={10} className="text-gray-500 shrink-0" />
+              </button>
+              {showPicker && (
+                <BranchPicker
+                  projectPath={projectPath}
+                  currentBranch={branchName}
+                  onSelect={selectBranch}
+                  onClose={closePicker}
+                  position="above"
+                />
+              )}
+            </div>
           </div>
         )}
 
@@ -71,7 +101,7 @@ export function SessionStatusBar({ terminalId }: Props) {
         <StatusBadge status={terminal.status} />
         <GitChangesIndicator terminalId={terminalId} />
         <BrowseFilesButton terminalId={terminalId} />
-        <OpenInButton projectPath={terminal.session.projectPath} direction="up" />
+        <OpenInButton projectPath={session.projectPath} direction="up" />
       </div>
     </div>
   )

--- a/src/renderer/components/ToolbarBreadcrumb.tsx
+++ b/src/renderer/components/ToolbarBreadcrumb.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback } from 'react'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL } from '../stores/types'
 import type { WorktreeInfo } from '../stores/types'
 import { ChevronRight, GitBranch, ChevronDown } from 'lucide-react'
 import { BranchPicker } from './BranchPicker'
-import { toast } from './Toast'
+import { useBranchSwitcher } from '../hooks/useBranchSwitcher'
 
 const EMPTY_WORKTREES: WorktreeInfo[] = []
 
@@ -13,7 +12,6 @@ export function ToolbarBreadcrumb() {
   const activeWorktreePath = useAppStore((s) => s.activeWorktreePath)
   const setActiveWorktreePath = useAppStore((s) => s.setActiveWorktreePath)
   const worktreeCache = useAppStore((s) => s.worktreeCache)
-  const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const projects = useAppStore((s) => s.config?.projects)
 
   const project = projects?.find((p) => p.name === activeProject)
@@ -29,29 +27,13 @@ export function ToolbarBreadcrumb() {
 
   const worktreeName = isMainWorktree ? null : activeWorktree?.name
   const branchName = activeWorktree?.branch
-  const branchCwd = isMainWorktree ? projectPath : activeWorktreePath
+  const branchCwd = isMainWorktree ? projectPath : (activeWorktreePath ?? undefined)
 
-  const [showBranchPicker, setShowBranchPicker] = useState(false)
-  const [isSwitching, setIsSwitching] = useState(false)
-
-  const handleBranchSelect = useCallback(
-    async (branch: string) => {
-      if (!branchCwd || !projectPath || branch === branchName || isSwitching) return
-      setIsSwitching(true)
-      try {
-        const result = await window.api.checkoutBranch(branchCwd, branch)
-        if (result.ok) {
-          loadWorktrees(projectPath, true)
-        } else {
-          toast.error(result.error || `Failed to checkout '${branch}'`)
-        }
-      } finally {
-        setIsSwitching(false)
-        setShowBranchPicker(false)
-      }
-    },
-    [branchCwd, projectPath, branchName, isSwitching, loadWorktrees]
-  )
+  const { showPicker, togglePicker, closePicker, isSwitching, selectBranch } = useBranchSwitcher({
+    projectPath,
+    branchCwd,
+    branchName
+  })
 
   if (!activeProject) return null
 
@@ -78,23 +60,21 @@ export function ToolbarBreadcrumb() {
               <ChevronRight size={10} className="text-gray-600 shrink-0 mx-0.5" />
               <div className="relative shrink-0">
                 <button
-                  onClick={() => setShowBranchPicker(!showBranchPicker)}
+                  onClick={togglePicker}
                   className={`flex items-center gap-1 transition-colors rounded px-1 -mx-1 ${
-                    showBranchPicker
-                      ? 'text-white bg-white/[0.08]'
-                      : 'text-white hover:bg-white/[0.06]'
+                    showPicker ? 'text-white bg-white/[0.08]' : 'text-white hover:bg-white/[0.06]'
                   } ${isSwitching ? 'opacity-50' : ''}`}
                 >
                   <GitBranch size={11} className="text-gray-500 shrink-0" />
                   <span className="truncate max-w-[120px]">{branchName}</span>
                   <ChevronDown size={10} className="text-gray-500 shrink-0" />
                 </button>
-                {showBranchPicker && (
+                {showPicker && (
                   <BranchPicker
                     projectPath={projectPath}
                     currentBranch={branchName}
-                    onSelect={handleBranchSelect}
-                    onClose={() => setShowBranchPicker(false)}
+                    onSelect={selectBranch}
+                    onClose={closePicker}
                   />
                 )}
               </div>

--- a/src/renderer/hooks/useBranchSwitcher.ts
+++ b/src/renderer/hooks/useBranchSwitcher.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+import { useAppStore } from '../stores'
+import { toast } from '../components/Toast'
+
+interface Params {
+  projectPath?: string
+  branchCwd?: string
+  branchName?: string
+}
+
+export function useBranchSwitcher({ projectPath, branchCwd, branchName }: Params) {
+  const loadWorktrees = useAppStore((s) => s.loadWorktrees)
+  const [showPicker, setShowPicker] = useState(false)
+  const [isSwitching, setIsSwitching] = useState(false)
+
+  const togglePicker = useCallback(() => setShowPicker((v) => !v), [])
+  const closePicker = useCallback(() => setShowPicker(false), [])
+
+  const selectBranch = useCallback(
+    async (branch: string) => {
+      if (!branchCwd || !projectPath || branch === branchName || isSwitching) return
+      setIsSwitching(true)
+      try {
+        const result = await window.api.checkoutBranch(branchCwd, branch)
+        if (result.ok) {
+          loadWorktrees(projectPath, true)
+        } else {
+          toast.error(result.error || `Failed to checkout '${branch}'`)
+        }
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : `Failed to checkout '${branch}'`)
+      } finally {
+        setIsSwitching(false)
+        setShowPicker(false)
+      }
+    },
+    [branchCwd, projectPath, branchName, isSwitching, loadWorktrees]
+  )
+
+  return { showPicker, togglePicker, closePicker, isSwitching, selectBranch }
+}

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -10,3 +10,8 @@ export const isWeb =
   window.api.getAppVersion() === 'web'
 
 export const isElectron = !isWeb
+
+export const isMac =
+  typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC')
+
+export const MOD = isMac ? '⌘' : 'Ctrl+'

--- a/tests/session-status-bar.test.tsx
+++ b/tests/session-status-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, within, act } from '@testing-library/react'
+import { render, screen, within, act, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { ReactNode } from 'react'
 
@@ -70,7 +70,10 @@ Object.defineProperty(window, 'api', {
     saveConfig: vi.fn(),
     notifyWidgetStatus: vi.fn(),
     getGitDiffStat: vi.fn().mockResolvedValue(null),
-    createTerminal: vi.fn()
+    createTerminal: vi.fn(),
+    listBranches: vi.fn().mockResolvedValue({ local: [], remote: [] }),
+    listRemoteBranches: vi.fn().mockResolvedValue([]),
+    checkoutBranch: vi.fn().mockResolvedValue({ ok: true })
   },
   writable: true
 })
@@ -133,7 +136,25 @@ describe('SessionStatusBar (homologated bottom bar)', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders worktree label for worktree sessions', () => {
+  it('opens BranchPicker and switches branches via the dropdown', async () => {
+    const listBranches = vi.fn().mockResolvedValue({ local: ['main', 'feature-x'], remote: [] })
+    const checkoutBranch = vi.fn().mockResolvedValue({ ok: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window.api as any).listBranches = listBranches
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window.api as any).checkoutBranch = checkoutBranch
+
+    render(<SessionStatusBar terminalId="term-1" />)
+    const branchButton = screen.getByRole('button', { name: /main/ })
+    fireEvent.click(branchButton)
+
+    const featureEntry = await screen.findByText('feature-x')
+    fireEvent.click(featureEntry)
+
+    await waitFor(() => expect(checkoutBranch).toHaveBeenCalledWith('/tmp/vorn', 'feature-x'))
+  })
+
+  it('renders worktree name and branch name for worktree sessions', () => {
     const terminals = new Map()
     terminals.set('wt-1', {
       id: 'wt-1',
@@ -142,6 +163,7 @@ describe('SessionStatusBar (homologated bottom bar)', () => {
         id: 'wt-1',
         branch: 'feature-x',
         isWorktree: true,
+        worktreeName: 'feature-x-wt',
         worktreePath: '/tmp/wt/feature-x'
       },
       status: 'running' as const,
@@ -151,7 +173,9 @@ describe('SessionStatusBar (homologated bottom bar)', () => {
       useAppStore.setState({ terminals })
     })
     render(<SessionStatusBar terminalId="wt-1" />)
-    expect(screen.getByText('worktree')).toBeInTheDocument()
+    expect(screen.getByText('feature-x-wt')).toBeInTheDocument()
+    expect(screen.getByText('feature-x')).toBeInTheDocument()
+    expect(screen.queryByText('worktree')).not.toBeInTheDocument()
   })
 })
 
@@ -218,7 +242,7 @@ describe('FocusedTerminal on mobile keeps branch + StatusBadge in the title bar'
     expect(screen.queryByTestId('git-changes')).not.toBeInTheDocument()
   })
 
-  it('renders the "worktree" label on mobile for worktree sessions', () => {
+  it('renders worktree name and branch name on mobile for worktree sessions', () => {
     mockIsMobile = true
     const terminals = new Map()
     terminals.set('wt-1', {
@@ -228,6 +252,7 @@ describe('FocusedTerminal on mobile keeps branch + StatusBadge in the title bar'
         id: 'wt-1',
         branch: 'feature-x',
         isWorktree: true,
+        worktreeName: 'feature-x-wt',
         worktreePath: '/tmp/wt/feature-x'
       },
       status: 'running' as const,
@@ -237,6 +262,8 @@ describe('FocusedTerminal on mobile keeps branch + StatusBadge in the title bar'
       useAppStore.setState({ terminals, focusedTerminalId: 'wt-1' })
     })
     render(<FocusedTerminal />)
-    expect(screen.getByText('worktree')).toBeInTheDocument()
+    expect(screen.getByText('feature-x-wt')).toBeInTheDocument()
+    expect(screen.getByText('feature-x')).toBeInTheDocument()
+    expect(screen.queryByText('worktree')).not.toBeInTheDocument()
   })
 })

--- a/tests/toolbar-breadcrumb.test.tsx
+++ b/tests/toolbar-breadcrumb.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+Object.defineProperty(window, 'api', {
+  value: {
+    listBranches: vi.fn().mockResolvedValue({ local: ['main', 'feat'], remote: [] }),
+    listRemoteBranches: vi.fn().mockResolvedValue([]),
+    checkoutBranch: vi.fn().mockResolvedValue({ ok: true })
+  },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { ToolbarBreadcrumb } from '../src/renderer/components/ToolbarBreadcrumb'
+
+const initialState = useAppStore.getState()
+
+beforeEach(() => {
+  act(() => {
+    useAppStore.setState({
+      activeProject: 'vorn',
+      activeWorktreePath: '/tmp/vorn/wt/feat',
+      worktreeCache: new Map([
+        [
+          '/tmp/vorn',
+          [
+            {
+              path: '/tmp/vorn/wt/feat',
+              name: 'feat',
+              branch: 'feat',
+              isMain: false
+            }
+          ]
+        ]
+      ]),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      config: { projects: [{ name: 'vorn', path: '/tmp/vorn' }] } as any
+    })
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    useAppStore.setState(initialState)
+  })
+})
+
+describe('ToolbarBreadcrumb', () => {
+  it('renders project, worktree, branch with interactive picker', async () => {
+    render(<ToolbarBreadcrumb />)
+    expect(screen.getByText('vorn')).toBeInTheDocument()
+    expect(screen.getAllByText('feat').length).toBeGreaterThan(0)
+  })
+
+  it('opens BranchPicker and invokes checkoutBranch on select', async () => {
+    render(<ToolbarBreadcrumb />)
+    const branchButton = screen.getByRole('button', { name: /feat/ })
+    fireEvent.click(branchButton)
+    const mainEntry = await screen.findByText('main')
+    fireEvent.click(mainEntry)
+    await waitFor(() =>
+      expect(window.api.checkoutBranch).toHaveBeenCalledWith('/tmp/vorn/wt/feat', 'main')
+    )
+  })
+
+  it('closes picker when BranchPicker requests onClose (Escape)', async () => {
+    render(<ToolbarBreadcrumb />)
+    const branchButton = screen.getByRole('button', { name: /feat/ })
+    fireEvent.click(branchButton)
+    await screen.findByText('main')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByText('main')).not.toBeInTheDocument())
+  })
+})

--- a/tests/use-branch-switcher.test.ts
+++ b/tests/use-branch-switcher.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+const { toastError, loadWorktrees } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  loadWorktrees: vi.fn()
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { error: toastError, success: vi.fn() }
+}))
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector: (s: { loadWorktrees: typeof loadWorktrees }) => unknown) =>
+    selector({ loadWorktrees })
+}))
+
+const checkoutBranch = vi.fn()
+Object.defineProperty(window, 'api', {
+  value: { checkoutBranch },
+  writable: true
+})
+
+import { useBranchSwitcher } from '../src/renderer/hooks/useBranchSwitcher'
+
+beforeEach(() => {
+  toastError.mockReset()
+  loadWorktrees.mockReset()
+  checkoutBranch.mockReset()
+})
+
+describe('useBranchSwitcher', () => {
+  const params = { projectPath: '/p', branchCwd: '/p', branchName: 'main' }
+
+  it('noops when required params are missing', async () => {
+    const { result } = renderHook(() =>
+      useBranchSwitcher({ projectPath: undefined, branchCwd: undefined, branchName: undefined })
+    )
+    await act(async () => {
+      await result.current.selectBranch('feat')
+    })
+    expect(checkoutBranch).not.toHaveBeenCalled()
+  })
+
+  it('noops when selected branch equals current', async () => {
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    await act(async () => {
+      await result.current.selectBranch('main')
+    })
+    expect(checkoutBranch).not.toHaveBeenCalled()
+  })
+
+  it('checkouts and reloads worktrees on success', async () => {
+    checkoutBranch.mockResolvedValue({ ok: true })
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    await act(async () => {
+      await result.current.selectBranch('feat')
+    })
+    expect(checkoutBranch).toHaveBeenCalledWith('/p', 'feat')
+    expect(loadWorktrees).toHaveBeenCalledWith('/p', true)
+    expect(toastError).not.toHaveBeenCalled()
+    expect(result.current.showPicker).toBe(false)
+    expect(result.current.isSwitching).toBe(false)
+  })
+
+  it('surfaces toast on failure and does not reload', async () => {
+    checkoutBranch.mockResolvedValue({ ok: false, error: 'boom' })
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    await act(async () => {
+      await result.current.selectBranch('feat')
+    })
+    expect(toastError).toHaveBeenCalledWith('boom')
+    expect(loadWorktrees).not.toHaveBeenCalled()
+  })
+
+  it('catches IPC rejection and surfaces error via toast', async () => {
+    checkoutBranch.mockRejectedValue(new Error('ipc down'))
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    await act(async () => {
+      await result.current.selectBranch('feat')
+    })
+    expect(toastError).toHaveBeenCalledWith('ipc down')
+    expect(result.current.isSwitching).toBe(false)
+    expect(result.current.showPicker).toBe(false)
+  })
+
+  it('falls back to generic error when result.error missing', async () => {
+    checkoutBranch.mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    await act(async () => {
+      await result.current.selectBranch('feat')
+    })
+    expect(toastError).toHaveBeenCalledWith("Failed to checkout 'feat'")
+  })
+
+  it('guards against concurrent calls via isSwitching', async () => {
+    let resolve!: (v: { ok: true }) => void
+    checkoutBranch.mockReturnValue(
+      new Promise<{ ok: true }>((r) => {
+        resolve = r
+      })
+    )
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    act(() => {
+      void result.current.selectBranch('feat')
+    })
+    await waitFor(() => expect(result.current.isSwitching).toBe(true))
+    await act(async () => {
+      await result.current.selectBranch('other')
+    })
+    expect(checkoutBranch).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      resolve({ ok: true })
+    })
+  })
+
+  it('togglePicker flips state; closePicker sets false', () => {
+    const { result } = renderHook(() => useBranchSwitcher(params))
+    expect(result.current.showPicker).toBe(false)
+    act(() => result.current.togglePicker())
+    expect(result.current.showPicker).toBe(true)
+    act(() => result.current.togglePicker())
+    expect(result.current.showPicker).toBe(false)
+    act(() => result.current.togglePicker())
+    act(() => result.current.closePicker())
+    expect(result.current.showPicker).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- **Bottom status bar hosts the branch switcher.** `SessionStatusBar` (mounted in both the focused view and `TabView`) now renders `BranchPicker` directly — one click from either view to check out a different branch in the session's worktree/project. Worktree sessions render `worktree-name` (amber folder) + `branch-name` instead of the literal "worktree" word.
- **Focused header cleanup.** Removed the permanent `⌘W collapse` / `⌘[ ⌘] cycle` `kbd` chip strip; moved `⌘W` into the collapse button's `Tooltip` via the existing `shortcut` prop. The grid card's expand button gets the same treatment (`⌘O`). Mobile branch row updated to the same mini-card format (no "worktree" word).
- **`isWorktree` flag fix.** Right-clicking the main-branch submenu item passed `existingWorktreePath` equal to the project root, which made the session renderer flag it as a managed worktree (amber folder icon). `pty-manager.createLocalPty` now compares normalized paths and skips the worktree fields when the existing path is the project root.

## Test plan

- [ ] Right-click a project → open main branch → card shows gray branch icon, not amber folder.
- [ ] Focused view (desktop): bottom status bar shows the session's branch with a dropdown arrow; clicking opens `BranchPicker`; switching branches runs `checkoutBranch` against the session's cwd.
- [ ] Same branch-switch flow from a tab view — behaves identically (same component).
- [ ] Worktree session in focused/tab view: status bar shows `📁 worktree-name 🌿 branch-name`; no "worktree" word.
- [ ] Mobile: focused header branch row shows the mini-card format; no chip strip; no top toolbar (as before).
- [ ] Expand button tooltip shows `⌘O`; collapse button tooltip shows `⌘W`.