### PR TITLE
Move Sessions/Tasks toggle to sidebar header & improve card sizing

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -464,12 +464,10 @@ export function App() {
                   </button>
                 </Tooltip>
               ))}
-            {/* Main view toggle: Sessions / Tasks (hidden on mobile — bottom tabs handle it) */}
-            {!isMobile && (
+            {/* Main view toggle: Sessions / Tasks — shown in top bar only when sidebar is closed (otherwise it's in the sidebar header) */}
+            {!isMobile && !isSidebarOpen && (
               <>
-                {(isMobile || !isSidebarOpen) && (
-                  <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-                )}
+                <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
                 <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
                   <Tooltip
                     label="Sessions"

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -71,7 +71,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           className={btn}
           aria-label="Browse files"
         >
-          <FolderOpen size={12} strokeWidth={2} />
+          <FolderOpen size={14} strokeWidth={2} />
         </button>
       </Tooltip>
 
@@ -84,7 +84,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             className={btn}
             aria-label="Minimize session"
           >
-            <Minus size={12} strokeWidth={2} />
+            <Minus size={14} strokeWidth={2} />
           </button>
         </Tooltip>
       )}
@@ -103,9 +103,9 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             aria-label={isFocused ? 'Collapse session' : 'Expand session'}
           >
             {isFocused ? (
-              <Minimize2 size={12} strokeWidth={2} />
+              <Minimize2 size={14} strokeWidth={2} />
             ) : (
-              <Maximize2 size={12} strokeWidth={2} />
+              <Maximize2 size={14} strokeWidth={2} />
             )}
           </button>
         </Tooltip>
@@ -119,7 +119,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             className="p-1 rounded text-gray-500 hover:text-red-400 hover:bg-white/[0.08] transition-colors"
             aria-label="Close session"
           >
-            <X size={12} strokeWidth={2} />
+            <X size={14} strokeWidth={2} />
           </button>
         </Tooltip>
       </ConfirmPopover>

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -49,7 +49,7 @@ export function CardHeader({
   const dragHandleClass = draggable && onDragStart ? 'drag-handle cursor-grab' : ''
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.04] shrink-0">
+    <div className="flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0">
       <div
         className={`flex-1 min-w-0 flex items-center gap-2 ${dragHandleClass}`}
         onDoubleClick={onDoubleClick}
@@ -58,7 +58,7 @@ export function CardHeader({
         <AgentStatusIcon
           agentType={terminal.session.agentType}
           status={terminal.status}
-          size={16}
+          size={18}
         />
         <div className="min-w-0 flex items-center gap-1 group/rename">
           {isRenaming ? (
@@ -102,7 +102,7 @@ export function CardHeader({
         {variant === 'mini' && typeof index === 'number' && index < 9 && !alwaysVisible && (
           <span
             className="absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none
-                       px-1 py-0.5 text-[9px] font-mono text-gray-600
+                       px-1.5 py-0.5 text-[10px] font-mono text-gray-600
                        bg-white/[0.04] border border-white/[0.06] rounded
                        leading-none opacity-100 group-hover/card:opacity-0 transition-opacity"
           >

--- a/src/renderer/components/project-sidebar/FlatSessionsSection.tsx
+++ b/src/renderer/components/project-sidebar/FlatSessionsSection.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../../stores'
 import { SessionItem } from './SessionItem'
 import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
 import { getDisplayName } from '../../lib/terminal-display'
-import { ChevronRight, Monitor } from 'lucide-react'
+import { ChevronRight, Layers } from 'lucide-react'
 import type { SidebarSessionInfo } from './types'
 
 export function FlatSessionsSection({
@@ -72,14 +72,14 @@ export function FlatSessionsSection({
             setActiveProject(null)
             setFocusedTerminal(null)
           }}
-          className={`w-full text-left px-2.5 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
+          className={`w-full text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
             activeProject === null
               ? 'bg-white/[0.08] text-white'
               : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
           } ${isCollapsed ? 'justify-center px-0' : ''}`}
           title={isCollapsed ? 'All Projects' : undefined}
         >
-          <Monitor size={isCollapsed ? 22 : 14} strokeWidth={1.5} className="shrink-0" />
+          <Layers size={isCollapsed ? 22 : 14} strokeWidth={1.5} className="shrink-0" />
           {!isCollapsed && (
             <>
               All Projects

--- a/src/renderer/components/project-sidebar/ProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSection.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
 import { ProjectItem } from './ProjectItem'
 import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
-import { ChevronRight, FolderPlus, Monitor } from 'lucide-react'
+import { ChevronRight, FolderPlus, Layers } from 'lucide-react'
 import type { ProjectConfig } from '../../../shared/types'
 import type { SidebarSessionInfo } from './types'
 
@@ -147,14 +147,14 @@ export function ProjectsSection({
             setActiveProject(null)
             setFocusedTerminal(null)
           }}
-          className={`w-full text-left px-2.5 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
+          className={`w-full text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
             activeProject === null
               ? 'bg-white/[0.08] text-white'
               : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
           } ${isCollapsed ? 'justify-center px-0' : ''}`}
           title={isCollapsed ? 'All Projects' : undefined}
         >
-          <Monitor size={iconSize} strokeWidth={1.5} className="shrink-0" />
+          <Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />
           {!isCollapsed && (
             <>
               All Projects

--- a/src/renderer/components/project-sidebar/SidebarHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarHeader.tsx
@@ -1,10 +1,13 @@
-import { isElectron } from '../../lib/platform'
+import { isElectron, MOD } from '../../lib/platform'
 import { useAppStore } from '../../stores'
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
 import { PanelLeft, Monitor, ListTodo } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
+const VIEW_MODES = [
+  { mode: 'sessions', label: 'Sessions', icon: Monitor, shortcutKey: 'S' },
+  { mode: 'tasks', label: 'Tasks', icon: ListTodo, shortcutKey: 'T' }
+] as const
 
 export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
@@ -13,7 +16,6 @@ export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
 
   return (
     <div className="shrink-0 border-b border-white/[0.06]">
-      {/* Row 1: Workspace switcher + sidebar toggle */}
       <div
         className={`titlebar-drag h-[52px] pr-3 flex items-center ${isElectron ? 'pl-[78px]' : 'pl-3'}`}
       >
@@ -32,50 +34,38 @@ export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
         )}
       </div>
 
-      {/* Row 2: Sessions / Tasks view toggle */}
       <div
         className={`titlebar-no-drag flex items-center gap-1 py-2 ${
           isCollapsed ? 'flex-col justify-center px-1.5' : 'px-3'
         }`}
       >
-        <Tooltip
-          label="Sessions"
-          shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`}
-          position={isCollapsed ? 'right' : 'bottom'}
-        >
-          <button
-            onClick={() => setMainViewMode('sessions')}
-            className={`flex items-center gap-1.5 rounded-lg text-[12px] font-medium transition-colors ${
-              isCollapsed ? 'p-2' : 'px-2.5 py-1.5'
-            } ${
-              mainViewMode === 'sessions'
-                ? 'bg-white/[0.1] text-white'
-                : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
-            }`}
-          >
-            <Monitor size={14} strokeWidth={2} />
-            {!isCollapsed && mainViewMode === 'sessions' && 'Sessions'}
-          </button>
-        </Tooltip>
-        <Tooltip
-          label="Tasks"
-          shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`}
-          position={isCollapsed ? 'right' : 'bottom'}
-        >
-          <button
-            onClick={() => setMainViewMode('tasks')}
-            className={`flex items-center gap-1.5 rounded-lg text-[12px] font-medium transition-colors ${
-              isCollapsed ? 'p-2' : 'px-2.5 py-1.5'
-            } ${
-              mainViewMode === 'tasks'
-                ? 'bg-white/[0.1] text-white'
-                : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
-            }`}
-          >
-            <ListTodo size={14} strokeWidth={2} />
-            {!isCollapsed && mainViewMode === 'tasks' && 'Tasks'}
-          </button>
-        </Tooltip>
+        {VIEW_MODES.map(({ mode, label, icon: Icon, shortcutKey }) => {
+          const isActive = mainViewMode === mode
+          return (
+            <Tooltip
+              key={mode}
+              label={label}
+              shortcut={`${MOD}${shortcutKey}`}
+              position={isCollapsed ? 'right' : 'bottom'}
+            >
+              <button
+                onClick={() => setMainViewMode(mode)}
+                aria-label={label}
+                aria-pressed={isActive}
+                className={`flex items-center gap-1.5 rounded-lg text-[12px] font-medium transition-colors ${
+                  isCollapsed ? 'p-2' : 'px-2.5 py-1.5'
+                } ${
+                  isActive
+                    ? 'bg-white/[0.1] text-white'
+                    : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
+                }`}
+              >
+                <Icon size={14} strokeWidth={2} />
+                {!isCollapsed && isActive && label}
+              </button>
+            </Tooltip>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/renderer/components/project-sidebar/SidebarHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarHeader.tsx
@@ -1,29 +1,82 @@
 import { isElectron } from '../../lib/platform'
 import { useAppStore } from '../../stores'
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
-import { PanelLeft } from 'lucide-react'
+import { PanelLeft, Monitor, ListTodo } from 'lucide-react'
+import { Tooltip } from '../Tooltip'
+
+const isMac = navigator.platform.toUpperCase().includes('MAC')
 
 export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
+  const mainViewMode = useAppStore((s) => s.config?.defaults?.mainViewMode ?? 'sessions')
+  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
 
   return (
-    <div
-      className={`titlebar-drag h-[52px] pr-3 flex items-center
-                    border-b border-white/[0.06] shrink-0 ${isElectron ? 'pl-[78px]' : 'pl-3'}`}
-    >
-      {!isCollapsed && (
-        <div className="flex-1 titlebar-no-drag min-w-0">
-          <WorkspaceSwitcher />
-        </div>
-      )}
-      {!isCollapsed && (
-        <button
-          onClick={toggleSidebar}
-          className="text-gray-400 hover:text-white titlebar-no-drag p-1 rounded-md transition-colors shrink-0"
+    <div className="shrink-0 border-b border-white/[0.06]">
+      {/* Row 1: Workspace switcher + sidebar toggle */}
+      <div
+        className={`titlebar-drag h-[52px] pr-3 flex items-center ${isElectron ? 'pl-[78px]' : 'pl-3'}`}
+      >
+        {!isCollapsed && (
+          <div className="flex-1 titlebar-no-drag min-w-0">
+            <WorkspaceSwitcher />
+          </div>
+        )}
+        {!isCollapsed && (
+          <button
+            onClick={toggleSidebar}
+            className="text-gray-400 hover:text-white titlebar-no-drag p-1 rounded-md transition-colors shrink-0"
+          >
+            <PanelLeft size={16} strokeWidth={2} />
+          </button>
+        )}
+      </div>
+
+      {/* Row 2: Sessions / Tasks view toggle */}
+      <div
+        className={`titlebar-no-drag flex items-center gap-1 py-2 ${
+          isCollapsed ? 'flex-col justify-center px-1.5' : 'px-3'
+        }`}
+      >
+        <Tooltip
+          label="Sessions"
+          shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`}
+          position={isCollapsed ? 'right' : 'bottom'}
         >
-          <PanelLeft size={16} strokeWidth={2} />
-        </button>
-      )}
+          <button
+            onClick={() => setMainViewMode('sessions')}
+            className={`flex items-center gap-1.5 rounded-lg text-[12px] font-medium transition-colors ${
+              isCollapsed ? 'p-2' : 'px-2.5 py-1.5'
+            } ${
+              mainViewMode === 'sessions'
+                ? 'bg-white/[0.1] text-white'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
+            }`}
+          >
+            <Monitor size={14} strokeWidth={2} />
+            {!isCollapsed && mainViewMode === 'sessions' && 'Sessions'}
+          </button>
+        </Tooltip>
+        <Tooltip
+          label="Tasks"
+          shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`}
+          position={isCollapsed ? 'right' : 'bottom'}
+        >
+          <button
+            onClick={() => setMainViewMode('tasks')}
+            className={`flex items-center gap-1.5 rounded-lg text-[12px] font-medium transition-colors ${
+              isCollapsed ? 'p-2' : 'px-2.5 py-1.5'
+            } ${
+              mainViewMode === 'tasks'
+                ? 'bg-white/[0.1] text-white'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
+            }`}
+          >
+            <ListTodo size={14} strokeWidth={2} />
+            {!isCollapsed && mainViewMode === 'tasks' && 'Tasks'}
+          </button>
+        </Tooltip>
+      </div>
     </div>
   )
 }

--- a/tests/sidebar-header.test.tsx
+++ b/tests/sidebar-header.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockStore = {
+  toggleSidebar: vi.fn(),
+  setMainViewMode: vi.fn(),
+  config: { defaults: { mainViewMode: 'sessions' as 'sessions' | 'tasks' } }
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockStore) : mockStore
+  }
+}))
+
+vi.mock('../src/renderer/components/WorkspaceSwitcher', () => ({
+  WorkspaceSwitcher: () => <div data-testid="workspace-switcher" />
+}))
+
+const { SidebarHeader } = await import('../src/renderer/components/project-sidebar/SidebarHeader')
+
+beforeEach(() => {
+  mockStore.toggleSidebar.mockReset()
+  mockStore.setMainViewMode.mockReset()
+  mockStore.config.defaults.mainViewMode = 'sessions'
+})
+
+describe('SidebarHeader', () => {
+  it('renders Sessions and Tasks toggle buttons with accessible names', () => {
+    render(<SidebarHeader isCollapsed={false} />)
+    expect(screen.getByRole('button', { name: 'Sessions' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tasks' })).toBeInTheDocument()
+  })
+
+  it('marks the active view with aria-pressed', () => {
+    render(<SidebarHeader isCollapsed={false} />)
+    expect(screen.getByRole('button', { name: 'Sessions' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Tasks' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('switches view mode when a toggle is clicked', () => {
+    render(<SidebarHeader isCollapsed={false} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks' }))
+    expect(mockStore.setMainViewMode).toHaveBeenCalledWith('tasks')
+  })
+
+  it('renders workspace switcher and toggles sidebar when expanded', () => {
+    render(<SidebarHeader isCollapsed={false} />)
+    expect(screen.getByTestId('workspace-switcher')).toBeInTheDocument()
+    const [sidebarToggle] = screen
+      .getAllByRole('button')
+      .filter((b) => b.getAttribute('aria-label') === null)
+    fireEvent.click(sidebarToggle)
+    expect(mockStore.toggleSidebar).toHaveBeenCalled()
+  })
+
+  it('hides workspace switcher and sidebar toggle when collapsed', () => {
+    render(<SidebarHeader isCollapsed={true} />)
+    expect(screen.queryByTestId('workspace-switcher')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sessions' })).toBeInTheDocument()
+  })
+
+  it('reflects tasks as active when mainViewMode is tasks', () => {
+    mockStore.config.defaults.mainViewMode = 'tasks'
+    render(<SidebarHeader isCollapsed={false} />)
+    expect(screen.getByRole('button', { name: 'Tasks' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Sessions' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Move the Sessions/Tasks view toggle from the top toolbar into the sidebar header (Windsurf-style), and increase card header icon/badge sizes for better visibility.

### Changes

**Sidebar view toggle**
- Sessions/Tasks toggle now lives in the sidebar header as a second row
- Active mode shows icon + label; inactive mode is icon-only
- Collapsed sidebar: vertical stack with compact icon buttons
- Top bar fallback: toggle still appears when sidebar is closed

**All Projects icon**
- Changed from Monitor → Layers to avoid confusion with the Sessions icon
- Aligned horizontal padding (px-2) with individual project items

**Card header sizing**
- Header padding: py-2 → py-2.5
- Agent status icon: 16px → 18px
- Action cluster icons (browse, minimize, expand, close): 12px → 14px
- Keyboard shortcut badge: 9px → 10px text with wider padding