### PR TITLE
Stream script output, resumable headless, resume from history

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -166,7 +166,17 @@ export function buildHeadlessSpawnArgs(
   const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
   const cmd = resolveAgentCommand(cmdConfig, env)
   const prompt = payload.initialPrompt || ''
-  const extraArgs = resolveHeadlessArgs(payload, cmdConfig, cmd.args)
+  const extraArgs = [...resolveHeadlessArgs(payload, cmdConfig, cmd.args)]
+
+  if (
+    payload.resumeSessionId &&
+    supportsExactSessionResume(payload.agentType) &&
+    (payload.agentType === 'claude' || payload.agentType === 'copilot')
+  ) {
+    extraArgs.push('--resume', payload.resumeSessionId)
+  } else if (payload.sessionId && supportsSessionIdPinning(payload.agentType)) {
+    extraArgs.push(getSessionIdPinningFlag(payload.agentType), payload.sessionId)
+  }
 
   switch (payload.agentType) {
     case 'claude':

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -364,6 +364,9 @@ function createSchema(): void {
       logs TEXT,
       task_id TEXT,
       agent_session_id TEXT,
+      agent_type TEXT,
+      project_name TEXT,
+      project_path TEXT,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -620,6 +623,14 @@ function verifySchema(d: Database.Database): void {
         column: 'headless_args',
         ddl: 'ALTER TABLE agent_commands ADD COLUMN headless_args TEXT'
       }
+    ],
+    workflow_run_nodes: [
+      { column: 'agent_type', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN agent_type TEXT' },
+      {
+        column: 'project_name',
+        ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_name TEXT'
+      },
+      { column: 'project_path', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_path TEXT' }
     ]
   }
 
@@ -1798,8 +1809,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -1812,7 +1823,10 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         ns.error ?? null,
         ns.logs ?? null,
         ns.taskId ?? null,
-        ns.agentSessionId ?? null
+        ns.agentSessionId ?? null,
+        ns.agentType ?? null,
+        ns.projectName ?? null,
+        ns.projectPath ?? null
       )
     }
 
@@ -1861,6 +1875,9 @@ export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecut
       logs: string | null
       task_id: string | null
       agent_session_id: string | null
+      agent_type: string | null
+      project_name: string | null
+      project_path: string | null
     }>
 
     return {
@@ -1878,7 +1895,10 @@ export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecut
         ...(n.error != null && { error: n.error }),
         ...(n.logs != null && { logs: n.logs }),
         ...(n.task_id != null && { taskId: n.task_id }),
-        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id })
+        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
+        ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
+        ...(n.project_name != null && { projectName: n.project_name }),
+        ...(n.project_path != null && { projectPath: n.project_path })
       }))
     }
   })

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -7,7 +7,8 @@ import {
   AgentCommandConfig,
   CreateTerminalPayload,
   HeadlessSession,
-  IPC
+  IPC,
+  supportsSessionIdPinning
 } from '@vornrun/shared/types'
 import { displayNameFromPrompt } from '@vornrun/shared/string-utils'
 import {
@@ -84,6 +85,18 @@ class HeadlessManager extends EventEmitter {
       }
     }
 
+    // Pre-generate the session id before buildHeadlessSpawnArgs so the --session-id
+    // flag can be injected; keeps parity with the interactive PTY path.
+    let agentSessionId: string | undefined
+    if (supportsSessionIdPinning(payload.agentType)) {
+      if (payload.resumeSessionId) {
+        agentSessionId = payload.resumeSessionId
+      } else {
+        agentSessionId = crypto.randomUUID()
+        payload.sessionId = agentSessionId
+      }
+    }
+
     const env = getSafeEnv()
     const spawnArgs = buildHeadlessSpawnArgs(payload, this.agentCommands, env)
     log.info(
@@ -126,7 +139,8 @@ class HeadlessManager extends EventEmitter {
       startedAt: Date.now(),
       ...(payload.workflowId != null && { workflowId: payload.workflowId }),
       ...(payload.workflowName != null && { workflowName: payload.workflowName }),
-      ...(payload.taskId != null && { taskId: payload.taskId })
+      ...(payload.taskId != null && { taskId: payload.taskId }),
+      ...(agentSessionId ? { agentSessionId } : {})
     }
     this.sessions.set(id, session)
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -56,7 +56,7 @@ import {
   listSessionEventsBySession
 } from './database'
 import { stripAnsi } from './ansi-strip'
-import { executeScript } from './script-runner'
+import { executeScript, scriptRunnerEvents } from './script-runner'
 import { getTailscaleStatus, clearBinaryCache } from './tailscale'
 import { checkAndRebind } from './server-rebind'
 import { testSshConnection } from './process-utils'
@@ -539,6 +539,13 @@ export function registerAllMethods(): void {
   })
   scheduler.on('client-message', (channel: string, payload: unknown) => {
     clientRegistry.broadcast(channel, payload)
+  })
+
+  scriptRunnerEvents.on(IPC.SCRIPT_DATA, (payload) => {
+    clientRegistry.broadcast(IPC.SCRIPT_DATA, payload)
+  })
+  scriptRunnerEvents.on(IPC.SCRIPT_EXIT, (payload) => {
+    clientRegistry.broadcast(IPC.SCRIPT_EXIT, payload)
   })
 
   // ─── Persistent session auto-save ──────────────────────────────

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
-import { ScriptConfig } from '@vornrun/shared/types'
+import { EventEmitter } from 'node:events'
+import { ScriptConfig, IPC } from '@vornrun/shared/types'
 import { getSafeEnv } from './process-utils'
 import log from './logger'
 
@@ -9,6 +10,8 @@ export interface ScriptExecutionResult {
   error?: string
   exitCode?: number
 }
+
+export const scriptRunnerEvents = new EventEmitter()
 
 export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
   return new Promise((resolve) => {
@@ -50,6 +53,7 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     }
 
     const cwd = config.cwd || config.projectPath || process.cwd()
+    const runId = config.runId
 
     log.info(`[script-runner] executing ${config.scriptType} script in ${cwd}`)
 
@@ -64,15 +68,23 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     let stderr = ''
 
     child.stdout.on('data', (data) => {
-      stdout += data.toString()
+      const chunk = data.toString()
+      stdout += chunk
+      if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: chunk })
     })
 
     child.stderr.on('data', (data) => {
-      stderr += data.toString()
+      const chunk = data.toString()
+      stderr += chunk
+      if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: chunk })
     })
 
     child.on('error', (err) => {
       log.error(`[script-runner] spawn error: ${err.message}`)
+      if (runId) {
+        scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: `Error: ${err.message}\n` })
+        scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: 1 })
+      }
       resolve({
         success: false,
         output: stdout,
@@ -82,6 +94,7 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
 
     child.on('close', (code) => {
       log.info(`[script-runner] exited with code ${code}`)
+      if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: code ?? 1 })
       resolve({
         success: code === 0,
         output: stdout,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -293,6 +293,10 @@ export interface ScriptConfig {
   projectName?: string // for resolving cwd
   projectPath?: string
   args?: string[]
+  /** Caller-supplied id to correlate streaming chunks back to a workflow step.
+   *  When set, the runner emits SCRIPT_DATA/SCRIPT_EXIT with this id so the
+   *  renderer can show output live in Run History. */
+  runId?: string
 }
 
 export type ConditionOperator =
@@ -499,6 +503,9 @@ export interface HeadlessSession {
   workflowName?: string
   /** Task this session is working on */
   taskId?: string
+  /** The agent's own session id (pinned via --session-id for claude/copilot),
+   *  enabling later --resume. Only set for agents that support pinning. */
+  agentSessionId?: string
 }
 
 export interface ResizePayload {
@@ -618,6 +625,8 @@ export const IPC = {
   HEADLESS_DATA: 'headless:data',
   HEADLESS_EXIT: 'headless:exit',
   SCRIPT_EXECUTE: 'script:execute',
+  SCRIPT_DATA: 'script:data',
+  SCRIPT_EXIT: 'script:exit',
   WORKFLOW_RUN_SAVE: 'workflowRun:save',
   WORKFLOW_RUN_LIST: 'workflowRun:list',
   WORKFLOW_RUN_LIST_BY_TASK: 'workflowRun:listByTask',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -345,6 +345,13 @@ export interface NodeExecutionState {
   output?: string
   taskId?: string
   agentSessionId?: string
+  /** Concrete agent type resolved at launch time. Distinct from the node's
+   *  configured agentType, which may be the 'fromTask' sentinel. */
+  agentType?: AgentType
+  /** Project name captured at launch so resume works for task-agnostic nodes. */
+  projectName?: string
+  /** Project path captured at launch. */
+  projectPath?: string
   worktreePath?: string
   worktreeName?: string
 }

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -353,6 +353,10 @@ export function createApiShim(wsUrl: string) {
 
     // ── Script Execution ──
     executeScript: (config: unknown) => rpc.invoke('script:execute', config),
+    onScriptData: (callback: (event: { runId: string; data: string }) => void) =>
+      rpc.on('script:data', callback as (p: unknown) => void),
+    onScriptExit: (callback: (event: { runId: string; exitCode: number }) => void) =>
+      rpc.on('script:exit', callback as (p: unknown) => void),
 
     // ── Worktree Cleanup ──
     onSessionUpdated: (callback: (session: unknown) => void) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -214,6 +214,8 @@ function wireServerNotifications(bridge: ServerBridge): void {
       case IPC.TERMINAL_EXIT:
       case IPC.HEADLESS_DATA:
       case IPC.HEADLESS_EXIT:
+      case IPC.SCRIPT_DATA:
+      case IPC.SCRIPT_EXIT:
       case IPC.WORKTREE_CONFIRM_CLEANUP:
       case IPC.SESSION_UPDATED:
       case IPC.SESSION_REORDERED:

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -240,6 +240,26 @@ const api = {
   ): Promise<{ success: boolean; output: string; error?: string; exitCode?: number }> =>
     ipcRenderer.invoke(IPC.SCRIPT_EXECUTE, config),
 
+  onScriptData: (callback: (event: { runId: string; data: string }) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, event: { runId: string; data: string }): void =>
+      callback(event)
+    ipcRenderer.on(IPC.SCRIPT_DATA, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.SCRIPT_DATA, listener)
+    }
+  },
+
+  onScriptExit: (callback: (event: { runId: string; exitCode: number }) => void) => {
+    const listener = (
+      _: Electron.IpcRendererEvent,
+      event: { runId: string; exitCode: number }
+    ): void => callback(event)
+    ipcRenderer.on(IPC.SCRIPT_EXIT, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.SCRIPT_EXIT, listener)
+    }
+  },
+
   onSessionUpdated: (callback: (session: TerminalSession) => void) => {
     const listener = (_: Electron.IpcRendererEvent, session: TerminalSession): void =>
       callback(session)

--- a/src/renderer/components/SessionActivityLog.tsx
+++ b/src/renderer/components/SessionActivityLog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
-import { XCircle, ChevronDown, ChevronRight, Maximize2, Play } from 'lucide-react'
+import { XCircle, ChevronDown, ChevronRight, Maximize2, RotateCcw } from 'lucide-react'
 import type { SessionLog, AgentType } from '../../shared/types'
 import { StatusDot } from './workflow-editor/RunEntry'
+import { Tooltip } from './Tooltip'
 
 function formatRunTime(iso: string): string {
   const d = new Date(iso)
@@ -194,32 +195,36 @@ export function SessionActivityLog({
                   )}
                 </div>
 
-                <div className="flex items-center gap-3 px-3 pb-2.5">
+                <div className="flex items-center gap-1 px-3 pb-2.5">
                   {onViewFullOutput && entry.logs && (
-                    <button
-                      onClick={() => onViewFullOutput(entry.logs!)}
-                      className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
-                    >
-                      <Maximize2 size={11} strokeWidth={2} />
-                      View Full Output
-                    </button>
+                    <Tooltip label="View full output">
+                      <button
+                        onClick={() => onViewFullOutput(entry.logs!)}
+                        aria-label="View full output"
+                        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                      >
+                        <Maximize2 size={12} strokeWidth={2} />
+                      </button>
+                    </Tooltip>
                   )}
                   {canResume && projectPath && (
-                    <button
-                      onClick={() =>
-                        onResumeSession!(
-                          agentSessionId!,
-                          (entry.agentType as AgentType) || 'claude',
-                          entry.projectName || '',
-                          projectPath,
-                          entry.branch
-                        )
-                      }
-                      className="flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 transition-colors"
-                    >
-                      <Play size={11} strokeWidth={2} />
-                      Resume Session
-                    </button>
+                    <Tooltip label="Resume session">
+                      <button
+                        onClick={() =>
+                          onResumeSession!(
+                            agentSessionId!,
+                            (entry.agentType as AgentType) || 'claude',
+                            entry.projectName || '',
+                            projectPath,
+                            entry.branch
+                          )
+                        }
+                        aria-label="Resume session"
+                        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                      >
+                        <RotateCcw size={12} strokeWidth={2} />
+                      </button>
+                    </Tooltip>
                   )}
                 </div>
               </div>

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ChevronDown, ChevronRight, Maximize2, Play } from 'lucide-react'
+import { ChevronDown, ChevronRight, Maximize2, RotateCcw } from 'lucide-react'
 import {
   WorkflowExecution,
   WorkflowNode,
@@ -11,6 +11,7 @@ import {
 
 import { formatRelativeTime } from '../../lib/format-time'
 import { STATUS_DOT_CLASSES as SHARED_STATUS_DOTS } from './statusDot'
+import { Tooltip } from '../Tooltip'
 
 function formatDuration(start: string, end?: string): string {
   if (!end) return 'running...'
@@ -139,6 +140,26 @@ export function RunEntry({
                 }
               | undefined
 
+            const resumeProjectName =
+              nodeConfig?.projectName || nodeTask?.projectName || triggerTask?.projectName || ''
+            const resumeBranch = nodeConfig?.branch ?? nodeTask?.branch ?? triggerTask?.branch
+            const resumeUseWorktree =
+              nodeConfig?.useWorktree ?? nodeTask?.useWorktree ?? triggerTask?.useWorktree
+            const canResume =
+              !!ns.agentSessionId &&
+              !!onResumeSession &&
+              !!nodeConfig &&
+              supportsExactSessionResume(nodeConfig.agentType || 'claude')
+            const handleResume = (): void =>
+              onResumeSession!(
+                ns.agentSessionId!,
+                nodeConfig!.agentType || 'claude',
+                resumeProjectName,
+                nodeConfig!.projectPath || '',
+                resumeBranch,
+                resumeUseWorktree
+              )
+
             return (
               <div key={ns.nodeId} className="border-b border-white/[0.04] last:border-b-0">
                 {/* Step header */}
@@ -190,37 +211,29 @@ export function RunEntry({
                     >
                       {ns.logs.length > 2000 ? ns.logs.slice(0, 2000) + '\n...' : ns.logs}
                     </pre>
-                    <div className="flex items-center gap-2 mt-1.5">
+                    <div className="flex items-center gap-1 mt-1.5">
                       {onViewFullOutput && (
-                        <button
-                          onClick={() => onViewFullOutput(ns.logs!)}
-                          className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
-                        >
-                          <Maximize2 size={11} strokeWidth={2} />
-                          View Full Output
-                        </button>
-                      )}
-                      {ns.agentSessionId &&
-                        onResumeSession &&
-                        nodeConfig &&
-                        supportsExactSessionResume(nodeConfig.agentType || 'claude') && (
+                        <Tooltip label="View full output">
                           <button
-                            onClick={() =>
-                              onResumeSession(
-                                ns.agentSessionId!,
-                                nodeConfig.agentType || 'claude',
-                                nodeConfig.projectName || '',
-                                nodeConfig.projectPath || '',
-                                nodeConfig.branch,
-                                nodeConfig.useWorktree
-                              )
-                            }
-                            className="flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 transition-colors"
+                            onClick={() => onViewFullOutput(ns.logs!)}
+                            aria-label="View full output"
+                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
                           >
-                            <Play size={11} strokeWidth={2} />
-                            Resume Session
+                            <Maximize2 size={12} strokeWidth={2} />
                           </button>
-                        )}
+                        </Tooltip>
+                      )}
+                      {canResume && (
+                        <Tooltip label="Resume session">
+                          <button
+                            onClick={handleResume}
+                            aria-label="Resume session"
+                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                          >
+                            <RotateCcw size={12} strokeWidth={2} />
+                          </button>
+                        </Tooltip>
+                      )}
                     </div>
                     {ns.error && <p className="text-[11px] text-red-400 mt-1">{ns.error}</p>}
                   </div>
@@ -230,27 +243,19 @@ export function RunEntry({
                 {expandedNodeId === ns.nodeId && !ns.logs && ns.error && (
                   <div className="px-4 pb-2">
                     <p className="text-[11px] text-red-400">{ns.error}</p>
-                    {ns.agentSessionId &&
-                      onResumeSession &&
-                      nodeConfig &&
-                      supportsExactSessionResume(nodeConfig.agentType || 'claude') && (
-                        <button
-                          onClick={() =>
-                            onResumeSession(
-                              ns.agentSessionId!,
-                              nodeConfig.agentType || 'claude',
-                              nodeConfig.projectName || '',
-                              nodeConfig.projectPath || '',
-                              nodeConfig.branch,
-                              nodeConfig.useWorktree
-                            )
-                          }
-                          className="flex items-center gap-1 mt-1.5 text-[11px] text-amber-400 hover:text-amber-300 transition-colors"
-                        >
-                          <Play size={11} strokeWidth={2} />
-                          Resume Session
-                        </button>
-                      )}
+                    {canResume && (
+                      <div className="mt-1.5">
+                        <Tooltip label="Resume session">
+                          <button
+                            onClick={handleResume}
+                            aria-label="Resume session"
+                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                          >
+                            <RotateCcw size={12} strokeWidth={2} />
+                          </button>
+                        </Tooltip>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -132,7 +132,7 @@ export function RunEntry({
             const node = nodes.find((n) => n.id === ns.nodeId)
             const nodeConfig = node?.config as
               | {
-                  agentType?: AgentType
+                  agentType?: AgentType | 'fromTask'
                   projectName?: string
                   projectPath?: string
                   branch?: string
@@ -140,22 +140,36 @@ export function RunEntry({
                 }
               | undefined
 
+            // Prefer the concrete values the engine recorded at launch
+            // (ns.agentType/projectName/projectPath) over node config, which
+            // may hold the 'fromTask' sentinel or be blank for task-driven nodes.
+            const configAgent =
+              nodeConfig?.agentType && nodeConfig.agentType !== 'fromTask'
+                ? nodeConfig.agentType
+                : undefined
+            const resumeAgentType: AgentType | undefined = ns.agentType ?? configAgent
             const resumeProjectName =
-              nodeConfig?.projectName || nodeTask?.projectName || triggerTask?.projectName || ''
+              ns.projectName ||
+              nodeConfig?.projectName ||
+              nodeTask?.projectName ||
+              triggerTask?.projectName ||
+              ''
+            const resumeProjectPath = ns.projectPath || nodeConfig?.projectPath || ''
             const resumeBranch = nodeConfig?.branch ?? nodeTask?.branch ?? triggerTask?.branch
             const resumeUseWorktree =
               nodeConfig?.useWorktree ?? nodeTask?.useWorktree ?? triggerTask?.useWorktree
             const canResume =
               !!ns.agentSessionId &&
               !!onResumeSession &&
-              !!nodeConfig &&
-              supportsExactSessionResume(nodeConfig.agentType || 'claude')
+              !!resumeAgentType &&
+              !!resumeProjectName &&
+              supportsExactSessionResume(resumeAgentType)
             const handleResume = (): void =>
               onResumeSession!(
                 ns.agentSessionId!,
-                nodeConfig!.agentType || 'claude',
+                resumeAgentType!,
                 resumeProjectName,
-                nodeConfig!.projectPath || '',
+                resumeProjectPath,
                 resumeBranch,
                 resumeUseWorktree
               )

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -31,6 +31,7 @@ import {
   removeNode
 } from '../../lib/workflow-helpers'
 import { executeWorkflow } from '../../lib/workflow-execution'
+import { toast } from '../Toast'
 import {
   slugify,
   ensureUniqueSlug,
@@ -397,7 +398,11 @@ export function WorkflowEditor() {
       const cfg = useAppStore.getState().config
       const proj = cfg?.projects.find((p) => p.name === projectName)
       const remoteHostId = proj ? getProjectRemoteHostId(proj) : undefined
-      const effectiveProjectPath = projectPath || proj?.path || ''
+      const effectiveProjectPath = projectPath || proj?.path
+      if (!effectiveProjectPath) {
+        toast.error(`Can't resume: project "${projectName}" not found`)
+        return
+      }
       const session = await window.api.createTerminal({
         agentType,
         projectName,

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -397,10 +397,11 @@ export function WorkflowEditor() {
       const cfg = useAppStore.getState().config
       const proj = cfg?.projects.find((p) => p.name === projectName)
       const remoteHostId = proj ? getProjectRemoteHostId(proj) : undefined
+      const effectiveProjectPath = projectPath || proj?.path || ''
       const session = await window.api.createTerminal({
         agentType,
         projectName,
-        projectPath,
+        projectPath: effectiveProjectPath,
         branch,
         useWorktree,
         resumeSessionId: agentSessionId,

--- a/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
@@ -28,7 +28,6 @@ export function RunHistoryPanel({
   onClickTask,
   onResumeSession
 }: Props) {
-  const sorted = [...executions].reverse()
   const [fullOutputLogs, setFullOutputLogs] = useState<string | null>(null)
 
   return (
@@ -45,10 +44,10 @@ export function RunHistoryPanel({
         </div>
 
         <div className="flex-1 overflow-y-auto p-3 space-y-2">
-          {sorted.length === 0 ? (
+          {executions.length === 0 ? (
             <p className="text-[12px] text-gray-600 text-center py-8">No runs yet</p>
           ) : (
-            sorted.map((exec, i) => (
+            executions.map((exec, i) => (
               <RunEntry
                 key={`${exec.workflowId}-${exec.startedAt}-${i}`}
                 execution={exec}

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -184,11 +184,14 @@ async function executeNode(
       const result = await window.api.executeScript(resolvedConfig)
 
       const finalLogs = streamedLogs || result.output
+      // Streamed logs already include stderr, so only surface result.error
+      // when we fell through the non-streaming path (finalLogs === result.output).
+      const errorTrailer = result.error && !streamedLogs ? `\nError: ${result.error}` : ''
       updateNodeState(execution, node.id, {
         status: result.success ? 'success' : 'error',
         completedAt: new Date().toISOString(),
         output: result.output,
-        logs: finalLogs + (result.error ? `\nError: ${result.error}` : ''),
+        logs: finalLogs + errorTrailer,
         error: result.error
       })
     } catch (err) {
@@ -382,6 +385,9 @@ async function executeNode(
         taskId: resolvedTaskId,
         worktreePath: headlessSession.worktreePath,
         worktreeName: headlessSession.worktreeName,
+        agentType: effectiveAgent,
+        projectName: effectiveProjectName,
+        projectPath: effectiveProjectPath,
         ...(headlessSession.agentSessionId
           ? { agentSessionId: headlessSession.agentSessionId }
           : {})
@@ -446,7 +452,10 @@ async function executeNode(
       logs: `Terminal session created: ${session.id}`,
       taskId: resolvedTaskId,
       worktreePath: session.worktreePath,
-      worktreeName: session.worktreeName
+      worktreeName: session.worktreeName,
+      agentType: effectiveAgent,
+      projectName: effectiveProjectName,
+      projectPath: effectiveProjectPath
     })
     persistExecution(workflow.id, execution)
   }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -160,19 +160,35 @@ async function executeNode(
     const config = node.config as ScriptConfig
     console.log(`[workflow] executing script: ${config.scriptType}`)
 
-    const resolvedConfig = {
+    const runId = crypto.randomUUID()
+    const resolvedConfig: ScriptConfig = {
       ...config,
-      scriptContent: resolveTemplateVars(config.scriptContent, context, stepOutputs)
+      scriptContent: resolveTemplateVars(config.scriptContent, context, stepOutputs),
+      runId
     }
+
+    let streamedLogs = ''
+    const removeScriptDataListener = window.api.onScriptData(
+      ({ runId: id, data }: { runId: string; data: string }) => {
+        if (id !== runId) return
+        streamedLogs += data
+        if (streamedLogs.length > 100000) {
+          streamedLogs = streamedLogs.slice(-80000)
+        }
+        updateNodeState(execution, node.id, { logs: streamedLogs })
+        useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
+      }
+    )
 
     try {
       const result = await window.api.executeScript(resolvedConfig)
 
+      const finalLogs = streamedLogs || result.output
       updateNodeState(execution, node.id, {
         status: result.success ? 'success' : 'error',
         completedAt: new Date().toISOString(),
         output: result.output,
-        logs: result.output + (result.error ? `\nError: ${result.error}` : ''),
+        logs: finalLogs + (result.error ? `\nError: ${result.error}` : ''),
         error: result.error
       })
     } catch (err) {
@@ -182,6 +198,8 @@ async function executeNode(
         completedAt: new Date().toISOString(),
         error: err instanceof Error ? err.message : String(err)
       })
+    } finally {
+      removeScriptDataListener()
     }
     persistExecution(workflow.id, execution)
     return
@@ -363,7 +381,10 @@ async function executeNode(
         sessionId: headlessSession.id,
         taskId: resolvedTaskId,
         worktreePath: headlessSession.worktreePath,
-        worktreeName: headlessSession.worktreeName
+        worktreeName: headlessSession.worktreeName,
+        ...(headlessSession.agentSessionId
+          ? { agentSessionId: headlessSession.agentSessionId }
+          : {})
       })
       persistExecution(workflow.id, execution)
 
@@ -609,11 +630,14 @@ export async function executeWorkflow(
     runningWorkflows.delete(workflow.id)
   }
 
-  const terminals = useAppStore.getState().terminals
+  const state = useAppStore.getState()
+  const terminals = state.terminals
+  const headlessById = new Map(state.headlessSessions.map((s) => [s.id, s]))
   for (const ns of execution.nodeStates) {
     if (ns.sessionId && !ns.agentSessionId) {
-      const terminal = terminals.get(ns.sessionId)
-      const agentSid = terminal?.session.agentSessionId
+      const agentSid =
+        terminals.get(ns.sessionId)?.session.agentSessionId ??
+        headlessById.get(ns.sessionId)?.agentSessionId
       if (agentSid) {
         ns.agentSessionId = agentSid
       }

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -220,4 +220,60 @@ describe('buildHeadlessSpawnArgs', () => {
     const result = buildHeadlessSpawnArgs(makePayload(), cmds, env)
     expect(result.args).toContain('')
   })
+
+  it('pins claude headless session via --session-id', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ sessionId: 'uuid-head', initialPrompt: 'go' }),
+      cmds,
+      env
+    )
+    const idx = result.args.indexOf('--session-id')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(result.args[idx + 1]).toBe('uuid-head')
+  })
+
+  it('pins copilot headless session via --resume (pinning flag is --resume for copilot)', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ agentType: 'copilot', sessionId: 'uuid-head', initialPrompt: 'go' }),
+      cmds,
+      env
+    )
+    const idx = result.args.indexOf('--resume')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(result.args[idx + 1]).toBe('uuid-head')
+  })
+
+  it('resumes claude headless via --resume', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ resumeSessionId: 'sess-prev', initialPrompt: 'go' }),
+      cmds,
+      env
+    )
+    const idx = result.args.indexOf('--resume')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(result.args[idx + 1]).toBe('sess-prev')
+  })
+
+  it('resume wins over session-id pinning', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ sessionId: 'uuid-head', resumeSessionId: 'sess-prev', initialPrompt: 'go' }),
+      cmds,
+      env
+    )
+    expect(result.args).toContain('--resume')
+    expect(result.args).toContain('sess-prev')
+    expect(result.args).not.toContain('--session-id')
+  })
+
+  it('does not inject session-id or resume flags for codex/opencode/gemini headless', () => {
+    for (const agentType of ['codex', 'opencode', 'gemini'] as const) {
+      const result = buildHeadlessSpawnArgs(
+        makePayload({ agentType, sessionId: 'uuid-head', resumeSessionId: 'sess-prev' }),
+        cmds,
+        env
+      )
+      expect(result.args).not.toContain('--session-id')
+      expect(result.args).not.toContain('--resume')
+    }
+  })
 })

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() }
+})
+
+import {
+  initTestDatabase,
+  saveWorkflowRun,
+  listWorkflowRuns
+} from '../packages/server/src/database'
+import type { WorkflowExecution } from '@vornrun/shared/types'
+
+let teardown: () => void
+
+beforeEach(() => {
+  teardown = initTestDatabase()
+})
+
+afterEach(() => {
+  teardown()
+})
+
+describe('workflow run persistence', () => {
+  it('round-trips agentType / projectName / projectPath on node states', () => {
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-1',
+      startedAt: '2026-04-20T10:00:00Z',
+      completedAt: '2026-04-20T10:00:05Z',
+      status: 'success',
+      nodeStates: [
+        {
+          nodeId: 'node-1',
+          status: 'success',
+          agentSessionId: 'agent-xyz',
+          agentType: 'claude',
+          projectName: 'proj',
+          projectPath: '/abs/proj'
+        }
+      ]
+    }
+
+    saveWorkflowRun(exec)
+    const runs = listWorkflowRuns('wf-1')
+    expect(runs).toHaveLength(1)
+    const state = runs[0].nodeStates[0]
+    expect(state.agentType).toBe('claude')
+    expect(state.projectName).toBe('proj')
+    expect(state.projectPath).toBe('/abs/proj')
+    expect(state.agentSessionId).toBe('agent-xyz')
+  })
+
+  it('omits fields that were not set', () => {
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-2',
+      startedAt: '2026-04-20T11:00:00Z',
+      status: 'success',
+      nodeStates: [{ nodeId: 'node-1', status: 'success' }]
+    }
+
+    saveWorkflowRun(exec)
+    const runs = listWorkflowRuns('wf-2')
+    const state = runs[0].nodeStates[0]
+    expect(state.agentType).toBeUndefined()
+    expect(state.projectName).toBeUndefined()
+    expect(state.projectPath).toBeUndefined()
+  })
+})

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', async () => {
+  const { EventEmitter } = await import('node:events')
+  class FakeChild extends EventEmitter {
+    pid = 4242
+    stdin = { on: vi.fn(), end: vi.fn() }
+    stdout = new EventEmitter()
+    stderr = new EventEmitter()
+    kill = vi.fn()
+  }
+  return {
+    spawn: vi.fn(() => new FakeChild()),
+    execFileSync: vi.fn(() => '/usr/bin/cmd')
+  }
+})
+
+vi.mock('../packages/server/src/git-utils', () => ({
+  getGitBranch: vi.fn(() => 'main'),
+  checkoutBranch: vi.fn(),
+  createWorktree: vi.fn(),
+  extractWorktreeName: vi.fn(),
+  isGitRepo: vi.fn(() => false)
+}))
+
+import { spawn as spawnImport } from 'node:child_process'
+import { headlessManager } from '../packages/server/src/headless-manager'
+
+const spawnMock = spawnImport as unknown as ReturnType<typeof vi.fn>
+
+describe('headlessManager.createHeadless', () => {
+  beforeEach(() => {
+    spawnMock.mockClear()
+  })
+
+  it('pins a fresh agentSessionId for claude and injects --session-id', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      headless: true
+    })
+
+    expect(session.agentSessionId).toMatch(/^[0-9a-f-]{36}$/)
+
+    const spawnCall = spawnMock.mock.calls[0]
+    const args = spawnCall[1] as string[]
+    const idx = args.indexOf('--session-id')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(args[idx + 1]).toBe(session.agentSessionId)
+
+    headlessManager.killHeadless(session.id)
+  })
+
+  it('reuses resumeSessionId and uses --resume for claude', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      resumeSessionId: 'existing-session',
+      headless: true
+    })
+
+    expect(session.agentSessionId).toBe('existing-session')
+
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).toContain('--resume')
+    expect(args).toContain('existing-session')
+
+    headlessManager.killHeadless(session.id)
+  })
+
+  it('does not populate agentSessionId for non-pinning agents', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'codex',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      headless: true
+    })
+
+    expect(session.agentSessionId).toBeUndefined()
+
+    headlessManager.killHeadless(session.id)
+  })
+
+  it('propagates taskId / workflowId onto the session', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      headless: true,
+      taskId: 'task-1',
+      workflowId: 'wf-1',
+      workflowName: 'wf'
+    })
+
+    expect(session.taskId).toBe('task-1')
+    expect(session.workflowId).toBe('wf-1')
+    expect(session.workflowName).toBe('wf')
+
+    headlessManager.killHeadless(session.id)
+  })
+})

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -25,12 +25,7 @@ vi.mock('lucide-react', () => ({
 }))
 
 import { RunEntry } from '../src/renderer/components/workflow-editor/RunEntry'
-import type {
-  WorkflowExecution,
-  WorkflowNode,
-  NodeExecutionState,
-  TaskConfig
-} from '../src/shared/types'
+import type { WorkflowExecution, WorkflowNode, NodeExecutionState } from '../src/shared/types'
 
 function makeExec(overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
   return {
@@ -105,36 +100,31 @@ describe('RunEntry', () => {
     expect(onView).toHaveBeenCalledWith('some streaming logs')
   })
 
-  it('falls back to the triggering task project when node config is blank', () => {
+  it('uses the resolved agent/project captured in node state (fromTask sentinel)', () => {
     const onResume = vi.fn()
     const exec = makeExec({
       triggerTaskId: 'task-1',
-      nodeStates: [makeState({ agentSessionId: 'agent-abc', taskId: 'task-1' })]
+      nodeStates: [
+        makeState({
+          agentSessionId: 'agent-abc',
+          agentType: 'claude',
+          projectName: 'from-task',
+          projectPath: '/abs/from-task',
+          taskId: 'task-1'
+        })
+      ]
     })
-    const blankNode = makeNode({
+    const fromTaskNode = makeNode({
       config: {
-        agentType: 'claude',
+        agentType: 'fromTask',
         projectName: '',
         projectPath: '',
         headless: true,
         prompt: 'hi'
       }
     })
-    const task: TaskConfig = {
-      id: 'task-1',
-      title: 'My task',
-      description: '',
-      status: 'in_progress',
-      priority: 'normal',
-      projectName: 'from-task',
-      branch: 'feature/x',
-      useWorktree: false,
-      assignedAgent: 'claude',
-      createdAt: '2026-04-20T09:00:00Z',
-      updatedAt: '2026-04-20T09:00:00Z'
-    }
     const { getByText, getByLabelText } = render(
-      <RunEntry execution={exec} nodes={[blankNode]} tasks={[task]} onResumeSession={onResume} />
+      <RunEntry execution={exec} nodes={[fromTaskNode]} onResumeSession={onResume} />
     )
     fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
     fireEvent.click(getByText('Run Claude').closest('button')!)
@@ -143,10 +133,29 @@ describe('RunEntry', () => {
       'agent-abc',
       'claude',
       'from-task',
-      '',
-      'feature/x',
-      false
+      '/abs/from-task',
+      undefined,
+      undefined
     )
+  })
+
+  it('hides Resume when project cannot be resolved (fromTask node without recorded state)', () => {
+    const fromTaskNode = makeNode({
+      config: {
+        agentType: 'fromTask',
+        projectName: '',
+        projectPath: '',
+        headless: true,
+        prompt: 'hi'
+      }
+    })
+    const exec = makeExec({ nodeStates: [makeState({ agentSessionId: 'agent-abc' })] })
+    const { getByText, queryByLabelText } = render(
+      <RunEntry execution={exec} nodes={[fromTaskNode]} onResumeSession={vi.fn()} />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    expect(queryByLabelText('Resume session')).not.toBeInTheDocument()
   })
 
   it('hides Resume button for unsupported agents (gemini)', () => {

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chev-down" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chev-right" {...p} />,
+  Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
+  RotateCcw: (p: Record<string, unknown>) => <svg data-testid="rotate-ccw" {...p} />
+}))
+
+import { RunEntry } from '../src/renderer/components/workflow-editor/RunEntry'
+import type {
+  WorkflowExecution,
+  WorkflowNode,
+  NodeExecutionState,
+  TaskConfig
+} from '../src/shared/types'
+
+function makeExec(overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
+  return {
+    workflowId: 'wf-1',
+    startedAt: '2026-04-20T10:00:00Z',
+    completedAt: '2026-04-20T10:00:05Z',
+    status: 'success',
+    nodeStates: [],
+    ...overrides
+  }
+}
+
+function makeNode(overrides: Partial<WorkflowNode> = {}): WorkflowNode {
+  return {
+    id: 'node-1',
+    type: 'launchAgent',
+    label: 'Run Claude',
+    slug: 'run-claude',
+    config: {
+      agentType: 'claude',
+      projectName: 'test',
+      projectPath: '/test',
+      branch: 'main',
+      useWorktree: true,
+      headless: true,
+      prompt: 'hi'
+    },
+    position: { x: 0, y: 0 },
+    ...overrides
+  }
+}
+
+function makeState(overrides: Partial<NodeExecutionState> = {}): NodeExecutionState {
+  return {
+    nodeId: 'node-1',
+    status: 'success',
+    startedAt: '2026-04-20T10:00:01Z',
+    completedAt: '2026-04-20T10:00:05Z',
+    logs: 'some streaming logs',
+    ...overrides
+  }
+}
+
+describe('RunEntry', () => {
+  it('expands and shows the Resume button when agentSessionId is present', () => {
+    const onResume = vi.fn()
+    const exec = makeExec({ nodeStates: [makeState({ agentSessionId: 'agent-abc' })] })
+    const { getByText, getByLabelText } = render(
+      <RunEntry execution={exec} nodes={[makeNode()]} onResumeSession={onResume} />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    const resumeBtn = getByLabelText('Resume session')
+    fireEvent.click(resumeBtn)
+    expect(onResume).toHaveBeenCalledWith('agent-abc', 'claude', 'test', '/test', 'main', true)
+  })
+
+  it('calls onViewFullOutput with node logs', () => {
+    const onView = vi.fn()
+    const exec = makeExec({ nodeStates: [makeState({ agentSessionId: 'agent-abc' })] })
+    const { getByText, getByLabelText } = render(
+      <RunEntry
+        execution={exec}
+        nodes={[makeNode()]}
+        onViewFullOutput={onView}
+        onResumeSession={vi.fn()}
+      />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    fireEvent.click(getByLabelText('View full output'))
+    expect(onView).toHaveBeenCalledWith('some streaming logs')
+  })
+
+  it('falls back to the triggering task project when node config is blank', () => {
+    const onResume = vi.fn()
+    const exec = makeExec({
+      triggerTaskId: 'task-1',
+      nodeStates: [makeState({ agentSessionId: 'agent-abc', taskId: 'task-1' })]
+    })
+    const blankNode = makeNode({
+      config: {
+        agentType: 'claude',
+        projectName: '',
+        projectPath: '',
+        headless: true,
+        prompt: 'hi'
+      }
+    })
+    const task: TaskConfig = {
+      id: 'task-1',
+      title: 'My task',
+      description: '',
+      status: 'in_progress',
+      priority: 'normal',
+      projectName: 'from-task',
+      branch: 'feature/x',
+      useWorktree: false,
+      assignedAgent: 'claude',
+      createdAt: '2026-04-20T09:00:00Z',
+      updatedAt: '2026-04-20T09:00:00Z'
+    }
+    const { getByText, getByLabelText } = render(
+      <RunEntry execution={exec} nodes={[blankNode]} tasks={[task]} onResumeSession={onResume} />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    fireEvent.click(getByLabelText('Resume session'))
+    expect(onResume).toHaveBeenCalledWith(
+      'agent-abc',
+      'claude',
+      'from-task',
+      '',
+      'feature/x',
+      false
+    )
+  })
+
+  it('hides Resume button for unsupported agents (gemini)', () => {
+    const exec = makeExec({ nodeStates: [makeState({ agentSessionId: 'agent-abc' })] })
+    const geminiNode = makeNode({
+      config: {
+        agentType: 'gemini',
+        projectName: 'test',
+        projectPath: '/test',
+        headless: true,
+        prompt: 'hi'
+      }
+    })
+    const { getByText, queryByLabelText } = render(
+      <RunEntry execution={exec} nodes={[geminiNode]} onResumeSession={vi.fn()} />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    expect(queryByLabelText('Resume session')).not.toBeInTheDocument()
+  })
+
+  it('shows Resume button on error-only branch (no logs, just error)', () => {
+    const onResume = vi.fn()
+    const exec = makeExec({
+      status: 'error',
+      nodeStates: [
+        makeState({
+          status: 'error',
+          agentSessionId: 'agent-abc',
+          logs: undefined,
+          error: 'boom'
+        })
+      ]
+    })
+    const { getByText, getByLabelText } = render(
+      <RunEntry execution={exec} nodes={[makeNode()]} onResumeSession={onResume} />
+    )
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    fireEvent.click(getByLabelText('Resume session'))
+    expect(onResume).toHaveBeenCalled()
+  })
+})

--- a/tests/run-history-panel.test.tsx
+++ b/tests/run-history-panel.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chev-down" {...p} />,
+  ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chev-right" {...p} />,
+  Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
+  RotateCcw: (p: Record<string, unknown>) => <svg data-testid="rotate-ccw" {...p} />,
+  X: (p: Record<string, unknown>) => <svg data-testid="x-icon" {...p} />
+}))
+
+vi.mock('../src/renderer/components/LogReplayModal', () => ({
+  LogReplayModal: () => <div data-testid="log-replay" />
+}))
+
+import { RunHistoryPanel } from '../src/renderer/components/workflow-editor/panels/RunHistoryPanel'
+import type { WorkflowExecution, WorkflowNode } from '../src/shared/types'
+
+function makeExec(
+  startedAt: string,
+  overrides: Partial<WorkflowExecution> = {}
+): WorkflowExecution {
+  return {
+    workflowId: 'wf-1',
+    startedAt,
+    completedAt: startedAt,
+    status: 'success',
+    nodeStates: [],
+    ...overrides
+  }
+}
+
+const node: WorkflowNode = {
+  id: 'node-1',
+  type: 'launchAgent',
+  label: 'Step',
+  slug: 'step',
+  config: { agentType: 'claude', projectName: 'p', projectPath: '/p', headless: true, prompt: 'x' },
+  position: { x: 0, y: 0 }
+}
+
+describe('RunHistoryPanel', () => {
+  it('shows empty state when no executions', () => {
+    const { getByText } = render(
+      <RunHistoryPanel executions={[]} nodes={[node]} onClose={vi.fn()} />
+    )
+    expect(getByText('No runs yet')).toBeInTheDocument()
+  })
+
+  it('renders executions in the order received (DB returns newest-first)', () => {
+    const a = makeExec('2026-04-20T10:00:00Z')
+    const b = makeExec('2026-04-20T09:00:00Z')
+    const { container } = render(
+      <RunHistoryPanel executions={[a, b]} nodes={[node]} onClose={vi.fn()} />
+    )
+    const entries = container.querySelectorAll('.border.border-white\\/\\[0\\.08\\].rounded-md')
+    expect(entries.length).toBe(2)
+  })
+})

--- a/tests/script-runner.test.ts
+++ b/tests/script-runner.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { executeScript, scriptRunnerEvents } from '../packages/server/src/script-runner'
+import { IPC } from '@vornrun/shared/types'
+
+describe('script-runner streaming', () => {
+  it('does not emit when runId is absent', async () => {
+    const seen: unknown[] = []
+    const onData = (payload: unknown): void => void seen.push(payload)
+    scriptRunnerEvents.on(IPC.SCRIPT_DATA, onData)
+    try {
+      const result = await executeScript({
+        scriptType: 'node',
+        scriptContent: 'console.log("silent")'
+      })
+      expect(result.success).toBe(true)
+      expect(result.output).toContain('silent')
+      expect(seen).toHaveLength(0)
+    } finally {
+      scriptRunnerEvents.off(IPC.SCRIPT_DATA, onData)
+    }
+  })
+
+  it('emits SCRIPT_DATA chunks and a terminal SCRIPT_EXIT when runId is set', async () => {
+    const data: Array<{ runId: string; data: string }> = []
+    const exit: Array<{ runId: string; exitCode: number }> = []
+    const onData = (p: { runId: string; data: string }): void => void data.push(p)
+    const onExit = (p: { runId: string; exitCode: number }): void => void exit.push(p)
+    scriptRunnerEvents.on(IPC.SCRIPT_DATA, onData)
+    scriptRunnerEvents.on(IPC.SCRIPT_EXIT, onExit)
+    try {
+      const result = await executeScript({
+        scriptType: 'node',
+        scriptContent: 'console.log("hello"); console.error("warn")',
+        runId: 'run-xyz'
+      })
+      expect(result.exitCode).toBe(0)
+      expect(data.every((d) => d.runId === 'run-xyz')).toBe(true)
+      const joined = data.map((d) => d.data).join('')
+      expect(joined).toContain('hello')
+      expect(joined).toContain('warn')
+      expect(exit).toEqual([{ runId: 'run-xyz', exitCode: 0 }])
+    } finally {
+      scriptRunnerEvents.off(IPC.SCRIPT_DATA, onData)
+      scriptRunnerEvents.off(IPC.SCRIPT_EXIT, onExit)
+    }
+  })
+
+  it('emits SCRIPT_EXIT with non-zero code on script failure', async () => {
+    const exit: Array<{ runId: string; exitCode: number }> = []
+    const onExit = (p: { runId: string; exitCode: number }): void => void exit.push(p)
+    scriptRunnerEvents.on(IPC.SCRIPT_EXIT, onExit)
+    try {
+      const result = await executeScript({
+        scriptType: 'node',
+        scriptContent: 'process.exit(7)',
+        runId: 'run-fail'
+      })
+      expect(result.success).toBe(false)
+      expect(result.exitCode).toBe(7)
+      expect(exit).toEqual([{ runId: 'run-fail', exitCode: 7 }])
+    } finally {
+      scriptRunnerEvents.off(IPC.SCRIPT_EXIT, onExit)
+    }
+  })
+})

--- a/tests/session-activity-log.test.tsx
+++ b/tests/session-activity-log.test.tsx
@@ -22,7 +22,8 @@ vi.mock('lucide-react', () => ({
   ChevronDown: (props: Record<string, unknown>) => <svg data-testid="chevron-down" {...props} />,
   ChevronRight: (props: Record<string, unknown>) => <svg data-testid="chevron-right" {...props} />,
   Maximize2: (props: Record<string, unknown>) => <svg data-testid="maximize-icon" {...props} />,
-  Play: (props: Record<string, unknown>) => <svg data-testid="play-icon" {...props} />
+  Play: (props: Record<string, unknown>) => <svg data-testid="play-icon" {...props} />,
+  RotateCcw: (props: Record<string, unknown>) => <svg data-testid="rotate-ccw-icon" {...props} />
 }))
 
 // Mock framer-motion (used by RunEntry's StatusIcon)
@@ -137,10 +138,10 @@ describe('SessionActivityLog', () => {
 
   it('shows "View Full Output" button and calls callback', () => {
     const log = makeLog({ logs: 'Some output content' })
-    const { getByText } = render(
+    const { getByLabelText } = render(
       <SessionActivityLog logs={[log]} onViewFullOutput={onViewFullOutput} />
     )
-    const btn = getByText('View Full Output')
+    const btn = getByLabelText('View full output')
     expect(btn).toBeInTheDocument()
     fireEvent.click(btn)
     expect(onViewFullOutput).toHaveBeenCalledWith('Some output content')
@@ -210,15 +211,15 @@ describe('SessionActivityLog', () => {
   })
 
   it('does not show Resume Session when no agentSessionId', () => {
-    const { queryByText } = render(
+    const { queryByLabelText } = render(
       <SessionActivityLog logs={[makeLog()]} onViewFullOutput={onViewFullOutput} />
     )
-    expect(queryByText('Resume Session')).not.toBeInTheDocument()
+    expect(queryByLabelText('Resume session')).not.toBeInTheDocument()
   })
 
   it('shows Resume Session for errored sessions when agentSessionId provided', () => {
     const onResume = vi.fn()
-    const { getByText } = render(
+    const { getByLabelText } = render(
       <SessionActivityLog
         logs={[makeLog({ status: 'error', exitCode: 1, logs: 'Error: failed' })]}
         onViewFullOutput={onViewFullOutput}
@@ -227,6 +228,6 @@ describe('SessionActivityLog', () => {
         projectPath="/test"
       />
     )
-    expect(getByText('Resume Session')).toBeInTheDocument()
+    expect(getByLabelText('Resume session')).toBeInTheDocument()
   })
 })

--- a/tests/session-activity-log.test.tsx
+++ b/tests/session-activity-log.test.tsx
@@ -230,4 +230,27 @@ describe('SessionActivityLog', () => {
     )
     expect(getByLabelText('Resume session')).toBeInTheDocument()
   })
+
+  it('clicking Resume Session fires the callback with session + project info', () => {
+    const onResume = vi.fn()
+    const { getByLabelText } = render(
+      <SessionActivityLog
+        logs={[
+          makeLog({
+            status: 'error',
+            exitCode: 1,
+            logs: 'Error: failed',
+            projectName: 'proj',
+            branch: 'feat/x'
+          })
+        ]}
+        onViewFullOutput={onViewFullOutput}
+        onResumeSession={onResume}
+        agentSessionId="agent-xyz"
+        projectPath="/abs/path"
+      />
+    )
+    fireEvent.click(getByLabelText('Resume session'))
+    expect(onResume).toHaveBeenCalledWith('agent-xyz', 'claude', 'proj', '/abs/path', 'feat/x')
+  })
 })

--- a/tests/session-activity-log.test.tsx
+++ b/tests/session-activity-log.test.tsx
@@ -253,4 +253,27 @@ describe('SessionActivityLog', () => {
     fireEvent.click(getByLabelText('Resume session'))
     expect(onResume).toHaveBeenCalledWith('agent-xyz', 'claude', 'proj', '/abs/path', 'feat/x')
   })
+
+  it('falls back to claude / empty project name when log fields are missing', () => {
+    const onResume = vi.fn()
+    const { getByLabelText } = render(
+      <SessionActivityLog
+        logs={[
+          makeLog({
+            status: 'error',
+            agentType: undefined,
+            projectName: undefined,
+            exitCode: 1,
+            logs: 'boom'
+          })
+        ]}
+        onViewFullOutput={onViewFullOutput}
+        onResumeSession={onResume}
+        agentSessionId="agent-2"
+        projectPath="/p"
+      />
+    )
+    fireEvent.click(getByLabelText('Resume session'))
+    expect(onResume).toHaveBeenCalledWith('agent-2', 'claude', '', '/p', 'main')
+  })
 })

--- a/tests/session-output-capture.test.ts
+++ b/tests/session-output-capture.test.ts
@@ -167,9 +167,13 @@ vi.mock('../packages/server/src/task-images', () => ({
   cleanupTaskImages: vi.fn()
 }))
 
-vi.mock('../packages/server/src/script-runner', () => ({
-  executeScript: vi.fn()
-}))
+vi.mock('../packages/server/src/script-runner', async () => {
+  const { EventEmitter } = await import('node:events')
+  return {
+    executeScript: vi.fn(),
+    scriptRunnerEvents: new EventEmitter()
+  }
+})
 
 vi.mock('../packages/server/src/tailscale', () => ({
   getTailscaleStatus: vi.fn(),


### PR DESCRIPTION
## Summary
- Script steps stream stdout/stderr live into Run History via new `SCRIPT_DATA`/`SCRIPT_EXIT` IPC, matching how headless agent output is captured.
- Headless agent runs for claude/copilot pin a session id on spawn (`--session-id`) and accept `--resume`, so they can be reopened after exit.
- Run History and task Session Activity expose a neutral icon-only Resume button (`RotateCcw`, matching the top-bar Recent Sessions control) that opens the session interactively in the grid.
- Trigger-driven workflow steps fall back to the triggering task's project when the node config is project-agnostic.
- Run History renders newest-first (dropped a spurious reverse on top of the DB's `ORDER BY started_at DESC`).

## Test plan
- [ ] Bash script step with `for i in 1..8; echo; sleep 1` — logs stream into Run History in real time
- [ ] Headless claude step — after completion, Resume button appears; clicking opens a terminal in the grid with `--resume <uuid>` in the launch line
- [ ] Headless copilot step — same as above with `--resume`
- [ ] Headless codex / opencode / gemini — run succeeds, no stray `--session-id` flag, no Resume button for non-pinning agents
- [ ] Interactive step — no regression, Resume still works
- [ ] Trigger-driven workflow with project-agnostic launchAgent node — Resume opens in the triggering task's project
- [ ] Script step exits non-zero — streamed logs and error/exit code visible in history
- [ ] Run History list order — newest run at the top