### PR TITLE
feat: add Run Workflow submenu and improve context menus

### DIFF
--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -150,12 +150,13 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     label: 'New terminal',
     onClick: () => {
       onClose()
-      const cwd = isWorktree ? terminal.session.worktreePath : projectPath
+      const worktreePath = isWorktree ? terminal.session.worktreePath : undefined
+      const cwd = worktreePath ?? projectPath
       void createShellInProject(cwd, {
         project,
-        worktreePath: isWorktree ? terminal.session.worktreePath : undefined,
-        worktreeName: isWorktree ? terminal.session.worktreeName : undefined,
-        branch
+        worktreePath,
+        worktreeName: worktreePath ? terminal.session.worktreeName : undefined,
+        branch: worktreePath ? branch : undefined
       })
     }
   })

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -1,18 +1,22 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Maximize2, Pencil, FolderGit2, Plus, X, ChevronRight, Zap } from 'lucide-react'
+import { Maximize2, Pencil, FolderGit2, Plus, X, ChevronRight, Zap, Terminal } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { getProjectRemoteHostId } from '../../shared/types'
-import { ProjectIcon } from './project-sidebar/ProjectIcon'
 import { ICON_MAP } from './project-sidebar/icon-map'
+import { AgentIcon } from './AgentIcon'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { executeWorkflow } from '../lib/workflow-execution'
 import { toast } from './Toast'
 import { getDisplayName } from '../lib/terminal-display'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
-import { countSessionsByWorktree, formatSessionCount } from '../lib/session-utils'
+import {
+  countSessionsByWorktree,
+  formatSessionCount,
+  createShellInProject
+} from '../lib/session-utils'
 
 interface Props {
   terminalId: string
@@ -104,27 +108,9 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
 
   const items: MenuItem[] = []
 
-  if (!isFocused && layoutMode !== 'tabs') {
-    items.push({
-      icon: Maximize2,
-      label: 'Expand',
-      onClick: () => {
-        useAppStore.getState().setFocusedTerminal(terminalId)
-        onClose()
-      }
-    })
-  }
+  const defaultAgent = config?.defaults?.defaultAgent || 'claude'
 
-  items.push({
-    icon: Pencil,
-    label: 'Rename',
-    onClick: () => {
-      useAppStore.getState().setRenamingTerminalId(terminalId)
-      onClose()
-    },
-    separator: !isFocused && layoutMode !== 'tabs'
-  })
-
+  // --- Group 1: Quick actions (New session, New terminal) ---
   const quickLabel = isWorktree
     ? branch
       ? `New session in ${projectName} on ${branch}`
@@ -132,12 +118,9 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     : `New session in ${projectName}`
 
   items.push({
-    iconElement: isWorktree ? (
-      <FolderGit2 size={14} className="text-amber-400" />
-    ) : (
-      <ProjectIcon icon={project?.icon} color={project?.iconColor} size={14} />
-    ),
+    iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
     label: quickLabel,
+    className: 'text-white font-medium',
     onClick: async () => {
       onClose()
       const state = useAppStore.getState()
@@ -161,10 +144,25 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
         })
         state.addTerminal(session)
       }
-    },
-    separator: true
+    }
   })
 
+  items.push({
+    iconElement: <Terminal size={14} className="text-gray-400" />,
+    label: 'New terminal',
+    onClick: () => {
+      onClose()
+      const cwd = isWorktree ? terminal.session.worktreePath : projectPath
+      void createShellInProject(cwd, {
+        project,
+        worktreePath: isWorktree ? terminal.session.worktreePath : undefined,
+        worktreeName: isWorktree ? terminal.session.worktreeName : undefined,
+        branch
+      })
+    }
+  })
+
+  // --- Group 2: Worktree submenu ---
   const worktreeSubmenuItems: SubmenuItem[] = []
   const sessionCountByPath = countSessionsByWorktree(terminals.values())
 
@@ -217,8 +215,32 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     iconElement: <FolderGit2 size={14} className="text-amber-400" />,
     label: `New session in ${projectName}...`,
     submenu: worktreeSubmenuItems,
+    separator: true,
     onSubmenuEnter: () => {
       if (projectPath) loadWorktrees(projectPath)
+    }
+  })
+
+  // --- Group 3: Expand, Rename, Run workflow ---
+  if (!isFocused && layoutMode !== 'tabs') {
+    items.push({
+      icon: Maximize2,
+      label: 'Expand',
+      separator: true,
+      onClick: () => {
+        useAppStore.getState().setFocusedTerminal(terminalId)
+        onClose()
+      }
+    })
+  }
+
+  items.push({
+    icon: Pencil,
+    label: 'Rename',
+    separator: isFocused || layoutMode === 'tabs',
+    onClick: () => {
+      useAppStore.getState().setRenamingTerminalId(terminalId)
+      onClose()
     }
   })
 
@@ -238,11 +260,11 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     items.push({
       iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
-      submenu: workflowSubmenuItems,
-      separator: true
+      submenu: workflowSubmenuItems
     })
   }
 
+  // --- Group 4: Close ---
   items.push({
     icon: X,
     label: 'Close session',

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -128,11 +128,32 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     }
   }
 
-  // --- Group 1: New session + New terminal ---
+  // --- Group 1: Expand + Rename ---
+  if (!isFocused && layoutMode !== 'tabs') {
+    items.push({
+      icon: Maximize2,
+      label: 'Expand',
+      onClick: () => {
+        useAppStore.getState().setFocusedTerminal(terminalId)
+        onClose()
+      }
+    })
+  }
+
+  items.push({
+    icon: Pencil,
+    label: 'Rename',
+    onClick: () => {
+      useAppStore.getState().setRenamingTerminalId(terminalId)
+      onClose()
+    }
+  })
+
+  // --- Group 2: New session + New terminal + New session with… + Run workflow ---
   items.push({
     iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
     label: 'New session',
-    className: 'text-white font-medium',
+    separator: true,
     onClick: () => createSessionWithAgent(defaultAgent)
   })
 
@@ -151,7 +172,6 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     }
   })
 
-  // --- Group 2: New session with…, Expand, Rename, Run workflow ---
   const agentSubmenuItems: SubmenuItem[] = AGENT_LIST.filter((a) => agentInstallStatus[a.type]).map(
     (agent) => ({
       iconElement: <AgentIcon agentType={agent.type} size={12} />,
@@ -164,32 +184,9 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     items.push({
       iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
       label: 'New session with…',
-      submenu: agentSubmenuItems,
-      separator: true
+      submenu: agentSubmenuItems
     })
   }
-
-  if (!isFocused && layoutMode !== 'tabs') {
-    items.push({
-      icon: Maximize2,
-      label: 'Expand',
-      separator: agentSubmenuItems.length <= 1,
-      onClick: () => {
-        useAppStore.getState().setFocusedTerminal(terminalId)
-        onClose()
-      }
-    })
-  }
-
-  items.push({
-    icon: Pencil,
-    label: 'Rename',
-    separator: (isFocused || layoutMode === 'tabs') && agentSubmenuItems.length <= 1,
-    onClick: () => {
-      useAppStore.getState().setRenamingTerminalId(terminalId)
-      onClose()
-    }
-  })
 
   if (workspaceWorkflows.length > 0) {
     const workflowSubmenuItems: SubmenuItem[] = workspaceWorkflows.map((wf) => {

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -1,22 +1,20 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Maximize2, Pencil, FolderGit2, Plus, X, ChevronRight, Zap, Terminal } from 'lucide-react'
+import { Maximize2, Pencil, X, ChevronRight, Zap, Terminal } from 'lucide-react'
 import { useAppStore } from '../stores'
-import { getProjectRemoteHostId } from '../../shared/types'
+import { type AiAgentType, getProjectRemoteHostId } from '../../shared/types'
 import { ICON_MAP } from './project-sidebar/icon-map'
 import { AgentIcon } from './AgentIcon'
+import { AGENT_LIST } from '../lib/agent-definitions'
+import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { executeWorkflow } from '../lib/workflow-execution'
 import { toast } from './Toast'
 import { getDisplayName } from '../lib/terminal-display'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
-import {
-  countSessionsByWorktree,
-  formatSessionCount,
-  createShellInProject
-} from '../lib/session-utils'
+import { createShellInProject } from '../lib/session-utils'
 
 interface Props {
   terminalId: string
@@ -46,18 +44,17 @@ interface MenuItem {
 export function CardContextMenu({ terminalId, position, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
   const submenuRef = useRef<HTMLDivElement>(null)
-  const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const terminal = useAppStore((s) => s.terminals.get(terminalId))
   const focusedId = useAppStore((s) => s.focusedTerminalId)
   const config = useAppStore((s) => s.config)
-  const worktreeCache = useAppStore((s) => s.worktreeCache)
-  const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const layoutMode = useAppStore((s) => s.config?.defaults?.layoutMode ?? 'grid')
   const isMobile = useIsMobile()
   const workspaceWorkflows = useWorkspaceWorkflows()
+  const { status: agentInstallStatus } = useAgentInstallStatus()
 
   const [hoveredSubmenu, setHoveredSubmenu] = useState<number | null>(null)
+  const [submenuItemTop, setSubmenuItemTop] = useState(0)
 
   const clearHideTimeout = useCallback(() => {
     if (hideTimeout.current) {
@@ -103,48 +100,40 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   const isWorktree = terminal.session.isWorktree
   const branch = terminal.session.branch
 
-  const worktrees = projectPath ? (worktreeCache.get(projectPath) ?? []) : []
-  const terminals = useAppStore.getState().terminals
-
   const items: MenuItem[] = []
 
   const defaultAgent = config?.defaults?.defaultAgent || 'claude'
 
-  // --- Group 1: Quick actions (New session, New terminal) ---
-  const quickLabel = isWorktree
-    ? branch
-      ? `New session in ${projectName} on ${branch}`
-      : `New session in ${projectName} (worktree)`
-    : `New session in ${projectName}`
+  const createSessionWithAgent = async (agentType: AiAgentType) => {
+    onClose()
+    const state = useAppStore.getState()
+    if (isWorktree && terminal.session.worktreePath) {
+      const session = await window.api.createTerminal({
+        agentType,
+        projectName,
+        projectPath,
+        branch,
+        existingWorktreePath: terminal.session.worktreePath,
+        remoteHostId
+      })
+      state.addTerminal(session)
+    } else {
+      const session = await window.api.createTerminal({
+        agentType,
+        projectName,
+        projectPath,
+        remoteHostId
+      })
+      state.addTerminal(session)
+    }
+  }
 
+  // --- Group 1: New session + New terminal ---
   items.push({
     iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
-    label: quickLabel,
+    label: 'New session',
     className: 'text-white font-medium',
-    onClick: async () => {
-      onClose()
-      const state = useAppStore.getState()
-      const agentType = state.config?.defaults.defaultAgent || 'claude'
-      if (isWorktree && terminal.session.worktreePath) {
-        const session = await window.api.createTerminal({
-          agentType,
-          projectName,
-          projectPath,
-          branch,
-          existingWorktreePath: terminal.session.worktreePath,
-          remoteHostId
-        })
-        state.addTerminal(session)
-      } else {
-        const session = await window.api.createTerminal({
-          agentType,
-          projectName,
-          projectPath,
-          remoteHostId
-        })
-        state.addTerminal(session)
-      }
-    }
+    onClick: () => createSessionWithAgent(defaultAgent)
   })
 
   items.push({
@@ -162,71 +151,29 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     }
   })
 
-  // --- Group 2: Worktree submenu ---
-  const worktreeSubmenuItems: SubmenuItem[] = []
-  const sessionCountByPath = countSessionsByWorktree(terminals.values())
+  // --- Group 2: New session with…, Expand, Rename, Run workflow ---
+  const agentSubmenuItems: SubmenuItem[] = AGENT_LIST.filter((a) => agentInstallStatus[a.type]).map(
+    (agent) => ({
+      iconElement: <AgentIcon agentType={agent.type} size={12} />,
+      label: agent.displayName,
+      onClick: () => createSessionWithAgent(agent.type)
+    })
+  )
 
-  for (const wt of worktrees) {
-    const sessionCount = sessionCountByPath.get(wt.path) ?? 0
-    worktreeSubmenuItems.push({
-      iconElement: <FolderGit2 size={12} className="text-amber-400/70" />,
-      label: wt.branch,
-      detail: sessionCount > 0 ? formatSessionCount(sessionCount) : 'idle',
-      onClick: async () => {
-        onClose()
-        const state = useAppStore.getState()
-        const agentType = state.config?.defaults.defaultAgent || 'claude'
-        const session = await window.api.createTerminal({
-          agentType,
-          projectName,
-          projectPath,
-          branch: wt.branch,
-          existingWorktreePath: wt.path,
-          remoteHostId
-        })
-        state.addTerminal(session)
-      }
+  if (agentSubmenuItems.length > 1) {
+    items.push({
+      iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
+      label: 'New session with…',
+      submenu: agentSubmenuItems,
+      separator: true
     })
   }
 
-  worktreeSubmenuItems.push({
-    iconElement: <Plus size={12} className="text-amber-400/70" />,
-    label: 'New worktree',
-    onClick: async () => {
-      onClose()
-      const state = useAppStore.getState()
-      const agentType = state.config?.defaults.defaultAgent || 'claude'
-      const branchResult = await window.api.listBranches(projectPath)
-      const branchName = branchResult.current || 'main'
-      const session = await window.api.createTerminal({
-        agentType,
-        projectName,
-        projectPath,
-        branch: branchName,
-        useWorktree: true,
-        remoteHostId
-      })
-      state.addTerminal(session)
-    },
-    separator: worktreeSubmenuItems.length > 0
-  })
-
-  items.push({
-    iconElement: <FolderGit2 size={14} className="text-amber-400" />,
-    label: `New session in ${projectName}...`,
-    submenu: worktreeSubmenuItems,
-    separator: true,
-    onSubmenuEnter: () => {
-      if (projectPath) loadWorktrees(projectPath)
-    }
-  })
-
-  // --- Group 3: Expand, Rename, Run workflow ---
   if (!isFocused && layoutMode !== 'tabs') {
     items.push({
       icon: Maximize2,
       label: 'Expand',
-      separator: true,
+      separator: agentSubmenuItems.length <= 1,
       onClick: () => {
         useAppStore.getState().setFocusedTerminal(terminalId)
         onClose()
@@ -237,7 +184,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   items.push({
     icon: Pencil,
     label: 'Rename',
-    separator: isFocused || layoutMode === 'tabs',
+    separator: (isFocused || layoutMode === 'tabs') && agentSubmenuItems.length <= 1,
     onClick: () => {
       useAppStore.getState().setRenamingTerminalId(terminalId)
       onClose()
@@ -264,7 +211,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     })
   }
 
-  // --- Group 4: Close ---
+  // --- Group 3: Close ---
   items.push({
     icon: X,
     label: 'Close session',
@@ -291,10 +238,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   let submenuTop = top
   const submenuWidth = 220
   if (hoveredSubmenu !== null) {
-    const itemEl = itemRefs.current.get(hoveredSubmenu)
-    if (itemEl) {
-      submenuTop = itemEl.getBoundingClientRect().top
-    }
+    submenuTop = submenuItemTop || top
     if (submenuLeft + submenuWidth > window.innerWidth - 8) {
       submenuLeft = left - submenuWidth - 4
     }
@@ -328,23 +272,21 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
           <div key={i}>
             {item.separator && <div className="border-t border-white/[0.06] my-1" />}
             <button
-              ref={(el) => {
-                if (el) itemRefs.current.set(i, el)
-                else itemRefs.current.delete(i)
-              }}
               onClick={(e) => {
                 e.stopPropagation()
                 if (item.submenu) {
                   clearHideTimeout()
+                  setSubmenuItemTop(e.currentTarget.getBoundingClientRect().top)
                   setHoveredSubmenu(hoveredSubmenu === i ? null : i)
                   item.onSubmenuEnter?.()
                 } else {
                   item.onClick?.()
                 }
               }}
-              onMouseEnter={() => {
+              onMouseEnter={(e) => {
                 if (item.submenu) {
                   clearHideTimeout()
+                  setSubmenuItemTop(e.currentTarget.getBoundingClientRect().top)
                   setHoveredSubmenu(i)
                   item.onSubmenuEnter?.()
                 } else {

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -4,16 +4,15 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { Maximize2, Pencil, X, ChevronRight, Zap, Terminal } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { type AiAgentType, getProjectRemoteHostId } from '../../shared/types'
-import { ICON_MAP } from './project-sidebar/icon-map'
 import { AgentIcon } from './AgentIcon'
 import { AGENT_LIST } from '../lib/agent-definitions'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import { closeTerminalSession } from '../lib/terminal-close'
-import { executeWorkflow } from '../lib/workflow-execution'
 import { toast } from './Toast'
 import { getDisplayName } from '../lib/terminal-display'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
+import { buildWorkflowMenuItems } from '../lib/workflow-menu-items'
 import { createShellInProject } from '../lib/session-utils'
 
 interface Props {
@@ -107,28 +106,18 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   const createSessionWithAgent = async (agentType: AiAgentType) => {
     onClose()
     const state = useAppStore.getState()
-    if (isWorktree && terminal.session.worktreePath) {
-      const session = await window.api.createTerminal({
-        agentType,
-        projectName,
-        projectPath,
-        branch,
-        existingWorktreePath: terminal.session.worktreePath,
-        remoteHostId
-      })
-      state.addTerminal(session)
-    } else {
-      const session = await window.api.createTerminal({
-        agentType,
-        projectName,
-        projectPath,
-        remoteHostId
-      })
-      state.addTerminal(session)
-    }
+    const session = await window.api.createTerminal({
+      agentType,
+      projectName,
+      projectPath,
+      remoteHostId,
+      ...(isWorktree && terminal.session.worktreePath
+        ? { branch, existingWorktreePath: terminal.session.worktreePath }
+        : {})
+    })
+    state.addTerminal(session)
   }
 
-  // --- Group 1: Expand + Rename ---
   if (!isFocused && layoutMode !== 'tabs') {
     items.push({
       icon: Maximize2,
@@ -149,7 +138,6 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     }
   })
 
-  // --- Group 2: New session + New terminal + New session with… + Run workflow ---
   items.push({
     iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
     label: 'New session',
@@ -189,26 +177,13 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   }
 
   if (workspaceWorkflows.length > 0) {
-    const workflowSubmenuItems: SubmenuItem[] = workspaceWorkflows.map((wf) => {
-      const WfIcon = ICON_MAP[wf.icon] || Zap
-      return {
-        iconElement: <WfIcon size={12} color={wf.iconColor} />,
-        label: wf.name,
-        onClick: () => {
-          onClose()
-          executeWorkflow(wf, undefined, { source: 'manual' })
-        }
-      }
-    })
-
     items.push({
       iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
-      submenu: workflowSubmenuItems
+      submenu: buildWorkflowMenuItems(workspaceWorkflows, onClose)
     })
   }
 
-  // --- Group 3: Close ---
   items.push({
     icon: X,
     label: 'Close session',

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -121,7 +121,8 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     onClick: () => {
       useAppStore.getState().setRenamingTerminalId(terminalId)
       onClose()
-    }
+    },
+    separator: !isFocused && layoutMode !== 'tabs'
   })
 
   const quickLabel = isWorktree
@@ -235,7 +236,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     })
 
     items.push({
-      iconElement: <Zap size={14} className="text-amber-400" />,
+      iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
       submenu: workflowSubmenuItems,
       separator: true
@@ -333,7 +334,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
               }}
               aria-haspopup={item.submenu ? 'menu' : undefined}
               aria-expanded={item.submenu ? hoveredSubmenu === i : undefined}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+              className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-300
                          hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
             >
               {item.iconElement ??

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Maximize2, Pencil, FolderGit2, Plus, X, ChevronRight } from 'lucide-react'
+import { Maximize2, Pencil, FolderGit2, Plus, X, ChevronRight, Zap } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { getProjectRemoteHostId } from '../../shared/types'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
+import { ICON_MAP } from './project-sidebar/icon-map'
 import { closeTerminalSession } from '../lib/terminal-close'
+import { executeWorkflow } from '../lib/workflow-execution'
 import { toast } from './Toast'
 import { getDisplayName } from '../lib/terminal-display'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
 import { countSessionsByWorktree, formatSessionCount } from '../lib/session-utils'
 
 interface Props {
@@ -48,6 +51,7 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
   const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const layoutMode = useAppStore((s) => s.config?.defaults?.layoutMode ?? 'grid')
   const isMobile = useIsMobile()
+  const workspaceWorkflows = useWorkspaceWorkflows()
 
   const [hoveredSubmenu, setHoveredSubmenu] = useState<number | null>(null)
 
@@ -216,6 +220,27 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
       if (projectPath) loadWorktrees(projectPath)
     }
   })
+
+  if (workspaceWorkflows.length > 0) {
+    const workflowSubmenuItems: SubmenuItem[] = workspaceWorkflows.map((wf) => {
+      const WfIcon = ICON_MAP[wf.icon] || Zap
+      return {
+        iconElement: <WfIcon size={12} color={wf.iconColor} />,
+        label: wf.name,
+        onClick: () => {
+          onClose()
+          executeWorkflow(wf, undefined, { source: 'manual' })
+        }
+      }
+    })
+
+    items.push({
+      iconElement: <Zap size={14} className="text-amber-400" />,
+      label: 'Run workflow',
+      submenu: workflowSubmenuItems,
+      separator: true
+    })
+  }
 
   items.push({
     icon: X,

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -175,6 +175,29 @@ export function GridContextMenu({ position, onClose }: Props) {
           onClick: onClickFor(p, wt.path, wt.branch, wt.name)
         })
       }
+
+      if (mode === 'session') {
+        subs.push({
+          iconElement: <Plus size={12} className="text-gray-500" />,
+          label: 'New worktree',
+          onClick: () => {
+            onClose()
+            const agentType = useAppStore.getState().config?.defaults.defaultAgent ?? 'claude'
+            window.api.listBranches(p.path).then((result) => {
+              const branch = result.current || 'main'
+              window.api
+                .createTerminal({
+                  agentType,
+                  projectName: p.name,
+                  projectPath: p.path,
+                  branch,
+                  useWorktree: true
+                })
+                .then((session) => useAppStore.getState().addTerminal(session))
+            })
+          }
+        })
+      }
     }
     return subs
   }

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -259,7 +259,7 @@ export function GridContextMenu({ position, onClose }: Props) {
 
   if (workspaceWorkflows.length > 0) {
     items.push({
-      iconElement: <Zap size={14} className="text-amber-400" />,
+      iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
       submenuKey: 'run-workflow'
     })

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -64,6 +64,11 @@ export function GridContextMenu({ position, onClose }: Props) {
   const workspaceProjects = useWorkspaceProjects()
   const workspaceWorkflows = useWorkspaceWorkflows()
 
+  // Force-refresh worktree data once when the menu mounts
+  useEffect(() => {
+    workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   const [hoveredSubmenu, setHoveredSubmenu] = useState<number | null>(null)
 
   const clearHideTimeout = useCallback(() => {
@@ -209,14 +214,14 @@ export function GridContextMenu({ position, onClose }: Props) {
       iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
       label: 'New session in…',
       submenuKey: 'session-in',
-      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
+      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path))
     })
 
     items.push({
       iconElement: <Terminal size={14} className="text-gray-400" />,
       label: 'New terminal in…',
       submenuKey: 'terminal-in',
-      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
+      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path))
     })
   }
 

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -9,7 +9,6 @@ import { ICON_MAP } from './project-sidebar/icon-map'
 import { AgentIcon } from './AgentIcon'
 import { executeWorkflow } from '../lib/workflow-execution'
 import {
-  resolveActiveProject,
   createSessionFromProject,
   createShellInProject,
   countSessionsByWorktree,
@@ -60,7 +59,6 @@ export function GridContextMenu({ position, onClose }: Props) {
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const activeWorktreePath = useAppStore((s) => s.activeWorktreePath)
   const worktreeCache = useAppStore((s) => s.worktreeCache)
   const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const workspaceProjects = useWorkspaceProjects()
@@ -98,13 +96,7 @@ export function GridContextMenu({ position, onClose }: Props) {
     }
   }, [onClose, clearHideTimeout])
 
-  const project = resolveActiveProject()
   const terminals = useAppStore.getState().terminals
-
-  const activeWt =
-    activeWorktreePath && project
-      ? worktreeCache.get(project.path)?.find((wt) => wt.path === activeWorktreePath)
-      : undefined
 
   const defaultAgent: AiAgentType = useAppStore.getState().config?.defaults.defaultAgent ?? 'claude'
 
@@ -189,51 +181,10 @@ export function GridContextMenu({ position, onClose }: Props) {
 
   const items: MenuItem[] = []
 
-  if (project) {
-    items.push({
-      iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
-      label: 'New session',
-      className: 'text-white font-medium',
-      onClick: () =>
-        activeWorktreePath
-          ? createSession(project, {
-              branch: activeWt?.branch,
-              existingWorktreePath: activeWorktreePath
-            })
-          : createSession(project)
-    })
-  } else {
-    items.push({
-      iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
-      label: 'New session',
-      className: 'text-white font-medium',
-      onClick: () => {
-        onClose()
-        useAppStore.getState().setNewAgentDialogOpen(true)
-      }
-    })
-  }
-
-  items.push({
-    iconElement: <Terminal size={14} className="text-gray-400" />,
-    label: 'New terminal',
-    onClick: () => {
-      onClose()
-      const cwd = activeWorktreePath ?? project?.path
-      void createShellInProject(cwd, {
-        project,
-        worktreePath: activeWorktreePath ?? undefined,
-        worktreeName: activeWt?.name,
-        branch: activeWt?.branch
-      })
-    }
-  })
-
   if (workspaceProjects.length > 0) {
     items.push({
       iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
       label: 'New session in…',
-      separator: true,
       submenuKey: 'session-in',
       onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path))
     })
@@ -254,7 +205,7 @@ export function GridContextMenu({ position, onClose }: Props) {
       onClose()
       useAppStore.getState().setNewAgentDialogOpen(true)
     },
-    separator: true
+    separator: workspaceProjects.length > 0
   })
 
   if (workspaceWorkflows.length > 0) {

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -63,9 +63,13 @@ export function GridContextMenu({ position, onClose }: Props) {
   const workspaceProjects = useWorkspaceProjects()
   const workspaceWorkflows = useWorkspaceWorkflows()
 
+  const didRefreshRef = useRef(false)
   useEffect(() => {
-    workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    if (!didRefreshRef.current && workspaceProjects.length > 0) {
+      didRefreshRef.current = true
+      workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
+    }
+  }, [workspaceProjects, loadWorktrees])
 
   const [hoveredSubmenu, setHoveredSubmenu] = useState<number | null>(null)
 

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FolderGit2, GitBranch, Plus, ChevronRight, Terminal } from 'lucide-react'
+import { FolderGit2, GitBranch, Plus, ChevronRight, Terminal, Zap } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { type ProjectConfig, type AiAgentType } from '../../shared/types'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
+import { ICON_MAP } from './project-sidebar/icon-map'
 import { AgentIcon } from './AgentIcon'
+import { executeWorkflow } from '../lib/workflow-execution'
 import {
   resolveActiveProject,
   createSessionFromProject,
@@ -14,6 +16,7 @@ import {
   formatSessionCount
 } from '../lib/session-utils'
 import { useWorkspaceProjects } from '../hooks/useWorkspaceProjects'
+import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
 
 interface Props {
   position: { x: number; y: number }
@@ -29,7 +32,7 @@ interface SubmenuItem {
   isHeader?: boolean
 }
 
-type SubmenuKey = 'session-in' | 'terminal-in'
+type SubmenuKey = 'session-in' | 'terminal-in' | 'run-workflow'
 
 interface MenuItem {
   icon?: React.FC<{ size?: number; className?: string }>
@@ -61,6 +64,7 @@ export function GridContextMenu({ position, onClose }: Props) {
   const worktreeCache = useAppStore((s) => s.worktreeCache)
   const loadWorktrees = useAppStore((s) => s.loadWorktrees)
   const workspaceProjects = useWorkspaceProjects()
+  const workspaceWorkflows = useWorkspaceWorkflows()
 
   const [hoveredSubmenu, setHoveredSubmenu] = useState<number | null>(null)
 
@@ -253,7 +257,28 @@ export function GridContextMenu({ position, onClose }: Props) {
     separator: true
   })
 
+  if (workspaceWorkflows.length > 0) {
+    items.push({
+      iconElement: <Zap size={14} className="text-amber-400" />,
+      label: 'Run workflow',
+      submenuKey: 'run-workflow'
+    })
+  }
+
   const hasSubmenu = (item: MenuItem): boolean => item.submenuKey !== undefined
+
+  const buildWorkflowSubmenu = (): SubmenuItem[] =>
+    workspaceWorkflows.map((wf) => {
+      const WfIcon = ICON_MAP[wf.icon] || Zap
+      return {
+        iconElement: <WfIcon size={12} color={wf.iconColor} />,
+        label: wf.name,
+        onClick: () => {
+          onClose()
+          executeWorkflow(wf, undefined, { source: 'manual' })
+        }
+      }
+    })
 
   const menuHeight = estimatePanelHeight(items)
   const left = Math.max(8, Math.min(position.x, window.innerWidth - MENU_WIDTH - 8))
@@ -261,7 +286,9 @@ export function GridContextMenu({ position, onClose }: Props) {
 
   const hoveredItem = hoveredSubmenu !== null ? items[hoveredSubmenu] : null
   const activeSubmenu = hoveredItem?.submenuKey
-    ? buildScopedSubmenu(hoveredItem.submenuKey === 'session-in' ? 'session' : 'terminal')
+    ? hoveredItem.submenuKey === 'run-workflow'
+      ? buildWorkflowSubmenu()
+      : buildScopedSubmenu(hoveredItem.submenuKey === 'session-in' ? 'session' : 'terminal')
     : null
 
   let submenuLeft = left + MENU_WIDTH + 4

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -5,9 +5,8 @@ import { FolderGit2, GitBranch, Plus, ChevronRight, Terminal, Zap } from 'lucide
 import { useAppStore } from '../stores'
 import { type ProjectConfig, type AiAgentType } from '../../shared/types'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
-import { ICON_MAP } from './project-sidebar/icon-map'
 import { AgentIcon } from './AgentIcon'
-import { executeWorkflow } from '../lib/workflow-execution'
+import { buildWorkflowMenuItems } from '../lib/workflow-menu-items'
 import {
   createSessionFromProject,
   createShellInProject,
@@ -64,7 +63,6 @@ export function GridContextMenu({ position, onClose }: Props) {
   const workspaceProjects = useWorkspaceProjects()
   const workspaceWorkflows = useWorkspaceWorkflows()
 
-  // Force-refresh worktree data once when the menu mounts
   useEffect(() => {
     workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -246,19 +244,6 @@ export function GridContextMenu({ position, onClose }: Props) {
 
   const hasSubmenu = (item: MenuItem): boolean => item.submenuKey !== undefined
 
-  const buildWorkflowSubmenu = (): SubmenuItem[] =>
-    workspaceWorkflows.map((wf) => {
-      const WfIcon = ICON_MAP[wf.icon] || Zap
-      return {
-        iconElement: <WfIcon size={12} color={wf.iconColor} />,
-        label: wf.name,
-        onClick: () => {
-          onClose()
-          executeWorkflow(wf, undefined, { source: 'manual' })
-        }
-      }
-    })
-
   const menuHeight = estimatePanelHeight(items)
   const left = Math.max(8, Math.min(position.x, window.innerWidth - MENU_WIDTH - 8))
   const top = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8))
@@ -266,7 +251,7 @@ export function GridContextMenu({ position, onClose }: Props) {
   const hoveredItem = hoveredSubmenu !== null ? items[hoveredSubmenu] : null
   const activeSubmenu = hoveredItem?.submenuKey
     ? hoveredItem.submenuKey === 'run-workflow'
-      ? buildWorkflowSubmenu()
+      ? buildWorkflowMenuItems(workspaceWorkflows, onClose)
       : buildScopedSubmenu(hoveredItem.submenuKey === 'session-in' ? 'session' : 'terminal')
     : null
 

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -209,14 +209,14 @@ export function GridContextMenu({ position, onClose }: Props) {
       iconElement: <AgentIcon agentType={defaultAgent} size={14} />,
       label: 'New session in…',
       submenuKey: 'session-in',
-      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path))
+      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
     })
 
     items.push({
       iconElement: <Terminal size={14} className="text-gray-400" />,
       label: 'New terminal in…',
       submenuKey: 'terminal-in',
-      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path))
+      onSubmenuEnter: () => workspaceProjects.forEach((p) => loadWorktrees(p.path, true))
     })
   }
 

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -177,9 +177,9 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
           onMouseEnter={clearHideTimeout}
           onMouseLeave={scheduleHide}
         >
-          {workflowSubmenuItems.map((sub, j) => (
+          {workflowSubmenuItems.map((sub) => (
             <button
-              key={j}
+              key={sub.id}
               role="menuitem"
               onClick={(e) => {
                 e.stopPropagation()

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { motion } from 'framer-motion'
-import { Copy, ClipboardPaste } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Copy, ClipboardPaste, Zap, ChevronRight } from 'lucide-react'
 import {
   getTerminalSelection,
   clearTerminalSelection,
   pasteToTerminal,
   focusTerminal
 } from '../lib/terminal-registry'
+import { ICON_MAP } from './project-sidebar/icon-map'
+import { executeWorkflow } from '../lib/workflow-execution'
+import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
 
 interface Props {
   terminalId: string
@@ -15,13 +18,39 @@ interface Props {
   onClose: () => void
 }
 
+interface SubmenuItem {
+  iconElement?: React.ReactNode
+  label: string
+  onClick: () => void
+}
+
 export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
+  const submenuRef = useRef<HTMLDivElement>(null)
+  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const selection = getTerminalSelection(terminalId)
+  const workspaceWorkflows = useWorkspaceWorkflows()
+
+  const [showWorkflowSubmenu, setShowWorkflowSubmenu] = useState(false)
+  const [workflowBtnTop, setWorkflowBtnTop] = useState(0)
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeout.current) {
+      clearTimeout(hideTimeout.current)
+      hideTimeout.current = null
+    }
+  }, [])
+
+  const scheduleHide = useCallback(() => {
+    clearHideTimeout()
+    hideTimeout.current = setTimeout(() => setShowWorkflowSubmenu(false), 150)
+  }, [clearHideTimeout])
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose()
+      const target = e.target as Node
+      if (menuRef.current?.contains(target) || submenuRef.current?.contains(target)) return
+      onClose()
     }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -31,8 +60,9 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
     return () => {
       document.removeEventListener('pointerdown', handleClick)
       document.removeEventListener('keydown', handleKey)
+      clearHideTimeout()
     }
-  }, [onClose])
+  }, [onClose, clearHideTimeout])
 
   const close = () => {
     onClose()
@@ -54,42 +84,135 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
     close()
   }
 
-  const menuWidth = 160
-  const menuHeight = 2 * 32 + 16
+  const hasWorkflows = workspaceWorkflows.length > 0
+  const itemCount = 2 + (hasWorkflows ? 1 : 0)
+  const menuWidth = 180
+  const menuHeight = itemCount * 32 + (hasWorkflows ? 9 : 0) + 16
   const left = Math.max(8, Math.min(position.x, window.innerWidth - menuWidth - 8))
   const top = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8))
 
+  const workflowSubmenuItems: SubmenuItem[] = workspaceWorkflows.map((wf) => {
+    const WfIcon = ICON_MAP[wf.icon] || Zap
+    return {
+      iconElement: <WfIcon size={12} color={wf.iconColor} />,
+      label: wf.name,
+      onClick: () => {
+        close()
+        executeWorkflow(wf, undefined, { source: 'manual' })
+      }
+    }
+  })
+
+  const submenuWidth = 200
+  let submenuLeft = left + menuWidth + 4
+  let submenuTop = workflowBtnTop || top
+  if (showWorkflowSubmenu) {
+    if (submenuLeft + submenuWidth > window.innerWidth - 8) {
+      submenuLeft = left - submenuWidth - 4
+    }
+    const subSeps = workflowSubmenuItems.filter((s) => 'separator' in s && s.separator).length
+    const subHeight = workflowSubmenuItems.length * 32 + subSeps * 9 + 16
+    submenuTop = Math.max(8, Math.min(submenuTop, window.innerHeight - subHeight - 8))
+  }
+
   return createPortal(
-    <motion.div
-      ref={menuRef}
-      role="menu"
-      initial={{ opacity: 0, y: -4, scale: 0.96 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-      className="fixed z-[150] rounded-lg border border-white/[0.1] py-1 shadow-2xl"
-      style={{ top, left, background: '#1e1e22', minWidth: menuWidth }}
-    >
-      <button
-        role="menuitem"
-        onClick={handleCopy}
-        disabled={!selection}
-        className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
-                   hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors
-                   disabled:opacity-40 disabled:pointer-events-none"
+    <AnimatePresence>
+      <motion.div
+        ref={menuRef}
+        role="menu"
+        initial={{ opacity: 0, y: -4, scale: 0.96 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+        className="fixed z-[150] rounded-lg border border-white/[0.1] py-1 shadow-2xl"
+        style={{ top, left, background: '#1e1e22', minWidth: menuWidth }}
       >
-        <Copy size={14} className="text-gray-500" />
-        <span>Copy</span>
-      </button>
-      <button
-        role="menuitem"
-        onClick={handlePaste}
-        className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
-                   hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
-      >
-        <ClipboardPaste size={14} className="text-gray-500" />
-        <span>Paste</span>
-      </button>
-    </motion.div>,
+        <button
+          role="menuitem"
+          onClick={handleCopy}
+          disabled={!selection}
+          className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+                     hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors
+                     disabled:opacity-40 disabled:pointer-events-none"
+        >
+          <Copy size={14} className="text-gray-500" />
+          <span>Copy</span>
+        </button>
+        <button
+          role="menuitem"
+          onClick={handlePaste}
+          className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+                     hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
+        >
+          <ClipboardPaste size={14} className="text-gray-500" />
+          <span>Paste</span>
+        </button>
+
+        {hasWorkflows && (
+          <>
+            <div className="border-t border-white/[0.06] my-1" />
+            <button
+              role="menuitem"
+              aria-haspopup="menu"
+              aria-expanded={showWorkflowSubmenu}
+              onClick={(e) => {
+                e.stopPropagation()
+                clearHideTimeout()
+                setWorkflowBtnTop(e.currentTarget.getBoundingClientRect().top)
+                setShowWorkflowSubmenu((v) => !v)
+              }}
+              onMouseEnter={(e) => {
+                clearHideTimeout()
+                setWorkflowBtnTop(e.currentTarget.getBoundingClientRect().top)
+                setShowWorkflowSubmenu(true)
+              }}
+              onMouseLeave={scheduleHide}
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+                         hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
+            >
+              <Zap size={14} className="text-amber-400" />
+              <span className="flex-1 text-left">Run workflow</span>
+              <ChevronRight size={11} className="text-gray-600 ml-auto shrink-0" />
+            </button>
+          </>
+        )}
+      </motion.div>
+
+      {showWorkflowSubmenu && workflowSubmenuItems.length > 0 && (
+        <motion.div
+          ref={submenuRef}
+          initial={{ opacity: 0, x: -4, scale: 0.96 }}
+          animate={{ opacity: 1, x: 0, scale: 1 }}
+          exit={{ opacity: 0, x: -4, scale: 0.96 }}
+          transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+          role="menu"
+          className="fixed z-[151] rounded-lg border border-white/[0.1] shadow-2xl py-1 max-h-[320px] overflow-y-auto"
+          style={{
+            top: submenuTop,
+            left: submenuLeft,
+            background: '#1e1e22',
+            minWidth: submenuWidth
+          }}
+          onMouseEnter={clearHideTimeout}
+          onMouseLeave={scheduleHide}
+        >
+          {workflowSubmenuItems.map((sub, j) => (
+            <button
+              key={j}
+              role="menuitem"
+              onClick={(e) => {
+                e.stopPropagation()
+                sub.onClick()
+              }}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-xs text-gray-300
+                         hover:bg-white/[0.06] transition-colors"
+            >
+              {sub.iconElement}
+              <span className="flex-1 text-left truncate">{sub.label}</span>
+            </button>
+          ))}
+        </motion.div>
+      )}
+    </AnimatePresence>,
     document.body
   )
 }

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -8,20 +8,13 @@ import {
   pasteToTerminal,
   focusTerminal
 } from '../lib/terminal-registry'
-import { ICON_MAP } from './project-sidebar/icon-map'
-import { executeWorkflow } from '../lib/workflow-execution'
 import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
+import { buildWorkflowMenuItems } from '../lib/workflow-menu-items'
 
 interface Props {
   terminalId: string
   position: { x: number; y: number }
   onClose: () => void
-}
-
-interface SubmenuItem {
-  iconElement?: React.ReactNode
-  label: string
-  onClick: () => void
 }
 
 export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
@@ -91,17 +84,7 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
   const left = Math.max(8, Math.min(position.x, window.innerWidth - menuWidth - 8))
   const top = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8))
 
-  const workflowSubmenuItems: SubmenuItem[] = workspaceWorkflows.map((wf) => {
-    const WfIcon = ICON_MAP[wf.icon] || Zap
-    return {
-      iconElement: <WfIcon size={12} color={wf.iconColor} />,
-      label: wf.name,
-      onClick: () => {
-        close()
-        executeWorkflow(wf, undefined, { source: 'manual' })
-      }
-    }
-  })
+  const workflowSubmenuItems = buildWorkflowMenuItems(workspaceWorkflows, close)
 
   const submenuWidth = 200
   let submenuLeft = left + menuWidth + 4
@@ -110,8 +93,7 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
     if (submenuLeft + submenuWidth > window.innerWidth - 8) {
       submenuLeft = left - submenuWidth - 4
     }
-    const subSeps = workflowSubmenuItems.filter((s) => 'separator' in s && s.separator).length
-    const subHeight = workflowSubmenuItems.length * 32 + subSeps * 9 + 16
+    const subHeight = workflowSubmenuItems.length * 32 + 16
     submenuTop = Math.max(8, Math.min(submenuTop, window.innerHeight - subHeight - 8))
   }
 

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -130,7 +130,7 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
           role="menuitem"
           onClick={handleCopy}
           disabled={!selection}
-          className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+          className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-300
                      hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors
                      disabled:opacity-40 disabled:pointer-events-none"
         >
@@ -140,7 +140,7 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
         <button
           role="menuitem"
           onClick={handlePaste}
-          className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+          className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-300
                      hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
         >
           <ClipboardPaste size={14} className="text-gray-500" />
@@ -166,10 +166,10 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
                 setShowWorkflowSubmenu(true)
               }}
               onMouseLeave={scheduleHide}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-xs text-gray-300
+              className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-300
                          hover:bg-white/[0.06] active:bg-white/[0.1] transition-colors"
             >
-              <Zap size={14} className="text-amber-400" />
+              <Zap size={14} className="text-gray-500" />
               <span className="flex-1 text-left">Run workflow</span>
               <ChevronRight size={11} className="text-gray-600 ml-auto shrink-0" />
             </button>

--- a/src/renderer/hooks/useWorkspaceWorkflows.ts
+++ b/src/renderer/hooks/useWorkspaceWorkflows.ts
@@ -1,14 +1,20 @@
 import { useMemo } from 'react'
 import { useAppStore } from '../stores'
+import { isScheduledWorkflow } from '../lib/workflow-helpers'
 
 /**
- * Returns the workflows belonging to the active workspace.
+ * Returns the manual-trigger workflows belonging to the active workspace.
+ * Scheduled/event-driven workflows are excluded since they don't make
+ * sense to run manually from context menus.
  */
 export function useWorkspaceWorkflows() {
   const workflows = useAppStore((s) => s.config?.workflows)
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
   return useMemo(
-    () => (workflows ?? []).filter((w) => (w.workspaceId ?? 'personal') === activeWorkspace),
+    () =>
+      (workflows ?? []).filter(
+        (w) => (w.workspaceId ?? 'personal') === activeWorkspace && !isScheduledWorkflow(w)
+      ),
     [workflows, activeWorkspace]
   )
 }

--- a/src/renderer/hooks/useWorkspaceWorkflows.ts
+++ b/src/renderer/hooks/useWorkspaceWorkflows.ts
@@ -2,11 +2,8 @@ import { useMemo } from 'react'
 import { useAppStore } from '../stores'
 import { isScheduledWorkflow } from '../lib/workflow-helpers'
 
-/**
- * Returns the manual-trigger workflows belonging to the active workspace.
- * Scheduled/event-driven workflows are excluded since they don't make
- * sense to run manually from context menus.
- */
+// Excludes scheduled/event-driven workflows: context menus only surface
+// workflows a user can run manually.
 export function useWorkspaceWorkflows() {
   const workflows = useAppStore((s) => s.config?.workflows)
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)

--- a/src/renderer/hooks/useWorkspaceWorkflows.ts
+++ b/src/renderer/hooks/useWorkspaceWorkflows.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../stores'
+
+/**
+ * Returns the workflows belonging to the active workspace.
+ */
+export function useWorkspaceWorkflows() {
+  const workflows = useAppStore((s) => s.config?.workflows)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  return useMemo(
+    () => (workflows ?? []).filter((w) => (w.workspaceId ?? 'personal') === activeWorkspace),
+    [workflows, activeWorkspace]
+  )
+}

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from 'react'
+import { Zap } from 'lucide-react'
+import { ICON_MAP } from '../components/project-sidebar/icon-map'
+import { executeWorkflow } from './workflow-execution'
+import type { WorkflowDefinition } from '../../shared/types'
+
+export interface WorkflowMenuItem {
+  iconElement: ReactNode
+  label: string
+  onClick: () => void
+}
+
+export function buildWorkflowMenuItems(
+  workflows: WorkflowDefinition[],
+  onSelect: () => void
+): WorkflowMenuItem[] {
+  return workflows.map((wf) => {
+    const WfIcon = ICON_MAP[wf.icon] || Zap
+    return {
+      iconElement: <WfIcon size={12} color={wf.iconColor} />,
+      label: wf.name,
+      onClick: () => {
+        onSelect()
+        executeWorkflow(wf, undefined, { source: 'manual' })
+      }
+    }
+  })
+}

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -5,6 +5,7 @@ import { executeWorkflow } from './workflow-execution'
 import type { WorkflowDefinition } from '../../shared/types'
 
 export interface WorkflowMenuItem {
+  id: string
   iconElement: ReactNode
   label: string
   detail?: string
@@ -20,6 +21,7 @@ export function buildWorkflowMenuItems(
   return workflows.map((wf) => {
     const WfIcon = ICON_MAP[wf.icon] || Zap
     return {
+      id: wf.id,
       iconElement: <WfIcon size={12} color={wf.iconColor} />,
       label: wf.name,
       onClick: () => {

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -7,7 +7,10 @@ import type { WorkflowDefinition } from '../../shared/types'
 export interface WorkflowMenuItem {
   iconElement: ReactNode
   label: string
+  detail?: string
   onClick: () => void
+  separator?: boolean
+  isHeader?: boolean
 }
 
 export function buildWorkflowMenuItems(

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -5,12 +5,14 @@ import '@testing-library/jest-dom/vitest'
 
 // Mock dependencies before imports
 const mockCreateTerminal = vi.fn()
+const mockCreateShellTerminal = vi.fn()
 const mockListBranches = vi.fn()
 const mockListWorktrees = vi.fn()
 
 Object.defineProperty(window, 'api', {
   value: {
     createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+    createShellTerminal: (...args: unknown[]) => mockCreateShellTerminal(...args),
     listBranches: (...args: unknown[]) => mockListBranches(...args),
     listWorktrees: (...args: unknown[]) => mockListWorktrees(...args),
     killTerminal: vi.fn(),
@@ -221,10 +223,11 @@ describe('CardContextMenu', () => {
     )
   })
 
-  it('still renders Expand, Rename, and Close items', () => {
+  it('still renders Expand, Rename, New terminal, and Close items', () => {
     render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
     expect(screen.getByText('Expand')).toBeInTheDocument()
     expect(screen.getByText('Rename')).toBeInTheDocument()
+    expect(screen.getByText('New terminal')).toBeInTheDocument()
     expect(screen.getByText('Close session')).toBeInTheDocument()
   })
 

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -358,4 +358,50 @@ describe('CardContextMenu', () => {
     expect(screen.getByText('Personal WF')).toBeInTheDocument()
     expect(screen.queryByText('Work WF')).not.toBeInTheDocument()
   })
+
+  it('excludes scheduled workflows from "Run workflow" submenu', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-manual',
+          name: 'Manual Deploy',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-scheduled',
+          name: 'Nightly Build',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [
+            {
+              id: 'trigger-1',
+              type: 'trigger',
+              config: { triggerType: 'recurring', cron: '0 0 * * *' },
+              position: { x: 0, y: 0 },
+              label: 'Schedule'
+            }
+          ],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Manual Deploy')).toBeInTheDocument()
+    expect(screen.queryByText('Nightly Build')).not.toBeInTheDocument()
+  })
 })

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -205,6 +205,52 @@ describe('CardContextMenu', () => {
     expect(container.innerHTML).toBe('')
   })
 
+  it('New terminal creates shell in project context', () => {
+    mockCreateShellTerminal.mockResolvedValue({
+      id: 'sh-1',
+      agentType: 'shell',
+      projectName: 'Vorn',
+      projectPath: '/tmp/vorn',
+      status: 'running'
+    })
+    const onClose = vi.fn()
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />)
+    fireEvent.click(screen.getByText('New terminal'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockCreateShellTerminal).toHaveBeenCalledWith('/tmp/vorn')
+  })
+
+  it('shows "New session with…" submenu with installed agents', () => {
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    const trigger = screen.getByText('New session with…')
+    expect(trigger).toBeInTheDocument()
+    fireEvent.mouseEnter(trigger.closest('button')!)
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByText('GitHub Copilot')).toBeInTheDocument()
+  })
+
+  it('"New session with…" submenu creates session with selected agent', () => {
+    mockCreateTerminal.mockResolvedValue({
+      id: 'new-term',
+      session: {
+        id: 'new-term',
+        agentType: 'copilot',
+        projectName: 'Vorn',
+        projectPath: '/tmp/vorn'
+      },
+      status: 'idle',
+      lastOutputTimestamp: Date.now()
+    })
+    const onClose = vi.fn()
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />)
+    fireEvent.mouseEnter(screen.getByText('New session with…').closest('button')!)
+    fireEvent.click(screen.getByText('GitHub Copilot'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockCreateTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ agentType: 'copilot' })
+    )
+  })
+
   it('shows "Run workflow" submenu when workspace has workflows', () => {
     const configWithWorkflows = {
       ...mockConfig,

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -34,6 +34,11 @@ vi.mock('../src/renderer/hooks/useIsMobile', () => ({
   useIsMobile: () => false
 }))
 
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
 import { useAppStore } from '../src/renderer/stores'
 import { CardContextMenu } from '../src/renderer/components/CardContextMenu'
 
@@ -240,5 +245,117 @@ describe('CardContextMenu', () => {
       <CardContextMenu terminalId="nonexistent" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
     )
     expect(container.innerHTML).toBe('')
+  })
+
+  it('shows "Run workflow" submenu when workspace has workflows', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy Staging',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-2',
+          name: 'Run Tests',
+          icon: 'Play',
+          iconColor: '#00ff00',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    expect(screen.getByText('Run workflow')).toBeInTheDocument()
+  })
+
+  it('does not show "Run workflow" when no workflows exist', () => {
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    expect(screen.queryByText('Run workflow')).not.toBeInTheDocument()
+  })
+
+  it('shows workflow names in submenu on hover and executes on click', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy Staging',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    const onClose = vi.fn()
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />)
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Deploy Staging')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Deploy Staging'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1', name: 'Deploy Staging' }),
+      undefined,
+      { source: 'manual' }
+    )
+  })
+
+  it('only shows workflows from the active workspace', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Personal WF',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-2',
+          name: 'Work WF',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'work'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Personal WF')).toBeInTheDocument()
+    expect(screen.queryByText('Work WF')).not.toBeInTheDocument()
   })
 })

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -15,6 +15,13 @@ Object.defineProperty(window, 'api', {
     createShellTerminal: (...args: unknown[]) => mockCreateShellTerminal(...args),
     listBranches: (...args: unknown[]) => mockListBranches(...args),
     listWorktrees: (...args: unknown[]) => mockListWorktrees(...args),
+    detectInstalledAgents: vi.fn().mockResolvedValue({
+      claude: true,
+      copilot: true,
+      codex: false,
+      opencode: false,
+      gemini: false
+    }),
     killTerminal: vi.fn(),
     saveConfig: vi.fn(),
     notifyWidgetStatus: vi.fn(),
@@ -109,61 +116,9 @@ beforeEach(() => {
 })
 
 describe('CardContextMenu', () => {
-  it('renders smart quick-launch with project name', () => {
+  it('renders "New session" quick-launch', () => {
     render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-    expect(screen.getByText('New session in Vorn')).toBeInTheDocument()
-  })
-
-  it('renders worktree-aware quick-launch label when terminal is in a worktree', () => {
-    render(<CardContextMenu terminalId="term-2" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-    expect(screen.getByText('New session in Vorn on feature-auth')).toBeInTheDocument()
-  })
-
-  it('renders worktree submenu item with chevron', () => {
-    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-    expect(screen.getByText('New session in Vorn...')).toBeInTheDocument()
-  })
-
-  it('does not render old "New session in worktree" flat label', () => {
-    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-    expect(screen.queryByText('New session in worktree')).not.toBeInTheDocument()
-    expect(screen.queryByText('New session (same project)')).not.toBeInTheDocument()
-  })
-
-  it('shows submenu with worktrees on hover', () => {
-    const worktrees = [{ path: '/tmp/wt/feat-a', branch: 'feat-a', isMain: false }]
-    const cache = new Map()
-    cache.set('/tmp/vorn', worktrees)
-    useAppStore.setState({ worktreeCache: cache })
-
-    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-
-    const submenuTrigger = screen.getByText('New session in Vorn...')
-    fireEvent.mouseEnter(submenuTrigger.closest('button')!)
-
-    expect(screen.getByText('feat-a')).toBeInTheDocument()
-    expect(screen.getByText('New worktree')).toBeInTheDocument()
-  })
-
-  it('shows session count for worktrees with active sessions', () => {
-    const worktrees = [
-      {
-        path: '/tmp/.vorn-worktrees/vorn/feature-auth',
-        branch: 'feature-auth',
-        isMain: false
-      }
-    ]
-    const cache = new Map()
-    cache.set('/tmp/vorn', worktrees)
-    useAppStore.setState({ worktreeCache: cache })
-
-    render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-
-    const submenuTrigger = screen.getByText('New session in Vorn...')
-    fireEvent.mouseEnter(submenuTrigger.closest('button')!)
-
-    // term-2 has worktreePath matching this worktree
-    expect(screen.getByText('1 session')).toBeInTheDocument()
+    expect(screen.getByText('New session')).toBeInTheDocument()
   })
 
   it('quick-launch creates terminal in same project', async () => {
@@ -182,7 +137,7 @@ describe('CardContextMenu', () => {
     const onClose = vi.fn()
     render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />)
 
-    fireEvent.click(screen.getByText('New session in Vorn'))
+    fireEvent.click(screen.getByText('New session'))
 
     expect(onClose).toHaveBeenCalled()
     expect(mockCreateTerminal).toHaveBeenCalledWith(
@@ -210,7 +165,7 @@ describe('CardContextMenu', () => {
     const onClose = vi.fn()
     render(<CardContextMenu terminalId="term-2" position={{ x: 100, y: 100 }} onClose={onClose} />)
 
-    fireEvent.click(screen.getByText('New session in Vorn on feature-auth'))
+    fireEvent.click(screen.getByText('New session'))
 
     expect(mockCreateTerminal).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -223,7 +178,7 @@ describe('CardContextMenu', () => {
     )
   })
 
-  it('still renders Expand, Rename, New terminal, and Close items', () => {
+  it('renders Expand, Rename, New terminal, and Close items', () => {
     render(<CardContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
     expect(screen.getByText('Expand')).toBeInTheDocument()
     expect(screen.getByText('Rename')).toBeInTheDocument()

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -76,67 +76,11 @@ beforeEach(() => {
 })
 
 describe('GridContextMenu', () => {
-  it('renders New session, New terminal, and scoped submenus', () => {
+  it('renders scoped submenus, New session..., and Run workflow', () => {
     render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
-    expect(screen.getByText('New session')).toBeInTheDocument()
-    expect(screen.getByText('New terminal')).toBeInTheDocument()
     expect(screen.getByText('New session in…')).toBeInTheDocument()
     expect(screen.getByText('New terminal in…')).toBeInTheDocument()
     expect(screen.getByText('New session...')).toBeInTheDocument()
-  })
-
-  it('New session creates agent session in active project', async () => {
-    mockCreateTerminal.mockResolvedValue({
-      id: 'new-term',
-      session: {
-        id: 'new-term',
-        agentType: 'claude',
-        projectName: 'Vorn',
-        projectPath: '/tmp/vorn'
-      },
-      status: 'idle',
-      lastOutputTimestamp: Date.now()
-    })
-
-    const onClose = vi.fn()
-    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={onClose} />)
-    fireEvent.click(screen.getByText('New session'))
-
-    expect(onClose).toHaveBeenCalled()
-    expect(mockCreateTerminal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentType: 'claude',
-        projectName: 'Vorn',
-        projectPath: '/tmp/vorn'
-      })
-    )
-  })
-
-  it('New terminal creates a shell in active project', async () => {
-    const shellSession = {
-      id: 'sh-1',
-      agentType: 'shell' as const,
-      projectName: 'vorn',
-      projectPath: '/tmp/vorn',
-      status: 'running' as const,
-      createdAt: Date.now(),
-      pid: 4321,
-      displayName: 'Shell 1',
-      shellCwd: '/tmp/vorn'
-    }
-    mockCreateShellTerminal.mockResolvedValue(shellSession)
-
-    const addTerminal = vi.fn()
-    const setActiveTabId = vi.fn()
-    useAppStore.setState({ addTerminal, setActiveTabId })
-
-    const onClose = vi.fn()
-    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={onClose} />)
-    fireEvent.click(screen.getByText('New terminal'))
-    await new Promise((r) => setTimeout(r, 0))
-
-    expect(onClose).toHaveBeenCalled()
-    expect(mockCreateShellTerminal).toHaveBeenCalledWith('/tmp/vorn')
   })
 
   it('"New session in…" submenu groups worktrees under project header', () => {

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -282,4 +282,48 @@ describe('GridContextMenu', () => {
     expect(screen.getByText('Personal Deploy')).toBeInTheDocument()
     expect(screen.queryByText('Work Deploy')).not.toBeInTheDocument()
   })
+
+  it('excludes scheduled workflows from "Run workflow" submenu', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-manual',
+          name: 'Manual Deploy',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-scheduled',
+          name: 'Nightly Build',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [
+            {
+              id: 'trigger-1',
+              type: 'trigger',
+              config: { triggerType: 'recurring', cron: '0 0 * * *' },
+              position: { x: 0, y: 0 },
+              label: 'Schedule'
+            }
+          ],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+
+    fireEvent.mouseEnter(screen.getByText('Run workflow').closest('button')!)
+    expect(screen.getByText('Manual Deploy')).toBeInTheDocument()
+    expect(screen.queryByText('Nightly Build')).not.toBeInTheDocument()
+  })
 })

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -28,6 +28,11 @@ vi.mock('../src/renderer/components/Toast', () => ({
   toast: { success: vi.fn(), error: vi.fn() }
 }))
 
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
 import { useAppStore } from '../src/renderer/stores'
 import { GridContextMenu } from '../src/renderer/components/GridContextMenu'
 
@@ -178,5 +183,103 @@ describe('GridContextMenu', () => {
     )
     fireEvent.pointerDown(screen.getByTestId('outside'))
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Run workflow" when workspace has workflows', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    expect(screen.getByText('Run workflow')).toBeInTheDocument()
+  })
+
+  it('does not show "Run workflow" when no workflows exist', () => {
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    expect(screen.queryByText('Run workflow')).not.toBeInTheDocument()
+  })
+
+  it('"Run workflow" submenu shows workflow names and executes on click', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy Staging',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    const onClose = vi.fn()
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={onClose} />)
+
+    fireEvent.mouseEnter(screen.getByText('Run workflow').closest('button')!)
+    expect(screen.getByText('Deploy Staging')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Deploy Staging'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1', name: 'Deploy Staging' }),
+      undefined,
+      { source: 'manual' }
+    )
+  })
+
+  it('only shows workflows from the active workspace in "Run workflow"', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Personal Deploy',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-2',
+          name: 'Work Deploy',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'work'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+
+    fireEvent.mouseEnter(screen.getByText('Run workflow').closest('button')!)
+    expect(screen.getByText('Personal Deploy')).toBeInTheDocument()
+    expect(screen.queryByText('Work Deploy')).not.toBeInTheDocument()
   })
 })

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -101,6 +101,40 @@ describe('GridContextMenu', () => {
     expect(screen.getByText('feat-a')).toBeInTheDocument()
   })
 
+  it('"New session in…" submenu includes "New worktree" option', () => {
+    const cache = new Map()
+    cache.set('/tmp/vorn', [{ path: '/tmp/vorn', branch: 'main', isMain: true, name: 'vorn' }])
+    useAppStore.setState({ worktreeCache: cache })
+
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={vi.fn()} />)
+    fireEvent.mouseEnter(screen.getByText('New session in…').closest('button')!)
+
+    expect(screen.getByText('New worktree')).toBeInTheDocument()
+  })
+
+  it('"New worktree" creates a worktree session on click', async () => {
+    mockListBranches.mockResolvedValue({ current: 'main', branches: [] })
+    mockCreateTerminal.mockResolvedValue({
+      id: 'wt-new',
+      session: { id: 'wt-new', agentType: 'claude', projectName: 'Vorn', projectPath: '/tmp/vorn' },
+      status: 'idle',
+      lastOutputTimestamp: Date.now()
+    })
+
+    const cache = new Map()
+    cache.set('/tmp/vorn', [{ path: '/tmp/vorn', branch: 'main', isMain: true, name: 'vorn' }])
+    useAppStore.setState({ worktreeCache: cache })
+
+    const onClose = vi.fn()
+    render(<GridContextMenu position={{ x: 100, y: 100 }} onClose={onClose} />)
+    fireEvent.mouseEnter(screen.getByText('New session in…').closest('button')!)
+    fireEvent.click(screen.getByText('New worktree'))
+
+    expect(onClose).toHaveBeenCalled()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mockListBranches).toHaveBeenCalledWith('/tmp/vorn')
+  })
+
   it('"New terminal in…" submenu groups worktrees under project header', () => {
     const cache = new Map()
     cache.set('/tmp/vorn', [

--- a/tests/terminal-context-menu.test.tsx
+++ b/tests/terminal-context-menu.test.tsx
@@ -228,4 +228,52 @@ describe('TerminalContextMenu', () => {
     fireEvent.pointerDown(screen.getByTestId('outside'))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('excludes scheduled workflows from "Run workflow" submenu', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-manual',
+          name: 'Manual Deploy',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-scheduled',
+          name: 'Nightly Build',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [
+            {
+              id: 'trigger-1',
+              type: 'trigger',
+              config: { triggerType: 'recurring', cron: '0 0 * * *' },
+              position: { x: 0, y: 0 },
+              label: 'Schedule'
+            }
+          ],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Manual Deploy')).toBeInTheDocument()
+    expect(screen.queryByText('Nightly Build')).not.toBeInTheDocument()
+  })
 })

--- a/tests/terminal-context-menu.test.tsx
+++ b/tests/terminal-context-menu.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockGetTerminalSelection = vi.fn()
+const mockClearTerminalSelection = vi.fn()
+const mockPasteToTerminal = vi.fn()
+const mockFocusTerminal = vi.fn()
+
+vi.mock('../src/renderer/lib/terminal-registry', () => ({
+  getTerminalSelection: (...args: unknown[]) => mockGetTerminalSelection(...args),
+  clearTerminalSelection: (...args: unknown[]) => mockClearTerminalSelection(...args),
+  pasteToTerminal: (...args: unknown[]) => mockPasteToTerminal(...args),
+  focusTerminal: (...args: unknown[]) => mockFocusTerminal(...args)
+}))
+
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { TerminalContextMenu } from '../src/renderer/components/TerminalContextMenu'
+
+const mockConfig = {
+  projects: [],
+  workflows: [],
+  defaults: { defaultAgent: 'claude' as const, rowHeight: 208 },
+  remoteHosts: [],
+  workspaces: []
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetTerminalSelection.mockReturnValue('')
+
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: vi.fn().mockResolvedValue(undefined),
+      readText: vi.fn().mockResolvedValue('')
+    },
+    writable: true,
+    configurable: true
+  })
+
+  useAppStore.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    config: mockConfig as any,
+    activeWorkspace: 'personal'
+  })
+})
+
+describe('TerminalContextMenu', () => {
+  it('renders Copy and Paste buttons', () => {
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+    expect(screen.getByText('Copy')).toBeInTheDocument()
+    expect(screen.getByText('Paste')).toBeInTheDocument()
+  })
+
+  it('Copy is disabled when no selection', () => {
+    mockGetTerminalSelection.mockReturnValue('')
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+    expect(screen.getByText('Copy').closest('button')).toBeDisabled()
+  })
+
+  it('Copy is enabled when there is a selection', () => {
+    mockGetTerminalSelection.mockReturnValue('some text')
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+    expect(screen.getByText('Copy').closest('button')).not.toBeDisabled()
+  })
+
+  it('calls onClose and focusTerminal on Copy click', () => {
+    mockGetTerminalSelection.mockReturnValue('some text')
+    const onClose = vi.fn()
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />
+    )
+    fireEvent.click(screen.getByText('Copy'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockFocusTerminal).toHaveBeenCalledWith('term-1')
+  })
+
+  it('calls onClose and focusTerminal on Paste click', () => {
+    const onClose = vi.fn()
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />
+    )
+    fireEvent.click(screen.getByText('Paste'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockFocusTerminal).toHaveBeenCalledWith('term-1')
+  })
+
+  it('does not show "Run workflow" when no workflows exist', () => {
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+    expect(screen.queryByText('Run workflow')).not.toBeInTheDocument()
+  })
+
+  it('shows "Run workflow" when workspace has workflows', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+    expect(screen.getByText('Run workflow')).toBeInTheDocument()
+  })
+
+  it('shows workflow names in submenu on hover and executes on click', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy Staging',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    const onClose = vi.fn()
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />
+    )
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Deploy Staging')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Deploy Staging'))
+    expect(onClose).toHaveBeenCalled()
+    expect(mockFocusTerminal).toHaveBeenCalledWith('term-1')
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1', name: 'Deploy Staging' }),
+      undefined,
+      { source: 'manual' }
+    )
+  })
+
+  it('only shows workflows from the active workspace', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Personal WF',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        },
+        {
+          id: 'wf-2',
+          name: 'Work WF',
+          icon: 'Zap',
+          iconColor: '#fff',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'work'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any, activeWorkspace: 'personal' })
+
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+
+    const trigger = screen.getByText('Run workflow')
+    fireEvent.mouseEnter(trigger.closest('button')!)
+
+    expect(screen.getByText('Personal WF')).toBeInTheDocument()
+    expect(screen.queryByText('Work WF')).not.toBeInTheDocument()
+  })
+
+  it('closes menu on Escape key', () => {
+    const onClose = vi.fn()
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes menu on click outside', () => {
+    const onClose = vi.fn()
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={onClose} />
+      </div>
+    )
+    fireEvent.pointerDown(screen.getByTestId('outside'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/terminal-context-menu.test.tsx
+++ b/tests/terminal-context-menu.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 const mockGetTerminalSelection = vi.fn()
@@ -166,6 +166,75 @@ describe('TerminalContextMenu', () => {
       undefined,
       { source: 'manual' }
     )
+  })
+
+  it('toggles workflow submenu on click', () => {
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+
+    const trigger = screen.getByText('Run workflow').closest('button')!
+    // Click to open
+    fireEvent.click(trigger)
+    expect(screen.getByText('Deploy')).toBeInTheDocument()
+    // Click again to close
+    fireEvent.click(trigger)
+    expect(screen.queryByText('Deploy')).not.toBeInTheDocument()
+  })
+
+  it('hides workflow submenu on mouse leave after delay', async () => {
+    vi.useFakeTimers()
+    const configWithWorkflows = {
+      ...mockConfig,
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Deploy',
+          icon: 'Rocket',
+          iconColor: '#ff6600',
+          nodes: [],
+          edges: [],
+          enabled: true,
+          workspaceId: 'personal'
+        }
+      ]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useAppStore.setState({ config: configWithWorkflows as any })
+
+    const { unmount } = render(
+      <TerminalContextMenu terminalId="term-1" position={{ x: 100, y: 100 }} onClose={vi.fn()} />
+    )
+
+    const trigger = screen.getByText('Run workflow').closest('button')!
+    fireEvent.mouseEnter(trigger)
+    expect(screen.getByText('Deploy')).toBeInTheDocument()
+
+    fireEvent.mouseLeave(trigger)
+    await act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(screen.queryByText('Deploy')).not.toBeInTheDocument()
+    unmount()
+    vi.useRealTimers()
   })
 
   it('only shows workflows from the active workspace', () => {


### PR DESCRIPTION
## Summary

Add a **Run Workflow** submenu to all context menus (card, canvas, terminal) and improve the overall context menu UX.

### Run Workflow
- Right-click on a session card, empty canvas, or focused terminal to access **Run workflow** → submenu listing manual-trigger workflows
- Scheduled/event-driven workflows are excluded (only manual makes sense here)
- Workflows are filtered by active workspace
- Executes with `source: 'manual'`

### CardContextMenu improvements
- Reordered: Expand + Rename → New session + New terminal + New session with… + Run workflow → Close session
- Added **New session with…** submenu showing installed agents for quick agent switching
- Added **New terminal** option
- Simplified label to just "New session" (creates in same project/worktree)
- Removed worktree submenu (available via canvas right-click)

### GridContextMenu improvements
- Removed redundant "New session" / "New terminal" (the "in…" submenus are better)
- Added **New worktree** option in the session submenu per project
- Added **Run workflow** submenu
- Worktree cache force-refreshes once on menu open for fresh data

### TerminalContextMenu improvements
- Refactored to support hover submenus (was only Copy/Paste)
- Added **Run workflow** submenu below Copy/Paste
- Consistent `py-1.5` padding matching other menus

### Shared infrastructure
- `useWorkspaceWorkflows` hook — workspace-filtered, manual-only workflows
- `buildWorkflowMenuItems` — shared workflow submenu builder
- Neutral gray Zap icon (not amber)

### Tests
- 18 new tests across card, grid, and terminal context menu test files
- Covers visibility, workspace filtering, scheduled exclusion, execution