### PR TITLE
fix: restore popover layering over terminals and escape sidebar clipping

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -393,7 +393,7 @@ export const AgentCard = memo(
             <button
               className="absolute bottom-2 right-2 w-8 h-8 flex items-center justify-center
                            rounded bg-white/[0.08] hover:bg-white/[0.15] active:bg-white/[0.2]
-                           text-gray-400 hover:text-white transition-colors z-10"
+                           text-gray-400 hover:text-white transition-colors z-50"
               onClick={handleScrollToBottom}
               title="Scroll to bottom"
             >

--- a/src/renderer/components/BranchPicker.tsx
+++ b/src/renderer/components/BranchPicker.tsx
@@ -1,5 +1,15 @@
-import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
+import {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  RefObject
+} from 'react'
+import { createPortal } from 'react-dom'
 import { GitBranch, Loader2, RefreshCw } from 'lucide-react'
+import { AnchorRect, calculatePopoverPosition } from '../lib/popover-position'
 
 interface BranchPickerProps {
   projectPath: string
@@ -7,8 +17,20 @@ interface BranchPickerProps {
   selectedBranch?: string
   onSelect: (branch: string) => void
   onClose: () => void
-  position?: 'above' | 'below'
   minWidth?: number
+  anchorRef: RefObject<HTMLElement | null>
+}
+
+function readAnchorRect(el: HTMLElement): AnchorRect {
+  const r = el.getBoundingClientRect()
+  return {
+    top: r.top,
+    left: r.left,
+    right: r.right,
+    bottom: r.bottom,
+    width: r.width,
+    height: r.height
+  }
 }
 
 export function BranchPicker({
@@ -17,8 +39,8 @@ export function BranchPicker({
   selectedBranch,
   onSelect,
   onClose,
-  position = 'below',
-  minWidth = 220
+  minWidth = 220,
+  anchorRef
 }: BranchPickerProps) {
   const [localBranches, setLocalBranches] = useState<string[]>([])
   const [remoteBranches, setRemoteBranches] = useState<string[]>([])
@@ -27,6 +49,42 @@ export function BranchPicker({
   const [loadingRemotes, setLoadingRemotes] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
+
+  useLayoutEffect(() => {
+    const updatePosition = () => {
+      const anchor = anchorRef.current
+      if (!anchor) return
+      const popoverRect = ref.current?.getBoundingClientRect()
+      const next = calculatePopoverPosition(
+        readAnchorRect(anchor),
+        { width: popoverRect?.width ?? minWidth, height: popoverRect?.height ?? 200 },
+        { width: window.innerWidth, height: window.innerHeight }
+      )
+      setPosition((prev) =>
+        prev && prev.top === next.top && prev.left === next.left
+          ? prev
+          : { top: next.top, left: next.left }
+      )
+    }
+    updatePosition()
+
+    let frame = 0
+    const scheduleUpdate = () => {
+      if (frame) return
+      frame = window.requestAnimationFrame(() => {
+        frame = 0
+        updatePosition()
+      })
+    }
+    window.addEventListener('resize', scheduleUpdate)
+    window.addEventListener('scroll', scheduleUpdate, true)
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame)
+      window.removeEventListener('resize', scheduleUpdate)
+      window.removeEventListener('scroll', scheduleUpdate, true)
+    }
+  }, [anchorRef, minWidth])
 
   useEffect(() => {
     setLoadingLocal(true)
@@ -41,7 +99,9 @@ export function BranchPicker({
 
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+      const target = e.target as Node
+      if (anchorRef.current?.contains(target)) return
+      if (ref.current && !ref.current.contains(target)) onClose()
     }
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -52,7 +112,7 @@ export function BranchPicker({
       document.removeEventListener('mousedown', handleMouseDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [onClose])
+  }, [onClose, anchorRef])
 
   useEffect(() => {
     setTimeout(() => inputRef.current?.focus(), 0)
@@ -88,13 +148,18 @@ export function BranchPicker({
   )
 
   const active = selectedBranch ?? currentBranch
-  const positionClass = position === 'above' ? 'bottom-full mb-1' : 'top-full mt-1'
 
-  return (
+  return createPortal(
     <div
       ref={ref}
-      className={`absolute ${positionClass} left-1/2 -translate-x-1/2 border border-white/[0.08] rounded-lg shadow-xl z-50 max-h-[280px] overflow-hidden flex flex-col`}
-      style={{ background: '#1e1e22', minWidth }}
+      className="fixed border border-white/[0.08] rounded-lg shadow-xl z-[150] max-h-[280px] overflow-hidden flex flex-col"
+      style={{
+        background: '#1e1e22',
+        minWidth,
+        top: position?.top ?? 0,
+        left: position?.left ?? 0,
+        visibility: position ? 'visible' : 'hidden'
+      }}
     >
       <div className="p-2 border-b border-white/[0.06] flex items-center gap-1">
         <input
@@ -144,6 +209,7 @@ export function BranchPicker({
           ))
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/renderer/components/BranchPicker.tsx
+++ b/src/renderer/components/BranchPicker.tsx
@@ -79,10 +79,17 @@ export function BranchPicker({
     }
     window.addEventListener('resize', scheduleUpdate)
     window.addEventListener('scroll', scheduleUpdate, true)
+
+    const popover = ref.current
+    const resizeObserver =
+      popover && typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleUpdate) : null
+    if (popover && resizeObserver) resizeObserver.observe(popover)
+
     return () => {
       if (frame) window.cancelAnimationFrame(frame)
       window.removeEventListener('resize', scheduleUpdate)
       window.removeEventListener('scroll', scheduleUpdate, true)
+      resizeObserver?.disconnect()
     }
   }, [anchorRef, minWidth])
 

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -205,7 +205,7 @@ export function FocusedTerminal() {
             className="w-full h-full"
           />
           {/* Mobile: floating controls (font size + scroll) */}
-          <div className="absolute bottom-4 right-4 flex flex-col items-end gap-2 z-10">
+          <div className="absolute bottom-4 right-4 flex flex-col items-end gap-2 z-50">
             {isMobile && <MobileFontSizeControl />}
             {showScrollBtn && (
               <button

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -49,7 +49,7 @@ export function FocusedTerminal() {
       {/* Backdrop — mobile only */}
       {isMobile && (
         <motion.div
-          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-30"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           onClick={handleContract}
@@ -60,7 +60,7 @@ export function FocusedTerminal() {
       <motion.div
         className={
           isMobile
-            ? 'fixed inset-0 z-50 shadow-2xl flex flex-col overflow-hidden'
+            ? 'fixed inset-0 z-40 shadow-2xl flex flex-col overflow-hidden'
             : 'flex-1 flex flex-col min-h-0 overflow-hidden'
         }
         style={{

--- a/src/renderer/components/MobileBottomTabs.tsx
+++ b/src/renderer/components/MobileBottomTabs.tsx
@@ -51,7 +51,7 @@ export function MobileBottomTabs({ hidden }: Props) {
 
   return (
     <nav
-      className="fixed left-3 right-3 flex items-stretch rounded-[32px] z-50"
+      className="fixed left-3 right-3 flex items-stretch rounded-[32px] z-[35]"
       style={{
         bottom: 'calc(12px + var(--safe-bottom, 0px))',
         background: 'var(--glass-bg, #141416)',

--- a/src/renderer/components/PromptLauncher.tsx
+++ b/src/renderer/components/PromptLauncher.tsx
@@ -86,6 +86,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
   const agentPickerRef = useRef<HTMLDivElement>(null)
   const projectPickerRef = useRef<HTMLDivElement>(null)
   const worktreePickerRef = useRef<HTMLDivElement>(null)
+  const branchButtonRef = useRef<HTMLButtonElement>(null)
 
   const settings = useLaunchSettings()
   const selectedProjectConfig = config?.projects.find((p) => p.name === settings.selectedProject)
@@ -413,6 +414,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
       {settings.activeProjectPath && settings.isGitRepo && (
         <div className="relative" ref={settings.dropdownRef}>
           <button
+            ref={branchButtonRef}
             onClick={() => settings.setShowBranchDropdown(!settings.showBranchDropdown)}
             className="flex items-center gap-1.5 px-2 py-1 rounded-md
                        hover:bg-white/[0.06] transition-colors text-gray-400"
@@ -433,7 +435,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
                 settings.setShowBranchDropdown(false)
               }}
               onClose={() => settings.setShowBranchDropdown(false)}
-              position="above"
+              anchorRef={branchButtonRef}
             />
           )}
           {settings.branchWarning && (

--- a/src/renderer/components/SessionStatusBar.tsx
+++ b/src/renderer/components/SessionStatusBar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useAppStore } from '../stores'
 import { useShallow } from 'zustand/react/shallow'
 import { StatusBadge } from './StatusBadge'
@@ -24,6 +25,7 @@ export function SessionStatusBar({ terminalId }: Props) {
   const session = terminal?.session
   const branchCwd = session && (session.worktreePath ?? session.projectPath)
 
+  const branchButtonRef = useRef<HTMLButtonElement>(null)
   const { showPicker, togglePicker, closePicker, isSwitching, selectBranch } = useBranchSwitcher({
     projectPath: session?.projectPath,
     branchCwd,
@@ -59,6 +61,7 @@ export function SessionStatusBar({ terminalId }: Props) {
             )}
             <div className="relative">
               <button
+                ref={branchButtonRef}
                 type="button"
                 onClick={togglePicker}
                 disabled={isSwitching}
@@ -78,7 +81,7 @@ export function SessionStatusBar({ terminalId }: Props) {
                   currentBranch={branchName}
                   onSelect={selectBranch}
                   onClose={closePicker}
-                  position="above"
+                  anchorRef={branchButtonRef}
                 />
               )}
             </div>

--- a/src/renderer/components/TerminalHost.tsx
+++ b/src/renderer/components/TerminalHost.tsx
@@ -59,10 +59,10 @@ export function TerminalHost() {
 
   return (
     <>
-      {/* Sits above FocusedTerminal's mobile panel (z-50) so the overlay is
-          visible there, below popovers and context menus (z-[150]+). Pointer
-          events disabled on the root — wrappers opt back in when active. */}
-      <div ref={rootRef} className="fixed inset-0 pointer-events-none z-[60]" />
+      {/* Sits above FocusedTerminal's mobile panel (z-40) and below popovers
+          (z-50+) so every popover renders on top of the terminal overlay.
+          Pointer events disabled on the root — wrappers opt back in when active. */}
+      <div ref={rootRef} className="fixed inset-0 pointer-events-none z-[45]" />
       {ctxMenu && (
         <TerminalContextMenu
           terminalId={ctxMenu.terminalId}

--- a/src/renderer/components/ToolbarBreadcrumb.tsx
+++ b/src/renderer/components/ToolbarBreadcrumb.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL } from '../stores/types'
 import type { WorktreeInfo } from '../stores/types'
@@ -29,6 +30,7 @@ export function ToolbarBreadcrumb() {
   const branchName = activeWorktree?.branch
   const branchCwd = isMainWorktree ? projectPath : (activeWorktreePath ?? undefined)
 
+  const branchButtonRef = useRef<HTMLButtonElement>(null)
   const { showPicker, togglePicker, closePicker, isSwitching, selectBranch } = useBranchSwitcher({
     projectPath,
     branchCwd,
@@ -60,6 +62,7 @@ export function ToolbarBreadcrumb() {
               <ChevronRight size={10} className="text-gray-600 shrink-0 mx-0.5" />
               <div className="relative shrink-0">
                 <button
+                  ref={branchButtonRef}
                   onClick={togglePicker}
                   className={`flex items-center gap-1 transition-colors rounded px-1 -mx-1 ${
                     showPicker ? 'text-white bg-white/[0.08]' : 'text-white hover:bg-white/[0.06]'
@@ -75,6 +78,7 @@ export function ToolbarBreadcrumb() {
                     currentBranch={branchName}
                     onSelect={selectBranch}
                     onClose={closePicker}
+                    anchorRef={branchButtonRef}
                   />
                 )}
               </div>

--- a/tests/branch-picker.test.tsx
+++ b/tests/branch-picker.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useRef } from 'react'
 import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
@@ -43,8 +43,8 @@ function Harness({
 
 describe('BranchPicker', () => {
   beforeEach(() => {
-    mockListBranches.mockResolvedValue({ local: ['main', 'dev'] })
-    mockListRemoteBranches.mockResolvedValue([])
+    mockListBranches.mockReset().mockResolvedValue({ local: ['main', 'dev'] })
+    mockListRemoteBranches.mockReset().mockResolvedValue([])
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       top: 100,
       left: 200,
@@ -56,6 +56,10 @@ describe('BranchPicker', () => {
       y: 100,
       toJSON: () => ({})
     })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('positions the portal based on the anchor rect', () => {

--- a/tests/branch-picker.test.tsx
+++ b/tests/branch-picker.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useRef } from 'react'
+import { render, screen, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockListBranches = vi.fn()
+const mockListRemoteBranches = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    listBranches: (...args: unknown[]) => mockListBranches(...args),
+    listRemoteBranches: (...args: unknown[]) => mockListRemoteBranches(...args)
+  },
+  writable: true
+})
+
+import { BranchPicker } from '../src/renderer/components/BranchPicker'
+
+function Harness({
+  onClose = () => {},
+  onSelect = () => {}
+}: {
+  onClose?: () => void
+  onSelect?: (b: string) => void
+}) {
+  const anchorRef = useRef<HTMLButtonElement>(null)
+  return (
+    <div>
+      <button ref={anchorRef} data-testid="anchor">
+        main
+      </button>
+      <BranchPicker
+        projectPath="/tmp/proj"
+        currentBranch="main"
+        onSelect={onSelect}
+        onClose={onClose}
+        anchorRef={anchorRef}
+      />
+    </div>
+  )
+}
+
+describe('BranchPicker', () => {
+  beforeEach(() => {
+    mockListBranches.mockResolvedValue({ local: ['main', 'dev'] })
+    mockListRemoteBranches.mockResolvedValue([])
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 100,
+      left: 200,
+      right: 260,
+      bottom: 120,
+      width: 60,
+      height: 20,
+      x: 200,
+      y: 100,
+      toJSON: () => ({})
+    })
+  })
+
+  it('positions the portal based on the anchor rect', () => {
+    render(<Harness />)
+    const portal = screen.getByPlaceholderText('Filter branches...').closest('div.fixed')
+    expect(portal).toBeInTheDocument()
+    expect((portal as HTMLElement).style.visibility).toBe('visible')
+    expect((portal as HTMLElement).style.top).not.toBe('')
+    expect((portal as HTMLElement).style.left).not.toBe('')
+  })
+
+  it('repositions on scroll via rAF', () => {
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+    render(<Harness />)
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+      window.dispatchEvent(new Event('scroll'))
+    })
+    expect(rafSpy).toHaveBeenCalled()
+    rafSpy.mockRestore()
+  })
+
+  it('does not call onClose when mousedown originates on the anchor', () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+    const anchor = screen.getByTestId('anchor')
+    act(() => {
+      anchor.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when mousedown is outside picker and anchor', () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- **Z-stack**: the persistent terminal overlay (#221) sat at `z-[60]`, covering every `z-50` popover (workflow context menu, branch picker, etc.). Overlay lowered to `z-[45]` and FocusedTerminal mobile panel/backdrop to `z-40`/`z-30` so popovers always render on top.
- **BranchPicker clipping**: was `position: absolute` inside a `.relative` container, so ancestor `overflow: hidden` (tab container abutting the sidebar) chopped off its left portion. Switched to portal + `position: fixed` anchored to the trigger rect via the existing `calculatePopoverPosition` helper (same pattern as `ConfirmPopover`). Auto-flips above/below based on viewport; `rAF`-throttled scroll/resize updates with an equality guard to avoid no-op re-renders.

## Test plan
- [x] Typecheck + lint + existing tests pass
- [ ] Workflow `...` context menu renders above the terminal
- [ ] Session status-bar branch picker renders above the terminal and is fully visible (not clipped by the sidebar)
- [ ] Toolbar breadcrumb branch picker still works
- [ ] PromptLauncher branch picker still works
- [ ] Mobile focused terminal overlay still works