### PR TITLE
fix: route todo→in_progress through default workflow

### DIFF
--- a/src/renderer/components/StatusPicker.tsx
+++ b/src/renderer/components/StatusPicker.tsx
@@ -29,6 +29,7 @@ export function StatusPicker({
   const cancelTask = useAppStore((s) => s.cancelTask)
   const reopenTask = useAppStore((s) => s.reopenTask)
   const reviewTask = useAppStore((s) => s.reviewTask)
+  const updateTask = useAppStore((s) => s.updateTask)
 
   const badge = STATUS_BADGE[currentStatus]
   const CurrentIcon = STATUS_ICON[currentStatus]
@@ -64,13 +65,13 @@ export function StatusPicker({
     // Store mode: call dedicated store methods for existing tasks
     if (!taskId) return
 
-    // todo -> in_progress is disabled (requires Start Task)
-    if (status === 'in_progress' && currentStatus === 'todo') return
-
     switch (status) {
       case 'todo':
         reopenTask(taskId)
         toast.success('Task reopened')
+        break
+      case 'in_progress':
+        updateTask(taskId, { status: 'in_progress' })
         break
       case 'in_review':
         reviewTask(taskId)
@@ -104,9 +105,6 @@ export function StatusPicker({
       document.removeEventListener('keydown', handleKey)
     }
   }, [open])
-
-  // In store mode (no onChange), disable in_progress when coming from todo
-  const isStoreMode = !onChange
 
   return (
     <>
@@ -142,28 +140,17 @@ export function StatusPicker({
                 const b = STATUS_BADGE[status]
                 const Icon = STATUS_ICON[status]
                 const isCurrent = status === currentStatus
-                const isItemDisabled =
-                  isStoreMode && status === 'in_progress' && currentStatus === 'todo'
 
                 return (
                   <button
                     key={status}
                     onClick={(e) => {
                       e.stopPropagation()
-                      if (!isItemDisabled) handleSelect(status)
+                      handleSelect(status)
                     }}
-                    disabled={isItemDisabled}
-                    className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-xs transition-colors ${
-                      isItemDisabled
-                        ? 'text-gray-600 cursor-not-allowed'
-                        : 'text-gray-300 hover:bg-white/[0.06] cursor-pointer'
-                    }`}
-                    title={isItemDisabled ? 'Use Start Task to begin work' : undefined}
+                    className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs transition-colors text-gray-300 hover:bg-white/[0.06] cursor-pointer"
                   >
-                    <Icon
-                      size={14}
-                      className={isItemDisabled ? 'text-gray-600' : STATUS_ICON_COLOR[status]}
-                    />
+                    <Icon size={14} className={STATUS_ICON_COLOR[status]} />
                     <span className="flex-1 text-left">{b.label}</span>
                     {isCurrent && <Check size={13} className="text-gray-400" />}
                   </button>

--- a/src/renderer/components/StatusPicker.tsx
+++ b/src/renderer/components/StatusPicker.tsx
@@ -71,6 +71,10 @@ export function StatusPicker({
         toast.success('Task reopened')
         break
       case 'in_progress':
+        // Only todo → in_progress is supported: the seeded Default Task
+        // Workflow listens for that exact transition. Other sources would
+        // leave completedAt/assignedSessionId stale with no agent spawn.
+        if (currentStatus !== 'todo') return
         updateTask(taskId, { status: 'in_progress' })
         break
       case 'in_review':
@@ -140,17 +144,30 @@ export function StatusPicker({
                 const b = STATUS_BADGE[status]
                 const Icon = STATUS_ICON[status]
                 const isCurrent = status === currentStatus
+                // In store mode, in_progress is only reachable from todo — the
+                // default workflow only fires on that transition.
+                const isItemDisabled =
+                  !onChange && status === 'in_progress' && currentStatus !== 'todo'
 
                 return (
                   <button
                     key={status}
                     onClick={(e) => {
                       e.stopPropagation()
-                      handleSelect(status)
+                      if (!isItemDisabled) handleSelect(status)
                     }}
-                    className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs transition-colors text-gray-300 hover:bg-white/[0.06] cursor-pointer"
+                    disabled={isItemDisabled}
+                    className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-xs transition-colors ${
+                      isItemDisabled
+                        ? 'text-gray-600 cursor-not-allowed'
+                        : 'text-gray-300 hover:bg-white/[0.06] cursor-pointer'
+                    }`}
+                    title={isItemDisabled ? 'Move to Todo first, then start the task' : undefined}
                   >
-                    <Icon size={14} className={STATUS_ICON_COLOR[status]} />
+                    <Icon
+                      size={14}
+                      className={isItemDisabled ? 'text-gray-600' : STATUS_ICON_COLOR[status]}
+                    />
                     <span className="flex-1 text-left">{b.label}</span>
                     {isCurrent && <Check size={13} className="text-gray-400" />}
                   </button>

--- a/src/renderer/components/TaskDetailPanel.tsx
+++ b/src/renderer/components/TaskDetailPanel.tsx
@@ -8,7 +8,7 @@ import {
   supportsExactSessionResume,
   getProjectRemoteHostId
 } from '../../shared/types'
-import { buildTaskPrompt, buildFeedbackPrompt } from '../../shared/prompt-builder'
+import { buildFeedbackPrompt } from '../../shared/prompt-builder'
 import { TASK_TEMPLATE } from './MarkdownEditor'
 const RichMarkdownEditor = lazy(() =>
   import('./rich-editor/RichMarkdownEditor').then((m) => ({ default: m.RichMarkdownEditor }))
@@ -370,25 +370,6 @@ export function TaskDetailPanel() {
     document.addEventListener('pointerup', onUp)
   }
 
-  const handleStartTask = async () => {
-    if (!project || !task) return
-    const agentType = formAssignedAgent ?? config?.defaults.defaultAgent ?? 'claude'
-    const siblingTasks = (config?.tasks || []).filter((t) => t.projectName === task.projectName)
-    const remoteHostId = getProjectRemoteHostId(project)
-    const session = await window.api.createTerminal({
-      agentType,
-      projectName: project.name,
-      projectPath: project.path,
-      branch: task.branch,
-      useWorktree: task.useWorktree,
-      initialPrompt: buildTaskPrompt({ task, project, siblingTasks }),
-      taskId: task.id,
-      remoteHostId
-    })
-    addTerminal(session)
-    startTask(task.id, session.id, agentType, session.worktreePath)
-  }
-
   const handleFocusSession = () => {
     if (task?.assignedSessionId) setFocusedTerminal(task.assignedSessionId)
   }
@@ -598,8 +579,7 @@ export function TaskDetailPanel() {
     })
   }
 
-  const hasSessionActions =
-    !isCreateMode && task && (task.status === 'todo' || sessionIsLive || canResume)
+  const hasSessionActions = !isCreateMode && task && (sessionIsLive || canResume)
 
   return (
     <div
@@ -807,17 +787,6 @@ export function TaskDetailPanel() {
         {/* Session action buttons (compact) */}
         {hasSessionActions && (
           <div className="px-4 py-2 border-t border-white/[0.06] flex flex-wrap gap-2">
-            {task.status === 'todo' && (
-              <button
-                onClick={handleStartTask}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium
-                           bg-green-500/10 hover:bg-green-500/20 border border-green-500/20
-                           rounded-md transition-colors text-green-400 hover:text-green-300"
-              >
-                <Play size={12} strokeWidth={2} />
-                Start Task
-              </button>
-            )}
             {sessionIsLive && (
               <button
                 onClick={handleFocusSession}

--- a/tests/status-picker.test.tsx
+++ b/tests/status-picker.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const completeTask = vi.fn()
+const cancelTask = vi.fn()
+const reopenTask = vi.fn()
+const reviewTask = vi.fn()
+const updateTask = vi.fn()
+
+const mockState = { completeTask, cancelTask, reopenTask, reviewTask, updateTask }
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() }
+}))
+
+const { StatusPicker } = await import('../src/renderer/components/StatusPicker')
+
+describe('StatusPicker — todo → in_progress routing', () => {
+  beforeEach(() => {
+    completeTask.mockReset()
+    cancelTask.mockReset()
+    reopenTask.mockReset()
+    reviewTask.mockReset()
+    updateTask.mockReset()
+  })
+
+  it('calls updateTask with in_progress when selecting In Progress from todo', () => {
+    const { getByText, getByRole } = render(<StatusPicker taskId="t1" currentStatus="todo" />)
+    fireEvent.click(getByRole('button', { name: /Todo/ }))
+    fireEvent.click(getByText('In Progress'))
+    expect(updateTask).toHaveBeenCalledWith('t1', { status: 'in_progress' })
+    expect(reopenTask).not.toHaveBeenCalled()
+  })
+
+  it('disables In Progress when currentStatus is done (store mode)', () => {
+    const { getByText, getByRole } = render(<StatusPicker taskId="t1" currentStatus="done" />)
+    fireEvent.click(getByRole('button', { name: /Done/ }))
+    const inProgressItem = getByText('In Progress').closest('button')!
+    expect(inProgressItem).toBeDisabled()
+    fireEvent.click(inProgressItem)
+    expect(updateTask).not.toHaveBeenCalled()
+  })
+
+  it('disables In Progress when currentStatus is in_review', () => {
+    const { getByText, getByRole } = render(<StatusPicker taskId="t1" currentStatus="in_review" />)
+    fireEvent.click(getByRole('button', { name: /In Review/ }))
+    const inProgressItem = getByText('In Progress').closest('button')!
+    expect(inProgressItem).toBeDisabled()
+  })
+
+  it('does NOT disable In Progress in controlled mode (onChange provided)', () => {
+    const onChange = vi.fn()
+    const { getByText, getByRole } = render(
+      <StatusPicker currentStatus="done" onChange={onChange} />
+    )
+    fireEvent.click(getByRole('button', { name: /Done/ }))
+    const inProgressItem = getByText('In Progress').closest('button')!
+    expect(inProgressItem).not.toBeDisabled()
+    fireEvent.click(inProgressItem)
+    expect(onChange).toHaveBeenCalledWith('in_progress')
+  })
+
+  it('routes other statuses through their dedicated store methods', () => {
+    const { getByText, getByRole, rerender } = render(
+      <StatusPicker taskId="t1" currentStatus="todo" />
+    )
+    fireEvent.click(getByRole('button', { name: /Todo/ }))
+    fireEvent.click(getByText('Done'))
+    expect(completeTask).toHaveBeenCalledWith('t1')
+
+    rerender(<StatusPicker taskId="t1" currentStatus="done" />)
+    fireEvent.click(getByRole('button', { name: /Done/ }))
+    fireEvent.click(getByText('Todo'))
+    expect(reopenTask).toHaveBeenCalledWith('t1')
+  })
+})


### PR DESCRIPTION
## Summary
- Remove the vestigial **Start Task** button from `TaskDetailPanel` — it was spawning a terminal directly and bypassing the seeded Default Task Workflow introduced in #211.
- Enable the `todo → in_progress` transition in `StatusPicker`; it now just calls `updateTask(taskId, { status: 'in_progress' })`, matching the kanban-drop path in `TaskBoardView`. The `taskStatusChanged` trigger launches the agent through the workflow engine.
- Drop the now-unused `buildTaskPrompt` import and simplify `hasSessionActions`.

## Test plan
- [ ] Drag a task from Todo to In Progress on the board — default workflow fires, agent launches.
- [ ] Open a todo task in the detail panel, click the status pill, pick **In Progress** — same flow triggers; no Start Task button is shown.
- [ ] Confirm the StatusPicker dropdown no longer disables the In Progress item or shows the "Use Start Task to begin work" tooltip.
- [ ] Resume Session / Focus Session / feedback flows in the detail panel still work.