### PR TITLE
Compact grid: flush cards with 1px dividers

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -118,7 +118,7 @@ export const AgentCard = memo(
     return (
       <div
         ref={ref}
-        className={`relative rounded-lg border overflow-hidden flex flex-col
+        className={`relative border overflow-hidden flex flex-col
                    transition-colors
                    ${flexible ? 'h-full' : ''}
                    ${
@@ -129,6 +129,9 @@ export const AgentCard = memo(
                          : isDragTarget
                            ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
                            : 'border-white/[0.06] hover:border-white/[0.12]'
+                   }
+                   ${
+                     flexible ? '' : isFocused || isSelected || isDragTarget ? 'z-10' : 'hover:z-10'
                    }`}
         style={{
           background: '#1a1a1e'

--- a/src/renderer/components/BackgroundTray.tsx
+++ b/src/renderer/components/BackgroundTray.tsx
@@ -53,7 +53,7 @@ export function BackgroundTray({
   const isGrid = variant === 'grid'
 
   return (
-    <div className={isGrid ? 'mb-4' : 'shrink-0 px-3 py-2 border-b border-white/[0.06]'}>
+    <div className={isGrid ? 'px-4 pt-4 mb-4' : 'shrink-0 px-3 py-2 border-b border-white/[0.06]'}>
       <button
         type="button"
         className={`flex items-center gap-1.5 w-full text-left cursor-pointer group ${isGrid ? 'px-1 mb-2' : 'mb-1.5'}`}

--- a/src/renderer/components/BackgroundTray.tsx
+++ b/src/renderer/components/BackgroundTray.tsx
@@ -53,7 +53,7 @@ export function BackgroundTray({
   const isGrid = variant === 'grid'
 
   return (
-    <div className={isGrid ? 'px-4 pt-4 mb-4' : 'shrink-0 px-3 py-2 border-b border-white/[0.06]'}>
+    <div className={isGrid ? 'mb-4' : 'shrink-0 px-3 py-2 border-b border-white/[0.06]'}>
       <button
         type="button"
         className={`flex items-center gap-1.5 w-full text-left cursor-pointer group ${isGrid ? 'px-1 mb-2' : 'mb-1.5'}`}

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -159,7 +159,7 @@ export const GridView = memo(function GridView() {
 
   return (
     <div
-      className="h-full overflow-auto p-4"
+      className="h-full overflow-auto"
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
@@ -207,7 +207,7 @@ export const GridView = memo(function GridView() {
           />
         ) : (
           <div
-            className="grid gap-4"
+            className="grid gap-0"
             style={gridStyle}
             onDoubleClick={handleGridDoubleClick}
             onContextMenu={handleGridContextMenu}
@@ -370,7 +370,7 @@ function FlexibleGrid({
         gridConfig={{
           cols: FLEX_COLS,
           rowHeight: FLEX_ROW_H,
-          margin: [16, 16],
+          margin: [0, 0],
           containerPadding: null,
           maxRows: Infinity
         }}

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -168,13 +168,15 @@ export const GridView = memo(function GridView() {
       onContextMenu={handleGridContextMenu}
     >
       {/* Background tray: headless + minimized */}
-      <BackgroundTray
-        headlessSessions={filteredHeadless}
-        minimizedIds={minimizedIds}
-        waitingApprovals={waitingApprovals}
-        variant="grid"
-        hasItemsBelow={orderedIds.length > 0}
-      />
+      <div className="px-4 pt-4">
+        <BackgroundTray
+          headlessSessions={filteredHeadless}
+          minimizedIds={minimizedIds}
+          waitingApprovals={waitingApprovals}
+          variant="grid"
+          hasItemsBelow={orderedIds.length > 0}
+        />
+      </div>
 
       {orderedIds.length === 0 && filteredHeadless.length === 0 && minimizedIds.length === 0 ? (
         isFiltered ? (

--- a/src/renderer/components/TerminalHost.tsx
+++ b/src/renderer/components/TerminalHost.tsx
@@ -6,6 +6,7 @@ import {
   onRegistryChange,
   TERMINAL_ID_ATTR
 } from '../lib/terminal-registry'
+import { useAppStore } from '../stores'
 import { TerminalContextMenu } from './TerminalContextMenu'
 
 interface CtxMenuState {
@@ -39,6 +40,19 @@ export function TerminalHost() {
     }
     el.addEventListener('contextmenu', handleContextMenu)
 
+    const handlePointerDown = (e: PointerEvent): void => {
+      const target = e.target as HTMLElement | null
+      const wrapper = target?.closest(`[${TERMINAL_ID_ATTR}]`) as HTMLElement | null
+      if (!wrapper) return
+      const terminalId = wrapper.getAttribute(TERMINAL_ID_ATTR)
+      if (!terminalId) return
+      const state = useAppStore.getState()
+      if (state.selectedTerminalId !== terminalId && state.focusedTerminalId !== terminalId) {
+        state.setSelectedTerminal(terminalId)
+      }
+    }
+    el.addEventListener('pointerdown', handlePointerDown)
+
     let rafId = requestAnimationFrame(function tick(): void {
       const ids = getRegisteredTerminalIds()
       for (const id of ids) syncTerminalOverlay(id)
@@ -51,6 +65,7 @@ export function TerminalHost() {
 
     return () => {
       el.removeEventListener('contextmenu', handleContextMenu)
+      el.removeEventListener('pointerdown', handlePointerDown)
       cancelAnimationFrame(rafId)
       unsubscribe()
       setHostRoot(null)


### PR DESCRIPTION
## Summary
- Cards tile edge-to-edge in both fixed and flexible grid modes, separated by a single hairline read from the existing card border. Outer scroll wrapper loses its `p-4` so the grid reaches the viewport edges; `BackgroundTray`'s grid variant now carries its own `px-4 pt-4` to compensate.
- Fixes active-card border not updating when clicking into a terminal to type. xterm renders in a fixed overlay above cards (`TerminalHost`), so clicks never reached `AgentCard`'s `onPointerDown`. `TerminalHost` now delegates `pointerdown` via the `data-terminal-id` attribute, mirroring its existing `contextmenu` handler, and calls `setSelectedTerminal` when the click target isn't already the selected/focused card.
- Flexible grid (`react-grid-layout`) `margin` reduced from `[16, 16]` to `[0, 0]` for the same flush look; `rounded-lg` removed from the card wrapper so corners tile cleanly in both modes.

## Test plan
- [ ] Fixed-column grid: cards sit flush, 1px divider between them, no gutter on any edge.
- [ ] Switch between Auto / 1 / 2 / 3 / 4 columns — dividers form a clean grid in each case.
- [ ] Click into a terminal (xterm) to type — active blue border updates to the clicked card.
- [ ] Hover a card (grid mode) — hover ring appears, no layout shift.
- [ ] Drag a card onto another in manual sort — drop-target highlight shows above any focused neighbor.
- [ ] Flexible layout: cards flush, drag/resize handles still work.
- [ ] Minimize a card or leave a headless session running — `BackgroundTray` renders with proper padding above the grid.
- [ ] Tabs layout: unchanged.