### PR TITLE
feat: approval gate node for workflows

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -367,6 +367,7 @@ function createSchema(): void {
       agent_type TEXT,
       project_name TEXT,
       project_path TEXT,
+      approved_at TEXT,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -579,6 +580,22 @@ function migrateSchema(d: Database.Database): void {
       '[database] migrated schema to version 7 (rename claude_session_id → agent_session_id)'
     )
   }
+
+  if (version < 8) {
+    d.transaction(() => {
+      const cols = d.prepare('PRAGMA table_info(workflow_run_nodes)').all() as Array<{
+        name: string
+      }>
+      if (!cols.some((c) => c.name === 'approved_at')) {
+        d.exec('ALTER TABLE workflow_run_nodes ADD COLUMN approved_at TEXT')
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '8')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 8 (approval gate timestamp)')
+  }
 }
 
 /**
@@ -630,7 +647,11 @@ function verifySchema(d: Database.Database): void {
         column: 'project_name',
         ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_name TEXT'
       },
-      { column: 'project_path', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_path TEXT' }
+      {
+        column: 'project_path',
+        ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_path TEXT'
+      },
+      { column: 'approved_at', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN approved_at TEXT' }
     ]
   }
 
@@ -1809,8 +1830,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -1826,7 +1847,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         ns.agentSessionId ?? null,
         ns.agentType ?? null,
         ns.projectName ?? null,
-        ns.projectPath ?? null
+        ns.projectPath ?? null,
+        ns.approvedAt ?? null
       )
     }
 
@@ -1878,6 +1900,7 @@ export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecut
       agent_type: string | null
       project_name: string | null
       project_path: string | null
+      approved_at: string | null
     }>
 
     return {
@@ -1898,7 +1921,8 @@ export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecut
         ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
         ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
         ...(n.project_name != null && { projectName: n.project_name }),
-        ...(n.project_path != null && { projectPath: n.project_path })
+        ...(n.project_path != null && { projectPath: n.project_path }),
+        ...(n.approved_at != null && { approvedAt: n.approved_at })
       }))
     }
   })
@@ -1946,6 +1970,7 @@ export function listWorkflowRunsByTask(
       logs: string | null
       task_id: string | null
       agent_session_id: string | null
+      approved_at: string | null
     }>
 
     return {
@@ -1964,10 +1989,84 @@ export function listWorkflowRunsByTask(
         ...(n.error != null && { error: n.error }),
         ...(n.logs != null && { logs: n.logs }),
         ...(n.task_id != null && { taskId: n.task_id }),
-        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id })
+        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
+        ...(n.approved_at != null && { approvedAt: n.approved_at })
       }))
     }
   })
+}
+
+export function listRunsWithWaitingGates(): WorkflowExecution[] {
+  const d = getDb()
+
+  const rows = d
+    .prepare(
+      `SELECT DISTINCT wr.*
+       FROM workflow_runs wr
+       JOIN workflow_run_nodes wrn ON wrn.run_id = wr.id
+       WHERE wrn.status = 'waiting'
+       ORDER BY wr.started_at DESC`
+    )
+    .all() as Array<{
+    id: string
+    workflow_id: string
+    started_at: string
+    completed_at: string | null
+    status: string
+    trigger_task_id: string | null
+  }>
+
+  if (rows.length === 0) return []
+
+  const placeholders = rows.map(() => '?').join(',')
+  const allNodeRows = d
+    .prepare(`SELECT * FROM workflow_run_nodes WHERE run_id IN (${placeholders})`)
+    .all(...rows.map((r) => r.id)) as Array<{
+    run_id: string
+    node_id: string
+    status: string
+    started_at: string | null
+    completed_at: string | null
+    session_id: string | null
+    error: string | null
+    logs: string | null
+    task_id: string | null
+    agent_session_id: string | null
+    agent_type: string | null
+    project_name: string | null
+    project_path: string | null
+    approved_at: string | null
+  }>
+
+  const nodesByRun = new Map<string, typeof allNodeRows>()
+  for (const n of allNodeRows) {
+    const bucket = nodesByRun.get(n.run_id)
+    if (bucket) bucket.push(n)
+    else nodesByRun.set(n.run_id, [n])
+  }
+
+  return rows.map((r) => ({
+    workflowId: r.workflow_id,
+    startedAt: r.started_at,
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    status: r.status as WorkflowExecution['status'],
+    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+    nodeStates: (nodesByRun.get(r.id) ?? []).map((n) => ({
+      nodeId: n.node_id,
+      status: n.status as NodeExecutionState['status'],
+      ...(n.started_at != null && { startedAt: n.started_at }),
+      ...(n.completed_at != null && { completedAt: n.completed_at }),
+      ...(n.session_id != null && { sessionId: n.session_id }),
+      ...(n.error != null && { error: n.error }),
+      ...(n.logs != null && { logs: n.logs }),
+      ...(n.task_id != null && { taskId: n.task_id }),
+      ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
+      ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
+      ...(n.project_name != null && { projectName: n.project_name }),
+      ...(n.project_path != null && { projectPath: n.project_path }),
+      ...(n.approved_at != null && { approvedAt: n.approved_at })
+    }))
+  }))
 }
 
 // ─── Session Logs ─────────────────────────────────────────────────

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -42,6 +42,7 @@ import {
   saveWorkflowRun,
   listWorkflowRuns,
   listWorkflowRunsByTask,
+  listRunsWithWaitingGates,
   updateWorkflowRunStatus,
   dbSaveSSHKey,
   dbListSSHKeys,
@@ -384,6 +385,7 @@ export function registerAllMethods(): void {
   registerMethod('workflowRun:listByTask', ({ taskId, limit }) =>
     listWorkflowRunsByTask(taskId, limit)
   )
+  registerMethod('workflowRun:listWaiting', () => listRunsWithWaitingGates())
 
   // Session logs
   registerMethod('sessionLog:list', ({ taskId }) => listSessionLogs(taskId))

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -220,7 +220,7 @@ export interface WorkflowExecutionContext {
   }
 }
 
-export type WorkflowNodeType = 'trigger' | 'launchAgent' | 'script' | 'condition'
+export type WorkflowNodeType = 'trigger' | 'launchAgent' | 'script' | 'condition' | 'approval'
 
 export interface WorkflowNodePosition {
   x: number
@@ -313,7 +313,17 @@ export interface ConditionConfig {
   value: string
 }
 
-export type WorkflowNodeConfig = TriggerConfig | LaunchAgentConfig | ScriptConfig | ConditionConfig
+export interface ApprovalConfig {
+  message?: string
+  timeoutMs?: number
+}
+
+export type WorkflowNodeConfig =
+  | TriggerConfig
+  | LaunchAgentConfig
+  | ScriptConfig
+  | ConditionConfig
+  | ApprovalConfig
 
 export interface WorkflowNode {
   id: string
@@ -332,7 +342,13 @@ export interface WorkflowEdge {
 }
 
 // Execution tracking (runtime only)
-export type NodeExecutionStatus = 'pending' | 'running' | 'success' | 'error' | 'skipped'
+export type NodeExecutionStatus =
+  | 'pending'
+  | 'running'
+  | 'success'
+  | 'error'
+  | 'skipped'
+  | 'waiting'
 
 export interface NodeExecutionState {
   nodeId: string
@@ -354,6 +370,8 @@ export interface NodeExecutionState {
   projectPath?: string
   worktreePath?: string
   worktreeName?: string
+  /** Timestamp when an approval gate was approved. */
+  approvedAt?: string
 }
 
 export interface WorkflowDefinition {
@@ -637,6 +655,7 @@ export const IPC = {
   WORKFLOW_RUN_SAVE: 'workflowRun:save',
   WORKFLOW_RUN_LIST: 'workflowRun:list',
   WORKFLOW_RUN_LIST_BY_TASK: 'workflowRun:listByTask',
+  WORKFLOW_RUN_LIST_WAITING: 'workflowRun:listWaiting',
   SESSION_LOG_LIST: 'sessionLog:list',
   SESSION_LOG_UPDATE: 'sessionLog:update',
   SESSION_EVENT_LIST: 'sessionEvent:list',

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -133,6 +133,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.WORKFLOW_RUN_LIST_BY_TASK, (_, taskId, limit) =>
     requireBridge().request(IPC.WORKFLOW_RUN_LIST_BY_TASK, { taskId, limit })
   )
+  safeHandle(IPC.WORKFLOW_RUN_LIST_WAITING, () =>
+    requireBridge().request(IPC.WORKFLOW_RUN_LIST_WAITING, {})
+  )
 
   // Session logs
   safeHandle(IPC.SESSION_LOG_LIST, (_, taskId) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -342,6 +342,9 @@ const api = {
   ): Promise<(WorkflowExecution & { workflowName?: string })[]> =>
     ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_BY_TASK, taskId, limit),
 
+  listRunsWithWaitingGates: (): Promise<WorkflowExecution[]> =>
+    ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_WAITING),
+
   listSessionLogs: (taskId: string): Promise<SessionLog[]> =>
     ipcRenderer.invoke(IPC.SESSION_LOG_LIST, taskId),
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -353,6 +353,17 @@ export function App() {
     pollHeadless()
     const headlessPollInterval = setInterval(pollHeadless, 5000)
 
+    window.api
+      .listRunsWithWaitingGates()
+      .then((runs) => {
+        const store = useAppStore.getState()
+        for (const run of runs) {
+          if (store.workflowExecutions.has(run.workflowId)) continue
+          store.setWorkflowExecution(run.workflowId, run)
+        }
+      })
+      .catch((err) => console.error('[App] failed to hydrate waiting gates:', err))
+
     // Auto-prune exited headless sessions
     const pruneInterval = setInterval(() => {
       const retentionMinutes =

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,7 +13,11 @@ import { AddProjectDialog } from './components/AddProjectDialog'
 const WorkflowEditor = lazy(() =>
   import('./components/workflow-editor/WorkflowEditor').then((m) => ({ default: m.WorkflowEditor }))
 )
-import { executeWorkflow as runWorkflow } from './lib/workflow-execution'
+import {
+  executeWorkflow as runWorkflow,
+  rescheduleWaitingGateTimers
+} from './lib/workflow-execution'
+import type { WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
 import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
@@ -357,10 +361,13 @@ export function App() {
       .listRunsWithWaitingGates()
       .then((runs) => {
         const store = useAppStore.getState()
+        const hydrated: WorkflowExecution[] = []
         for (const run of runs) {
           if (store.workflowExecutions.has(run.workflowId)) continue
           store.setWorkflowExecution(run.workflowId, run)
+          hydrated.push(run)
         }
+        rescheduleWaitingGateTimers(hydrated, store.config?.workflows ?? [])
       })
       .catch((err) => console.error('[App] failed to hydrate waiting gates:', err))
 

--- a/src/renderer/components/BackgroundTray.tsx
+++ b/src/renderer/components/BackgroundTray.tsx
@@ -1,18 +1,37 @@
 import { useShallow } from 'zustand/react/shallow'
-import { HeadlessSession } from '../../shared/types'
+import {
+  HeadlessSession,
+  WorkflowExecution,
+  NodeExecutionState,
+  WorkflowDefinition
+} from '../../shared/types'
 import { HeadlessPill } from './HeadlessPill'
 import { MinimizedPill } from './MinimizedPill'
+import { WaitingApprovalPill } from './WaitingApprovalPill'
 import { useAppStore } from '../stores'
 import { ChevronRight } from 'lucide-react'
+
+export interface WaitingApproval {
+  execution: WorkflowExecution
+  nodeState: NodeExecutionState
+  workflow?: WorkflowDefinition
+}
 
 interface Props {
   headlessSessions: HeadlessSession[]
   minimizedIds: string[]
+  waitingApprovals: WaitingApproval[]
   variant: 'grid' | 'tabs'
   hasItemsBelow?: boolean
 }
 
-export function BackgroundTray({ headlessSessions, minimizedIds, variant, hasItemsBelow }: Props) {
+export function BackgroundTray({
+  headlessSessions,
+  minimizedIds,
+  waitingApprovals,
+  variant,
+  hasItemsBelow
+}: Props) {
   const { collapsed, toggle } = useAppStore(
     useShallow((s) => ({
       collapsed: s.backgroundTrayCollapsed,
@@ -22,18 +41,19 @@ export function BackgroundTray({ headlessSessions, minimizedIds, variant, hasIte
 
   const headlessCount = headlessSessions.length
   const minimizedCount = minimizedIds.length
-  const totalCount = headlessCount + minimizedCount
+  const waitingCount = waitingApprovals.length
+  const totalCount = headlessCount + minimizedCount + waitingCount
 
   if (totalCount === 0) return null
 
   const runningCount = headlessSessions.filter((s) => s.status === 'running').length
-  const hasBoth = headlessCount > 0 && minimizedCount > 0
+  const groupCount = [headlessCount, minimizedCount, waitingCount].filter((n) => n > 0).length
+  const hasMultipleGroups = groupCount > 1
 
   const isGrid = variant === 'grid'
 
   return (
     <div className={isGrid ? 'mb-4' : 'shrink-0 px-3 py-2 border-b border-white/[0.06]'}>
-      {/* Header row */}
       <button
         type="button"
         className={`flex items-center gap-1.5 w-full text-left cursor-pointer group ${isGrid ? 'px-1 mb-2' : 'mb-1.5'}`}
@@ -50,25 +70,52 @@ export function BackgroundTray({ headlessSessions, minimizedIds, variant, hasIte
           Background
         </span>
 
-        {/* Count badges */}
         <div className="flex items-center gap-1.5 text-[10px] text-gray-600">
+          {waitingCount > 0 && (
+            <span className="text-amber-400/80">
+              {waitingCount} waiting approval{waitingCount === 1 ? '' : 's'}
+            </span>
+          )}
+          {waitingCount > 0 && (headlessCount > 0 || minimizedCount > 0) && <span>&middot;</span>}
           {headlessCount > 0 && (
             <span>
               {runningCount > 0 ? `${runningCount} running` : `${headlessCount} headless`}
             </span>
           )}
-          {hasBoth && <span>&middot;</span>}
+          {headlessCount > 0 && minimizedCount > 0 && <span>&middot;</span>}
           {minimizedCount > 0 && <span>{minimizedCount} minimized</span>}
         </div>
       </button>
 
-      {/* Collapsible content — unmounted when collapsed to stop timers and remove from tab order */}
       {!collapsed && (
-        <div className={`flex max-h-[120px] overflow-y-auto ${hasBoth ? 'gap-4' : ''}`}>
-          {/* Headless group */}
+        <div className={`flex max-h-[120px] overflow-y-auto ${hasMultipleGroups ? 'gap-4' : ''}`}>
+          {waitingCount > 0 && (
+            <div className={hasMultipleGroups ? 'flex-1 min-w-0' : 'w-full'}>
+              {hasMultipleGroups && (
+                <span className="text-[9px] font-medium text-amber-400/70 uppercase tracking-wider mb-1 block">
+                  waiting approval
+                </span>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                {waitingApprovals.map((w) => (
+                  <WaitingApprovalPill
+                    key={`${w.execution.workflowId}-${w.execution.startedAt}-${w.nodeState.nodeId}`}
+                    execution={w.execution}
+                    nodeState={w.nodeState}
+                    workflow={w.workflow}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {waitingCount > 0 && (headlessCount > 0 || minimizedCount > 0) && (
+            <div className="w-px bg-white/[0.08] self-stretch" />
+          )}
+
           {headlessCount > 0 && (
-            <div className={hasBoth ? 'flex-1 min-w-0' : 'w-full'}>
-              {hasBoth && (
+            <div className={hasMultipleGroups ? 'flex-1 min-w-0' : 'w-full'}>
+              {hasMultipleGroups && (
                 <span className="text-[9px] font-medium text-gray-600 uppercase tracking-wider mb-1 block">
                   headless
                 </span>
@@ -81,13 +128,13 @@ export function BackgroundTray({ headlessSessions, minimizedIds, variant, hasIte
             </div>
           )}
 
-          {/* Vertical divider */}
-          {hasBoth && <div className="w-px bg-white/[0.08] self-stretch" />}
+          {headlessCount > 0 && minimizedCount > 0 && (
+            <div className="w-px bg-white/[0.08] self-stretch" />
+          )}
 
-          {/* Minimized group */}
           {minimizedCount > 0 && (
-            <div className={hasBoth ? 'flex-1 min-w-0' : 'w-full'}>
-              {hasBoth && (
+            <div className={hasMultipleGroups ? 'flex-1 min-w-0' : 'w-full'}>
+              {hasMultipleGroups && (
                 <span className="text-[9px] font-medium text-gray-600 uppercase tracking-wider mb-1 block">
                   minimized
                 </span>
@@ -102,7 +149,6 @@ export function BackgroundTray({ headlessSessions, minimizedIds, variant, hasIte
         </div>
       )}
 
-      {/* Bottom divider */}
       {hasItemsBelow && !collapsed && <div className="h-px bg-white/[0.06] mt-4" />}
     </div>
   )

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -13,6 +13,7 @@ import { GridContextMenu } from './GridContextMenu'
 import { AgentIcon } from './AgentIcon'
 import { useVisibleTerminals } from '../hooks/useVisibleTerminals'
 import { useFilteredHeadless } from '../hooks/useFilteredHeadless'
+import { useWaitingApprovals } from '../hooks/useWaitingApprovals'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { resolveActiveProject } from '../lib/session-utils'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
@@ -42,6 +43,7 @@ export const GridView = memo(function GridView() {
     }))
   )
   const filteredHeadless = useFilteredHeadless()
+  const waitingApprovals = useWaitingApprovals()
 
   const [dragState, setDragState] = useState<DragState | null>(null)
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null)
@@ -169,6 +171,7 @@ export const GridView = memo(function GridView() {
       <BackgroundTray
         headlessSessions={filteredHeadless}
         minimizedIds={minimizedIds}
+        waitingApprovals={waitingApprovals}
         variant="grid"
         hasItemsBelow={orderedIds.length > 0}
       />

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -6,6 +6,7 @@ import { getProjectRemoteHostId } from '../../shared/types'
 import { useVisibleTerminals } from '../hooks/useVisibleTerminals'
 import { useFilteredHeadless } from '../hooks/useFilteredHeadless'
 import { AgentStatusIcon } from './AgentStatusIcon'
+import { useWaitingApprovals } from '../hooks/useWaitingApprovals'
 import { TerminalSlot } from './TerminalSlot'
 import { PromptLauncher } from './PromptLauncher'
 import { InlineRename } from './InlineRename'
@@ -108,6 +109,7 @@ export function TabView() {
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
   const tasks = useAppStore((s) => s.config?.tasks)
   const filteredHeadless = useFilteredHeadless()
+  const waitingApprovals = useWaitingApprovals()
 
   const [contextMenu, setContextMenu] = useState<{
     terminalId: string
@@ -266,7 +268,8 @@ export function TabView() {
     )
   }
 
-  const hasBackground = minimizedIds.length > 0 || filteredHeadless.length > 0
+  const hasBackground =
+    minimizedIds.length > 0 || filteredHeadless.length > 0 || waitingApprovals.length > 0
 
   if (orderedIds.length === 0 && hasBackground) {
     return (
@@ -275,6 +278,7 @@ export function TabView() {
           <BackgroundTray
             headlessSessions={filteredHeadless}
             minimizedIds={minimizedIds}
+            waitingApprovals={waitingApprovals}
             variant="grid"
           />
         </div>
@@ -290,6 +294,7 @@ export function TabView() {
       <BackgroundTray
         headlessSessions={filteredHeadless}
         minimizedIds={minimizedIds}
+        waitingApprovals={waitingApprovals}
         variant="tabs"
       />
 

--- a/src/renderer/components/WaitingApprovalPill.tsx
+++ b/src/renderer/components/WaitingApprovalPill.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { Check, X, Zap } from 'lucide-react'
+import {
+  WorkflowExecution,
+  NodeExecutionState,
+  WorkflowDefinition,
+  ApprovalConfig
+} from '../../shared/types'
+import { useAppStore } from '../stores'
+import { ICON_MAP } from './project-sidebar/icon-map'
+import { approveWorkflowGate, rejectWorkflowGate } from '../lib/workflow-execution'
+import { Tooltip } from './Tooltip'
+
+interface Props {
+  execution: WorkflowExecution
+  nodeState: NodeExecutionState
+  workflow?: WorkflowDefinition
+}
+
+export function WaitingApprovalPill({ execution, nodeState, workflow }: Props) {
+  const { setEditingWorkflowId, setWorkflowEditorOpen } = useAppStore(
+    useShallow((s) => ({
+      setEditingWorkflowId: s.setEditingWorkflowId,
+      setWorkflowEditorOpen: s.setWorkflowEditorOpen
+    }))
+  )
+
+  const node = useMemo(
+    () => workflow?.nodes.find((n) => n.id === nodeState.nodeId),
+    [workflow, nodeState.nodeId]
+  )
+  const message = node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
+
+  const WfIcon = workflow ? ICON_MAP[workflow.icon] || Zap : Zap
+  const wfIconColor = workflow?.iconColor
+
+  const handleOpen = useCallback(() => {
+    setEditingWorkflowId(execution.workflowId)
+    setWorkflowEditorOpen(true)
+  }, [execution.workflowId, setEditingWorkflowId, setWorkflowEditorOpen])
+
+  const handleApprove = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      void approveWorkflowGate(execution, nodeState.nodeId)
+    },
+    [execution, nodeState.nodeId]
+  )
+
+  const handleReject = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      void rejectWorkflowGate(execution, nodeState.nodeId)
+    },
+    [execution, nodeState.nodeId]
+  )
+
+  return (
+    <div
+      onClick={handleOpen}
+      className="inline-flex items-center gap-1.5 rounded-md border bg-[#1a1a1e] px-2.5 py-1
+                 cursor-pointer transition-colors select-none
+                 border-amber-500/30 hover:border-amber-500/50"
+    >
+      <div className="relative flex-shrink-0">
+        <div className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+        <div
+          className="absolute inset-[-1px] rounded-full bg-amber-400 opacity-40 animate-ping"
+          style={{ animationDuration: '2s' }}
+        />
+      </div>
+
+      <WfIcon size={12} strokeWidth={1.5} color={wfIconColor || undefined} />
+
+      <span className="text-[11px] font-medium text-gray-200 truncate max-w-[140px]">
+        {workflow?.name || 'Workflow'}
+      </span>
+
+      {message && (
+        <>
+          <span className="text-[10px] text-gray-600 flex-shrink-0">&middot;</span>
+          <span className="text-[10px] text-gray-500 truncate max-w-[180px]">{message}</span>
+        </>
+      )}
+
+      <div className="flex items-center gap-0.5 ml-1 flex-shrink-0">
+        <Tooltip label="Approve">
+          <button
+            onClick={handleApprove}
+            aria-label="Approve"
+            className="p-0.5 rounded text-green-400 hover:text-green-300 hover:bg-green-500/10 transition-colors"
+          >
+            <Check size={12} strokeWidth={2.5} />
+          </button>
+        </Tooltip>
+        <Tooltip label="Reject">
+          <button
+            onClick={handleReject}
+            aria-label="Reject"
+            className="p-0.5 rounded text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors"
+          >
+            <X size={12} strokeWidth={2.5} />
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -7,9 +7,14 @@ import { executeWorkflow } from '../../lib/workflow-execution'
 import { Zap, Play, MoreHorizontal } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 
-type DotColor = 'blue' | 'gray' | 'red' | null
+type DotColor = 'blue' | 'gray' | 'red' | 'amber' | null
 
-function statusDotColor(workflow: WorkflowDefinition, scheduled: boolean): DotColor {
+function statusDotColor(
+  workflow: WorkflowDefinition,
+  scheduled: boolean,
+  hasWaitingGate: boolean
+): DotColor {
+  if (hasWaitingGate) return 'amber'
   if (scheduled) return workflow.enabled ? 'blue' : 'gray'
   if (workflow.lastRunStatus === 'error') return 'red'
   return null
@@ -18,7 +23,8 @@ function statusDotColor(workflow: WorkflowDefinition, scheduled: boolean): DotCo
 const DOT_CLASSES: Record<Exclude<DotColor, null>, string> = {
   blue: 'bg-blue-400',
   gray: 'bg-gray-600',
-  red: 'bg-red-500'
+  red: 'bg-red-500',
+  amber: 'bg-amber-400 animate-pulse'
 }
 
 export function WorkflowItem({
@@ -39,7 +45,11 @@ export function WorkflowItem({
   const WfIcon = ICON_MAP[workflow.icon] || Zap
   const isScheduled = isScheduledWorkflow(workflow)
   const isDisabled = isScheduled && !workflow.enabled
-  const dot = statusDotColor(workflow, isScheduled)
+  const hasWaitingGate = useAppStore((s) => {
+    const exec = s.workflowExecutions.get(workflow.id)
+    return exec ? exec.nodeStates.some((ns) => ns.status === 'waiting') : false
+  })
+  const dot = statusDotColor(workflow, isScheduled, hasWaitingGate)
 
   const handleEdit = () => {
     setEditingWorkflowId(workflow.id)

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,17 +1,19 @@
-import { useState } from 'react'
-import { ChevronDown, ChevronRight, Maximize2, RotateCcw } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { ChevronDown, ChevronRight, Maximize2, RotateCcw, Check, X } from 'lucide-react'
 import {
   WorkflowExecution,
   WorkflowNode,
   NodeExecutionState,
   TaskConfig,
   AgentType,
+  ApprovalConfig,
   supportsExactSessionResume
 } from '../../../shared/types'
 
 import { formatRelativeTime } from '../../lib/format-time'
 import { STATUS_DOT_CLASSES as SHARED_STATUS_DOTS } from './statusDot'
 import { Tooltip } from '../Tooltip'
+import { approveWorkflowGate, rejectWorkflowGate } from '../../lib/workflow-execution'
 
 function formatDuration(start: string, end?: string): string {
   if (!end) return 'running...'
@@ -21,12 +23,13 @@ function formatDuration(start: string, end?: string): string {
   return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
 }
 
-const STATUS_LABELS: Record<string, string> = {
+const STATUS_LABELS: Record<WorkflowExecution['status'] | NodeExecutionState['status'], string> = {
   success: 'Success',
   error: 'Error',
   running: 'Running',
   pending: 'Pending',
-  skipped: 'Skipped'
+  skipped: 'Skipped',
+  waiting: 'Waiting for approval'
 }
 
 export function StatusDot({
@@ -76,8 +79,14 @@ export function RunEntry({
   onClickTask,
   onResumeSession
 }: RunEntryProps) {
-  const [expanded, setExpanded] = useState(false)
+  const hasWaitingGate = execution.nodeStates.some((ns) => ns.status === 'waiting')
+  const [expanded, setExpanded] = useState(hasWaitingGate)
   const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null)
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (hasWaitingGate) setExpanded(true)
+  }, [hasWaitingGate])
 
   // Filter to non-trigger nodes for display
   const actionStates = execution.nodeStates.filter((ns) => {
@@ -174,6 +183,10 @@ export function RunEntry({
                 resumeUseWorktree
               )
 
+            const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
+            const approvalMessage =
+              node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
+
             return (
               <div key={ns.nodeId} className="border-b border-white/[0.04] last:border-b-0">
                 {/* Step header */}
@@ -215,6 +228,37 @@ export function RunEntry({
                     </span>
                   )}
                 </button>
+
+                {/* Approval gate controls */}
+                {isWaitingGate && (
+                  <div className="px-4 pb-3 -mt-0.5 flex items-start gap-2">
+                    <div className="flex-1 min-w-0 text-[11px] text-amber-300/90">
+                      {approvalMessage || 'Waiting for approval.'}
+                    </div>
+                    <button
+                      onClick={() => {
+                        void approveWorkflowGate(execution, ns.nodeId)
+                      }}
+                      className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
+                                 text-green-300 hover:text-green-200 hover:bg-green-500/10
+                                 border border-green-500/30 transition-colors shrink-0"
+                    >
+                      <Check size={11} strokeWidth={2.5} />
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => {
+                        void rejectWorkflowGate(execution, ns.nodeId)
+                      }}
+                      className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
+                                 text-red-300 hover:text-red-200 hover:bg-red-500/10
+                                 border border-red-500/30 transition-colors shrink-0"
+                    >
+                      <X size={11} strokeWidth={2.5} />
+                      Reject
+                    </button>
+                  </div>
+                )}
 
                 {/* Expanded logs */}
                 {expandedNodeId === ns.nodeId && ns.logs && (

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -3,6 +3,7 @@ import { TriggerNode } from './nodes/TriggerNode'
 import { LaunchAgentNode } from './nodes/LaunchAgentNode'
 import { ScriptNode } from './nodes/ScriptNode'
 import { ConditionNode } from './nodes/ConditionNode'
+import { ApprovalNode } from './nodes/ApprovalNode'
 import { ConnectorButton } from './nodes/AddStepNode'
 import {
   WorkflowNode,
@@ -10,19 +11,18 @@ import {
   TriggerConfig,
   LaunchAgentConfig,
   ScriptConfig,
-  ConditionConfig
+  ConditionConfig,
+  ApprovalConfig
 } from '../../../shared/types'
 import { computeFlowLayout, FlowRow } from '../../lib/workflow-helpers'
+
+export type AddableNodeType = 'agent' | 'script' | 'condition' | 'approval'
 
 interface Props {
   nodes: WorkflowNode[]
   edges: WorkflowEdge[]
   onNodeClick: (nodeId: string) => void
-  onInsertNode: (
-    afterNodeId: string,
-    beforeNodeId: string | null,
-    type: 'agent' | 'script' | 'condition'
-  ) => void
+  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
   selectedNodeId: string | null
 }
@@ -80,6 +80,17 @@ function NodeCard({
     )
   }
 
+  if (node.type === 'approval') {
+    return (
+      <ApprovalNode
+        label={node.label}
+        config={node.config as ApprovalConfig}
+        selected={selected}
+        onClick={onClick}
+      />
+    )
+  }
+
   return (
     <LaunchAgentNode
       label={node.label}
@@ -104,11 +115,7 @@ function FlowRowRenderer({
   edges?: WorkflowEdge[]
   nodes?: WorkflowNode[]
   onNodeClick: (nodeId: string) => void
-  onInsertNode: (
-    afterNodeId: string,
-    beforeNodeId: string | null,
-    type: 'agent' | 'script' | 'condition'
-  ) => void
+  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
   selectedNodeId: string | null
   isInsideBranch?: boolean
@@ -145,6 +152,7 @@ function FlowRowRenderer({
                     onAddAction={() => onInsertNode(row.node.id, beforeNodeId, 'agent')}
                     onAddScript={() => onInsertNode(row.node.id, beforeNodeId, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, beforeNodeId, 'condition')}
+                    onAddApproval={() => onInsertNode(row.node.id, beforeNodeId, 'approval')}
                     onAddParallelBranch={() => onAddParallelBranch(row.node.id, 'agent')}
                   />
                 </>
@@ -157,6 +165,7 @@ function FlowRowRenderer({
                     onAddAction={() => onInsertNode(row.node.id, null, 'agent')}
                     onAddScript={() => onInsertNode(row.node.id, null, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, null, 'condition')}
+                    onAddApproval={() => onInsertNode(row.node.id, null, 'approval')}
                     onAddParallelBranch={
                       !isInsideBranch ? () => onAddParallelBranch(row.node.id, 'agent') : undefined
                     }
@@ -210,11 +219,7 @@ function ForkRenderer({
 }: {
   row: Extract<FlowRow, { kind: 'fork' }>
   onNodeClick: (nodeId: string) => void
-  onInsertNode: (
-    afterNodeId: string,
-    beforeNodeId: string | null,
-    type: 'agent' | 'script' | 'condition'
-  ) => void
+  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
   selectedNodeId: string | null
   edges?: WorkflowEdge[]

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -14,7 +14,7 @@ import {
   supportsExactSessionResume,
   getProjectRemoteHostId
 } from '../../../shared/types'
-import { WorkflowCanvas } from './WorkflowCanvas'
+import { WorkflowCanvas, AddableNodeType } from './WorkflowCanvas'
 import { NodeConfigPanel } from './panels/NodeConfigPanel'
 import { RunHistoryPanel } from './panels/RunHistoryPanel'
 import { WorkflowPropertiesPanel } from './panels/WorkflowPropertiesPanel'
@@ -23,6 +23,7 @@ import {
   createLaunchAgentNode,
   createScriptNode,
   createConditionNode,
+  createApprovalNode,
   appendNodeAfter,
   insertNodeBetween,
   insertBeforeFork,
@@ -106,6 +107,29 @@ export function WorkflowEditor() {
       setExecutionHistory([])
     }
   }, [editingId, isOpen])
+
+  // Re-query on status transitions for this workflow only, plus whenever a
+  // node flips into or out of 'waiting' (gate approve/reject). Selecting
+  // scalars avoids refetching on every streaming log chunk.
+  const liveExecStatus = useAppStore((s) =>
+    editingId ? s.workflowExecutions.get(editingId)?.status : undefined
+  )
+  const liveExecCompletedAt = useAppStore((s) =>
+    editingId ? s.workflowExecutions.get(editingId)?.completedAt : undefined
+  )
+  const liveWaitingSignature = useAppStore((s) => {
+    if (!editingId) return ''
+    const ns = s.workflowExecutions.get(editingId)?.nodeStates
+    if (!ns) return ''
+    return ns
+      .filter((n) => n.status === 'waiting')
+      .map((n) => n.nodeId)
+      .join(',')
+  })
+  useEffect(() => {
+    if (!editingId || !isOpen || !liveExecStatus) return
+    window.api.listWorkflowRuns(editingId, 20).then(setExecutionHistory).catch(console.error)
+  }, [editingId, isOpen, liveExecStatus, liveExecCompletedAt, liveWaitingSignature])
 
   // Load existing workflow when editing (with slug migration)
   useEffect(() => {
@@ -265,21 +289,20 @@ export function WorkflowEditor() {
     handleClose()
   }, [editingId, removeWorkflowFromStore, handleClose])
 
-  // Helper: create a node with a unique slug
   const createNodeWithUniqueSlug = useCallback(
-    (type: 'agent' | 'script' | 'condition') => {
+    (type: AddableNodeType) => {
       const projects = useAppStore.getState().config?.projects || []
       const firstProject = projects[0]
-      const newNode =
-        type === 'condition'
-          ? createConditionNode()
-          : type === 'script'
-            ? createScriptNode()
-            : createLaunchAgentNode(
-                firstProject
-                  ? { projectName: firstProject.name, projectPath: firstProject.path }
-                  : {}
-              )
+      const factories: Record<AddableNodeType, () => WorkflowNode> = {
+        condition: () => createConditionNode(),
+        approval: () => createApprovalNode(),
+        script: () => createScriptNode(),
+        agent: () =>
+          createLaunchAgentNode(
+            firstProject ? { projectName: firstProject.name, projectPath: firstProject.path } : {}
+          )
+      }
+      const newNode = factories[type]()
       if (newNode.slug) {
         const existingSlugs = new Set(nodes.filter((n) => n.slug).map((n) => n.slug!))
         newNode.slug = ensureUniqueSlug(newNode.slug, existingSlugs)
@@ -290,7 +313,7 @@ export function WorkflowEditor() {
   )
 
   const handleInsertNode = useCallback(
-    (afterNodeId: string, beforeNodeId: string | null, type: 'agent' | 'script' | 'condition') => {
+    (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => {
       // Condition nodes use a special insertion that creates true/false branches
       if (type === 'condition') {
         const result = insertConditionBetween(nodes, edges, afterNodeId, beforeNodeId)

--- a/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
@@ -1,18 +1,20 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Play, GitBranch, Terminal, Split } from 'lucide-react'
+import { Plus, Play, GitBranch, Terminal, Split, Hand } from 'lucide-react'
 
 interface Props {
   onAddAction: () => void
   onAddParallelBranch?: () => void
   onAddScript?: () => void
   onAddCondition?: () => void
+  onAddApproval?: () => void
 }
 
 export function ConnectorButton({
   onAddAction,
   onAddParallelBranch,
   onAddScript,
-  onAddCondition
+  onAddCondition,
+  onAddApproval
 }: Props) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -93,6 +95,21 @@ export function ConnectorButton({
             >
               <Split size={14} className="text-purple-400 shrink-0" />
               Add a condition
+            </button>
+          )}
+
+          {onAddApproval && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setOpen(false)
+                onAddApproval()
+              }}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-gray-300
+                         hover:bg-white/[0.06] hover:text-white transition-colors text-left"
+            >
+              <Hand size={14} className="text-gray-400 shrink-0" />
+              Add an approval gate
             </button>
           )}
 

--- a/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
@@ -1,0 +1,47 @@
+import { Hand } from 'lucide-react'
+import type { ApprovalConfig, NodeExecutionStatus } from '../../../../shared/types'
+import { STATUS_DOT_CLASSES } from '../statusDot'
+
+interface Props {
+  label: string
+  config: ApprovalConfig
+  selected?: boolean
+  executionStatus?: NodeExecutionStatus
+  onClick: () => void
+}
+
+export function ApprovalNode({ label, config, selected, executionStatus, onClick }: Props) {
+  const subtitle = config.timeoutMs
+    ? `Waits for approval · ${Math.round(config.timeoutMs / 1000)}s timeout`
+    : 'Waits for approval'
+
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
+                  ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
+                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+    >
+      {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
+        <span
+          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${STATUS_DOT_CLASSES[executionStatus]}`}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <Hand size={14} className="shrink-0 text-amber-400" strokeWidth={2} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-medium text-white truncate">{label}</div>
+          <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
+        </div>
+      </div>
+      {config.message && (
+        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2">
+          {config.message.length > 60 ? config.message.slice(0, 60) + '...' : config.message}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/ApprovalConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ApprovalConfigForm.tsx
@@ -1,0 +1,52 @@
+import { ApprovalConfig } from '../../../../shared/types'
+
+interface Props {
+  config: ApprovalConfig
+  onChange: (config: ApprovalConfig) => void
+}
+
+export function ApprovalConfigForm({ config, onChange }: Props) {
+  const timeoutSeconds =
+    config.timeoutMs && config.timeoutMs > 0 ? Math.round(config.timeoutMs / 1000) : ''
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Message</label>
+        <textarea
+          value={config.message || ''}
+          onChange={(e) => onChange({ ...config, message: e.target.value })}
+          placeholder="Shown next to the Approve / Reject buttons"
+          rows={3}
+          className="w-full px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                     text-[13px] text-gray-200 placeholder:text-gray-600
+                     focus:outline-none focus:border-blue-500/50 resize-none"
+        />
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">
+          Timeout <span className="text-gray-600">(seconds, optional)</span>
+        </label>
+        <input
+          type="number"
+          min={0}
+          value={timeoutSeconds}
+          onChange={(e) => {
+            const raw = e.target.value.trim()
+            const secs = Number(raw)
+            const valid = raw !== '' && Number.isFinite(secs) && secs > 0
+            onChange({ ...config, timeoutMs: valid ? Math.round(secs * 1000) : undefined })
+          }}
+          placeholder="Leave blank to wait forever"
+          className="w-full px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                     text-[13px] text-gray-200 placeholder:text-gray-600
+                     focus:outline-none focus:border-blue-500/50"
+        />
+        <div className="mt-1.5 text-[11px] text-gray-500">
+          Auto-rejects the gate if nobody approves in time.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect, useRef } from 'react'
-import { X, Zap, Play, Terminal, GitFork, MoreHorizontal, Trash2 } from 'lucide-react'
+import { X, Zap, Play, Terminal, GitFork, Hand, MoreHorizontal, Trash2 } from 'lucide-react'
 import {
   WorkflowNode,
   TriggerConfig,
   LaunchAgentConfig,
   ScriptConfig,
-  ConditionConfig
+  ConditionConfig,
+  ApprovalConfig
 } from '../../../../shared/types'
 import { TriggerConfigForm } from './TriggerConfigForm'
 import { LaunchAgentConfigForm } from './LaunchAgentConfigForm'
 import { ScriptConfigForm } from './ScriptConfigForm'
 import { ConditionConfigForm } from './ConditionConfigForm'
+import { ApprovalConfigForm } from './ApprovalConfigForm'
 import type { StepVariableGroup } from '../../../lib/template-vars'
 
 const NODE_TYPE_CONFIG: Record<
@@ -20,7 +22,13 @@ const NODE_TYPE_CONFIG: Record<
   trigger: { icon: Zap, label: 'Trigger', color: 'text-blue-400', bg: 'bg-blue-500/10' },
   launchAgent: { icon: Play, label: 'Agent', color: 'text-green-400', bg: 'bg-green-500/10' },
   script: { icon: Terminal, label: 'Script', color: 'text-amber-400', bg: 'bg-amber-500/10' },
-  condition: { icon: GitFork, label: 'Condition', color: 'text-purple-400', bg: 'bg-purple-500/10' }
+  condition: {
+    icon: GitFork,
+    label: 'Condition',
+    color: 'text-purple-400',
+    bg: 'bg-purple-500/10'
+  },
+  approval: { icon: Hand, label: 'Approval', color: 'text-amber-400', bg: 'bg-amber-500/10' }
 }
 
 interface Props {
@@ -157,6 +165,13 @@ export function NodeConfigPanel({
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
             stepGroups={stepGroups || []}
+          />
+        )}
+
+        {node.type === 'approval' && (
+          <ApprovalConfigForm
+            config={node.config as ApprovalConfig}
+            onChange={(config) => onChange(node.id, config)}
           />
         )}
       </div>

--- a/src/renderer/components/workflow-editor/statusDot.ts
+++ b/src/renderer/components/workflow-editor/statusDot.ts
@@ -5,5 +5,6 @@ export const STATUS_DOT_CLASSES: Record<NodeExecutionStatus | 'running', string>
   error: 'bg-red-500',
   running: 'bg-yellow-400 animate-pulse',
   pending: 'bg-gray-600',
-  skipped: 'bg-gray-600'
+  skipped: 'bg-gray-600',
+  waiting: 'bg-amber-400 animate-pulse'
 }

--- a/src/renderer/hooks/useWaitingApprovals.ts
+++ b/src/renderer/hooks/useWaitingApprovals.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../stores'
+import type { WaitingApproval } from '../components/BackgroundTray'
+
+const EMPTY: WaitingApproval[] = []
+
+export function useWaitingApprovals(): WaitingApproval[] {
+  const workflowExecutions = useAppStore((s) => s.workflowExecutions)
+  const workflows = useAppStore((s) => s.config?.workflows)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+
+  return useMemo(() => {
+    if (workflowExecutions.size === 0) return EMPTY
+    const out: WaitingApproval[] = []
+    for (const execution of workflowExecutions.values()) {
+      const workflow = workflows?.find((w) => w.id === execution.workflowId)
+      if (workflow && (workflow.workspaceId ?? 'personal') !== activeWorkspace) continue
+      for (const ns of execution.nodeStates) {
+        if (ns.status === 'waiting') {
+          out.push({ execution, nodeState: ns, workflow })
+        }
+      }
+    }
+    return out
+  }, [workflowExecutions, workflows, activeWorkspace])
+}

--- a/src/renderer/hooks/useWaitingApprovals.ts
+++ b/src/renderer/hooks/useWaitingApprovals.ts
@@ -4,15 +4,34 @@ import type { WaitingApproval } from '../components/BackgroundTray'
 
 const EMPTY: WaitingApproval[] = []
 
+/**
+ * Selector returns a string signature of the waiting-gate set so the hook only
+ * re-runs when a gate enters or exits `waiting` — not on every log-chunk
+ * mutation of `workflowExecutions`.
+ */
+function waitingSignature(
+  workflowExecutions: Map<string, { nodeStates: Array<{ nodeId: string; status: string }> }>
+): string {
+  const parts: string[] = []
+  for (const [id, exec] of workflowExecutions) {
+    for (const ns of exec.nodeStates) {
+      if (ns.status === 'waiting') parts.push(`${id}:${ns.nodeId}`)
+    }
+  }
+  parts.sort()
+  return parts.join(',')
+}
+
 export function useWaitingApprovals(): WaitingApproval[] {
-  const workflowExecutions = useAppStore((s) => s.workflowExecutions)
+  const signature = useAppStore((s) => waitingSignature(s.workflowExecutions))
   const workflows = useAppStore((s) => s.config?.workflows)
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
 
   return useMemo(() => {
-    if (workflowExecutions.size === 0) return EMPTY
+    if (signature === '') return EMPTY
     const out: WaitingApproval[] = []
-    for (const execution of workflowExecutions.values()) {
+    const executions = useAppStore.getState().workflowExecutions
+    for (const execution of executions.values()) {
       const workflow = workflows?.find((w) => w.id === execution.workflowId)
       if (workflow && (workflow.workspaceId ?? 'personal') !== activeWorkspace) continue
       for (const ns of execution.nodeStates) {
@@ -22,5 +41,5 @@ export function useWaitingApprovals(): WaitingApproval[] {
       }
     }
     return out
-  }, [workflowExecutions, workflows, activeWorkspace])
+  }, [signature, workflows, activeWorkspace])
 }

--- a/src/renderer/lib/notifications.ts
+++ b/src/renderer/lib/notifications.ts
@@ -1,4 +1,4 @@
-import { AgentStatus, AppConfig } from '../../shared/types'
+import { AgentStatus, AppConfig, WorkflowDefinition } from '../../shared/types'
 import { TerminalState } from '../stores/types'
 import { getDisplayName } from './terminal-display'
 import { AGENT_DEFINITIONS } from './agent-definitions'
@@ -64,6 +64,32 @@ export function shouldNotifyBell(config: AppConfig | null): boolean {
   return !!prefs?.enabled && prefs.onBell !== false
 }
 
+function dispatch(
+  reason: NotificationReason,
+  cooldownKey: string,
+  prefs: AppConfig['defaults']['notifications'] | undefined,
+  title: string,
+  body: string,
+  onClick?: () => void
+): void {
+  if (prefs?.soundEnabled) {
+    playNotificationSound(reason, prefs.soundVolume ?? 0.5)
+  }
+
+  if (Notification.permission !== 'granted') return
+  if (document.hasFocus()) return
+
+  const lastTime = lastNotified.get(cooldownKey) ?? 0
+  if (Date.now() - lastTime < COOLDOWN_MS) return
+  lastNotified.set(cooldownKey, Date.now())
+
+  const notification = new Notification(title, { body, silent: false })
+  notification.onclick = () => {
+    window.focus()
+    onClick?.()
+  }
+}
+
 export function sendAgentNotification(
   terminal: TerminalState,
   reason: NotificationReason,
@@ -71,21 +97,6 @@ export function sendAgentNotification(
   onClick?: () => void
 ): void {
   const prefs = config?.defaults.notifications
-
-  // Play sound even when window is focused
-  if (prefs?.soundEnabled) {
-    playNotificationSound(reason, prefs.soundVolume ?? 0.5)
-  }
-
-  // OS notification only when window is not focused
-  if (Notification.permission !== 'granted') return
-  if (document.hasFocus()) return
-
-  // Cooldown per terminal
-  const lastTime = lastNotified.get(terminal.id) ?? 0
-  if (Date.now() - lastTime < COOLDOWN_MS) return
-  lastNotified.set(terminal.id, Date.now())
-
   const name = getDisplayName(terminal.session)
   const agent = AGENT_DEFINITIONS[terminal.session.agentType].displayName
 
@@ -107,9 +118,25 @@ export function sendAgentNotification(
       break
   }
 
-  const notification = new Notification(title, { body, silent: false })
-  notification.onclick = () => {
-    window.focus()
-    onClick?.()
-  }
+  dispatch(reason, terminal.id, prefs, title, body, onClick)
+}
+
+export function sendWorkflowGateNotification(
+  workflow: WorkflowDefinition,
+  nodeLabel: string,
+  message: string | undefined,
+  config: AppConfig | null,
+  onClick?: () => void
+): void {
+  const prefs = config?.defaults.notifications
+  if (!prefs?.enabled || prefs.onWaiting === false) return
+
+  dispatch(
+    'waiting',
+    `workflow-gate:${workflow.id}:${nodeLabel}`,
+    prefs,
+    `${workflow.name} · awaiting approval`,
+    message || `${nodeLabel} is waiting for your approval`,
+    onClick
+  )
 }

--- a/src/renderer/lib/notifications.ts
+++ b/src/renderer/lib/notifications.ts
@@ -123,6 +123,7 @@ export function sendAgentNotification(
 
 export function sendWorkflowGateNotification(
   workflow: WorkflowDefinition,
+  nodeId: string,
   nodeLabel: string,
   message: string | undefined,
   config: AppConfig | null,
@@ -133,7 +134,7 @@ export function sendWorkflowGateNotification(
 
   dispatch(
     'waiting',
-    `workflow-gate:${workflow.id}:${nodeLabel}`,
+    `workflow-gate:${workflow.id}:${nodeId}`,
     prefs,
     `${workflow.name} · awaiting approval`,
     message || `${nodeLabel} is waiting for your approval`,

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -27,6 +27,50 @@ function gateKey(workflowId: string, nodeId: string): string {
   return `${workflowId}:${nodeId}`
 }
 
+function scheduleGateTimeout(
+  workflowId: string,
+  nodeId: string,
+  timeoutMs: number | undefined,
+  execution: WorkflowExecution,
+  elapsedMs = 0
+): void {
+  if (!timeoutMs || timeoutMs <= 0) return
+  const key = gateKey(workflowId, nodeId)
+  const prev = gateTimers.get(key)
+  if (prev) clearTimeout(prev)
+  const remaining = Math.max(0, timeoutMs - elapsedMs)
+  const timer = setTimeout(() => {
+    gateTimers.delete(key)
+    void rejectWorkflowGate(execution, nodeId, `Approval timed out after ${timeoutMs}ms`)
+  }, remaining)
+  gateTimers.set(key, timer)
+}
+
+/**
+ * Re-arm timeout timers for any approval gates that were `waiting` before the
+ * app restarted. Called once after startup hydration; timers elsewhere are set
+ * as gates enter `waiting` for the first time.
+ */
+export function rescheduleWaitingGateTimers(
+  executions: Iterable<WorkflowExecution>,
+  workflows: WorkflowDefinition[]
+): void {
+  const now = Date.now()
+  for (const execution of executions) {
+    const workflow = workflows.find((w) => w.id === execution.workflowId)
+    if (!workflow) continue
+    for (const ns of execution.nodeStates) {
+      if (ns.status !== 'waiting') continue
+      const node = workflow.nodes.find((n) => n.id === ns.nodeId)
+      if (node?.type !== 'approval') continue
+      const timeoutMs = (node.config as ApprovalConfig).timeoutMs
+      if (!timeoutMs || timeoutMs <= 0) continue
+      const startedAt = ns.startedAt ? new Date(ns.startedAt).getTime() : now
+      scheduleGateTimeout(workflow.id, ns.nodeId, timeoutMs, execution, now - startedAt)
+    }
+  }
+}
+
 export interface ExecuteWorkflowOptions {
   source?: 'scheduler' | 'manual'
 }
@@ -154,6 +198,7 @@ async function executeNode(
 
     sendWorkflowGateNotification(
       workflow,
+      node.id,
       node.label,
       config.message,
       useAppStore.getState().config ?? null,
@@ -163,20 +208,7 @@ async function executeNode(
       }
     )
 
-    if (config.timeoutMs && config.timeoutMs > 0) {
-      const key = gateKey(workflow.id, node.id)
-      const prev = gateTimers.get(key)
-      if (prev) clearTimeout(prev)
-      const timer = setTimeout(() => {
-        gateTimers.delete(key)
-        void rejectWorkflowGate(
-          execution,
-          node.id,
-          `Approval timed out after ${config.timeoutMs}ms`
-        )
-      }, config.timeoutMs)
-      gateTimers.set(key, timer)
-    }
+    scheduleGateTimeout(workflow.id, node.id, config.timeoutMs, execution)
     return
   }
 
@@ -556,6 +588,14 @@ export async function executeWorkflow(
     const existing = useAppStore.getState().workflowExecutions.get(workflow.id)
     if (existing) return existing
     throw new Error(`Workflow "${workflow.name}" is already executing`)
+  }
+
+  const pending = useAppStore.getState().workflowExecutions.get(workflow.id)
+  if (pending && pending.nodeStates.some((ns) => ns.status === 'waiting')) {
+    console.warn(
+      `[workflow] skipping execution of "${workflow.name}" — existing run is waiting for approval`
+    )
+    return pending
   }
 
   const execution: WorkflowExecution = {

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -9,16 +9,23 @@ import {
   ScriptConfig,
   ConditionConfig,
   ConditionOperator,
+  ApprovalConfig,
   TaskConfig,
   getProjectRemoteHostId
 } from '../../shared/types'
-import { getTriggerNode } from './workflow-helpers'
 import { resolveTemplateVars, StepOutputs } from './template-vars'
 import { buildTaskPrompt, buildWorkflowPrompt } from '../../shared/prompt-builder'
 import { useAppStore } from '../stores'
+import { sendWorkflowGateNotification } from './notifications'
 
-/** Guard against concurrent execution of the same workflow */
 const runningWorkflows = new Set<string>()
+
+/** Cleared on approve/reject so a late timer can't reject an already-resolved gate. */
+const gateTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+function gateKey(workflowId: string, nodeId: string): string {
+  return `${workflowId}:${nodeId}`
+}
 
 export interface ExecuteWorkflowOptions {
   source?: 'scheduler' | 'manual'
@@ -131,6 +138,48 @@ async function executeNode(
   context?: WorkflowExecutionContext,
   stepOutputs?: StepOutputs
 ): Promise<void> {
+  if (node.type === 'approval') {
+    const existing = execution.nodeStates.find((s) => s.nodeId === node.id)
+    if (existing?.status === 'waiting') return
+
+    const config = node.config as ApprovalConfig
+    const timeoutSuffix = config.timeoutMs ? ` (timeout ${config.timeoutMs}ms)` : ''
+    console.log(`[workflow] approval gate "${node.label}" waiting${timeoutSuffix}`)
+
+    updateNodeState(execution, node.id, {
+      status: 'waiting',
+      startedAt: new Date().toISOString()
+    })
+    persistExecution(workflow.id, execution)
+
+    sendWorkflowGateNotification(
+      workflow,
+      node.label,
+      config.message,
+      useAppStore.getState().config ?? null,
+      () => {
+        useAppStore.getState().setEditingWorkflowId(workflow.id)
+        useAppStore.getState().setWorkflowEditorOpen(true)
+      }
+    )
+
+    if (config.timeoutMs && config.timeoutMs > 0) {
+      const key = gateKey(workflow.id, node.id)
+      const prev = gateTimers.get(key)
+      if (prev) clearTimeout(prev)
+      const timer = setTimeout(() => {
+        gateTimers.delete(key)
+        void rejectWorkflowGate(
+          execution,
+          node.id,
+          `Approval timed out after ${config.timeoutMs}ms`
+        )
+      }, config.timeoutMs)
+      gateTimers.set(key, timer)
+    }
+    return
+  }
+
   updateNodeState(execution, node.id, {
     status: 'running',
     startedAt: new Date().toISOString()
@@ -461,21 +510,53 @@ async function executeNode(
   }
 }
 
+function buildGraph(edges: readonly { source: string; target: string }[]): {
+  successors: Map<string, string[]>
+  predecessors: Map<string, string[]>
+} {
+  const successors = new Map<string, string[]>()
+  const predecessors = new Map<string, string[]>()
+  for (const e of edges) {
+    successors.set(e.source, [...(successors.get(e.source) || []), e.target])
+    predecessors.set(e.target, [...(predecessors.get(e.target) || []), e.source])
+  }
+  return { successors, predecessors }
+}
+
+/** Stops at join points whose other predecessors aren't already terminal/skipped. */
+function collectSkippedBranch(
+  startNodeId: string,
+  successors: Map<string, string[]>,
+  predecessors: Map<string, string[]>,
+  isTerminal: (nodeId: string) => boolean
+): Set<string> {
+  const skipped = new Set<string>()
+  const queue = [startNodeId]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (skipped.has(id) || isTerminal(id)) continue
+    skipped.add(id)
+    for (const s of successors.get(id) || []) {
+      const otherPreds = (predecessors.get(s) || []).filter(
+        (p) => p !== id && !skipped.has(p) && !isTerminal(p)
+      )
+      if (otherPreds.length === 0) queue.push(s)
+    }
+  }
+  return skipped
+}
+
 export async function executeWorkflow(
   workflow: WorkflowDefinition,
   context?: WorkflowExecutionContext,
   options?: ExecuteWorkflowOptions
 ): Promise<WorkflowExecution> {
-  // Concurrency guard — prevent duplicate runs of the same workflow
   if (runningWorkflows.has(workflow.id)) {
     console.warn(`[workflow] skipping execution of "${workflow.name}" — already running`)
     const existing = useAppStore.getState().workflowExecutions.get(workflow.id)
     if (existing) return existing
     throw new Error(`Workflow "${workflow.name}" is already executing`)
   }
-  runningWorkflows.add(workflow.id)
-
-  const triggerNode = getTriggerNode(workflow)
 
   const execution: WorkflowExecution = {
     workflowId: workflow.id,
@@ -495,43 +576,47 @@ export async function executeWorkflow(
 
   persistExecution(workflow.id, execution)
 
-  const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]))
-  const successorsMap = new Map<string, string[]>()
-  const predecessorsMap = new Map<string, string[]>()
+  return runExecution(workflow, execution, context, options)
+}
 
-  for (const edge of workflow.edges) {
-    successorsMap.set(edge.source, [...(successorsMap.get(edge.source) || []), edge.target])
-    predecessorsMap.set(edge.target, [...(predecessorsMap.get(edge.target) || []), edge.source])
+async function runExecution(
+  workflow: WorkflowDefinition,
+  execution: WorkflowExecution,
+  context: WorkflowExecutionContext | undefined,
+  options?: ExecuteWorkflowOptions
+): Promise<WorkflowExecution> {
+  if (runningWorkflows.has(workflow.id)) {
+    console.warn(`[workflow] runExecution: ${workflow.id} already running, skipping`)
+    return execution
+  }
+  runningWorkflows.add(workflow.id)
+
+  const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]))
+  const { successors: successorsMap, predecessors: predecessorsMap } = buildGraph(workflow.edges)
+
+  // Rebuilt at the start of every wave so external mutations (e.g. a sibling
+  // gate approved mid-loop by another re-entry) are picked up.
+  const completed = new Set<string>()
+  const skippedByCondition = new Set<string>()
+  function rebuildCompletionSets(): void {
+    completed.clear()
+    skippedByCondition.clear()
+    for (const ns of execution.nodeStates) {
+      if (ns.status === 'success' || ns.status === 'error') completed.add(ns.nodeId)
+      else if (ns.status === 'skipped') skippedByCondition.add(ns.nodeId)
+    }
   }
 
-  const completed = new Set<string>()
   const running = new Set<string>()
 
-  if (triggerNode) {
-    completed.add(triggerNode.id)
-  }
-
-  // Track which nodes are blocked by condition branches
-  const skippedByCondition = new Set<string>()
-
   function markSkippedBranch(startNodeId: string): void {
-    const queue = [startNodeId]
-    while (queue.length > 0) {
-      const id = queue.shift()!
-      if (skippedByCondition.has(id) || completed.has(id)) continue
-      skippedByCondition.add(id)
-      // Only follow edges that stay within this branch (stop at join points)
-      const succs = successorsMap.get(id) || []
-      for (const s of succs) {
-        // Don't skip nodes that have other incoming paths (join points)
-        const otherPreds = (predecessorsMap.get(s) || []).filter(
-          (p) => p !== id && !skippedByCondition.has(p)
-        )
-        if (otherPreds.length === 0) {
-          queue.push(s)
-        }
-      }
-    }
+    const branch = collectSkippedBranch(
+      startNodeId,
+      successorsMap,
+      predecessorsMap,
+      (id) => completed.has(id) || skippedByCondition.has(id)
+    )
+    for (const id of branch) skippedByCondition.add(id)
   }
 
   function getReadyNodes(): WorkflowNode[] {
@@ -540,6 +625,8 @@ export async function executeWorkflow(
       if (node.type === 'trigger') continue
       if (completed.has(node.id) || running.has(node.id)) continue
       if (skippedByCondition.has(node.id)) continue
+      const ns = execution.nodeStates.find((s) => s.nodeId === node.id)
+      if (ns?.status === 'waiting') continue
 
       const preds = predecessorsMap.get(node.id) || []
       const allPredsReady = preds.every((p) => completed.has(p) || skippedByCondition.has(p))
@@ -550,9 +637,12 @@ export async function executeWorkflow(
     return ready
   }
 
+  const actionNodeCount = workflow.nodes.filter((n) => n.type !== 'trigger').length
+
   try {
     let wave = 0
     while (true) {
+      rebuildCompletionSets()
       const ready = getReadyNodes()
       if (ready.length === 0) break
 
@@ -581,6 +671,10 @@ export async function executeWorkflow(
           persistExecution(workflow.id, execution)
         }
         running.delete(node.id)
+
+        const postState = execution.nodeStates.find((s) => s.nodeId === node.id)
+        if (postState?.status === 'waiting') return
+
         completed.add(node.id)
 
         // After a condition node completes, skip the non-matching branch
@@ -606,6 +700,12 @@ export async function executeWorkflow(
       })
 
       await Promise.all(promises)
+    }
+
+    const hasWaiting = execution.nodeStates.some((ns) => ns.status === 'waiting')
+    if (hasWaiting) {
+      persistExecution(workflow.id, execution)
+      return execution
     }
 
     // Mark any nodes still pending as skipped (unreachable due to missing edges or cycles)
@@ -705,4 +805,107 @@ export async function executeWorkflow(
   }
 
   return execution
+}
+
+/**
+ * Only `triggerTaskId` is persisted — trigger.fromStatus/toStatus aren't,
+ * so `{{trigger.fromStatus}}` template vars in post-gate nodes are empty on resume.
+ */
+function rebuildContextForResume(
+  execution: WorkflowExecution
+): WorkflowExecutionContext | undefined {
+  if (!execution.triggerTaskId) return undefined
+  const task = (useAppStore.getState().config?.tasks || []).find(
+    (t) => t.id === execution.triggerTaskId
+  )
+  return task ? { task } : undefined
+}
+
+function resolveWaitingGate(
+  execution: WorkflowExecution,
+  nodeId: string,
+  caller: 'approve' | 'reject'
+): { workflow: WorkflowDefinition } | null {
+  const workflow = (useAppStore.getState().config?.workflows || []).find(
+    (w) => w.id === execution.workflowId
+  )
+  if (!workflow) {
+    console.warn(`[workflow] ${caller}WorkflowGate: workflow ${execution.workflowId} not found`)
+    return null
+  }
+
+  const ns = execution.nodeStates.find((s) => s.nodeId === nodeId)
+  if (!ns || ns.status !== 'waiting') {
+    console.warn(
+      `[workflow] ${caller}WorkflowGate: node ${nodeId} not waiting (status=${ns?.status})`
+    )
+    return null
+  }
+
+  const key = gateKey(workflow.id, nodeId)
+  const timer = gateTimers.get(key)
+  if (timer) {
+    clearTimeout(timer)
+    gateTimers.delete(key)
+  }
+
+  return { workflow }
+}
+
+/** Safe to call on an execution loaded from the database (cross-session resume). */
+export async function approveWorkflowGate(
+  execution: WorkflowExecution,
+  nodeId: string
+): Promise<WorkflowExecution> {
+  const resolved = resolveWaitingGate(execution, nodeId, 'approve')
+  if (!resolved) return execution
+  const { workflow } = resolved
+
+  const now = new Date().toISOString()
+  updateNodeState(execution, nodeId, {
+    status: 'success',
+    completedAt: now,
+    approvedAt: now
+  })
+  persistExecution(workflow.id, execution)
+
+  const context = rebuildContextForResume(execution)
+  return runExecution(workflow, execution, context)
+}
+
+export async function rejectWorkflowGate(
+  execution: WorkflowExecution,
+  nodeId: string,
+  reason = 'Rejected by user'
+): Promise<WorkflowExecution> {
+  const resolved = resolveWaitingGate(execution, nodeId, 'reject')
+  if (!resolved) return execution
+  const { workflow } = resolved
+
+  const now = new Date().toISOString()
+  updateNodeState(execution, nodeId, {
+    status: 'error',
+    completedAt: now,
+    error: reason
+  })
+
+  const { successors, predecessors } = buildGraph(workflow.edges)
+  const isTerminal = (id: string): boolean => {
+    const s = execution.nodeStates.find((n) => n.nodeId === id)
+    return !!s && (s.status === 'success' || s.status === 'error' || s.status === 'skipped')
+  }
+  for (const succ of successors.get(nodeId) || []) {
+    const branch = collectSkippedBranch(succ, successors, predecessors, isTerminal)
+    for (const id of branch) {
+      const state = execution.nodeStates.find((n) => n.nodeId === id)
+      if (state?.status === 'pending') {
+        updateNodeState(execution, id, { status: 'skipped', completedAt: now })
+      }
+    }
+  }
+
+  persistExecution(workflow.id, execution)
+
+  const context = rebuildContextForResume(execution)
+  return runExecution(workflow, execution, context)
 }

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -6,6 +6,7 @@ import {
   LaunchAgentConfig,
   ScriptConfig,
   ConditionConfig,
+  ApprovalConfig,
   WorkflowNodePosition
 } from '../../shared/types'
 import { slugify } from './template-vars'
@@ -183,6 +184,20 @@ export function createScriptNode(config: Partial<ScriptConfig> = {}): WorkflowNo
       projectPath: '',
       ...config
     } as ScriptConfig,
+    position: { x: 0, y: 0 }
+  }
+}
+
+export function createApprovalNode(config: Partial<ApprovalConfig> = {}): WorkflowNode {
+  return {
+    id: crypto.randomUUID(),
+    type: 'approval',
+    label: 'Approval Gate',
+    slug: slugify('Approval Gate'),
+    config: {
+      message: '',
+      ...config
+    } as ApprovalConfig,
     position: { x: 0, y: 0 }
   }
 }

--- a/tests/approval-config-form.test.tsx
+++ b/tests/approval-config-form.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ApprovalConfigForm } from '../src/renderer/components/workflow-editor/panels/ApprovalConfigForm'
+import type { ApprovalConfig } from '../src/shared/types'
+
+describe('ApprovalConfigForm', () => {
+  it('renders message textarea and timeout input', () => {
+    const { container } = render(<ApprovalConfigForm config={{}} onChange={vi.fn()} />)
+    expect(container.querySelector('textarea')).toBeTruthy()
+    expect(container.querySelector('input[type="number"]')).toBeTruthy()
+    expect(container.textContent).toContain('Message')
+    expect(container.textContent).toContain('Timeout')
+  })
+
+  it('invokes onChange with new message text', () => {
+    const onChange = vi.fn()
+    const { container } = render(<ApprovalConfigForm config={{}} onChange={onChange} />)
+    const textarea = container.querySelector('textarea')!
+    fireEvent.change(textarea, { target: { value: 'Please review' } })
+    expect(onChange).toHaveBeenCalledWith({ message: 'Please review' })
+  })
+
+  it('converts seconds input to timeoutMs on change', () => {
+    const onChange = vi.fn()
+    const { container } = render(<ApprovalConfigForm config={{}} onChange={onChange} />)
+    const input = container.querySelector('input[type="number"]')!
+    fireEvent.change(input, { target: { value: '30' } })
+    expect(onChange).toHaveBeenCalledWith({ timeoutMs: 30000 })
+  })
+
+  it('clears timeoutMs when input is emptied', () => {
+    const onChange = vi.fn()
+    const config: ApprovalConfig = { timeoutMs: 5000 }
+    const { container } = render(<ApprovalConfigForm config={config} onChange={onChange} />)
+    const input = container.querySelector('input[type="number"]')!
+    fireEvent.change(input, { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith({ timeoutMs: undefined })
+  })
+
+  it('displays existing timeout converted to seconds', () => {
+    const config: ApprovalConfig = { timeoutMs: 60000 }
+    const { container } = render(<ApprovalConfigForm config={config} onChange={vi.fn()} />)
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement
+    expect(input.value).toBe('60')
+  })
+
+  it('rejects zero/negative timeout input', () => {
+    const onChange = vi.fn()
+    const { container } = render(<ApprovalConfigForm config={{}} onChange={onChange} />)
+    const input = container.querySelector('input[type="number"]')!
+    fireEvent.change(input, { target: { value: '0' } })
+    expect(onChange).toHaveBeenCalledWith({ timeoutMs: undefined })
+  })
+})

--- a/tests/approval-node.test.tsx
+++ b/tests/approval-node.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ApprovalNode } from '../src/renderer/components/workflow-editor/nodes/ApprovalNode'
+
+describe('ApprovalNode', () => {
+  it('renders label and default subtitle when no timeout', () => {
+    const { container } = render(<ApprovalNode label="Human gate" config={{}} onClick={vi.fn()} />)
+    expect(container.textContent).toContain('Human gate')
+    expect(container.textContent).toContain('Waits for approval')
+    expect(container.textContent).not.toContain('timeout')
+  })
+
+  it('shows timeout in subtitle when configured', () => {
+    const { container } = render(
+      <ApprovalNode label="Gate" config={{ timeoutMs: 120000 }} onClick={vi.fn()} />
+    )
+    expect(container.textContent).toContain('120s timeout')
+  })
+
+  it('renders the message preview truncated to 60 chars', () => {
+    const long = 'a'.repeat(80)
+    const { container } = render(
+      <ApprovalNode label="Gate" config={{ message: long }} onClick={vi.fn()} />
+    )
+    expect(container.textContent).toContain('aaaa...')
+  })
+
+  it('does not truncate short messages', () => {
+    const { container } = render(
+      <ApprovalNode label="Gate" config={{ message: 'short' }} onClick={vi.fn()} />
+    )
+    expect(container.textContent).toContain('short')
+    expect(container.textContent).not.toContain('...')
+  })
+
+  it('fires onClick when the card is clicked and stops propagation', () => {
+    const parent = vi.fn()
+    const inner = vi.fn()
+    const { container } = render(
+      <div onClick={parent}>
+        <ApprovalNode label="Gate" config={{}} onClick={inner} />
+      </div>
+    )
+    const card = container.querySelector('[class*="cursor-pointer"]') as HTMLElement
+    fireEvent.click(card)
+    expect(inner).toHaveBeenCalled()
+    expect(parent).not.toHaveBeenCalled()
+  })
+
+  it('renders status dot when executionStatus maps to a class', () => {
+    const { container } = render(
+      <ApprovalNode label="Gate" config={{}} executionStatus="waiting" onClick={vi.fn()} />
+    )
+    expect(container.querySelector('.bg-amber-400')).toBeTruthy()
+  })
+
+  it('applies selected border when selected', () => {
+    const { container } = render(
+      <ApprovalNode label="Gate" config={{}} selected onClick={vi.fn()} />
+    )
+    expect(container.querySelector('[class*="border-blue-500"]')).toBeTruthy()
+  })
+})

--- a/tests/background-tray.test.tsx
+++ b/tests/background-tray.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const toggle = vi.fn()
+let collapsed = false
+const mockState = {
+  get backgroundTrayCollapsed() {
+    return collapsed
+  },
+  toggleBackgroundTray: toggle
+}
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      backgroundTrayCollapsed: collapsed,
+      toggleBackgroundTray: toggle,
+      setEditingWorkflowId: vi.fn(),
+      setWorkflowEditorOpen: vi.fn()
+    }
+    return selector ? selector(state) : state
+  }
+}))
+
+vi.mock('../src/renderer/components/HeadlessPill', () => ({
+  HeadlessPill: ({ session }: { session: { id: string } }) => (
+    <div data-testid="headless-pill">{session.id}</div>
+  )
+}))
+vi.mock('../src/renderer/components/MinimizedPill', () => ({
+  MinimizedPill: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="minimized-pill">{terminalId}</div>
+  )
+}))
+vi.mock('../src/renderer/components/WaitingApprovalPill', () => ({
+  WaitingApprovalPill: ({
+    execution,
+    nodeState
+  }: {
+    execution: { workflowId: string }
+    nodeState: { nodeId: string }
+  }) => (
+    <div data-testid="waiting-pill">
+      {execution.workflowId}:{nodeState.nodeId}
+    </div>
+  )
+}))
+
+import { BackgroundTray } from '../src/renderer/components/BackgroundTray'
+import type { WaitingApproval } from '../src/renderer/components/BackgroundTray'
+import type { HeadlessSession } from '../src/shared/types'
+
+const _unused: unknown = mockState
+
+function waiting(workflowId = 'wf-1', nodeId = 'n1'): WaitingApproval {
+  return {
+    execution: {
+      workflowId,
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'running',
+      nodeStates: [{ nodeId, status: 'waiting' }]
+    },
+    nodeState: { nodeId, status: 'waiting' }
+  }
+}
+
+function headless(id: string): HeadlessSession {
+  return {
+    id,
+    agentType: 'claude',
+    projectName: 'p',
+    projectPath: '/p',
+    status: 'running',
+    startedAt: '2026-04-20T10:00:00Z',
+    prompt: '',
+    logs: ''
+  } as unknown as HeadlessSession
+}
+
+beforeEach(() => {
+  toggle.mockReset()
+  collapsed = false
+})
+
+describe('BackgroundTray', () => {
+  it('returns null when there are no background items', () => {
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[]}
+        minimizedIds={[]}
+        waitingApprovals={[]}
+        variant="grid"
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a waiting approval pill when gates are present', () => {
+    const { getAllByTestId, container } = render(
+      <BackgroundTray
+        headlessSessions={[]}
+        minimizedIds={[]}
+        waitingApprovals={[waiting()]}
+        variant="grid"
+      />
+    )
+    expect(getAllByTestId('waiting-pill')).toHaveLength(1)
+    expect(container.textContent).toContain('1 waiting approval')
+  })
+
+  it('uses plural phrasing for multiple waiting approvals', () => {
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[]}
+        minimizedIds={[]}
+        waitingApprovals={[waiting('a', 'n1'), waiting('b', 'n2')]}
+        variant="grid"
+      />
+    )
+    expect(container.textContent).toContain('2 waiting approvals')
+  })
+
+  it('renders headless and minimized pills alongside waiting', () => {
+    const { getAllByTestId } = render(
+      <BackgroundTray
+        headlessSessions={[headless('h1')]}
+        minimizedIds={['m1', 'm2']}
+        waitingApprovals={[waiting()]}
+        variant="tabs"
+      />
+    )
+    expect(getAllByTestId('waiting-pill')).toHaveLength(1)
+    expect(getAllByTestId('headless-pill')).toHaveLength(1)
+    expect(getAllByTestId('minimized-pill')).toHaveLength(2)
+  })
+
+  it('shows group labels when multiple groups are present', () => {
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[headless('h1')]}
+        minimizedIds={['m1']}
+        waitingApprovals={[waiting()]}
+        variant="grid"
+      />
+    )
+    expect(container.textContent?.toLowerCase()).toContain('waiting approval')
+    expect(container.textContent?.toLowerCase()).toContain('headless')
+    expect(container.textContent?.toLowerCase()).toContain('minimized')
+  })
+
+  it('invokes toggle when the header button is clicked', () => {
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[]}
+        minimizedIds={[]}
+        waitingApprovals={[waiting()]}
+        variant="grid"
+      />
+    )
+    const header = container.querySelector('button[aria-label="Toggle background tray"]')!
+    fireEvent.click(header)
+    expect(toggle).toHaveBeenCalled()
+  })
+
+  it('hides group content when collapsed', () => {
+    collapsed = true
+    const { queryAllByTestId } = render(
+      <BackgroundTray
+        headlessSessions={[]}
+        minimizedIds={[]}
+        waitingApprovals={[waiting()]}
+        variant="grid"
+      />
+    )
+    expect(queryAllByTestId('waiting-pill')).toHaveLength(0)
+  })
+
+  it('prefers running count in the summary when at least one headless is running', () => {
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[headless('h1'), headless('h2')]}
+        minimizedIds={[]}
+        waitingApprovals={[]}
+        variant="grid"
+      />
+    )
+    expect(container.textContent).toContain('2 running')
+  })
+
+  it('falls back to headless count when none are running', () => {
+    const idle = { ...headless('h1'), status: 'exited' } as HeadlessSession
+    const { container } = render(
+      <BackgroundTray
+        headlessSessions={[idle]}
+        minimizedIds={[]}
+        waitingApprovals={[]}
+        variant="grid"
+      />
+    )
+    expect(container.textContent).toContain('1 headless')
+  })
+})

--- a/tests/database-waiting-gates.test.ts
+++ b/tests/database-waiting-gates.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() }
+})
+
+import {
+  initTestDatabase,
+  saveWorkflowRun,
+  listRunsWithWaitingGates
+} from '../packages/server/src/database'
+import type { WorkflowExecution } from '@vornrun/shared/types'
+
+let teardown: () => void
+
+beforeEach(() => {
+  teardown = initTestDatabase()
+})
+
+afterEach(() => {
+  teardown()
+})
+
+function run(
+  id: string,
+  status: 'running' | 'success' | 'error',
+  nodeStatus: 'waiting' | 'success' | 'pending'
+): WorkflowExecution {
+  return {
+    workflowId: id,
+    startedAt: `2026-04-20T10:00:0${id.slice(-1)}Z`,
+    status,
+    nodeStates: [{ nodeId: 'gate', status: nodeStatus }]
+  }
+}
+
+describe('listRunsWithWaitingGates', () => {
+  it('returns an empty array when no runs have waiting nodes', () => {
+    saveWorkflowRun(run('wf-1', 'success', 'success'))
+    expect(listRunsWithWaitingGates()).toEqual([])
+  })
+
+  it('returns runs that contain a waiting node', () => {
+    saveWorkflowRun(run('wf-1', 'running', 'waiting'))
+    saveWorkflowRun(run('wf-2', 'success', 'success'))
+    const result = listRunsWithWaitingGates()
+    expect(result).toHaveLength(1)
+    expect(result[0].workflowId).toBe('wf-1')
+    expect(result[0].nodeStates[0].status).toBe('waiting')
+  })
+
+  it('batches node fetch for multiple waiting runs and preserves ordering', () => {
+    saveWorkflowRun(run('wf-1', 'running', 'waiting'))
+    saveWorkflowRun(run('wf-2', 'running', 'waiting'))
+    saveWorkflowRun(run('wf-3', 'running', 'waiting'))
+    const result = listRunsWithWaitingGates()
+    expect(result.map((r) => r.workflowId).sort()).toEqual(['wf-1', 'wf-2', 'wf-3'])
+    for (const r of result) {
+      expect(r.nodeStates[0].status).toBe('waiting')
+    }
+  })
+
+  it('preserves approved_at and agent metadata through the round-trip', () => {
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-9',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'running',
+      nodeStates: [
+        {
+          nodeId: 'gate',
+          status: 'waiting',
+          startedAt: '2026-04-20T10:00:00Z',
+          completedAt: '2026-04-20T10:00:05Z',
+          sessionId: 's1',
+          error: 'none',
+          logs: 'log line',
+          taskId: 't1',
+          agentSessionId: 'as1',
+          agentType: 'claude',
+          projectName: 'p',
+          projectPath: '/p',
+          approvedAt: '2026-04-20T10:00:10Z'
+        }
+      ],
+      triggerTaskId: 'trig-1',
+      completedAt: '2026-04-20T10:00:10Z'
+    }
+    saveWorkflowRun(exec)
+    const [got] = listRunsWithWaitingGates()
+    const ns = got.nodeStates[0]
+    expect(ns.status).toBe('waiting')
+    expect(ns.agentType).toBe('claude')
+    expect(ns.projectName).toBe('p')
+    expect(ns.projectPath).toBe('/p')
+    expect(ns.approvedAt).toBe('2026-04-20T10:00:10Z')
+    expect(ns.agentSessionId).toBe('as1')
+    expect(ns.taskId).toBe('t1')
+    expect(ns.logs).toBe('log line')
+    expect(got.completedAt).toBe('2026-04-20T10:00:10Z')
+    expect(got.triggerTaskId).toBe('trig-1')
+  })
+})

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -39,7 +39,8 @@ describe('workflow run persistence', () => {
           agentSessionId: 'agent-xyz',
           agentType: 'claude',
           projectName: 'proj',
-          projectPath: '/abs/proj'
+          projectPath: '/abs/proj',
+          approvedAt: '2026-04-20T10:00:04Z'
         }
       ]
     }
@@ -52,6 +53,7 @@ describe('workflow run persistence', () => {
     expect(state.projectName).toBe('proj')
     expect(state.projectPath).toBe('/abs/proj')
     expect(state.agentSessionId).toBe('agent-xyz')
+    expect(state.approvedAt).toBe('2026-04-20T10:00:04Z')
   })
 
   it('omits fields that were not set', () => {

--- a/tests/node-config-panel.test.tsx
+++ b/tests/node-config-panel.test.tsx
@@ -43,7 +43,9 @@ function makeNode(type: WorkflowNode['type']): WorkflowNode {
           ? { scriptType: 'bash' }
           : type === 'condition'
             ? { variable: '', operator: 'equals', value: '' }
-            : { agentType: 'claude', projectName: '', projectPath: '' },
+            : type === 'approval'
+              ? { message: '' }
+              : { agentType: 'claude', projectName: '', projectPath: '' },
     position: { x: 0, y: 0 }
   }
 }
@@ -137,5 +139,22 @@ describe('NodeConfigPanel', () => {
       />
     )
     expect(screen.getByText(/steps\.my_step\.output/)).toBeInTheDocument()
+  })
+
+  it('renders the approval form for approval nodes', () => {
+    const onChange = vi.fn()
+    render(
+      <NodeConfigPanel
+        node={makeNode('approval')}
+        onChange={onChange}
+        onLabelChange={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    const textarea = document.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea).toBeTruthy()
+    fireEvent.change(textarea, { target: { value: 'ok?' } })
+    expect(onChange).toHaveBeenCalledWith('n1', expect.objectContaining({ message: 'ok?' }))
   })
 })

--- a/tests/notifications-send.test.ts
+++ b/tests/notifications-send.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  sendAgentNotification,
+  sendWorkflowGateNotification
+} from '../src/renderer/lib/notifications'
+import type { AppConfig, WorkflowDefinition } from '../src/shared/types'
+import type { TerminalState } from '../src/renderer/stores/types'
+
+function makeConfig(overrides: Partial<AppConfig['defaults']['notifications']> = {}): AppConfig {
+  return {
+    version: 1,
+    defaults: {
+      shell: '/bin/zsh',
+      fontSize: 13,
+      theme: 'dark',
+      notifications: {
+        enabled: true,
+        onWaiting: true,
+        onError: true,
+        onBell: true,
+        soundEnabled: false,
+        ...overrides
+      }
+    },
+    projects: []
+  } as AppConfig
+}
+
+function terminal(id: string = `t-${Math.random().toString(36).slice(2, 8)}`): TerminalState {
+  return {
+    id,
+    session: {
+      id,
+      agentType: 'claude',
+      projectName: 'demo',
+      projectPath: '/demo',
+      cwd: '/demo',
+      status: 'idle',
+      startedAt: '2026-04-20T10:00:00Z',
+      name: 'demo'
+    }
+  } as unknown as TerminalState
+}
+
+function wf(id: string = `wf-${Math.random().toString(36).slice(2, 8)}`): WorkflowDefinition {
+  return { ...workflow(), id }
+}
+
+function workflow(): WorkflowDefinition {
+  return {
+    id: 'wf-1',
+    name: 'Deploy',
+    icon: 'Zap',
+    trigger: { type: 'manual' },
+    nodes: [],
+    edges: []
+  }
+}
+
+let notificationInstances: Array<{ onclick?: () => void }> = []
+const NotificationMock = vi.fn(function (this: { onclick?: () => void }) {
+  this.onclick = undefined
+  notificationInstances.push(this)
+})
+
+beforeEach(() => {
+  NotificationMock.mockReset()
+  notificationInstances = []
+  ;(globalThis as unknown as { Notification: unknown }).Notification = Object.assign(
+    NotificationMock,
+    { permission: 'granted' as const }
+  )
+  // Force the window to be unfocused so the notification dispatches
+  vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('sendWorkflowGateNotification', () => {
+  it('does nothing when notifications are disabled', () => {
+    const config = makeConfig({ enabled: false })
+    sendWorkflowGateNotification(wf(), 'n1', 'Gate', 'hi', config)
+    expect(NotificationMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when onWaiting is false', () => {
+    const config = makeConfig({ onWaiting: false })
+    sendWorkflowGateNotification(wf(), 'n1', 'Gate', 'hi', config)
+    expect(NotificationMock).not.toHaveBeenCalled()
+  })
+
+  it('dispatches a notification with workflow name and message', () => {
+    sendWorkflowGateNotification(wf(), 'n1', 'Gate', 'please review', makeConfig())
+    expect(NotificationMock).toHaveBeenCalledTimes(1)
+    const [title, opts] = NotificationMock.mock.calls[0]
+    expect(title).toContain('Deploy')
+    expect((opts as { body: string }).body).toBe('please review')
+  })
+
+  it('falls back to node label when message is undefined', () => {
+    sendWorkflowGateNotification(wf(), 'n1', 'Approve Deploy', undefined, makeConfig())
+    const [, opts] = NotificationMock.mock.calls[0]
+    expect((opts as { body: string }).body).toContain('Approve Deploy')
+  })
+
+  it('runs onClick when the notification is clicked', () => {
+    const onClick = vi.fn()
+    sendWorkflowGateNotification(wf(), 'n1', 'Gate', 'hi', makeConfig(), onClick)
+    notificationInstances[0]?.onclick?.()
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('keys cooldown by nodeId so distinct nodes with the same label both fire', () => {
+    const w = wf()
+    sendWorkflowGateNotification(w, 'node-a', 'Gate', 'x', makeConfig())
+    sendWorkflowGateNotification(w, 'node-b', 'Gate', 'y', makeConfig())
+    expect(NotificationMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('sendAgentNotification', () => {
+  it('dispatches a notification for the waiting reason', () => {
+    sendAgentNotification(terminal(), 'waiting', makeConfig())
+    expect(NotificationMock).toHaveBeenCalledTimes(1)
+    const [title] = NotificationMock.mock.calls[0]
+    expect(title).toContain('needs input')
+  })
+
+  it('dispatches for the error reason', () => {
+    sendAgentNotification(terminal(), 'error', makeConfig())
+    expect(NotificationMock).toHaveBeenCalledTimes(1)
+    const [title] = NotificationMock.mock.calls[0]
+    expect(title).toContain('error')
+  })
+
+  it('dispatches for the bell reason', () => {
+    sendAgentNotification(terminal(), 'bell', makeConfig())
+    expect(NotificationMock).toHaveBeenCalledTimes(1)
+    const [title] = NotificationMock.mock.calls[0]
+    expect(title).toContain('notification')
+  })
+
+  it('does nothing when the window is focused', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    sendAgentNotification(terminal(), 'waiting', makeConfig())
+    expect(NotificationMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const approve = vi.fn()
+const reject = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  approveWorkflowGate: (...args: unknown[]) => approve(...args),
+  rejectWorkflowGate: (...args: unknown[]) => reject(...args)
+}))
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+import { RunEntry } from '../src/renderer/components/workflow-editor/RunEntry'
+import type { WorkflowExecution, WorkflowNode } from '../src/shared/types'
+
+function makeExec(overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
+  return {
+    workflowId: 'wf-1',
+    startedAt: '2026-04-20T10:00:00Z',
+    status: 'running',
+    nodeStates: [{ nodeId: 'gate', status: 'waiting', startedAt: '2026-04-20T10:00:00Z' }],
+    ...overrides
+  }
+}
+
+const approvalNode: WorkflowNode = {
+  id: 'gate',
+  type: 'approval',
+  label: 'Ship it?',
+  position: { x: 0, y: 0 },
+  config: { message: 'Please confirm' }
+}
+
+beforeEach(() => {
+  approve.mockReset()
+  reject.mockReset()
+})
+
+describe('RunEntry — approval gate controls', () => {
+  it('renders the approval message and controls when expanded', () => {
+    const { getByText } = render(<RunEntry execution={makeExec()} nodes={[approvalNode]} />)
+    expect(getByText('Please confirm')).toBeTruthy()
+    expect(getByText('Approve')).toBeTruthy()
+    expect(getByText('Reject')).toBeTruthy()
+  })
+
+  it('falls back to default text when message is empty', () => {
+    const node: WorkflowNode = { ...approvalNode, config: {} }
+    const { getByText } = render(<RunEntry execution={makeExec()} nodes={[node]} />)
+    expect(getByText('Waiting for approval.')).toBeTruthy()
+  })
+
+  it('invokes approveWorkflowGate when Approve is clicked', () => {
+    const { getByText } = render(<RunEntry execution={makeExec()} nodes={[approvalNode]} />)
+    fireEvent.click(getByText('Approve'))
+    expect(approve).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }), 'gate')
+  })
+
+  it('invokes rejectWorkflowGate when Reject is clicked', () => {
+    const { getByText } = render(<RunEntry execution={makeExec()} nodes={[approvalNode]} />)
+    fireEvent.click(getByText('Reject'))
+    expect(reject).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }), 'gate')
+  })
+
+  it('does not render approval controls for non-approval waiting nodes', () => {
+    const nonApproval: WorkflowNode = {
+      id: 'gate',
+      type: 'script',
+      label: 'Script',
+      position: { x: 0, y: 0 },
+      config: { scriptType: 'bash', scriptContent: '' }
+    }
+    const { queryByText } = render(<RunEntry execution={makeExec()} nodes={[nonApproval]} />)
+    expect(queryByText('Approve')).toBeNull()
+  })
+})

--- a/tests/waiting-approval-pill.test.tsx
+++ b/tests/waiting-approval-pill.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const approve = vi.fn()
+const reject = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  approveWorkflowGate: (...args: unknown[]) => approve(...args),
+  rejectWorkflowGate: (...args: unknown[]) => reject(...args)
+}))
+
+const setEditingWorkflowId = vi.fn()
+const setWorkflowEditorOpen = vi.fn()
+const mockState = { setEditingWorkflowId, setWorkflowEditorOpen }
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+}))
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+import { WaitingApprovalPill } from '../src/renderer/components/WaitingApprovalPill'
+import type { WorkflowExecution, NodeExecutionState, WorkflowDefinition } from '../src/shared/types'
+
+function execution(): WorkflowExecution {
+  return {
+    workflowId: 'wf-1',
+    startedAt: '2026-04-20T10:00:00Z',
+    status: 'running',
+    nodeStates: [{ nodeId: 'n1', status: 'waiting' }]
+  }
+}
+
+function nodeState(): NodeExecutionState {
+  return { nodeId: 'n1', status: 'waiting' }
+}
+
+function workflow(msg?: string): WorkflowDefinition {
+  return {
+    id: 'wf-1',
+    name: 'Deploy',
+    icon: 'Zap',
+    iconColor: '#ff0',
+    trigger: { type: 'manual' },
+    nodes: [
+      {
+        id: 'n1',
+        type: 'approval',
+        label: 'Gate',
+        position: { x: 0, y: 0 },
+        config: msg !== undefined ? { message: msg } : {}
+      }
+    ],
+    edges: []
+  }
+}
+
+beforeEach(() => {
+  approve.mockReset()
+  reject.mockReset()
+  setEditingWorkflowId.mockReset()
+  setWorkflowEditorOpen.mockReset()
+})
+
+describe('WaitingApprovalPill', () => {
+  it('renders workflow name and message', () => {
+    const { container } = render(
+      <WaitingApprovalPill
+        execution={execution()}
+        nodeState={nodeState()}
+        workflow={workflow('please review')}
+      />
+    )
+    expect(container.textContent).toContain('Deploy')
+    expect(container.textContent).toContain('please review')
+  })
+
+  it('falls back to "Workflow" when workflow prop is missing', () => {
+    const { container } = render(
+      <WaitingApprovalPill execution={execution()} nodeState={nodeState()} />
+    )
+    expect(container.textContent).toContain('Workflow')
+  })
+
+  it('opens the workflow editor when the pill is clicked', () => {
+    const { container } = render(
+      <WaitingApprovalPill execution={execution()} nodeState={nodeState()} workflow={workflow()} />
+    )
+    const pill = container.firstElementChild as HTMLElement
+    fireEvent.click(pill)
+    expect(setEditingWorkflowId).toHaveBeenCalledWith('wf-1')
+    expect(setWorkflowEditorOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('invokes approveWorkflowGate when Approve is clicked and stops propagation', () => {
+    const { getByLabelText } = render(
+      <WaitingApprovalPill execution={execution()} nodeState={nodeState()} workflow={workflow()} />
+    )
+    fireEvent.click(getByLabelText('Approve'))
+    expect(approve).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }), 'n1')
+    expect(setEditingWorkflowId).not.toHaveBeenCalled()
+  })
+
+  it('invokes rejectWorkflowGate when Reject is clicked and stops propagation', () => {
+    const { getByLabelText } = render(
+      <WaitingApprovalPill execution={execution()} nodeState={nodeState()} workflow={workflow()} />
+    )
+    fireEvent.click(getByLabelText('Reject'))
+    expect(reject).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }), 'n1')
+    expect(setEditingWorkflowId).not.toHaveBeenCalled()
+  })
+})

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -53,7 +53,8 @@ const mockState = {
   addTerminal: vi.fn(),
   setFocusedTerminal: vi.fn(),
   setSelectedTaskId: vi.fn(),
-  activeWorkspace: 'personal'
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, unknown>()
 }
 
 vi.mock('../src/renderer/stores', () => {

--- a/tests/workflow-helpers.test.ts
+++ b/tests/workflow-helpers.test.ts
@@ -29,6 +29,7 @@ import {
   createLaunchAgentNode,
   createScriptNode,
   createConditionNode,
+  createApprovalNode,
   autoLayoutNodes,
   appendNode,
   removeNode,
@@ -225,6 +226,22 @@ describe('createConditionNode', () => {
     const node = createConditionNode()
     expect(node.type).toBe('condition')
     expect((node.config as { operator: string }).operator).toBe('equals')
+  })
+})
+
+describe('createApprovalNode', () => {
+  it('creates node with defaults', () => {
+    const node = createApprovalNode()
+    expect(node.type).toBe('approval')
+    expect(node.slug).toBe('approval_gate')
+    expect((node.config as { message?: string }).message).toBe('')
+  })
+
+  it('merges overrides', () => {
+    const node = createApprovalNode({ message: 'please', timeoutMs: 30000 })
+    const cfg = node.config as { message: string; timeoutMs: number }
+    expect(cfg.message).toBe('please')
+    expect(cfg.timeoutMs).toBe(30000)
   })
 })
 

--- a/tests/workflow-item.test.tsx
+++ b/tests/workflow-item.test.tsx
@@ -6,7 +6,8 @@ import type { WorkflowDefinition } from '../src/shared/types'
 
 const mockStore = {
   setEditingWorkflowId: vi.fn(),
-  setWorkflowEditorOpen: vi.fn()
+  setWorkflowEditorOpen: vi.fn(),
+  workflowExecutions: new Map<string, unknown>()
 }
 
 vi.mock('../src/renderer/stores', () => ({

--- a/tests/workflows-section.test.tsx
+++ b/tests/workflows-section.test.tsx
@@ -11,7 +11,8 @@ const mockStore = {
   updateWorkflow: vi.fn(),
   reorderWorkflows: vi.fn(),
   sidebarWorkflowFilter: 'all' as 'all' | 'manual' | 'scheduled',
-  setSidebarWorkflowFilter: vi.fn()
+  setSidebarWorkflowFilter: vi.fn(),
+  workflowExecutions: new Map<string, unknown>()
 }
 
 vi.mock('../src/renderer/stores', () => ({


### PR DESCRIPTION
## Summary
- Adds an `approval` node type to the workflow editor that pauses execution until a user approves or rejects
- Surfaces waiting approvals via a new pill in the background tray, a status dot in the sidebar, and resume-safe gate controls in the run history
- Persists gate state across sessions (new `listRunsWithWaitingGates` query with a single batched node-row fetch) and supports optional timeout-based auto-reject
- Fires a desktop notification on gate entry (reusing the existing cooldown/focus/sound scaffolding via a shared dispatch helper)

## Test plan
- [ ] Create a workflow with an approval step; run it and verify the run pauses with the pill visible
- [ ] Approve via the pill and via the run-history controls; verify downstream steps resume
- [ ] Reject and verify the branch is marked skipped
- [ ] Restart the app while a gate is pending; verify the pill reappears and approve still resumes
- [ ] Set a short timeout and verify auto-reject fires with the correct reason
- [ ] All 927 tests pass locally; typecheck clean