### PR TITLE
Fix tab double-header, restore Open-in menu, fix flexible-grid drag

### DIFF
--- a/src/renderer/components/OpenInButton.tsx
+++ b/src/renderer/components/OpenInButton.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { ChevronDown } from 'lucide-react'
 
 import vscodeSvg from '../assets/icons/vscode.svg?raw'
@@ -45,31 +46,45 @@ function IDEIcon({ ideId, size = 14 }: { ideId: string; size?: number }) {
 }
 
 let ideCache: DetectedIDE[] | null = null
+let ideCachePromise: Promise<DetectedIDE[]> | null = null
+
+function loadIDEs(): Promise<DetectedIDE[]> {
+  if (ideCache) return Promise.resolve(ideCache)
+  if (!ideCachePromise) {
+    ideCachePromise = window.api.detectIDEs().then((detected) => {
+      ideCache = detected
+      return detected
+    })
+  }
+  return ideCachePromise
+}
 
 interface Props {
   projectPath: string
   direction?: 'up' | 'down'
 }
 
+const MENU_WIDTH = 180
+
 export function OpenInButton({ projectPath, direction = 'down' }: Props) {
   const [ides, setIdes] = useState<DetectedIDE[]>(ideCache || [])
   const [isOpen, setIsOpen] = useState(false)
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const anchorRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (ideCache) return
-    window.api.detectIDEs().then((detected) => {
-      ideCache = detected
-      setIdes(detected)
-    })
+    loadIDEs().then(setIdes)
   }, [])
 
   useEffect(() => {
     if (!isOpen) return
     const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsOpen(false)
-      }
+      const target = e.target as Node
+      if (menuRef.current?.contains(target)) return
+      if (anchorRef.current?.contains(target)) return
+      setIsOpen(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -86,7 +101,21 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
 
   const handleToggle = (e: React.MouseEvent) => {
     e.stopPropagation()
-    setIsOpen(!isOpen)
+    if (isOpen) {
+      setIsOpen(false)
+      return
+    }
+    const rect = anchorRef.current?.getBoundingClientRect()
+    if (rect) {
+      const estimatedHeight = 32 + ides.length * 30
+      const left = Math.max(
+        8,
+        Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - 8)
+      )
+      const top = direction === 'up' ? Math.max(8, rect.top - estimatedHeight - 4) : rect.bottom + 4
+      setMenuPos({ top, left })
+    }
+    setIsOpen(true)
   }
 
   const handleSelect = (ide: DetectedIDE, e: React.MouseEvent) => {
@@ -96,7 +125,7 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
   }
 
   return (
-    <div className="relative" ref={menuRef}>
+    <div className="relative" ref={anchorRef}>
       <div className="flex items-center">
         <button
           onClick={handleOpen}
@@ -118,27 +147,34 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
         </button>
       </div>
 
-      {isOpen && (
-        <div
-          className={`absolute right-0 z-50 min-w-[160px] py-1
-                     border border-white/[0.08] rounded-lg shadow-xl
-                     ${direction === 'up' ? 'bottom-full mb-1' : 'top-full mt-1'}`}
-          style={{ background: '#1e1e22' }}
-        >
-          <div className="px-3 py-1.5 text-[11px] text-gray-500 font-medium">Open in</div>
-          {ides.map((ide) => (
-            <button
-              key={ide.id}
-              onClick={(e) => handleSelect(ide, e)}
-              className="w-full px-3 py-1.5 text-left text-[13px] text-gray-300 hover:text-white
-                         hover:bg-white/[0.06] flex items-center gap-2.5 transition-colors"
-            >
-              <IDEIcon ideId={ide.id} size={14} />
-              {ide.name}
-            </button>
-          ))}
-        </div>
-      )}
+      {isOpen &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[9999] py-1 border border-white/[0.08] rounded-lg shadow-xl"
+            style={{
+              background: '#1e1e22',
+              top: menuPos.top,
+              left: menuPos.left,
+              width: MENU_WIDTH
+            }}
+          >
+            <div className="px-3 py-1.5 text-[11px] text-gray-500 font-medium">Open in</div>
+            {ides.map((ide) => (
+              <button
+                key={ide.id}
+                onClick={(e) => handleSelect(ide, e)}
+                className="w-full px-3 py-1.5 text-left text-[13px] text-gray-300 hover:text-white
+                           hover:bg-white/[0.06] flex items-center gap-2.5 transition-colors"
+              >
+                <IDEIcon ideId={ide.id} size={14} />
+                {ide.name}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
     </div>
   )
 }

--- a/src/renderer/components/OpenInButton.tsx
+++ b/src/renderer/components/OpenInButton.tsx
@@ -51,10 +51,16 @@ let ideCachePromise: Promise<DetectedIDE[]> | null = null
 function loadIDEs(): Promise<DetectedIDE[]> {
   if (ideCache) return Promise.resolve(ideCache)
   if (!ideCachePromise) {
-    ideCachePromise = window.api.detectIDEs().then((detected) => {
-      ideCache = detected
-      return detected
-    })
+    ideCachePromise = window.api.detectIDEs().then(
+      (detected) => {
+        ideCache = detected
+        return detected
+      },
+      (err) => {
+        ideCachePromise = null
+        throw err
+      }
+    )
   }
   return ideCachePromise
 }
@@ -75,7 +81,9 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
 
   useEffect(() => {
     if (ideCache) return
-    loadIDEs().then(setIdes)
+    loadIDEs().then(setIdes, () => {
+      /* detection failed; UI stays hidden until a later retry */
+    })
   }, [])
 
   useEffect(() => {
@@ -139,6 +147,7 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
         </button>
         <button
           onClick={handleToggle}
+          aria-label="Choose IDE"
           className="flex items-center px-0.5 py-0.5 text-gray-500 hover:text-white
                      bg-white/[0.04] hover:bg-white/[0.08] rounded-r-md border border-white/[0.06]
                      transition-colors self-stretch"
@@ -152,7 +161,7 @@ export function OpenInButton({ projectPath, direction = 'down' }: Props) {
         createPortal(
           <div
             ref={menuRef}
-            className="fixed z-[9999] py-1 border border-white/[0.08] rounded-lg shadow-xl"
+            className="fixed z-[150] py-1 border border-white/[0.08] rounded-lg shadow-xl"
             style={{
               background: '#1e1e22',
               top: menuPos.top,

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -12,15 +12,15 @@ import { PromptLauncher } from './PromptLauncher'
 import { InlineRename } from './InlineRename'
 import { CardContextMenu } from './CardContextMenu'
 import { BackgroundTray } from './BackgroundTray'
-import { CardHeader } from './card/CardHeader'
 import { CardStatusBar } from './card/CardStatusBar'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { resolveActiveProject } from '../lib/session-utils'
 import type { AgentStatus } from '../../shared/types'
 import { ConfirmPopover } from './ConfirmPopover'
+import { Tooltip } from './Tooltip'
 import { toast } from './Toast'
-import { ChevronDown, GripVertical, Pencil, X } from 'lucide-react'
+import { ChevronDown, FolderOpen, GripVertical, Pencil, X } from 'lucide-react'
 import { GridContextMenu } from './GridContextMenu'
 import { MOD } from '../lib/platform'
 
@@ -63,6 +63,34 @@ function getHorizontalDropIndex(
   }
 
   return closestIndex
+}
+
+const TAB_ICON_BTN =
+  'w-5 h-5 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-gray-500'
+
+function TabIconButton({
+  label,
+  icon,
+  onClick,
+  hoverClass = 'hover:text-gray-300'
+}: {
+  label: string
+  icon: React.ReactNode
+  onClick?: (e: React.MouseEvent) => void
+  hoverClass?: string
+}) {
+  return (
+    <Tooltip label={label} position="bottom">
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${TAB_ICON_BTN} ${hoverClass}`}
+        aria-label={label}
+      >
+        {icon}
+      </button>
+    </Tooltip>
+  )
 }
 
 function buildTooltip(
@@ -108,6 +136,7 @@ export function TabView() {
   const renameTerminal = useAppStore((s) => s.renameTerminal)
   const sortMode = useAppStore((s) => s.sortMode)
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
+  const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
   const tasks = useAppStore((s) => s.config?.tasks)
   const filteredHeadless = useFilteredHeadless()
   const waitingApprovals = useWaitingApprovals()
@@ -350,8 +379,8 @@ export function TabView() {
                 e.stopPropagation()
                 setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
               }}
-              className={`group relative flex items-center gap-2 px-3 h-[36px] text-[13px] cursor-pointer
-                         transition-colors flex-1 min-w-[120px] max-w-[180px] select-none border-b
+              className={`group relative flex items-center gap-2 pl-3 pr-2 h-[36px] text-[13px] cursor-pointer
+                         transition-colors flex-1 min-w-[120px] max-w-[260px] select-none border-b
                          ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                          ${isDragging ? 'opacity-50' : ''}
                          ${
@@ -393,12 +422,12 @@ export function TabView() {
                   className="text-xs w-[100px]"
                 />
               ) : (
-                <span className="truncate" title={tooltip}>
+                <span className="truncate flex-1 min-w-0" title={tooltip}>
                   {displayName}
                 </span>
               )}
 
-              <span className="shrink-0 ml-auto relative flex items-center gap-1">
+              <span className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
                 {index < 9 && !isRenaming && (
                   <span
                     className="absolute right-0 top-1/2 -translate-y-1/2
@@ -412,36 +441,35 @@ export function TabView() {
                   </span>
                 )}
                 {!isRenaming && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setRenamingTerminalId(id)
-                    }}
-                    className="w-4 h-4 flex items-center justify-center rounded
-                               opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity
-                               text-gray-500 hover:text-gray-300"
-                    title="Rename session"
-                    aria-label="Rename session"
-                  >
-                    <Pencil size={10} />
-                  </button>
+                  <>
+                    <TabIconButton
+                      label="Browse files"
+                      icon={<FolderOpen size={13} />}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setDiffSidebar(id, 'all-files')
+                      }}
+                    />
+                    <TabIconButton
+                      label="Rename session"
+                      icon={<Pencil size={13} />}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setRenamingTerminalId(id)
+                      }}
+                    />
+                  </>
                 )}
                 <ConfirmPopover
                   message="Close this session?"
                   confirmLabel="Close"
                   onConfirm={() => handleCloseTab(id)}
                 >
-                  <button
-                    type="button"
-                    className="w-4 h-4 flex items-center justify-center rounded
-                               opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity
-                               text-gray-500 hover:text-gray-200 hover:bg-white/[0.1]"
-                    title="Close session"
-                    aria-label="Close session"
-                  >
-                    <X size={10} strokeWidth={2} />
-                  </button>
+                  <TabIconButton
+                    label="Close session"
+                    icon={<X size={13} strokeWidth={2} />}
+                    hoverClass="hover:text-gray-200 hover:bg-white/[0.1]"
+                  />
                 </ConfirmPopover>
               </span>
             </div>
@@ -496,12 +524,6 @@ export function TabView() {
           <PlusDropdown position={plusDropdownPos} onClose={() => setPlusDropdownPos(null)} />
         )}
       </div>
-
-      {activeTabId && activeTerminal && (
-        <div className="group/card shrink-0" style={{ background: '#1a1a1e' }}>
-          <CardHeader terminalId={activeTabId} variant="tab" />
-        </div>
-      )}
 
       <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
         {activeTabId && activeTerminal && (

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -68,7 +68,7 @@ function getHorizontalDropIndex(
 const TAB_ICON_BTN =
   'w-5 h-5 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-gray-500'
 
-function TabIconButton({
+export function TabIconButton({
   label,
   icon,
   onClick,
@@ -76,14 +76,18 @@ function TabIconButton({
 }: {
   label: string
   icon: React.ReactNode
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: () => void
   hoverClass?: string
 }) {
+  const handleClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    onClick?.()
+  }
   return (
     <Tooltip label={label} position="bottom">
       <button
         type="button"
-        onClick={onClick}
+        onClick={handleClick}
         className={`${TAB_ICON_BTN} ${hoverClass}`}
         aria-label={label}
       >
@@ -445,18 +449,12 @@ export function TabView() {
                     <TabIconButton
                       label="Browse files"
                       icon={<FolderOpen size={13} />}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setDiffSidebar(id, 'all-files')
-                      }}
+                      onClick={() => setDiffSidebar(id, 'all-files')}
                     />
                     <TabIconButton
                       label="Rename session"
                       icon={<Pencil size={13} />}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setRenamingTerminalId(id)
-                      }}
+                      onClick={() => setRenamingTerminalId(id)}
                     />
                   </>
                 )}

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -8,7 +8,7 @@ import { toast } from '../Toast'
 import { getDisplayName } from '../../lib/terminal-display'
 import { MOD } from '../../lib/platform'
 
-export type CardVariant = 'mini' | 'focused' | 'tab'
+export type CardVariant = 'mini' | 'focused'
 
 interface Props {
   terminalId: string
@@ -53,10 +53,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
     toast.success(`Session "${name}" closed`)
   }
 
-  // Minimize only in grid mini (drop card from grid into minimized tray).
-  // Expand/Collapse only in grid contexts (mini → expand; focused → collapse back to grid).
   const showMinimize = variant === 'mini'
-  const showExpandCollapse = variant === 'mini' || variant === 'focused'
   const isFocused = variant === 'focused'
 
   const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
@@ -71,7 +68,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           className={btn}
           aria-label="Browse files"
         >
-          <FolderOpen size={12} strokeWidth={2} />
+          <FolderOpen size={14} strokeWidth={2} />
         </button>
       </Tooltip>
 
@@ -84,32 +81,30 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             className={btn}
             aria-label="Minimize session"
           >
-            <Minus size={12} strokeWidth={2} />
+            <Minus size={14} strokeWidth={2} />
           </button>
         </Tooltip>
       )}
 
-      {showExpandCollapse && (
-        <Tooltip
-          label={isFocused ? 'Collapse to grid' : 'Expand'}
-          shortcut={isFocused ? `${MOD}W` : `${MOD}O`}
-          position="top"
+      <Tooltip
+        label={isFocused ? 'Collapse to grid' : 'Expand'}
+        shortcut={isFocused ? `${MOD}W` : `${MOD}O`}
+        position="top"
+      >
+        <button
+          type="button"
+          onClick={isFocused ? handleCollapse : handleExpand}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={btn}
+          aria-label={isFocused ? 'Collapse session' : 'Expand session'}
         >
-          <button
-            type="button"
-            onClick={isFocused ? handleCollapse : handleExpand}
-            onPointerDown={(e) => e.stopPropagation()}
-            className={btn}
-            aria-label={isFocused ? 'Collapse session' : 'Expand session'}
-          >
-            {isFocused ? (
-              <Minimize2 size={12} strokeWidth={2} />
-            ) : (
-              <Maximize2 size={12} strokeWidth={2} />
-            )}
-          </button>
-        </Tooltip>
-      )}
+          {isFocused ? (
+            <Minimize2 size={14} strokeWidth={2} />
+          ) : (
+            <Maximize2 size={14} strokeWidth={2} />
+          )}
+        </button>
+      </Tooltip>
 
       <ConfirmPopover message="Close this session?" confirmLabel="Close" onConfirm={handleClose}>
         <Tooltip label="Close session" position="top">
@@ -119,7 +114,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             className="p-1 rounded text-gray-500 hover:text-red-400 hover:bg-white/[0.08] transition-colors"
             aria-label="Close session"
           >
-            <X size={12} strokeWidth={2} />
+            <X size={14} strokeWidth={2} />
           </button>
         </Tooltip>
       </ConfirmPopover>

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -46,7 +46,7 @@ export function CardHeader({
     ? 'opacity-100'
     : 'opacity-0 group-hover/card:opacity-100 focus-within:opacity-100 transition-opacity'
 
-  const dragHandleClass = draggable && onDragStart ? 'drag-handle cursor-grab' : ''
+  const dragHandleClass = draggable ? `drag-handle${onDragStart ? ' cursor-grab' : ''}` : ''
 
   return (
     <div className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.04] shrink-0">

--- a/src/renderer/components/card/CardStatusBar.tsx
+++ b/src/renderer/components/card/CardStatusBar.tsx
@@ -22,14 +22,15 @@ export function CardStatusBar({ terminalId }: Props) {
   )
 
   if (!terminal) return null
-  if (!terminal.session.branch && !assignedTask) return null
+
+  const hasBranch = Boolean(terminal.session.branch)
 
   return (
     <div
       className="shrink-0 flex items-center gap-2 px-2 h-[22px] border-t border-white/[0.04] text-[11px]"
       style={{ background: '#17171a' }}
     >
-      <BranchChip terminalId={terminalId} />
+      {hasBranch && <BranchChip terminalId={terminalId} />}
 
       {assignedTask && (
         <button

--- a/src/renderer/components/card/CardStatusBar.tsx
+++ b/src/renderer/components/card/CardStatusBar.tsx
@@ -1,6 +1,7 @@
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../stores'
 import { GitChangesIndicator } from '../GitChangesIndicator'
+import { OpenInButton } from '../OpenInButton'
 import { BranchChip } from './BranchChip'
 import { ListTodo } from 'lucide-react'
 
@@ -52,6 +53,7 @@ export function CardStatusBar({ terminalId }: Props) {
       <div className="flex-1" />
 
       <GitChangesIndicator terminalId={terminalId} />
+      <OpenInButton projectPath={terminal.session.projectPath} direction="up" />
     </div>
   )
 }

--- a/tests/agent-card-flexible-slot.test.tsx
+++ b/tests/agent-card-flexible-slot.test.tsx
@@ -10,7 +10,9 @@ vi.hoisted(() => {
       isWorktreeDirty: () => Promise.resolve(false),
       getGitDiffStat: () => Promise.resolve(null),
       getGitBranch: () => Promise.resolve(null),
-      notifyWidgetStatus: () => {}
+      notifyWidgetStatus: () => {},
+      detectIDEs: () => Promise.resolve([]),
+      openInIDE: () => {}
     },
     writable: true
   })

--- a/tests/card-action-cluster.test.tsx
+++ b/tests/card-action-cluster.test.tsx
@@ -137,17 +137,6 @@ describe('CardActionCluster — focused variant (full overlay, always visible)',
   })
 })
 
-describe('CardActionCluster — tab variant (no grid semantics)', () => {
-  it('renders folder + close only; no minimize / expand / collapse', () => {
-    render(<CardActionCluster terminalId="term-1" variant="tab" />)
-    expect(screen.getByRole('button', { name: /Browse files/ })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Minimize/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Expand/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Collapse/ })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Close/ })).toBeInTheDocument()
-  })
-})
-
 describe('CardActionCluster guards', () => {
   it('renders nothing when the terminal is missing', () => {
     const { container } = render(<CardActionCluster terminalId="nope" variant="mini" />)

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -70,7 +70,9 @@ Object.defineProperty(window, 'api', {
     createTerminal: vi.fn(),
     listBranches: vi.fn().mockResolvedValue({ local: [], remote: [] }),
     listRemoteBranches: vi.fn().mockResolvedValue([]),
-    checkoutBranch: vi.fn().mockResolvedValue({ ok: true })
+    checkoutBranch: vi.fn().mockResolvedValue({ ok: true }),
+    detectIDEs: vi.fn().mockResolvedValue([]),
+    openInIDE: vi.fn()
   },
   writable: true
 })

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -131,7 +131,7 @@ describe('CardStatusBar — bottom VS Code style strip', () => {
     expect(screen.getByRole('button', { name: /Switch branch/ })).toBeInTheDocument()
   })
 
-  it('renders nothing when the terminal has no branch and no task', () => {
+  it('hides the branch chip when the terminal has no branch but still renders the bar', () => {
     const terminals = new Map()
     terminals.set('blank', {
       id: 'blank',
@@ -142,8 +142,8 @@ describe('CardStatusBar — bottom VS Code style strip', () => {
     act(() => {
       useAppStore.setState({ terminals })
     })
-    const { container } = render(<CardStatusBar terminalId="blank" />)
-    expect(container).toBeEmptyDOMElement()
+    render(<CardStatusBar terminalId="blank" />)
+    expect(screen.queryByRole('button', { name: /Switch branch/ })).toBeNull()
   })
 
   it('renders nothing when the terminal is missing', () => {

--- a/tests/open-in-button.test.tsx
+++ b/tests/open-in-button.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/assets/icons/vscode.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/cursor.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/windsurf.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/zed.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/sublime.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/webstorm.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/intellij.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/xcode.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/terminal.svg?raw', () => ({ default: '<svg />' }))
+vi.mock('../src/renderer/assets/icons/finder.svg?raw', () => ({ default: '<svg />' }))
+
+const detectIDEs = vi.fn()
+const openInIDE = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: { detectIDEs, openInIDE },
+  writable: true
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  detectIDEs.mockReset()
+  openInIDE.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+async function importButton() {
+  const mod = await import('../src/renderer/components/OpenInButton')
+  return mod.OpenInButton
+}
+
+describe('OpenInButton', () => {
+  it('renders nothing until detectIDEs resolves with at least one IDE', async () => {
+    detectIDEs.mockResolvedValue([])
+    const OpenInButton = await importButton()
+    const { container } = render(<OpenInButton projectPath="/tmp/proj" />)
+    await waitFor(() => expect(detectIDEs).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the default IDE split button and calls openInIDE on primary click', async () => {
+    detectIDEs.mockResolvedValue([
+      { id: 'vscode', name: 'VS Code', command: 'code' },
+      { id: 'cursor', name: 'Cursor', command: 'cursor' }
+    ])
+    const OpenInButton = await importButton()
+    render(<OpenInButton projectPath="/tmp/proj" />)
+
+    const primary = await screen.findByTitle('Open in VS Code')
+    fireEvent.click(primary)
+    expect(openInIDE).toHaveBeenCalledWith('vscode', '/tmp/proj')
+  })
+
+  it('toggles the dropdown menu and opens a non-default IDE when selected', async () => {
+    detectIDEs.mockResolvedValue([
+      { id: 'vscode', name: 'VS Code', command: 'code' },
+      { id: 'cursor', name: 'Cursor', command: 'cursor' }
+    ])
+    const OpenInButton = await importButton()
+    render(<OpenInButton projectPath="/tmp/proj" direction="up" />)
+
+    const toggle = await screen.findByLabelText('Choose IDE')
+    fireEvent.click(toggle)
+
+    const cursorOption = await screen.findByRole('button', { name: /Cursor/ })
+    fireEvent.click(cursorOption)
+    expect(openInIDE).toHaveBeenCalledWith('cursor', '/tmp/proj')
+
+    // Menu closes after selection
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Cursor/ })).toBeNull())
+  })
+
+  it('closes the menu on outside mousedown', async () => {
+    detectIDEs.mockResolvedValue([{ id: 'vscode', name: 'VS Code', command: 'code' }])
+    const OpenInButton = await importButton()
+    render(<OpenInButton projectPath="/tmp/proj" />)
+
+    const toggle = await screen.findByLabelText('Choose IDE')
+    fireEvent.click(toggle)
+    expect(await screen.findByText('Open in')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+    await waitFor(() => expect(screen.queryByText('Open in')).toBeNull())
+  })
+
+  it('retries detectIDEs after a rejection by clearing the in-flight cache', async () => {
+    detectIDEs.mockRejectedValueOnce(new Error('rpc down'))
+    const OpenInButton = await importButton()
+    const { unmount } = render(<OpenInButton projectPath="/tmp/proj" />)
+    await waitFor(() => expect(detectIDEs).toHaveBeenCalledTimes(1))
+    unmount()
+
+    detectIDEs.mockResolvedValueOnce([{ id: 'vscode', name: 'VS Code', command: 'code' }])
+    render(<OpenInButton projectPath="/tmp/proj" />)
+    await waitFor(() => expect(detectIDEs).toHaveBeenCalledTimes(2))
+    expect(await screen.findByTitle('Open in VS Code')).toBeInTheDocument()
+  })
+})

--- a/tests/tab-icon-button.test.tsx
+++ b/tests/tab-icon-button.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+// Stub every store/hook/API the module imports transitively.
+Object.defineProperty(window, 'api', {
+  value: { detectIDEs: vi.fn().mockResolvedValue([]) },
+  writable: true
+})
+
+import { TabIconButton } from '../src/renderer/components/TabView'
+
+describe('TabIconButton', () => {
+  it('fires onClick and prevents bubbling so the tab does not activate', () => {
+    const onClick = vi.fn()
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <TabIconButton label="Browse files" icon={<span>icon</span>} onClick={onClick} />
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Browse files' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('still stops propagation when no onClick is provided', () => {
+    const onParentClick = vi.fn()
+    render(
+      <div onClick={onParentClick}>
+        <TabIconButton label="Close session" icon={<span>icon</span>} />
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Close session' }))
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('applies a custom hover class', () => {
+    render(
+      <TabIconButton
+        label="Close session"
+        icon={<span>icon</span>}
+        hoverClass="hover:text-red-400"
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Close session' }).className).toContain(
+      'hover:text-red-400'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Three fixes that surfaced from PR #234 (Unify session card UI) plus one long-standing drag bug:

- **Tab mode double-header** — `TabView` rendered a `CardHeader` below the tab bar that duplicated the tab's status icon, name, and close button. Dropped it and moved the unique action (Browse files / folder) into the tab's hover row alongside Rename and Close, via a local `TabIconButton` helper. Tabs now widen to `max-w-260`, and the action cluster is absolute-positioned so hidden buttons no longer reserve layout width (idle tabs give the name its full tab width).
- **"Open in VS Code/Cursor/…" menu** — was lost when `SessionStatusBar` was removed in #234. Re-added to `CardStatusBar` (so it shows in grid, focused overlay, and tab modes) and switched its dropdown to a `createPortal` + fixed positioning, which clears the xterm stacking context that was clipping it. Deduped `detectIDEs()` with a shared in-flight promise so cold start doesn't fan out N parallel IPC calls.
- **Flexible-grid drag broken** — `.drag-handle` was only applied when *both* `draggable` and `onDragStart` were truthy, but react-grid-layout mode passes `draggable={true}` without an `onDragStart`. `CardHeader` now applies `drag-handle` whenever `draggable` is set, and adds `cursor-grab` only when there's a manual handler.
- **Cleanup**: removed the now-unused `'tab'` variant from `CardVariant` / `CardActionCluster`, bumped action-cluster icons to size 14, and kept tooltips consistent (project `Tooltip` instead of native `title`).

## Test plan
- [ ] `yarn typecheck` — clean
- [ ] `yarn test` — 1002 tests pass (updated two test mocks to include `detectIDEs` / `openInIDE`)
- [ ] Tab mode shows a single header row and the Browse-files button appears on hover next to Rename/Close
- [ ] Grid/focused/tab all show the Open-in-IDE split button in the bottom status bar; its dropdown renders above the terminal
- [ ] Flexible-grid (`gridColumns === -1`) cards can be dragged by the card header again
- [ ] Manual-sort non-flexible grid drag still works; auto-sort cards are not draggable