### PR TITLE
Compact grid follow-up: focus-within ring + empty-tray gutter

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -131,7 +131,11 @@ export const AgentCard = memo(
                            : 'border-white/[0.06] hover:border-white/[0.12]'
                    }
                    ${
-                     flexible ? '' : isFocused || isSelected || isDragTarget ? 'z-10' : 'hover:z-10'
+                     flexible
+                       ? ''
+                       : isFocused || isSelected || isDragTarget
+                         ? 'z-10'
+                         : 'hover:z-10 focus-within:z-10'
                    }`}
         style={{
           background: '#1a1a1e'

--- a/src/renderer/components/BackgroundTray.tsx
+++ b/src/renderer/components/BackgroundTray.tsx
@@ -1,21 +1,13 @@
 import { useShallow } from 'zustand/react/shallow'
-import {
-  HeadlessSession,
-  WorkflowExecution,
-  NodeExecutionState,
-  WorkflowDefinition
-} from '../../shared/types'
+import { HeadlessSession } from '../../shared/types'
 import { HeadlessPill } from './HeadlessPill'
 import { MinimizedPill } from './MinimizedPill'
 import { WaitingApprovalPill } from './WaitingApprovalPill'
 import { useAppStore } from '../stores'
 import { ChevronRight } from 'lucide-react'
+import { backgroundTrayHasItems, type WaitingApproval } from '../lib/background-tray'
 
-export interface WaitingApproval {
-  execution: WorkflowExecution
-  nodeState: NodeExecutionState
-  workflow?: WorkflowDefinition
-}
+export { type WaitingApproval }
 
 interface Props {
   headlessSessions: HeadlessSession[]
@@ -39,12 +31,11 @@ export function BackgroundTray({
     }))
   )
 
+  if (!backgroundTrayHasItems(headlessSessions, minimizedIds, waitingApprovals)) return null
+
   const headlessCount = headlessSessions.length
   const minimizedCount = minimizedIds.length
   const waitingCount = waitingApprovals.length
-  const totalCount = headlessCount + minimizedCount + waitingCount
-
-  if (totalCount === 0) return null
 
   const runningCount = headlessSessions.filter((s) => s.status === 'running').length
   const groupCount = [headlessCount, minimizedCount, waitingCount].filter((n) => n > 0).length

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -8,6 +8,7 @@ import 'react-resizable/css/styles.css'
 import { useAppStore } from '../stores'
 import { AgentCard } from './AgentCard'
 import { BackgroundTray } from './BackgroundTray'
+import { backgroundTrayHasItems } from '../lib/background-tray'
 import { PromptLauncher } from './PromptLauncher'
 import { GridContextMenu } from './GridContextMenu'
 import { AgentIcon } from './AgentIcon'
@@ -168,7 +169,7 @@ export const GridView = memo(function GridView() {
       onContextMenu={handleGridContextMenu}
     >
       {/* Background tray: headless + minimized */}
-      {(filteredHeadless.length > 0 || minimizedIds.length > 0 || waitingApprovals.length > 0) && (
+      {backgroundTrayHasItems(filteredHeadless, minimizedIds, waitingApprovals) && (
         <div className="px-4 pt-4">
           <BackgroundTray
             headlessSessions={filteredHeadless}

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -168,15 +168,17 @@ export const GridView = memo(function GridView() {
       onContextMenu={handleGridContextMenu}
     >
       {/* Background tray: headless + minimized */}
-      <div className="px-4 pt-4">
-        <BackgroundTray
-          headlessSessions={filteredHeadless}
-          minimizedIds={minimizedIds}
-          waitingApprovals={waitingApprovals}
-          variant="grid"
-          hasItemsBelow={orderedIds.length > 0}
-        />
-      </div>
+      {(filteredHeadless.length > 0 || minimizedIds.length > 0 || waitingApprovals.length > 0) && (
+        <div className="px-4 pt-4">
+          <BackgroundTray
+            headlessSessions={filteredHeadless}
+            minimizedIds={minimizedIds}
+            waitingApprovals={waitingApprovals}
+            variant="grid"
+            hasItemsBelow={orderedIds.length > 0}
+          />
+        </div>
+      )}
 
       {orderedIds.length === 0 && filteredHeadless.length === 0 && minimizedIds.length === 0 ? (
         isFiltered ? (

--- a/src/renderer/lib/background-tray.ts
+++ b/src/renderer/lib/background-tray.ts
@@ -1,0 +1,20 @@
+import type {
+  HeadlessSession,
+  WorkflowExecution,
+  NodeExecutionState,
+  WorkflowDefinition
+} from '../../shared/types'
+
+export interface WaitingApproval {
+  execution: WorkflowExecution
+  nodeState: NodeExecutionState
+  workflow?: WorkflowDefinition
+}
+
+export function backgroundTrayHasItems(
+  headlessSessions: HeadlessSession[],
+  minimizedIds: string[],
+  waitingApprovals: WaitingApproval[]
+): boolean {
+  return headlessSessions.length + minimizedIds.length + waitingApprovals.length > 0
+}


### PR DESCRIPTION
## Summary
Follow-up to #233 addressing two items from Copilot review that landed after the merge:
- **Keyboard focus ring no longer clipped by neighbor cards.** Added `focus-within:z-10` alongside the existing `hover:z-10` on `AgentCard`, so a focused child control (button/menu) raises its card above adjacent seams.
- **No permanent 16px gutter when the background tray is empty.** Skip the `px-4 pt-4` wrapper in `GridView` when there are no headless, minimized, or waiting-approval items — the tray itself returns `null` in that case, so the padded wrapper was leaving a blank strip above the grid.

## Test plan
- [ ] Tab into a button inside a grid card — the focus ring renders fully, not clipped by the neighbor.
- [ ] With no headless/minimized/waiting sessions, the top row of cards reaches the top edge of the grid area (no 16px gutter).
- [ ] Start a headless session or minimize a card — the background tray appears with proper `px-4 pt-4` padding around it.