### PR TITLE
fix: raise settings page and popover backdrops above terminal overlay

### DIFF
--- a/src/renderer/components/RecentSessionsPopover.tsx
+++ b/src/renderer/components/RecentSessionsPopover.tsx
@@ -67,7 +67,7 @@ export function RecentSessionsPopover({ isOpen, onClose }: Props) {
       {isOpen && (
         <>
           {/* Backdrop — titlebar-no-drag so clicks on Electron drag regions still close */}
-          <div className="fixed inset-0 z-40 titlebar-no-drag" onClick={onClose} />
+          <div className="fixed inset-0 z-50 titlebar-no-drag" onClick={onClose} />
           <motion.div
             className="absolute top-full right-0 mt-2 z-50 w-[380px] max-h-[400px]
                        border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden flex flex-col"

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -159,7 +159,7 @@ export function SettingsPage() {
 
   return (
     <motion.div
-      className="fixed inset-0 z-40 flex"
+      className="fixed inset-0 z-50 flex"
       style={{
         background: '#1a1a1e',
         paddingTop: 'var(--safe-top, 0px)',

--- a/src/renderer/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/components/WorkspaceSwitcher.tsx
@@ -227,7 +227,7 @@ export function WorkspaceSwitcher() {
       {/* Backdrop — titlebar-no-drag so clicks on Electron drag regions still close */}
       {isOpen && (
         <div
-          className="fixed inset-0 z-40 titlebar-no-drag"
+          className="fixed inset-0 z-50 titlebar-no-drag"
           onClick={() => {
             setIsOpen(false)
             resetForm()


### PR DESCRIPTION
## Summary
- Raise `SettingsPage` from `z-40` to `z-50` so the full-screen settings page paints above the persistent `TerminalHost` (`z-[45]`) instead of letting terminal content bleed through.
- Raise the click-outside backdrops of `WorkspaceSwitcher` and `RecentSessionsPopover` from `z-40` to `z-50` so backdrop clicks over the terminal area still dismiss those popovers.

Same class of bug fixed for `WorkflowEditor` in #223 — sweeping the rest of the app caught these three. `FocusedTerminal` (mobile panel `z-40` / backdrop `z-30`) and `MobileBottomTabs` (`z-[35]`) intentionally sit below the terminal overlay and were left alone.

## Test plan
- [x] Open Settings with live terminals running in the grid — page covers cleanly, no bleed-through.
- [ ] Open the workspace switcher dropdown, click over a visible terminal area — popover closes.
- [ ] Open recent-sessions popover, click over a visible terminal area — popover closes.