### PR TITLE
Redesign tasks view sidebar with project-scoped navigation

### DIFF
--- a/src/renderer/components/project-sidebar/ProjectSidebar.tsx
+++ b/src/renderer/components/project-sidebar/ProjectSidebar.tsx
@@ -7,6 +7,7 @@ import { SidebarHeader } from './SidebarHeader'
 import { ProjectsSection } from './ProjectsSection'
 import { FlatSessionsSection } from './FlatSessionsSection'
 import { WorkflowsSection } from './WorkflowsSection'
+import { TasksProjectsSection } from './TasksProjectsSection'
 import { SidebarFooter } from './SidebarFooter'
 import type { SidebarSessionInfo } from './types'
 
@@ -121,6 +122,8 @@ export function ProjectSidebar() {
       <div className={`flex-1 overflow-auto space-y-0.5 ${isCollapsed ? 'px-1.5' : 'px-3'}`}>
         {mainViewMode === 'workflows' ? (
           <WorkflowsSection isCollapsed={isCollapsed} workspaceWorkflows={workspaceWorkflows} />
+        ) : mainViewMode === 'tasks' ? (
+          <TasksProjectsSection isCollapsed={isCollapsed} workspaceProjects={workspaceProjects} />
         ) : sidebarViewMode === 'sessions-flat' ? (
           <FlatSessionsSection
             isCollapsed={isCollapsed}

--- a/src/renderer/components/project-sidebar/ProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSection.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
 import { ProjectItem } from './ProjectItem'
 import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
+import { SidebarNavItem } from './SidebarNavItem'
 import { ChevronRight, FolderPlus, Layers } from 'lucide-react'
 import type { ProjectConfig } from '../../../shared/types'
 import type { SidebarSessionInfo } from './types'
@@ -142,26 +143,17 @@ export function ProjectsSection({
       {isCollapsed && <div className="pt-4" />}
 
       {!sectionCollapsed && (
-        <button
+        <SidebarNavItem
+          isActive={activeProject === null}
+          isCollapsed={isCollapsed}
+          icon={<Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />}
+          label="All Projects"
+          badge={workspaceTerminalCount}
           onClick={() => {
             setActiveProject(null)
             setFocusedTerminal(null)
           }}
-          className={`w-full text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
-            activeProject === null
-              ? 'bg-white/[0.08] text-white'
-              : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
-          } ${isCollapsed ? 'justify-center px-0' : ''}`}
-          title={isCollapsed ? 'All Projects' : undefined}
-        >
-          <Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />
-          {!isCollapsed && (
-            <>
-              All Projects
-              <span className="text-gray-500 text-xs ml-auto">{workspaceTerminalCount}</span>
-            </>
-          )}
-        </button>
+        />
       )}
       {!isCollapsed && !sectionCollapsed && workspaceProjects.length === 0 && (
         <p className="text-[13px] text-gray-600 px-2.5 py-1">No projects</p>

--- a/src/renderer/components/project-sidebar/ProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSection.tsx
@@ -137,7 +137,7 @@ export function ProjectsSection({
         <SidebarNavItem
           isActive={activeProject === null}
           isCollapsed={isCollapsed}
-          icon={<Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />}
+          icon={<Layers size={iconSize} strokeWidth={1.5} />}
           label="All Projects"
           badge={workspaceTerminalCount}
           onClick={() => {

--- a/src/renderer/components/project-sidebar/ProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSection.tsx
@@ -4,7 +4,8 @@ import { Tooltip } from '../Tooltip'
 import { ProjectItem } from './ProjectItem'
 import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
 import { SidebarNavItem } from './SidebarNavItem'
-import { ChevronRight, FolderPlus, Layers } from 'lucide-react'
+import { SidebarSectionHeader } from './SidebarSectionHeader'
+import { FolderPlus, Layers } from 'lucide-react'
 import type { ProjectConfig } from '../../../shared/types'
 import type { SidebarSessionInfo } from './types'
 
@@ -112,22 +113,13 @@ export function ProjectsSection({
 
   return (
     <>
-      {!isCollapsed && (
-        <div className="group/section pt-3 pb-1.5 flex items-center justify-between">
-          <button
-            onClick={() => setSectionCollapsed(!sectionCollapsed)}
-            className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
-          >
-            <ChevronRight
-              size={10}
-              strokeWidth={2}
-              className={`text-gray-600 transition-transform ${sectionCollapsed ? '' : 'rotate-90'}`}
-            />
-            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
-              Projects
-            </span>
-          </button>
-          <div className="flex items-center gap-0.5">
+      <SidebarSectionHeader
+        title="Projects"
+        isCollapsed={isCollapsed}
+        sectionCollapsed={sectionCollapsed}
+        onToggle={() => setSectionCollapsed(!sectionCollapsed)}
+        actions={
+          <>
             <ProjectsSectionToolbar />
             <Tooltip label="Add project" position="bottom">
               <button
@@ -137,10 +129,9 @@ export function ProjectsSection({
                 <FolderPlus size={13} strokeWidth={1.5} />
               </button>
             </Tooltip>
-          </div>
-        </div>
-      )}
-      {isCollapsed && <div className="pt-4" />}
+          </>
+        }
+      />
 
       {!sectionCollapsed && (
         <SidebarNavItem

--- a/src/renderer/components/project-sidebar/SidebarNavItem.tsx
+++ b/src/renderer/components/project-sidebar/SidebarNavItem.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react'
+
+export function SidebarNavItem({
+  isActive,
+  isCollapsed,
+  icon,
+  label,
+  badge,
+  title,
+  onClick
+}: {
+  isActive: boolean
+  isCollapsed: boolean
+  icon: ReactNode
+  label: string
+  badge?: ReactNode
+  title?: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
+        isActive
+          ? 'bg-white/[0.08] text-white'
+          : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+      } ${isCollapsed ? 'justify-center px-0' : ''}`}
+      title={isCollapsed ? (title ?? label) : undefined}
+    >
+      {icon}
+      {!isCollapsed && (
+        <>
+          <span className="truncate">{label}</span>
+          {badge && <span className="text-gray-500 text-xs ml-auto">{badge}</span>}
+        </>
+      )}
+    </button>
+  )
+}

--- a/src/renderer/components/project-sidebar/SidebarNavItem.tsx
+++ b/src/renderer/components/project-sidebar/SidebarNavItem.tsx
@@ -25,11 +25,11 @@ export function SidebarNavItem({
       } ${isCollapsed ? 'justify-center px-0' : ''}`}
       title={isCollapsed ? label : undefined}
     >
-      {icon}
+      <span className="shrink-0 flex items-center">{icon}</span>
       {!isCollapsed && (
         <>
           <span className="truncate">{label}</span>
-          {badge && <span className="text-gray-500 text-xs ml-auto">{badge}</span>}
+          {badge != null && <span className="text-gray-500 text-xs ml-auto">{badge}</span>}
         </>
       )}
     </button>

--- a/src/renderer/components/project-sidebar/SidebarNavItem.tsx
+++ b/src/renderer/components/project-sidebar/SidebarNavItem.tsx
@@ -6,7 +6,6 @@ export function SidebarNavItem({
   icon,
   label,
   badge,
-  title,
   onClick
 }: {
   isActive: boolean
@@ -14,7 +13,6 @@ export function SidebarNavItem({
   icon: ReactNode
   label: string
   badge?: ReactNode
-  title?: string
   onClick: () => void
 }) {
   return (
@@ -25,7 +23,7 @@ export function SidebarNavItem({
           ? 'bg-white/[0.08] text-white'
           : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
       } ${isCollapsed ? 'justify-center px-0' : ''}`}
-      title={isCollapsed ? (title ?? label) : undefined}
+      title={isCollapsed ? label : undefined}
     >
       {icon}
       {!isCollapsed && (

--- a/src/renderer/components/project-sidebar/SidebarSectionHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarSectionHeader.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react'
+import { ChevronRight } from 'lucide-react'
+
+export function SidebarSectionHeader({
+  title,
+  isCollapsed,
+  sectionCollapsed,
+  onToggle,
+  actions
+}: {
+  title: string
+  isCollapsed: boolean
+  sectionCollapsed: boolean
+  onToggle: () => void
+  actions?: ReactNode
+}) {
+  if (isCollapsed) {
+    return <div className="pt-4" />
+  }
+
+  return (
+    <div className="group/section pt-3 pb-1.5 flex items-center justify-between">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
+      >
+        <ChevronRight
+          size={10}
+          strokeWidth={2}
+          className={`text-gray-600 transition-transform ${sectionCollapsed ? '' : 'rotate-90'}`}
+        />
+        <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
+          {title}
+        </span>
+      </button>
+      {actions && <div className="flex items-center gap-0.5">{actions}</div>}
+    </div>
+  )
+}

--- a/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
@@ -33,7 +33,7 @@ export function TasksProjectsSection({
         <SidebarNavItem
           isActive={activeProject === null}
           isCollapsed={isCollapsed}
-          icon={<Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />}
+          icon={<Layers size={iconSize} strokeWidth={1.5} />}
           label="All Projects"
           onClick={() => setActiveProject(null)}
         />

--- a/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { useAppStore } from '../../stores'
+import { ChevronRight, Layers } from 'lucide-react'
+import { ProjectIcon } from './ProjectIcon'
+import { SidebarNavItem } from './SidebarNavItem'
+import type { ProjectConfig } from '../../../shared/types'
+
+export function TasksProjectsSection({
+  isCollapsed,
+  workspaceProjects
+}: {
+  isCollapsed: boolean
+  workspaceProjects: ProjectConfig[]
+}) {
+  const activeProject = useAppStore((s) => s.activeProject)
+  const setActiveProject = useAppStore((s) => s.setActiveProject)
+
+  const [sectionCollapsed, setSectionCollapsed] = useState(false)
+
+  const iconSize = isCollapsed ? 22 : 14
+
+  return (
+    <>
+      {!isCollapsed && (
+        <div className="group/section pt-3 pb-1.5 flex items-center justify-between">
+          <button
+            onClick={() => setSectionCollapsed(!sectionCollapsed)}
+            className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
+          >
+            <ChevronRight
+              size={10}
+              strokeWidth={2}
+              className={`text-gray-600 transition-transform ${sectionCollapsed ? '' : 'rotate-90'}`}
+            />
+            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
+              Projects
+            </span>
+          </button>
+        </div>
+      )}
+      {isCollapsed && <div className="pt-4" />}
+
+      {!sectionCollapsed && (
+        <SidebarNavItem
+          isActive={activeProject === null}
+          isCollapsed={isCollapsed}
+          icon={<Layers size={iconSize} strokeWidth={1.5} className="shrink-0" />}
+          label="All Projects"
+          onClick={() => setActiveProject(null)}
+        />
+      )}
+
+      {!isCollapsed && !sectionCollapsed && workspaceProjects.length === 0 && (
+        <p className="text-[13px] text-gray-600 px-2.5 py-1">No projects</p>
+      )}
+
+      {!sectionCollapsed &&
+        workspaceProjects.map((project) => (
+          <SidebarNavItem
+            key={project.name}
+            isActive={activeProject === project.name}
+            isCollapsed={isCollapsed}
+            icon={<ProjectIcon icon={project.icon} color={project.iconColor} size={iconSize} />}
+            label={project.name}
+            onClick={() => setActiveProject(project.name)}
+          />
+        ))}
+    </>
+  )
+}

--- a/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
+++ b/src/renderer/components/project-sidebar/TasksProjectsSection.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { useAppStore } from '../../stores'
-import { ChevronRight, Layers } from 'lucide-react'
+import { Layers } from 'lucide-react'
 import { ProjectIcon } from './ProjectIcon'
 import { SidebarNavItem } from './SidebarNavItem'
+import { SidebarSectionHeader } from './SidebarSectionHeader'
 import type { ProjectConfig } from '../../../shared/types'
 
 export function TasksProjectsSection({
@@ -21,24 +22,12 @@ export function TasksProjectsSection({
 
   return (
     <>
-      {!isCollapsed && (
-        <div className="group/section pt-3 pb-1.5 flex items-center justify-between">
-          <button
-            onClick={() => setSectionCollapsed(!sectionCollapsed)}
-            className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
-          >
-            <ChevronRight
-              size={10}
-              strokeWidth={2}
-              className={`text-gray-600 transition-transform ${sectionCollapsed ? '' : 'rotate-90'}`}
-            />
-            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
-              Projects
-            </span>
-          </button>
-        </div>
-      )}
-      {isCollapsed && <div className="pt-4" />}
+      <SidebarSectionHeader
+        title="Projects"
+        isCollapsed={isCollapsed}
+        sectionCollapsed={sectionCollapsed}
+        onToggle={() => setSectionCollapsed(!sectionCollapsed)}
+      />
 
       {!sectionCollapsed && (
         <SidebarNavItem

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -4,8 +4,9 @@ import { Tooltip } from '../Tooltip'
 import { WorkflowItem } from './WorkflowItem'
 import { WorkflowFilterToolbar } from './WorkflowFilterToolbar'
 import { WorkflowContextMenu } from './WorkflowContextMenu'
+import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { isScheduledWorkflow } from '../../lib/workflow-helpers'
-import { ChevronRight, Zap } from 'lucide-react'
+import { Zap } from 'lucide-react'
 import type { WorkflowDefinition } from '../../../shared/types'
 
 type ContextMenuState = { id: string; x: number; y: number } | null
@@ -77,22 +78,13 @@ export function WorkflowsSection({
 
   return (
     <>
-      {!isCollapsed && (
-        <div className="group/section pt-3 pb-1.5 flex items-center justify-between">
-          <button
-            onClick={() => setSectionCollapsed(!sectionCollapsed)}
-            className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
-          >
-            <ChevronRight
-              size={10}
-              strokeWidth={2}
-              className={`text-gray-600 transition-transform ${sectionCollapsed ? '' : 'rotate-90'}`}
-            />
-            <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
-              Workflows
-            </span>
-          </button>
-          <div className="flex items-center gap-0.5">
+      <SidebarSectionHeader
+        title="Workflows"
+        isCollapsed={isCollapsed}
+        sectionCollapsed={sectionCollapsed}
+        onToggle={() => setSectionCollapsed(!sectionCollapsed)}
+        actions={
+          <>
             <WorkflowFilterToolbar />
             <Tooltip label="New workflow" position="bottom">
               <button
@@ -106,10 +98,9 @@ export function WorkflowsSection({
                 <Zap size={13} strokeWidth={1.5} />
               </button>
             </Tooltip>
-          </div>
-        </div>
-      )}
-      {isCollapsed && <div className="pt-4" />}
+          </>
+        }
+      />
 
       {!isCollapsed && !sectionCollapsed && filteredWorkflows.length === 0 && (
         <p className="text-[13px] text-gray-600 px-2.5 py-1">No workflows</p>

--- a/tests/sidebar-nav-item.test.tsx
+++ b/tests/sidebar-nav-item.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import { SidebarNavItem } from '../src/renderer/components/project-sidebar/SidebarNavItem'
+
+const ICON = <svg data-testid="icon" />
+
+describe('SidebarNavItem', () => {
+  it('renders icon and label when expanded', () => {
+    render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="All Projects"
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByText('All Projects')).toBeInTheDocument()
+  })
+
+  it('hides label and uses it as title when collapsed', () => {
+    render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={true}
+        icon={ICON}
+        label="All Projects"
+        onClick={() => {}}
+      />
+    )
+    expect(screen.queryByText('All Projects')).not.toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveAttribute('title', 'All Projects')
+  })
+
+  it('renders zero badge (regression: do not hide 0)', () => {
+    render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="All Projects"
+        badge={0}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('renders non-zero badge', () => {
+    render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="All Projects"
+        badge={7}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('omits badge node when undefined', () => {
+    const { container } = render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="All Projects"
+        onClick={() => {}}
+      />
+    )
+    expect(container.querySelector('.ml-auto')).toBeNull()
+  })
+
+  it('applies active styling when isActive', () => {
+    render(
+      <SidebarNavItem
+        isActive={true}
+        isCollapsed={false}
+        icon={ICON}
+        label="Active"
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByRole('button').className).toMatch(/bg-white\/\[0\.08\]/)
+  })
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn()
+    render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="x"
+        onClick={onClick}
+      />
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps icon with shrink-0 to prevent shrink under long labels', () => {
+    const { container } = render(
+      <SidebarNavItem
+        isActive={false}
+        isCollapsed={false}
+        icon={ICON}
+        label="x"
+        onClick={() => {}}
+      />
+    )
+    const wrapper = container.querySelector('span.shrink-0')
+    expect(wrapper).not.toBeNull()
+    expect(wrapper?.querySelector('[data-testid="icon"]')).not.toBeNull()
+  })
+})

--- a/tests/tasks-projects-section.test.tsx
+++ b/tests/tasks-projects-section.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ProjectConfig } from '../src/shared/types'
+
+const mockStore = {
+  activeProject: null as string | null,
+  setActiveProject: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockStore) : mockStore
+  }
+}))
+
+const { TasksProjectsSection } =
+  await import('../src/renderer/components/project-sidebar/TasksProjectsSection')
+
+function makeProject(name: string): ProjectConfig {
+  return {
+    name,
+    path: `/tmp/${name}`,
+    icon: 'Folder',
+    iconColor: '#888'
+  } as ProjectConfig
+}
+
+beforeEach(() => {
+  mockStore.activeProject = null
+  mockStore.setActiveProject.mockReset()
+})
+
+describe('TasksProjectsSection', () => {
+  it('renders the Projects header and All Projects entry', () => {
+    render(<TasksProjectsSection isCollapsed={false} workspaceProjects={[]} />)
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.getByText('All Projects')).toBeInTheDocument()
+  })
+
+  it('shows empty-state message when no projects', () => {
+    render(<TasksProjectsSection isCollapsed={false} workspaceProjects={[]} />)
+    expect(screen.getByText('No projects')).toBeInTheDocument()
+  })
+
+  it('renders one row per project', () => {
+    render(
+      <TasksProjectsSection
+        isCollapsed={false}
+        workspaceProjects={[makeProject('alpha'), makeProject('beta')]}
+      />
+    )
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('beta')).toBeInTheDocument()
+  })
+
+  it('clicking All Projects clears the active project', () => {
+    mockStore.activeProject = 'alpha'
+    render(<TasksProjectsSection isCollapsed={false} workspaceProjects={[makeProject('alpha')]} />)
+    fireEvent.click(screen.getByText('All Projects'))
+    expect(mockStore.setActiveProject).toHaveBeenCalledWith(null)
+  })
+
+  it('clicking a project sets it as active', () => {
+    render(<TasksProjectsSection isCollapsed={false} workspaceProjects={[makeProject('alpha')]} />)
+    fireEvent.click(screen.getByText('alpha'))
+    expect(mockStore.setActiveProject).toHaveBeenCalledWith('alpha')
+  })
+
+  it('collapsing the section hides project rows', () => {
+    render(<TasksProjectsSection isCollapsed={false} workspaceProjects={[makeProject('alpha')]} />)
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Projects'))
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('All Projects')).not.toBeInTheDocument()
+  })
+
+  it('hides the header text when sidebar is collapsed', () => {
+    render(<TasksProjectsSection isCollapsed={true} workspaceProjects={[makeProject('alpha')]} />)
+    expect(screen.queryByText('Projects')).not.toBeInTheDocument()
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Replace the session/worktree tree in the sidebar with a clean project list when in tasks view. Clicking a project scopes the task board to that project, matching Linear's team-scoping pattern.

## Changes
- Add `TasksProjectsSection` for the tasks sidebar body
- Extract reusable `SidebarNavItem` component shared by both `ProjectsSection` and `TasksProjectsSection`
- Fix `project.iconColor` usage so icons render correctly