### PR TITLE
fix: restore flex-grid resize handle and keep top bar above scrolled terminals

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -398,9 +398,9 @@ export function App() {
             : undefined
         }
       >
-        {/* Top bar */}
+        {/* Top bar — z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
         <div
-          className={`titlebar-drag shrink-0 border-b border-white/[0.06]
+          className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} h-[52px]`}
           style={!isSidebarOpen && !isWeb && !isMobile ? { paddingLeft: '80px' } : undefined}
         >

--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -358,10 +358,12 @@ export const AgentCard = memo(
         {/* Terminal */}
         <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
           {!isFocused && (
+            // In flexible mode, reserve 16px at SE so the react-grid-layout
+            // resize handle isn't covered by the TerminalHost overlay (z-45).
             <TerminalSlot
               terminalId={terminalId}
               isFocused={isSelected}
-              className="w-full h-full"
+              className={flexible ? 'absolute inset-0 right-4 bottom-4' : 'w-full h-full'}
             />
           )}
           {isFocused && (

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -240,6 +240,9 @@ const FLEX_ROW_H = 80
 const FLEX_DEFAULT_W = 4
 const FLEX_DEFAULT_H = 3
 
+// noCompactor gives free positioning; preventCollision blocks drag/resize into a neighbour.
+const flexCompactor = { ...noCompactor, preventCollision: true }
+
 function getStableKey(session: TerminalState['session']): string {
   return session.hookSessionId || session.agentSessionId || ''
 }
@@ -368,7 +371,7 @@ function FlexibleGrid({
           containerPadding: null,
           maxRows: Infinity
         }}
-        compactor={noCompactor}
+        compactor={flexCompactor}
         dragConfig={{ enabled: true, handle: '.drag-handle', bounded: false, threshold: 3 }}
         resizeConfig={{ enabled: true, handles: ['se'] }}
         onDragStop={handleDragStop}

--- a/tests/agent-card-flexible-slot.test.tsx
+++ b/tests/agent-card-flexible-slot.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Stubs that AgentCard reads at module load; installed before the import below.
+vi.hoisted(() => {
+  Object.defineProperty(window, 'api', {
+    value: {
+      isWorktreeDirty: () => Promise.resolve(false),
+      getGitDiffStat: () => Promise.resolve(null),
+      getGitBranch: () => Promise.resolve(null),
+      notifyWidgetStatus: () => {}
+    },
+    writable: true
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+})
+
+const slotCalls: Array<{ terminalId: string; className?: string }> = []
+
+vi.mock('../src/renderer/components/TerminalSlot', () => ({
+  TerminalSlot: (props: { terminalId: string; className?: string }) => {
+    slotCalls.push({ terminalId: props.terminalId, className: props.className })
+    return <div data-testid={`slot-${props.terminalId}`} className={props.className} />
+  }
+}))
+
+vi.mock('../src/renderer/hooks/useTerminalScrollButton', () => ({
+  useTerminalScrollButton: () => ({ showScrollBtn: false, handleScrollToBottom: () => {} })
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { AgentCard } from '../src/renderer/components/AgentCard'
+
+function seedTerminal(id: string) {
+  const terminals = new Map()
+  terminals.set(id, {
+    id,
+    session: {
+      id,
+      agentType: 'claude' as const,
+      projectName: 'Vorn',
+      projectPath: '/tmp/vorn',
+      isWorktree: false,
+      branch: 'main',
+      createdAt: Date.now()
+    },
+    status: 'idle',
+    lastOutputTimestamp: Date.now()
+  })
+  useAppStore.setState({
+    terminals,
+    focusedTerminalId: null,
+    selectedTerminalId: null,
+    renamingTerminalId: null,
+    minimizedTerminals: new Set<string>()
+  })
+}
+
+beforeEach(() => {
+  slotCalls.length = 0
+  seedTerminal('t1')
+})
+
+afterEach(() => cleanup())
+
+describe('AgentCard TerminalSlot sizing', () => {
+  it('uses w-full h-full in tab/grid mode', () => {
+    render(<AgentCard terminalId="t1" />)
+    const call = slotCalls.find((c) => c.terminalId === 't1')
+    expect(call?.className).toBe('w-full h-full')
+  })
+
+  it('reserves 16px SE in flexible mode so the resize handle stays reachable', () => {
+    render(<AgentCard terminalId="t1" flexible />)
+    const call = slotCalls.find((c) => c.terminalId === 't1')
+    expect(call?.className).toBe('absolute inset-0 right-4 bottom-4')
+  })
+})


### PR DESCRIPTION
## Summary

- The persistent TerminalHost overlay (z-45) covered the SE resize handle in flexible-grid cards and bled over the top bar when the grid scrolled.
- Free-positioning cards (`noCompactor`) could also overlap on drag/resize.

Fixes:
- **AgentCard**: in flexible mode, inset the `TerminalSlot` 16px at SE so the react-grid-layout handle sits in uncovered space.
- **GridView**: combine `noCompactor` with `preventCollision` so drag/resize snaps back instead of overlapping a neighbour.
- **App top bar**: add `z-46` and an opaque `#1a1a1e` background so scrolled terminal content no longer paints over it.

## Test plan

- [ ] Open a project in flexible-grid mode and grab the SE corner of a card — it should resize.
- [ ] Try to drag/resize a card over a neighbour — it should snap back rather than overlap.
- [ ] Scroll the grid until content passes the top bar — the top bar stays opaque over the terminal.
- [ ] Confirm drag-by-header and typing into the terminal still work.
- [ ] Check that tab view, focused view, and the terminal panel are unaffected (they don't use `flexible`).