### PR TITLE
fix: sync branch change across all sessions sharing a worktree

### DIFF
--- a/src/renderer/hooks/useBranchSwitcher.ts
+++ b/src/renderer/hooks/useBranchSwitcher.ts
@@ -10,6 +10,7 @@ interface Params {
 
 export function useBranchSwitcher({ projectPath, branchCwd, branchName }: Params) {
   const loadWorktrees = useAppStore((s) => s.loadWorktrees)
+  const setBranchForCwd = useAppStore((s) => s.setBranchForCwd)
   const [showPicker, setShowPicker] = useState(false)
   const [isSwitching, setIsSwitching] = useState(false)
 
@@ -23,7 +24,9 @@ export function useBranchSwitcher({ projectPath, branchCwd, branchName }: Params
       try {
         const result = await window.api.checkoutBranch(branchCwd, branch)
         if (result.ok) {
+          setBranchForCwd(branchCwd, branch)
           loadWorktrees(projectPath, true)
+          toast.success(`Switched to '${branch}'`)
         } else {
           toast.error(result.error || `Failed to checkout '${branch}'`)
         }
@@ -34,7 +37,7 @@ export function useBranchSwitcher({ projectPath, branchCwd, branchName }: Params
         setShowPicker(false)
       }
     },
-    [branchCwd, projectPath, branchName, isSwitching, loadWorktrees]
+    [branchCwd, projectPath, branchName, isSwitching, loadWorktrees, setBranchForCwd]
   )
 
   return { showPicker, togglePicker, closePicker, isSwitching, selectBranch }

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -1,5 +1,5 @@
 import { StateCreator } from 'zustand'
-import { AppStore, TerminalsSlice } from './types'
+import { AppStore, TerminalsSlice, TerminalState } from './types'
 
 export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice> = (set) => ({
   terminals: new Map(),
@@ -76,6 +76,18 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       const next = new Map(state.terminals)
       next.set(id, { ...term, session: { ...term.session, branch } })
       return { terminals: next }
+    }),
+
+  setBranchForCwd: (cwd, branch) =>
+    set((state) => {
+      let next: Map<string, TerminalState> | null = null
+      for (const [id, term] of state.terminals) {
+        const sessionCwd = term.session.worktreePath ?? term.session.projectPath
+        if (sessionCwd !== cwd || term.session.branch === branch) continue
+        if (!next) next = new Map(state.terminals)
+        next.set(id, { ...term, session: { ...term.session, branch } })
+      }
+      return next ? { terminals: next } : state
     }),
 
   updateSessionWorktree: (id, updates) =>

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -58,6 +58,7 @@ export interface TerminalsSlice {
   updateLastOutput: (id: string, timestamp: number) => void
   renameTerminal: (id: string, displayName: string) => void
   updateSessionBranch: (id: string, branch: string) => void
+  setBranchForCwd: (cwd: string, branch: string) => void
   updateSessionWorktree: (
     id: string,
     updates: { worktreePath?: string; worktreeName?: string }

--- a/tests/terminals-slice.test.ts
+++ b/tests/terminals-slice.test.ts
@@ -76,3 +76,80 @@ describe('updateSessionBranch', () => {
     expect(store.getState().terminals.get('term-2')?.session.branch).toBe('dev')
   })
 })
+
+describe('setBranchForCwd', () => {
+  let store: ReturnType<typeof createStore>
+
+  beforeEach(() => {
+    store = createStore()
+  })
+
+  it('updates every session whose worktreePath matches cwd', () => {
+    store.getState().addTerminal(
+      makeSession({
+        id: 'a',
+        branch: 'main',
+        worktreePath: '/wt/emerald',
+        projectPath: '/proj'
+      })
+    )
+    store.getState().addTerminal(
+      makeSession({
+        id: 'b',
+        branch: 'main',
+        worktreePath: '/wt/emerald',
+        projectPath: '/proj'
+      })
+    )
+
+    store.getState().setBranchForCwd('/wt/emerald', 'feature/x')
+
+    expect(store.getState().terminals.get('a')?.session.branch).toBe('feature/x')
+    expect(store.getState().terminals.get('b')?.session.branch).toBe('feature/x')
+  })
+
+  it('falls back to projectPath when session has no worktreePath', () => {
+    store
+      .getState()
+      .addTerminal(
+        makeSession({ id: 'a', branch: 'main', projectPath: '/proj', worktreePath: undefined })
+      )
+
+    store.getState().setBranchForCwd('/proj', 'feature/x')
+
+    expect(store.getState().terminals.get('a')?.session.branch).toBe('feature/x')
+  })
+
+  it('leaves non-matching sessions untouched', () => {
+    store
+      .getState()
+      .addTerminal(
+        makeSession({ id: 'match', branch: 'main', worktreePath: '/wt/a', projectPath: '/proj' })
+      )
+    store
+      .getState()
+      .addTerminal(
+        makeSession({ id: 'other', branch: 'dev', worktreePath: '/wt/b', projectPath: '/proj' })
+      )
+
+    store.getState().setBranchForCwd('/wt/a', 'feature/x')
+
+    expect(store.getState().terminals.get('match')?.session.branch).toBe('feature/x')
+    expect(store.getState().terminals.get('other')?.session.branch).toBe('dev')
+  })
+
+  it('preserves terminals Map reference when nothing changes', () => {
+    store
+      .getState()
+      .addTerminal(
+        makeSession({ id: 'a', branch: 'main', worktreePath: '/wt/a', projectPath: '/proj' })
+      )
+    const before = store.getState().terminals
+
+    store.getState().setBranchForCwd('/wt/unrelated', 'feature/x')
+    expect(store.getState().terminals).toBe(before)
+
+    store.getState().setBranchForCwd('/wt/a', 'main')
+    expect(store.getState().terminals).toBe(before)
+  })
+})

--- a/tests/use-branch-switcher.test.ts
+++ b/tests/use-branch-switcher.test.ts
@@ -2,18 +2,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 
-const { toastError, loadWorktrees } = vi.hoisted(() => ({
+const { toastError, toastSuccess, loadWorktrees, setBranchForCwd } = vi.hoisted(() => ({
   toastError: vi.fn(),
-  loadWorktrees: vi.fn()
+  toastSuccess: vi.fn(),
+  loadWorktrees: vi.fn(),
+  setBranchForCwd: vi.fn()
 }))
 
 vi.mock('../src/renderer/components/Toast', () => ({
-  toast: { error: toastError, success: vi.fn() }
+  toast: { error: toastError, success: toastSuccess }
 }))
 
+type StoreShape = {
+  loadWorktrees: typeof loadWorktrees
+  setBranchForCwd: typeof setBranchForCwd
+}
+
 vi.mock('../src/renderer/stores', () => ({
-  useAppStore: (selector: (s: { loadWorktrees: typeof loadWorktrees }) => unknown) =>
-    selector({ loadWorktrees })
+  useAppStore: (selector: (s: StoreShape) => unknown) =>
+    selector({ loadWorktrees, setBranchForCwd })
 }))
 
 const checkoutBranch = vi.fn()
@@ -26,7 +33,9 @@ import { useBranchSwitcher } from '../src/renderer/hooks/useBranchSwitcher'
 
 beforeEach(() => {
   toastError.mockReset()
+  toastSuccess.mockReset()
   loadWorktrees.mockReset()
+  setBranchForCwd.mockReset()
   checkoutBranch.mockReset()
 })
 
@@ -51,14 +60,16 @@ describe('useBranchSwitcher', () => {
     expect(checkoutBranch).not.toHaveBeenCalled()
   })
 
-  it('checkouts and reloads worktrees on success', async () => {
+  it('checkouts, fans out branch to sessions, reloads worktrees, and toasts on success', async () => {
     checkoutBranch.mockResolvedValue({ ok: true })
     const { result } = renderHook(() => useBranchSwitcher(params))
     await act(async () => {
       await result.current.selectBranch('feat')
     })
     expect(checkoutBranch).toHaveBeenCalledWith('/p', 'feat')
+    expect(setBranchForCwd).toHaveBeenCalledWith('/p', 'feat')
     expect(loadWorktrees).toHaveBeenCalledWith('/p', true)
+    expect(toastSuccess).toHaveBeenCalledWith("Switched to 'feat'")
     expect(toastError).not.toHaveBeenCalled()
     expect(result.current.showPicker).toBe(false)
     expect(result.current.isSwitching).toBe(false)
@@ -72,6 +83,8 @@ describe('useBranchSwitcher', () => {
     })
     expect(toastError).toHaveBeenCalledWith('boom')
     expect(loadWorktrees).not.toHaveBeenCalled()
+    expect(setBranchForCwd).not.toHaveBeenCalled()
+    expect(toastSuccess).not.toHaveBeenCalled()
   })
 
   it('catches IPC rejection and surfaces error via toast', async () => {


### PR DESCRIPTION
## Summary
- Clicking a branch in the session status-bar picker ran `git checkout` successfully but the status bar didn't update — `session.branch` only refreshed via the 30s polling loop in `useGitDiffPolling`, so the UI looked like nothing happened.
- New `setBranchForCwd(cwd, branch)` action in `terminals-slice` updates every terminal whose `worktreePath ?? projectPath` matches the checked-out path, in a single `set()` call so the re-render fans out once instead of N times.
- `useBranchSwitcher` calls it on success and shows a green success toast (errors already toasted).

## Test plan
- [ ] Open two session cards attached to the same worktree
- [ ] Click the branch dropdown on one, pick a different branch
- [ ] Both cards' status bars flip to the new branch, success toast appears
- [ ] Pick an invalid branch or one already checked out elsewhere → red error toast with the git message