### PR TITLE
feat: redesign tabs with underline style and sidebar line indicator

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -172,7 +172,7 @@ export const AgentCard = memo(
             <AgentStatusIcon
               agentType={terminal.session.agentType}
               status={terminal.status}
-              size={20}
+              size={16}
             />
             <div className="flex-1 min-w-0">
               {isRenaming ? (
@@ -358,7 +358,7 @@ export const AgentCard = memo(
         </div>
 
         {/* Terminal */}
-        <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
+        <div className="relative flex-1 min-h-0 pt-0.5" style={{ background: '#141416' }}>
           {!isFocused && (
             // In flexible mode, reserve 16px at SE so the react-grid-layout
             // resize handle isn't covered by the TerminalHost overlay (z-45).

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -346,7 +346,7 @@ export function TabView() {
                 setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
               }}
               className={`group relative flex items-center gap-2 px-3 h-[36px] text-[13px] cursor-pointer
-                         transition-colors flex-1 min-w-0 max-w-[180px] select-none border-b
+                         transition-colors flex-1 min-w-[120px] max-w-[180px] select-none border-b
                          ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                          ${isDragging ? 'opacity-50' : ''}
                          ${
@@ -394,10 +394,12 @@ export function TabView() {
                 </span>
               )}
 
-              <span className="shrink-0 ml-auto flex items-center gap-1">
+              <span className="shrink-0 ml-auto relative flex items-center gap-1">
                 {index < 9 && !isRenaming && (
                   <span
-                    className="group-hover:hidden px-1 py-0.5 text-[9px] font-mono text-gray-500
+                    className="absolute right-0 top-1/2 -translate-y-1/2
+                                 opacity-100 group-hover:opacity-0 transition-opacity
+                                 px-1 py-0.5 text-[9px] font-mono text-gray-500
                                  bg-white/[0.06] border border-white/[0.1] rounded leading-none
                                  pointer-events-none"
                   >
@@ -407,13 +409,16 @@ export function TabView() {
                 )}
                 {!isRenaming && (
                   <button
+                    type="button"
                     onClick={(e) => {
                       e.stopPropagation()
                       setRenamingTerminalId(id)
                     }}
-                    className="hidden group-hover:flex w-4 h-4 items-center justify-center rounded
-                               transition-colors text-gray-500 hover:text-gray-300"
+                    className="w-4 h-4 flex items-center justify-center rounded
+                               opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity
+                               text-gray-500 hover:text-gray-300"
                     title="Rename session"
+                    aria-label="Rename session"
                   >
                     <Pencil size={10} />
                   </button>
@@ -423,13 +428,16 @@ export function TabView() {
                   confirmLabel="Close"
                   onConfirm={() => handleCloseTab(id)}
                 >
-                  <span
-                    className="hidden group-hover:flex w-4 h-4 items-center justify-center rounded
-                               transition-colors text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
+                  <button
+                    type="button"
+                    className="w-4 h-4 flex items-center justify-center rounded
+                               opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity
+                               text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
                     title="Close session"
+                    aria-label="Close session"
                   >
                     <X size={10} strokeWidth={2} />
-                  </span>
+                  </button>
                 </ConfirmPopover>
               </span>
             </div>

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -296,8 +296,8 @@ export function TabView() {
 
       {/* Tab bar */}
       <div
-        className="shrink-0 flex items-center gap-0.5 px-2 py-1.5 border-b border-white/[0.06] overflow-x-auto"
-        style={{ minHeight: 36 }}
+        className="shrink-0 flex items-end gap-1 px-2 border-b border-white/[0.06] overflow-x-auto"
+        style={{ minHeight: 40 }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerUp}
@@ -346,15 +346,15 @@ export function TabView() {
                 e.stopPropagation()
                 setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
               }}
-              title={tooltip}
-              className={`group relative flex items-center gap-1.5 px-2.5 h-[28px] rounded-md text-xs
-                         transition-colors shrink-0 max-w-[240px] select-none
+              title={undefined}
+              className={`group relative flex items-center gap-2 px-3 h-[36px] text-[13px] cursor-pointer
+                         transition-colors flex-1 min-w-0 max-w-[180px] select-none
                          ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                          ${isDragging ? 'opacity-50' : ''}
                          ${
                            isActive
-                             ? 'bg-white/[0.1] text-white'
-                             : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
+                             ? 'text-white border-b border-white'
+                             : 'text-gray-500 hover:text-gray-300 border-b border-transparent'
                          }`}
               style={isIdlePinned ? { opacity: 0.55 } : undefined}
             >
@@ -373,11 +373,13 @@ export function TabView() {
                 </span>
               )}
 
-              <AgentStatusIcon
-                agentType={terminal.session.agentType}
-                status={terminal.status}
-                size={12}
-              />
+              <span className="shrink-0 flex items-center justify-center w-[16px] h-[16px]">
+                <AgentStatusIcon
+                  agentType={terminal.session.agentType}
+                  status={terminal.status}
+                  size={16}
+                />
+              </span>
 
               {isRenaming ? (
                 <InlineRename
@@ -391,55 +393,59 @@ export function TabView() {
                   className="text-xs w-[100px]"
                 />
               ) : (
-                <>
-                  <span className="truncate">{displayName}</span>
+                <span className="truncate" title={tooltip}>
+                  {displayName}
+                </span>
+              )}
+
+              {/* Right slot: badge (default) ↔ edit + close (hover) */}
+              <span className="shrink-0 ml-auto flex items-center gap-1">
+                {index < 9 && !isRenaming && (
+                  <span
+                    className="group-hover:hidden px-1 py-0.5 text-[9px] font-mono text-gray-500
+                                 bg-white/[0.06] border border-white/[0.1] rounded leading-none
+                                 pointer-events-none"
+                  >
+                    {isMac ? '\u2318' : 'Ctrl+'}
+                    {index + 1}
+                  </span>
+                )}
+                {!isRenaming && (
                   <button
                     onClick={(e) => {
                       e.stopPropagation()
                       setRenamingTerminalId(id)
                     }}
-                    className="shrink-0 opacity-0 group-hover:opacity-100 text-gray-500 hover:text-gray-300 transition-opacity"
-                    title="Rename"
+                    className="hidden group-hover:flex w-4 h-4 items-center justify-center rounded
+                               transition-colors text-gray-500 hover:text-gray-300"
+                    title="Rename session"
                   >
-                    <Pencil size={9} />
+                    <Pencil size={10} />
                   </button>
-                </>
-              )}
-
-              {/* Keyboard shortcut badge */}
-              {index < 9 && !isRenaming && (
-                <span
-                  className="shrink-0 ml-auto px-0.5 text-[8px] font-mono text-gray-600
-                               bg-white/[0.04] border border-white/[0.06] rounded leading-none
-                               pointer-events-none"
+                )}
+                <ConfirmPopover
+                  message="Close this session?"
+                  confirmLabel="Close"
+                  onConfirm={() => handleCloseTab(id)}
                 >
-                  {isMac ? '\u2318' : 'Ctrl+'}
-                  {index + 1}
-                </span>
-              )}
-
-              <ConfirmPopover
-                message="Close this session?"
-                confirmLabel="Close"
-                onConfirm={() => handleCloseTab(id)}
-              >
-                <span
-                  className="ml-0.5 shrink-0 w-4 h-4 flex items-center justify-center rounded
-                             transition-colors opacity-0 group-hover:opacity-100 text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
-                  title="Close session"
-                >
-                  <svg
-                    width="8"
-                    height="8"
-                    viewBox="0 0 8 8"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
+                  <span
+                    className="hidden group-hover:flex w-4 h-4 items-center justify-center rounded
+                               transition-colors text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
+                    title="Close session"
                   >
-                    <path d="M1 1l6 6M7 1l-6 6" />
-                  </svg>
-                </span>
-              </ConfirmPopover>
+                    <svg
+                      width="9"
+                      height="9"
+                      viewBox="0 0 8 8"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    >
+                      <path d="M1 1l6 6M7 1l-6 6" />
+                    </svg>
+                  </span>
+                </ConfirmPopover>
+              </span>
             </div>
           )
         })}
@@ -448,7 +454,7 @@ export function TabView() {
         <div className="shrink-0 flex items-center">
           <button
             onClick={handleQuickLaunch}
-            className="h-[28px] w-[24px] flex items-center justify-center rounded-l-md
+            className="h-[36px] w-[24px] flex items-center justify-center rounded-l-md
                        text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
             title="New session"
           >
@@ -479,7 +485,7 @@ export function TabView() {
                 })
               }
             }}
-            className="h-[28px] w-[16px] flex items-center justify-center rounded-r-md
+            className="h-[36px] w-[16px] flex items-center justify-center rounded-r-md
                        text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors
                        border-l border-white/[0.06]"
             title="More launch options"
@@ -494,7 +500,7 @@ export function TabView() {
       </div>
 
       {/* Terminal content */}
-      <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
+      <div className="relative flex-1 min-h-0 pt-4" style={{ background: '#141416' }}>
         {activeTabId && activeTerminal && (
           <TerminalSlot
             key={activeTabId}

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -18,10 +18,9 @@ import { resolveActiveProject } from '../lib/session-utils'
 import type { AgentStatus } from '../../shared/types'
 import { ConfirmPopover } from './ConfirmPopover'
 import { toast } from './Toast'
-import { ChevronDown, GripVertical, Pencil } from 'lucide-react'
+import { ChevronDown, GripVertical, Pencil, X } from 'lucide-react'
 import { GridContextMenu } from './GridContextMenu'
-
-const isMac = navigator.platform.toUpperCase().includes('MAC')
+import { MOD } from '../lib/platform'
 
 const STATUS_LABEL: Record<AgentStatus, string> = {
   running: 'Running',
@@ -346,15 +345,14 @@ export function TabView() {
                 e.stopPropagation()
                 setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
               }}
-              title={undefined}
               className={`group relative flex items-center gap-2 px-3 h-[36px] text-[13px] cursor-pointer
-                         transition-colors flex-1 min-w-0 max-w-[180px] select-none
+                         transition-colors flex-1 min-w-0 max-w-[180px] select-none border-b
                          ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                          ${isDragging ? 'opacity-50' : ''}
                          ${
                            isActive
-                             ? 'text-white border-b border-white'
-                             : 'text-gray-500 hover:text-gray-300 border-b border-transparent'
+                             ? 'text-white border-white'
+                             : 'text-gray-500 hover:text-gray-300 border-transparent'
                          }`}
               style={isIdlePinned ? { opacity: 0.55 } : undefined}
             >
@@ -373,13 +371,11 @@ export function TabView() {
                 </span>
               )}
 
-              <span className="shrink-0 flex items-center justify-center w-[16px] h-[16px]">
-                <AgentStatusIcon
-                  agentType={terminal.session.agentType}
-                  status={terminal.status}
-                  size={16}
-                />
-              </span>
+              <AgentStatusIcon
+                agentType={terminal.session.agentType}
+                status={terminal.status}
+                size={16}
+              />
 
               {isRenaming ? (
                 <InlineRename
@@ -398,7 +394,6 @@ export function TabView() {
                 </span>
               )}
 
-              {/* Right slot: badge (default) ↔ edit + close (hover) */}
               <span className="shrink-0 ml-auto flex items-center gap-1">
                 {index < 9 && !isRenaming && (
                   <span
@@ -406,7 +401,7 @@ export function TabView() {
                                  bg-white/[0.06] border border-white/[0.1] rounded leading-none
                                  pointer-events-none"
                   >
-                    {isMac ? '\u2318' : 'Ctrl+'}
+                    {MOD}
                     {index + 1}
                   </span>
                 )}
@@ -433,16 +428,7 @@ export function TabView() {
                                transition-colors text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
                     title="Close session"
                   >
-                    <svg
-                      width="9"
-                      height="9"
-                      viewBox="0 0 8 8"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                    >
-                      <path d="M1 1l6 6M7 1l-6 6" />
-                    </svg>
+                    <X size={10} strokeWidth={2} />
                   </span>
                 </ConfirmPopover>
               </span>

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -73,12 +73,16 @@ export function SessionItem({
       }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className={`group/session w-full text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
+      className={`group/session w-full text-left px-2 py-1 text-[12px] flex items-center gap-2 min-w-0 transition-colors relative ${
         isActive || isPreviewing
-          ? 'bg-white/[0.08] text-white'
-          : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
+          ? 'text-white'
+          : 'text-gray-400 hover:text-white hover:bg-white/[0.04] rounded-md'
       }`}
     >
+      {/* Active session indicator — minimal left line */}
+      {(isActive || isPreviewing) && (
+        <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />
+      )}
       <span className="shrink-0" title={`${session.agentType} · ${STATUS_LABEL[session.status]}`}>
         <AgentStatusIcon agentType={session.agentType} status={session.status} size={14} />
       </span>

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -27,6 +27,7 @@ export function SessionItem({
   const isActive =
     layoutMode === 'tabs' ? activeTabId === session.id : focusedTerminalId === session.id
   const isPreviewing = previewTerminalId === session.id
+  const isSelected = isActive || isPreviewing
 
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -73,16 +74,11 @@ export function SessionItem({
       }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className={`group/session w-full text-left px-2 py-1 text-[12px] flex items-center gap-2 min-w-0 transition-colors relative ${
-        isActive || isPreviewing
-          ? 'text-white'
-          : 'text-gray-400 hover:text-white hover:bg-white/[0.04] rounded-md'
+      className={`group/session relative w-full text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
+        isSelected ? 'text-white' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
       }`}
     >
-      {/* Active session indicator — minimal left line */}
-      {(isActive || isPreviewing) && (
-        <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />
-      )}
+      {isSelected && <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />}
       <span className="shrink-0" title={`${session.agentType} · ${STATUS_LABEL[session.status]}`}>
         <AgentStatusIcon agentType={session.agentType} status={session.status} size={14} />
       </span>

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -60,7 +60,7 @@ describe('SessionItem', () => {
     useAppStore.setState({ focusedTerminalId: 'sess-1' })
     const { container } = render(<SessionItem session={session} />)
     const button = container.querySelector('button')
-    expect(button?.className).toContain('bg-white/[0.08]')
+    expect(button?.className).toContain('text-white')
   })
 
   it('applies unfocused style when session is not focused', () => {


### PR DESCRIPTION
## Changes

### Tab Bar
- Replace background highlight with bottom **underline** for active tab
- Equal-width tabs (`flex-1`, max 180px) with text truncation
- Badge/close **swap on hover** — ⌘N badge visible by default, rename + close icons on hover
- Larger icons (16px agent, 10px pencil, 9px close)
- More pronounced shortcut badges (9px, stronger border/bg)
- `cursor-pointer` and proper per-element tooltips
- `pt-4` spacing between tab bar and terminal content

### Sidebar
- Replace full-row background highlight with **1px left vertical line** for active session

### AgentCard
- Reduce agent icon from 20px to 16px
- Add `pt-0.5` spacing between header and terminal content

### Files Changed
- `src/renderer/components/TabView.tsx`
- `src/renderer/components/project-sidebar/SessionItem.tsx`
- `src/renderer/components/AgentCard.tsx`