### PR TITLE
fix: tab mode hint overlap and merge toolbar into tab bar

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -101,6 +101,9 @@ export function App() {
   const isTabToolbarMerged =
     layoutMode === 'tabs' && mainViewMode === 'sessions' && !isMobile && !focusedId && !previewId
 
+  // Hide toolbar when a session is focused/previewed to maximize terminal space
+  const isFocusedFullScreen = !isMobile && (!!focusedId || !!previewId)
+
   // On mobile, auto-close sidebar on initial load
   useEffect(() => {
     if (isMobile && isSidebarOpen) {
@@ -390,7 +393,7 @@ export function App() {
         }
       >
         {/* Top bar — z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
-        {!isInlineWorkflowEditor && !isTabToolbarMerged && (
+        {!isInlineWorkflowEditor && !isTabToolbarMerged && !isFocusedFullScreen && (
           <div
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} h-[52px]`}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,9 +23,11 @@ import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
 import { ToolbarBreadcrumb } from './components/ToolbarBreadcrumb'
 import { SettingsPage } from './components/SettingsPage'
-import { RecentSessionsPopover } from './components/RecentSessionsPopover'
+import { SidebarToggleButton } from './components/SidebarToggleButton'
+import { MainViewPills } from './components/MainViewPills'
+import { RecentSessionsButton } from './components/RecentSessionsButton'
 import { Tooltip } from './components/Tooltip'
-import { RotateCcw, Monitor, ListTodo, Zap, Plus, Menu } from 'lucide-react'
+import { Plus, Menu } from 'lucide-react'
 import { MobileBottomTabs } from './components/MobileBottomTabs'
 import { TaskToolbar } from './components/TaskToolbar'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
@@ -49,10 +51,9 @@ import { ToastContainer } from './components/Toast'
 import { AddTaskDialog } from './components/AddTaskDialog'
 import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
-import { isWeb } from './lib/platform'
+import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
 import { resolveResumeSessionId, buildRestorePayload } from './lib/session-utils'
-const isMac = navigator.platform.toUpperCase().includes('MAC')
 
 export function App() {
   const {
@@ -88,8 +89,6 @@ export function App() {
   )
   const setDialogOpen = useAppStore((s) => s.setNewAgentDialogOpen)
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
-  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
-  const [recentOpen, setRecentOpen] = useState(false)
   const [topPlusMenuPos, setTopPlusMenuPos] = useState<{ x: number; y: number } | null>(null)
   const isMobile = useIsMobile()
   const isInlineWorkflowEditor =
@@ -97,12 +96,11 @@ export function App() {
     !isMobile &&
     (editingWorkflowId !== null || isWorkflowEditorOpen)
 
-  // In tab mode (sessions view, desktop), TabView renders its own toolbar-merged tab bar
   const isTabToolbarMerged =
     layoutMode === 'tabs' && mainViewMode === 'sessions' && !isMobile && !focusedId && !previewId
 
-  // Hide toolbar when a session is focused/previewed to maximize terminal space
-  const isFocusedFullScreen = !isMobile && (!!focusedId || !!previewId)
+  // Only hide toolbar on macOS focused view — Windows/Linux need it for window controls
+  const isFocusedFullScreen = isMac && !isMobile && (!!focusedId || !!previewId)
 
   // On mobile, auto-close sidebar on initial load
   useEffect(() => {
@@ -392,105 +390,38 @@ export function App() {
             : undefined
         }
       >
-        {/* Top bar — z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
+        {/* z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
         {!isInlineWorkflowEditor && !isTabToolbarMerged && !isFocusedFullScreen && (
           <div
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} h-[52px]`}
-            style={!isSidebarOpen && !isWeb && !isMobile ? { paddingLeft: '80px' } : undefined}
+            style={
+              !isSidebarOpen && !isWeb && !isMobile
+                ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
+                : undefined
+            }
           >
             <div className={`flex items-center titlebar-no-drag ${isMobile ? 'gap-2.5' : 'gap-1'}`}>
-              {/* Mobile: always show hamburger. Desktop: show sidebar toggle only when closed */}
-              {(isMobile || !isSidebarOpen) &&
-                (isMobile ? (
-                  <button
-                    onClick={toggleSidebar}
-                    className="text-gray-400 hover:text-white active:text-white p-2 transition-colors rounded-full"
-                    style={{
-                      background: 'var(--glass-bg, transparent)',
-                      backdropFilter: 'var(--glass-blur, none)',
-                      WebkitBackdropFilter: 'var(--glass-blur, none)',
-                      boxShadow: 'var(--glass-shadow, none)'
-                    }}
-                    title="Show sidebar"
-                  >
-                    <Menu size={20} strokeWidth={2} />
-                  </button>
-                ) : (
-                  <Tooltip
-                    label="Toggle sidebar"
-                    shortcut={`${isMac ? '⌘' : 'Ctrl+'}B`}
-                    position="bottom"
-                  >
-                    <button
-                      onClick={toggleSidebar}
-                      className="text-gray-400 hover:text-white active:text-white p-1 transition-colors rounded-md"
-                      title="Show sidebar"
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <rect x="3" y="3" width="18" height="18" rx="2" />
-                        <path d="M9 3v18" />
-                      </svg>
-                    </button>
-                  </Tooltip>
-                ))}
-              {/* Main view toggle: Sessions / Tasks — shown in top bar only when sidebar is closed (otherwise it's in the sidebar header) */}
+              {isMobile && (
+                <button
+                  onClick={toggleSidebar}
+                  className="text-gray-400 hover:text-white active:text-white p-2 transition-colors rounded-full"
+                  style={{
+                    background: 'var(--glass-bg, transparent)',
+                    backdropFilter: 'var(--glass-blur, none)',
+                    WebkitBackdropFilter: 'var(--glass-blur, none)',
+                    boxShadow: 'var(--glass-shadow, none)'
+                  }}
+                  title="Show sidebar"
+                >
+                  <Menu size={20} strokeWidth={2} />
+                </button>
+              )}
               {!isMobile && !isSidebarOpen && (
                 <>
+                  <SidebarToggleButton />
                   <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-                  <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
-                    <Tooltip
-                      label="Sessions"
-                      shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`}
-                      position="bottom"
-                    >
-                      <button
-                        onClick={() => setMainViewMode('sessions')}
-                        className={`px-2.5 py-1 rounded-md transition-colors ${
-                          mainViewMode === 'sessions'
-                            ? 'bg-white/[0.1] text-white'
-                            : 'text-gray-500 hover:text-gray-300'
-                        }`}
-                      >
-                        <Monitor size={14} strokeWidth={2} />
-                      </button>
-                    </Tooltip>
-                    <Tooltip label="Tasks" shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`} position="bottom">
-                      <button
-                        onClick={() => setMainViewMode('tasks')}
-                        className={`px-2.5 py-1 rounded-md transition-colors ${
-                          mainViewMode === 'tasks'
-                            ? 'bg-white/[0.1] text-white'
-                            : 'text-gray-500 hover:text-gray-300'
-                        }`}
-                      >
-                        <ListTodo size={14} strokeWidth={2} />
-                      </button>
-                    </Tooltip>
-                    <Tooltip
-                      label="Workflows"
-                      shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`}
-                      position="bottom"
-                    >
-                      <button
-                        onClick={() => setMainViewMode('workflows')}
-                        className={`px-2.5 py-1 rounded-md transition-colors ${
-                          mainViewMode === 'workflows'
-                            ? 'bg-white/[0.1] text-white'
-                            : 'text-gray-500 hover:text-gray-300'
-                        }`}
-                      >
-                        <Zap size={14} strokeWidth={2} />
-                      </button>
-                    </Tooltip>
-                  </div>
+                  <MainViewPills />
                 </>
               )}
             </div>
@@ -502,24 +433,11 @@ export function App() {
             <div className={`flex items-center titlebar-no-drag ${isMobile ? 'gap-1.5' : 'gap-1'}`}>
               {mainViewMode === 'workflows' && !isMobile ? null : mainViewMode !== 'tasks' ? (
                 <>
-                  {!isMobile && <GridToolbar />}
                   {!isMobile && (
                     <>
+                      <GridToolbar />
                       <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-                      <div className="relative flex items-center">
-                        <Tooltip label="Recent sessions" position="bottom">
-                          <button
-                            onClick={() => setRecentOpen(!recentOpen)}
-                            className="p-1 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-md transition-colors"
-                          >
-                            <RotateCcw size={16} strokeWidth={1.5} />
-                          </button>
-                        </Tooltip>
-                        <RecentSessionsPopover
-                          isOpen={recentOpen}
-                          onClose={() => setRecentOpen(false)}
-                        />
-                      </div>
+                      <RecentSessionsButton />
                     </>
                   )}
                   {isMobile ? (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -48,61 +48,11 @@ import { UpdateBanner } from './components/UpdateBanner'
 import { ToastContainer } from './components/Toast'
 import { AddTaskDialog } from './components/AddTaskDialog'
 import { GridContextMenu } from './components/GridContextMenu'
+import { WindowControls } from './components/WindowControls'
 import { isWeb } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
 import { resolveResumeSessionId, buildRestorePayload } from './lib/session-utils'
 const isMac = navigator.platform.toUpperCase().includes('MAC')
-
-function WindowControls() {
-  if (isMac || isWeb) return null
-  return (
-    <div className="flex items-center titlebar-no-drag ml-2">
-      <button
-        onClick={() => window.api.windowMinimize()}
-        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
-        title="Minimize"
-      >
-        <svg width="10" height="1" viewBox="0 0 10 1" fill="currentColor" className="text-gray-400">
-          <rect width="10" height="1" />
-        </svg>
-      </button>
-      <button
-        onClick={() => window.api.windowMaximize()}
-        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
-        title="Maximize"
-      >
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          className="text-gray-400"
-        >
-          <rect x="0.5" y="0.5" width="9" height="9" />
-        </svg>
-      </button>
-      <button
-        onClick={() => window.api.windowClose()}
-        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-red-500/80 transition-colors group"
-        title="Close"
-      >
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.2"
-          className="text-gray-400 group-hover:text-white"
-        >
-          <path d="M1 1l8 8M9 1l-8 8" />
-        </svg>
-      </button>
-    </div>
-  )
-}
 
 export function App() {
   const {
@@ -146,6 +96,10 @@ export function App() {
     mainViewMode === 'workflows' &&
     !isMobile &&
     (editingWorkflowId !== null || isWorkflowEditorOpen)
+
+  // In tab mode (sessions view, desktop), TabView renders its own toolbar-merged tab bar
+  const isTabToolbarMerged =
+    layoutMode === 'tabs' && mainViewMode === 'sessions' && !isMobile && !focusedId && !previewId
 
   // On mobile, auto-close sidebar on initial load
   useEffect(() => {
@@ -436,7 +390,7 @@ export function App() {
         }
       >
         {/* Top bar — z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
-        {!isInlineWorkflowEditor && (
+        {!isInlineWorkflowEditor && !isTabToolbarMerged && (
           <div
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} h-[52px]`}

--- a/src/renderer/components/MainViewPills.tsx
+++ b/src/renderer/components/MainViewPills.tsx
@@ -1,0 +1,49 @@
+import { Monitor, ListTodo, Zap } from 'lucide-react'
+import { useAppStore } from '../stores'
+import { Tooltip } from './Tooltip'
+import { isMac } from '../lib/platform'
+
+const pillClass = (active: boolean): string =>
+  `px-2.5 py-1 rounded-md transition-colors ${
+    active ? 'bg-white/[0.1] text-white' : 'text-gray-500 hover:text-gray-300'
+  }`
+
+export function MainViewPills() {
+  const mainViewMode = useAppStore((s) => s.config?.defaults?.mainViewMode ?? 'sessions')
+  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
+
+  return (
+    <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
+      <Tooltip label="Sessions" shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`} position="bottom">
+        <button
+          onClick={() => setMainViewMode('sessions')}
+          className={pillClass(mainViewMode === 'sessions')}
+          aria-label="Sessions"
+          aria-pressed={mainViewMode === 'sessions'}
+        >
+          <Monitor size={14} strokeWidth={2} />
+        </button>
+      </Tooltip>
+      <Tooltip label="Tasks" shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`} position="bottom">
+        <button
+          onClick={() => setMainViewMode('tasks')}
+          className={pillClass(mainViewMode === 'tasks')}
+          aria-label="Tasks"
+          aria-pressed={mainViewMode === 'tasks'}
+        >
+          <ListTodo size={14} strokeWidth={2} />
+        </button>
+      </Tooltip>
+      <Tooltip label="Workflows" shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`} position="bottom">
+        <button
+          onClick={() => setMainViewMode('workflows')}
+          className={pillClass(mainViewMode === 'workflows')}
+          aria-label="Workflows"
+          aria-pressed={mainViewMode === 'workflows'}
+        >
+          <Zap size={14} strokeWidth={2} />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/renderer/components/RecentSessionsButton.tsx
+++ b/src/renderer/components/RecentSessionsButton.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { RotateCcw } from 'lucide-react'
+import { Tooltip } from './Tooltip'
+import { RecentSessionsPopover } from './RecentSessionsPopover'
+
+export function RecentSessionsButton() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative flex items-center">
+      <Tooltip label="Recent sessions" position="bottom">
+        <button
+          onClick={() => setOpen(!open)}
+          className="p-1 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-md transition-colors"
+          aria-label="Recent sessions"
+        >
+          <RotateCcw size={16} strokeWidth={1.5} />
+        </button>
+      </Tooltip>
+      <RecentSessionsPopover isOpen={open} onClose={() => setOpen(false)} />
+    </div>
+  )
+}

--- a/src/renderer/components/SidebarToggleButton.tsx
+++ b/src/renderer/components/SidebarToggleButton.tsx
@@ -1,0 +1,29 @@
+import { useAppStore } from '../stores'
+import { Tooltip } from './Tooltip'
+import { isMac } from '../lib/platform'
+
+export function SidebarToggleButton() {
+  const toggleSidebar = useAppStore((s) => s.toggleSidebar)
+  return (
+    <Tooltip label="Toggle sidebar" shortcut={`${isMac ? '⌘' : 'Ctrl+'}B`} position="bottom">
+      <button
+        onClick={toggleSidebar}
+        className="text-gray-400 hover:text-white active:text-white p-1 transition-colors rounded-md"
+        title="Show sidebar"
+        aria-label="Toggle sidebar"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <path d="M9 3v18" />
+        </svg>
+      </button>
+    </Tooltip>
+  )
+}

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -17,10 +17,24 @@ import { buildTooltip } from '../lib/tab-tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
 import { Tooltip } from './Tooltip'
 import { toast } from './Toast'
-import { ChevronDown, FolderOpen, GripVertical, Pencil, Plus, X } from 'lucide-react'
+import {
+  ChevronDown,
+  FolderOpen,
+  GripVertical,
+  Monitor,
+  ListTodo,
+  Pencil,
+  Plus,
+  RotateCcw,
+  X,
+  Zap
+} from 'lucide-react'
 import { GridContextMenu } from './GridContextMenu'
+import { GridToolbar } from './GridToolbar'
+import { RecentSessionsPopover } from './RecentSessionsPopover'
+import { WindowControls } from './WindowControls'
 import { resolveActiveProject, createSessionFromProject } from '../lib/session-utils'
-import { MOD } from '../lib/platform'
+import { MOD, isMac, isWeb } from '../lib/platform'
 
 const DRAG_THRESHOLD = 5
 
@@ -116,6 +130,10 @@ export function TabView() {
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
   const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
   const tasks = useAppStore((s) => s.config?.tasks)
+  const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
+  const toggleSidebar = useAppStore((s) => s.toggleSidebar)
+  const mainViewMode = useAppStore((s) => s.config?.defaults?.mainViewMode ?? 'sessions')
+  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
   const filteredHeadless = useFilteredHeadless()
   const waitingApprovals = useWaitingApprovals()
 
@@ -127,10 +145,12 @@ export function TabView() {
   const [dragState, setDragState] = useState<DragState | null>(null)
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null)
   const [plusDropdownPos, setPlusDropdownPos] = useState<{ top: number; left: number } | null>(null)
+  const [recentOpen, setRecentOpen] = useState(false)
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   const isFiltered = statusFilter !== 'all'
   const isManualSort = sortMode === 'manual'
+  const needsTrafficLightPad = !isSidebarOpen && !isWeb
 
   // Auto-select first tab if activeTabId is null or not in orderedIds
   useEffect(() => {
@@ -226,43 +246,353 @@ export function TabView() {
     setDropTargetIndex(null)
   }, [])
 
-  /* ── Empty state ───────────────────────────────────────────── */
-
-  if (orderedIds.length === 0 && minimizedIds.length === 0) {
-    return (
-      <div className="h-full overflow-auto p-4">
-        {isFiltered ? (
-          <div className="flex flex-col items-center justify-center h-full">
-            <svg
-              width="64"
-              height="64"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1"
-              className="text-white/20 mb-6"
-            >
-              <rect x="2" y="3" width="20" height="14" rx="2" />
-              <path d="M8 21h8M12 17v4" />
-              <path d="M7 8l3 3-3 3M12 14h4" />
-            </svg>
-            <p className="text-2xl font-semibold text-white mb-2">No matching agents</p>
-            <p className="text-sm text-gray-500 mb-6">Try changing the status filter</p>
-          </div>
-        ) : (
-          <PromptLauncher mode="inline" />
-        )}
-      </div>
-    )
-  }
+  /* ── Render ─────────────────────────────────────────────────── */
 
   const hasBackground =
     minimizedIds.length > 0 || filteredHeadless.length > 0 || waitingApprovals.length > 0
+  const hasTabs = orderedIds.length > 0
+  const activeTerminal = activeTabId ? terminals.get(activeTabId) : null
 
-  if (orderedIds.length === 0 && hasBackground) {
-    return (
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="p-4">
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Background tray: headless + minimized (above tab bar when tabs exist) */}
+      {hasTabs && (
+        <BackgroundTray
+          headlessSessions={filteredHeadless}
+          minimizedIds={minimizedIds}
+          waitingApprovals={waitingApprovals}
+          variant="tabs"
+        />
+      )}
+
+      {/* Toolbar-merged tab bar — always rendered */}
+      <div
+        className="titlebar-drag shrink-0 flex items-center border-b border-white/[0.06] bg-[#1a1a1e] relative z-[46]"
+        style={{ minHeight: 40, paddingLeft: needsTrafficLightPad ? '80px' : undefined }}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+      >
+        {/* Left: sidebar toggle + view mode toggles (when sidebar closed) */}
+        {!isSidebarOpen && (
+          <div className="shrink-0 flex items-center gap-1 pl-2 titlebar-no-drag">
+            <Tooltip
+              label="Toggle sidebar"
+              shortcut={`${isMac ? '⌘' : 'Ctrl+'}B`}
+              position="bottom"
+            >
+              <button
+                onClick={toggleSidebar}
+                className="text-gray-400 hover:text-white active:text-white p-1 transition-colors rounded-md"
+                title="Show sidebar"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <path d="M9 3v18" />
+                </svg>
+              </button>
+            </Tooltip>
+
+            <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
+            <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
+              <Tooltip label="Sessions" shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`} position="bottom">
+                <button
+                  onClick={() => setMainViewMode('sessions')}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${
+                    mainViewMode === 'sessions'
+                      ? 'bg-white/[0.1] text-white'
+                      : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                >
+                  <Monitor size={14} strokeWidth={2} />
+                </button>
+              </Tooltip>
+              <Tooltip label="Tasks" shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`} position="bottom">
+                <button
+                  onClick={() => setMainViewMode('tasks')}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${
+                    mainViewMode === 'tasks'
+                      ? 'bg-white/[0.1] text-white'
+                      : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                >
+                  <ListTodo size={14} strokeWidth={2} />
+                </button>
+              </Tooltip>
+              <Tooltip
+                label="Workflows"
+                shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`}
+                position="bottom"
+              >
+                <button
+                  onClick={() => setMainViewMode('workflows')}
+                  className={`px-2.5 py-1 rounded-md transition-colors ${
+                    mainViewMode === 'workflows'
+                      ? 'bg-white/[0.1] text-white'
+                      : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                >
+                  <Zap size={14} strokeWidth={2} />
+                </button>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+
+        {/* Middle: scrollable tabs */}
+        <div
+          className="flex-1 flex items-end gap-1 px-1 overflow-x-auto min-w-0 titlebar-no-drag"
+          style={{ minHeight: 40 }}
+        >
+          {orderedIds.map((id, index) => {
+            const terminal = terminals.get(id)
+            if (!terminal) return null
+            const isActive = id === activeTabId
+            const isRenaming = renamingTerminalId === id
+            const isDragTarget = dragState?.isDragging === true && dropTargetIndex === index
+            const isDragging = dragState?.isDragging === true && dragState.draggingId === id
+
+            const assignedTask = tasks?.find(
+              (t) => t.assignedSessionId === id && t.status === 'in_progress'
+            )
+            const displayName = terminal.session.displayName?.trim()
+              ? getDisplayName(terminal.session)
+              : assignedTask
+                ? assignedTask.title
+                : getDisplayName(terminal.session)
+
+            const tooltipTaskTitle =
+              displayName === assignedTask?.title ? undefined : assignedTask?.title
+            const isShell = terminal.session.agentType === 'shell'
+            const tooltip = buildTooltip(
+              displayName,
+              terminal.status,
+              isShell ? undefined : getBranchLabel(terminal.session),
+              isShell ? undefined : terminal.session.isWorktree,
+              isShell ? undefined : tooltipTaskTitle,
+              isShell ? terminal.session.shellCwd : undefined,
+              isShell ? terminal.session.shellExitCode : undefined
+            )
+
+            return (
+              <div
+                key={id}
+                role="tab"
+                tabIndex={0}
+                ref={(el) => {
+                  if (el) tabRefs.current.set(id, el)
+                  else tabRefs.current.delete(id)
+                }}
+                onClick={() => handleSelectTab(id)}
+                onContextMenu={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
+                }}
+                className={`group relative flex items-center gap-2 pl-3 pr-10 h-[36px] text-[13px] cursor-pointer
+                           transition-colors flex-1 min-w-[120px] max-w-[260px] select-none border-b
+                           ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
+                           ${isDragging ? 'opacity-50' : ''}
+                           ${
+                             isActive
+                               ? 'text-white border-white'
+                               : 'text-gray-500 hover:text-gray-300 border-transparent'
+                           }`}
+              >
+                {/* Drag handle — left edge, only in manual sort */}
+                {isManualSort && (
+                  <span
+                    className={`absolute left-0 top-0 bottom-0 w-[14px] flex items-center justify-center
+                               opacity-0 group-hover:opacity-100 transition-opacity z-10
+                               ${isDragging ? 'cursor-grabbing opacity-100' : 'cursor-grab'}`}
+                    onPointerDown={(e) => {
+                      e.stopPropagation()
+                      handleDragStart(id, e)
+                    }}
+                  >
+                    <GripVertical size={8} className="text-gray-600" strokeWidth={2} />
+                  </span>
+                )}
+
+                <AgentStatusIcon
+                  agentType={terminal.session.agentType}
+                  status={terminal.status}
+                  size={16}
+                />
+
+                {isRenaming ? (
+                  <InlineRename
+                    value={getDisplayName(terminal.session)}
+                    onCommit={(name) => {
+                      renameTerminal(id, name)
+                      setRenamingTerminalId(null)
+                      toast.success(`Renamed to "${name}"`)
+                    }}
+                    onCancel={() => setRenamingTerminalId(null)}
+                    className="text-xs w-[100px]"
+                  />
+                ) : (
+                  <span className="truncate flex-1 min-w-0" title={tooltip}>
+                    {displayName}
+                  </span>
+                )}
+
+                <span className="absolute right-2 top-0 bottom-0 flex items-center gap-1 group-hover:bg-[#1a1a1e] group-hover:rounded-l-sm">
+                  {index < 9 && !isRenaming && (
+                    <span
+                      className="absolute right-0 top-1/2 -translate-y-1/2
+                                   opacity-100 group-hover:opacity-0 transition-opacity
+                                   px-1 py-0.5 text-[9px] font-mono text-gray-500
+                                   bg-white/[0.06] border border-white/[0.1] rounded leading-none
+                                   pointer-events-none"
+                    >
+                      {MOD}
+                      {index + 1}
+                    </span>
+                  )}
+                  {!isRenaming && (
+                    <>
+                      <TabIconButton
+                        label="Browse files"
+                        icon={<FolderOpen size={13} />}
+                        onClick={() => setDiffSidebar(id, 'all-files')}
+                      />
+                      <TabIconButton
+                        label="Rename session"
+                        icon={<Pencil size={13} />}
+                        onClick={() => setRenamingTerminalId(id)}
+                      />
+                    </>
+                  )}
+                  <ConfirmPopover
+                    message="Close this session?"
+                    confirmLabel="Close"
+                    onConfirm={() => handleCloseTab(id)}
+                  >
+                    <TabIconButton
+                      label="Close session"
+                      icon={<X size={13} strokeWidth={2} />}
+                      hoverClass="hover:text-gray-200 hover:bg-white/[0.1]"
+                    />
+                  </ConfirmPopover>
+                </span>
+              </div>
+            )
+          })}
+
+          <div className="shrink-0 flex items-center">
+            <button
+              onClick={() => {
+                const project = resolveActiveProject()
+                if (!project) {
+                  useAppStore.getState().setNewAgentDialogOpen(true)
+                  return
+                }
+                const activeWorktreePath = useAppStore.getState().activeWorktreePath
+                const activeWt = activeWorktreePath
+                  ? useAppStore
+                      .getState()
+                      .worktreeCache.get(project.path)
+                      ?.find((wt) => wt.path === activeWorktreePath)
+                  : undefined
+                void createSessionFromProject(
+                  project,
+                  activeWorktreePath
+                    ? { branch: activeWt?.branch, existingWorktreePath: activeWorktreePath }
+                    : {}
+                )
+              }}
+              className="h-[36px] w-[28px] flex items-center justify-center rounded-md
+                         text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
+              title="New session"
+              aria-label="New session"
+            >
+              <Plus size={14} strokeWidth={1.5} />
+            </button>
+            <button
+              onClick={(e) => {
+                if (plusDropdownPos) {
+                  setPlusDropdownPos(null)
+                  return
+                }
+                const rect = e.currentTarget.getBoundingClientRect()
+                const menuWidth = 220
+                setPlusDropdownPos({
+                  left: Math.max(
+                    8,
+                    Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8)
+                  ),
+                  top: rect.bottom + 4
+                })
+              }}
+              className="h-[36px] w-[22px] flex items-center justify-center rounded-md
+                         text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
+              title="More session options"
+              aria-label="More session options"
+            >
+              <ChevronDown size={12} strokeWidth={1.5} />
+            </button>
+          </div>
+
+          {plusDropdownPos && (
+            <PlusDropdown position={plusDropdownPos} onClose={() => setPlusDropdownPos(null)} />
+          )}
+        </div>
+
+        {/* Right: toolbar controls */}
+        <div className="shrink-0 flex items-center gap-1 px-2 titlebar-no-drag">
+          <GridToolbar />
+          <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
+          <div className="relative flex items-center">
+            <Tooltip label="Recent sessions" position="bottom">
+              <button
+                onClick={() => setRecentOpen(!recentOpen)}
+                className="p-1 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-md transition-colors"
+              >
+                <RotateCcw size={16} strokeWidth={1.5} />
+              </button>
+            </Tooltip>
+            <RecentSessionsPopover isOpen={recentOpen} onClose={() => setRecentOpen(false)} />
+          </div>
+          <WindowControls />
+        </div>
+      </div>
+
+      {/* Content area */}
+      {!hasTabs && !hasBackground ? (
+        <div className="flex-1 overflow-auto p-4">
+          {isFiltered ? (
+            <div className="flex flex-col items-center justify-center h-full">
+              <svg
+                width="64"
+                height="64"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1"
+                className="text-white/20 mb-6"
+              >
+                <rect x="2" y="3" width="20" height="14" rx="2" />
+                <path d="M8 21h8M12 17v4" />
+                <path d="M7 8l3 3-3 3M12 14h4" />
+              </svg>
+              <p className="text-2xl font-semibold text-white mb-2">No matching agents</p>
+              <p className="text-sm text-gray-500 mb-6">Try changing the status filter</p>
+            </div>
+          ) : (
+            <PromptLauncher mode="inline" />
+          )}
+        </div>
+      ) : !hasTabs && hasBackground ? (
+        <div className="flex-1 overflow-auto p-4">
           <BackgroundTray
             headlessSessions={filteredHeadless}
             minimizedIds={minimizedIds}
@@ -270,256 +600,38 @@ export function TabView() {
             variant="grid"
           />
         </div>
-      </div>
-    )
-  }
-
-  const activeTerminal = activeTabId ? terminals.get(activeTabId) : null
-
-  return (
-    <div className="flex flex-col h-full overflow-hidden">
-      {/* Background tray: headless + minimized */}
-      <BackgroundTray
-        headlessSessions={filteredHeadless}
-        minimizedIds={minimizedIds}
-        waitingApprovals={waitingApprovals}
-        variant="tabs"
-      />
-
-      {/* Tab bar */}
-      <div
-        className="shrink-0 flex items-end gap-1 px-2 border-b border-white/[0.06] overflow-x-auto"
-        style={{ minHeight: 40 }}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerUp}
-        onPointerCancel={handlePointerCancel}
-      >
-        {orderedIds.map((id, index) => {
-          const terminal = terminals.get(id)
-          if (!terminal) return null
-          const isActive = id === activeTabId
-          const isRenaming = renamingTerminalId === id
-          const isDragTarget = dragState?.isDragging === true && dropTargetIndex === index
-          const isDragging = dragState?.isDragging === true && dragState.draggingId === id
-
-          const assignedTask = tasks?.find(
-            (t) => t.assignedSessionId === id && t.status === 'in_progress'
-          )
-          const displayName = terminal.session.displayName?.trim()
-            ? getDisplayName(terminal.session)
-            : assignedTask
-              ? assignedTask.title
-              : getDisplayName(terminal.session)
-
-          const tooltipTaskTitle =
-            displayName === assignedTask?.title ? undefined : assignedTask?.title
-          const isShell = terminal.session.agentType === 'shell'
-          const tooltip = buildTooltip(
-            displayName,
-            terminal.status,
-            isShell ? undefined : getBranchLabel(terminal.session),
-            isShell ? undefined : terminal.session.isWorktree,
-            isShell ? undefined : tooltipTaskTitle,
-            isShell ? terminal.session.shellCwd : undefined,
-            isShell ? terminal.session.shellExitCode : undefined
-          )
-
-          return (
+      ) : (
+        <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
+          {activeTabId && activeTerminal && (
+            <TerminalSlot
+              key={activeTabId}
+              terminalId={activeTabId}
+              isFocused={true}
+              className="w-full h-full"
+            />
+          )}
+          {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
             <div
-              key={id}
-              role="tab"
-              tabIndex={0}
-              ref={(el) => {
-                if (el) tabRefs.current.set(id, el)
-                else tabRefs.current.delete(id)
-              }}
-              onClick={() => handleSelectTab(id)}
-              onContextMenu={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
-              }}
-              className={`group relative flex items-center gap-2 pl-3 pr-2 h-[36px] text-[13px] cursor-pointer
-                         transition-colors flex-1 min-w-[120px] max-w-[260px] select-none border-b
-                         ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
-                         ${isDragging ? 'opacity-50' : ''}
-                         ${
-                           isActive
-                             ? 'text-white border-white'
-                             : 'text-gray-500 hover:text-gray-300 border-transparent'
-                         }`}
+              className="absolute inset-0 p-3 space-y-2 pointer-events-none"
+              style={{ background: '#141416' }}
             >
-              {/* Drag handle — left edge, only in manual sort */}
-              {isManualSort && (
-                <span
-                  className={`absolute left-0 top-0 bottom-0 w-[14px] flex items-center justify-center
-                             opacity-0 group-hover:opacity-100 transition-opacity z-10
-                             ${isDragging ? 'cursor-grabbing opacity-100' : 'cursor-grab'}`}
-                  onPointerDown={(e) => {
-                    e.stopPropagation()
-                    handleDragStart(id, e)
-                  }}
-                >
-                  <GripVertical size={8} className="text-gray-600" strokeWidth={2} />
-                </span>
-              )}
-
-              <AgentStatusIcon
-                agentType={terminal.session.agentType}
-                status={terminal.status}
-                size={16}
+              <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
+              <div
+                className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
+                style={{ animationDelay: '0.15s' }}
               />
-
-              {isRenaming ? (
-                <InlineRename
-                  value={getDisplayName(terminal.session)}
-                  onCommit={(name) => {
-                    renameTerminal(id, name)
-                    setRenamingTerminalId(null)
-                    toast.success(`Renamed to "${name}"`)
-                  }}
-                  onCancel={() => setRenamingTerminalId(null)}
-                  className="text-xs w-[100px]"
-                />
-              ) : (
-                <span className="truncate flex-1 min-w-0" title={tooltip}>
-                  {displayName}
-                </span>
-              )}
-
-              <span className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
-                {index < 9 && !isRenaming && (
-                  <span
-                    className="absolute right-0 top-1/2 -translate-y-1/2
-                                 opacity-100 group-hover:opacity-0 transition-opacity
-                                 px-1 py-0.5 text-[9px] font-mono text-gray-500
-                                 bg-white/[0.06] border border-white/[0.1] rounded leading-none
-                                 pointer-events-none"
-                  >
-                    {MOD}
-                    {index + 1}
-                  </span>
-                )}
-                {!isRenaming && (
-                  <>
-                    <TabIconButton
-                      label="Browse files"
-                      icon={<FolderOpen size={13} />}
-                      onClick={() => setDiffSidebar(id, 'all-files')}
-                    />
-                    <TabIconButton
-                      label="Rename session"
-                      icon={<Pencil size={13} />}
-                      onClick={() => setRenamingTerminalId(id)}
-                    />
-                  </>
-                )}
-                <ConfirmPopover
-                  message="Close this session?"
-                  confirmLabel="Close"
-                  onConfirm={() => handleCloseTab(id)}
-                >
-                  <TabIconButton
-                    label="Close session"
-                    icon={<X size={13} strokeWidth={2} />}
-                    hoverClass="hover:text-gray-200 hover:bg-white/[0.1]"
-                  />
-                </ConfirmPopover>
-              </span>
+              <div
+                className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
+                style={{ animationDelay: '0.3s' }}
+              />
+              <div
+                className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
+                style={{ animationDelay: '0.45s' }}
+              />
             </div>
-          )
-        })}
-
-        <div className="shrink-0 flex items-center">
-          <button
-            onClick={() => {
-              const project = resolveActiveProject()
-              if (!project) {
-                useAppStore.getState().setNewAgentDialogOpen(true)
-                return
-              }
-              const activeWorktreePath = useAppStore.getState().activeWorktreePath
-              const activeWt = activeWorktreePath
-                ? useAppStore
-                    .getState()
-                    .worktreeCache.get(project.path)
-                    ?.find((wt) => wt.path === activeWorktreePath)
-                : undefined
-              void createSessionFromProject(
-                project,
-                activeWorktreePath
-                  ? { branch: activeWt?.branch, existingWorktreePath: activeWorktreePath }
-                  : {}
-              )
-            }}
-            className="h-[36px] w-[28px] flex items-center justify-center rounded-md
-                       text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
-            title="New session"
-            aria-label="New session"
-          >
-            <Plus size={14} strokeWidth={1.5} />
-          </button>
-          <button
-            onClick={(e) => {
-              if (plusDropdownPos) {
-                setPlusDropdownPos(null)
-                return
-              }
-              const rect = e.currentTarget.getBoundingClientRect()
-              const menuWidth = 220
-              setPlusDropdownPos({
-                left: Math.max(
-                  8,
-                  Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - 8)
-                ),
-                top: rect.bottom + 4
-              })
-            }}
-            className="h-[36px] w-[22px] flex items-center justify-center rounded-md
-                       text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
-            title="More session options"
-            aria-label="More session options"
-          >
-            <ChevronDown size={12} strokeWidth={1.5} />
-          </button>
+          )}
         </div>
-
-        {plusDropdownPos && (
-          <PlusDropdown position={plusDropdownPos} onClose={() => setPlusDropdownPos(null)} />
-        )}
-      </div>
-
-      <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
-        {activeTabId && activeTerminal && (
-          <TerminalSlot
-            key={activeTabId}
-            terminalId={activeTabId}
-            isFocused={true}
-            className="w-full h-full"
-          />
-        )}
-        {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
-          <div
-            className="absolute inset-0 p-3 space-y-2 pointer-events-none"
-            style={{ background: '#141416' }}
-          >
-            <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
-            <div
-              className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
-              style={{ animationDelay: '0.15s' }}
-            />
-            <div
-              className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
-              style={{ animationDelay: '0.3s' }}
-            />
-            <div
-              className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
-              style={{ animationDelay: '0.45s' }}
-            />
-          </div>
-        )}
-      </div>
+      )}
 
       {contextMenu && (
         <CardContextMenu

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -85,8 +85,10 @@ export function TabIconButton({
   hoverClass?: string
 }) {
   const handleClick = (e: React.MouseEvent): void => {
-    e.stopPropagation()
-    onClick?.()
+    if (onClick) {
+      e.stopPropagation()
+      onClick()
+    }
   }
   return (
     <Tooltip label={label} position="bottom">

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
@@ -17,24 +17,15 @@ import { buildTooltip } from '../lib/tab-tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
 import { Tooltip } from './Tooltip'
 import { toast } from './Toast'
-import {
-  ChevronDown,
-  FolderOpen,
-  GripVertical,
-  Monitor,
-  ListTodo,
-  Pencil,
-  Plus,
-  RotateCcw,
-  X,
-  Zap
-} from 'lucide-react'
+import { ChevronDown, FolderOpen, GripVertical, Pencil, Plus, X } from 'lucide-react'
 import { GridContextMenu } from './GridContextMenu'
 import { GridToolbar } from './GridToolbar'
-import { RecentSessionsPopover } from './RecentSessionsPopover'
 import { WindowControls } from './WindowControls'
+import { SidebarToggleButton } from './SidebarToggleButton'
+import { MainViewPills } from './MainViewPills'
+import { RecentSessionsButton } from './RecentSessionsButton'
 import { resolveActiveProject, createSessionFromProject } from '../lib/session-utils'
-import { MOD, isMac, isWeb } from '../lib/platform'
+import { MOD, isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from '../lib/platform'
 
 const DRAG_THRESHOLD = 5
 
@@ -133,9 +124,6 @@ export function TabView() {
   const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
   const tasks = useAppStore((s) => s.config?.tasks)
   const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
-  const toggleSidebar = useAppStore((s) => s.toggleSidebar)
-  const mainViewMode = useAppStore((s) => s.config?.defaults?.mainViewMode ?? 'sessions')
-  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
   const filteredHeadless = useFilteredHeadless()
   const waitingApprovals = useWaitingApprovals()
 
@@ -147,14 +135,21 @@ export function TabView() {
   const [dragState, setDragState] = useState<DragState | null>(null)
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null)
   const [plusDropdownPos, setPlusDropdownPos] = useState<{ top: number; left: number } | null>(null)
-  const [recentOpen, setRecentOpen] = useState(false)
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   const isFiltered = statusFilter !== 'all'
   const isManualSort = sortMode === 'manual'
-  const needsTrafficLightPad = !isSidebarOpen && !isWeb
+  const needsTrafficLightPad = isMac && !isSidebarOpen && !isWeb
 
-  // Auto-select first tab if activeTabId is null or not in orderedIds
+  const assignedTaskBySessionId = useMemo(() => {
+    type Task = NonNullable<typeof tasks>[number]
+    const map = new Map<string, Task>()
+    for (const t of tasks ?? []) {
+      if (t.status === 'in_progress' && t.assignedSessionId) map.set(t.assignedSessionId, t)
+    }
+    return map
+  }, [tasks])
+
   useEffect(() => {
     if (orderedIds.length === 0) {
       if (activeTabId !== null) setActiveTabId(null)
@@ -257,7 +252,6 @@ export function TabView() {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Background tray: headless + minimized (above tab bar when tabs exist) */}
       {hasTabs && (
         <BackgroundTray
           headlessSessions={filteredHeadless}
@@ -267,89 +261,25 @@ export function TabView() {
         />
       )}
 
-      {/* Toolbar-merged tab bar — always rendered */}
       <div
         className="titlebar-drag shrink-0 flex items-center border-b border-white/[0.06] bg-[#1a1a1e] relative z-[46]"
-        style={{ minHeight: 40, paddingLeft: needsTrafficLightPad ? '80px' : undefined }}
+        style={{
+          minHeight: 40,
+          paddingLeft: needsTrafficLightPad ? `${TRAFFIC_LIGHT_PAD_PX}px` : undefined
+        }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerUp}
         onPointerCancel={handlePointerCancel}
       >
-        {/* Left: sidebar toggle + view mode toggles (when sidebar closed) */}
         {!isSidebarOpen && (
           <div className="shrink-0 flex items-center gap-1 pl-2 titlebar-no-drag">
-            <Tooltip
-              label="Toggle sidebar"
-              shortcut={`${isMac ? '⌘' : 'Ctrl+'}B`}
-              position="bottom"
-            >
-              <button
-                onClick={toggleSidebar}
-                className="text-gray-400 hover:text-white active:text-white p-1 transition-colors rounded-md"
-                title="Show sidebar"
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                >
-                  <rect x="3" y="3" width="18" height="18" rx="2" />
-                  <path d="M9 3v18" />
-                </svg>
-              </button>
-            </Tooltip>
-
+            <SidebarToggleButton />
             <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-            <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
-              <Tooltip label="Sessions" shortcut={`${isMac ? '⌘' : 'Ctrl+'}S`} position="bottom">
-                <button
-                  onClick={() => setMainViewMode('sessions')}
-                  className={`px-2.5 py-1 rounded-md transition-colors ${
-                    mainViewMode === 'sessions'
-                      ? 'bg-white/[0.1] text-white'
-                      : 'text-gray-500 hover:text-gray-300'
-                  }`}
-                >
-                  <Monitor size={14} strokeWidth={2} />
-                </button>
-              </Tooltip>
-              <Tooltip label="Tasks" shortcut={`${isMac ? '⌘' : 'Ctrl+'}T`} position="bottom">
-                <button
-                  onClick={() => setMainViewMode('tasks')}
-                  className={`px-2.5 py-1 rounded-md transition-colors ${
-                    mainViewMode === 'tasks'
-                      ? 'bg-white/[0.1] text-white'
-                      : 'text-gray-500 hover:text-gray-300'
-                  }`}
-                >
-                  <ListTodo size={14} strokeWidth={2} />
-                </button>
-              </Tooltip>
-              <Tooltip
-                label="Workflows"
-                shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`}
-                position="bottom"
-              >
-                <button
-                  onClick={() => setMainViewMode('workflows')}
-                  className={`px-2.5 py-1 rounded-md transition-colors ${
-                    mainViewMode === 'workflows'
-                      ? 'bg-white/[0.1] text-white'
-                      : 'text-gray-500 hover:text-gray-300'
-                  }`}
-                >
-                  <Zap size={14} strokeWidth={2} />
-                </button>
-              </Tooltip>
-            </div>
+            <MainViewPills />
           </div>
         )}
 
-        {/* Middle: scrollable tabs */}
         <div
           className="flex-1 flex items-end gap-1 px-1 overflow-x-auto min-w-0 titlebar-no-drag"
           style={{ minHeight: 40 }}
@@ -362,9 +292,7 @@ export function TabView() {
             const isDragTarget = dragState?.isDragging === true && dropTargetIndex === index
             const isDragging = dragState?.isDragging === true && dragState.draggingId === id
 
-            const assignedTask = tasks?.find(
-              (t) => t.assignedSessionId === id && t.status === 'in_progress'
-            )
+            const assignedTask = assignedTaskBySessionId.get(id)
             const displayName = terminal.session.displayName?.trim()
               ? getDisplayName(terminal.session)
               : assignedTask
@@ -549,21 +477,10 @@ export function TabView() {
           )}
         </div>
 
-        {/* Right: toolbar controls */}
         <div className="shrink-0 flex items-center gap-1 px-2 titlebar-no-drag">
           <GridToolbar />
           <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-          <div className="relative flex items-center">
-            <Tooltip label="Recent sessions" position="bottom">
-              <button
-                onClick={() => setRecentOpen(!recentOpen)}
-                className="p-1 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-md transition-colors"
-              >
-                <RotateCcw size={16} strokeWidth={1.5} />
-              </button>
-            </Tooltip>
-            <RecentSessionsPopover isOpen={recentOpen} onClose={() => setRecentOpen(false)} />
-          </div>
+          <RecentSessionsButton />
           <WindowControls />
         </div>
       </div>

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -8,6 +8,7 @@ export function WindowControls() {
         onClick={() => window.api.windowMinimize()}
         className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
         title="Minimize"
+        aria-label="Minimize"
       >
         <svg width="10" height="1" viewBox="0 0 10 1" fill="currentColor" className="text-gray-400">
           <rect width="10" height="1" />
@@ -17,6 +18,7 @@ export function WindowControls() {
         onClick={() => window.api.windowMaximize()}
         className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
         title="Maximize"
+        aria-label="Maximize"
       >
         <svg
           width="10"
@@ -34,6 +36,7 @@ export function WindowControls() {
         onClick={() => window.api.windowClose()}
         className="w-[46px] h-[32px] flex items-center justify-center hover:bg-red-500/80 transition-colors group"
         title="Close"
+        aria-label="Close"
       >
         <svg
           width="10"

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,0 +1,52 @@
+import { isMac, isWeb } from '../lib/platform'
+
+export function WindowControls() {
+  if (isMac || isWeb) return null
+  return (
+    <div className="flex items-center titlebar-no-drag ml-2">
+      <button
+        onClick={() => window.api.windowMinimize()}
+        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
+        title="Minimize"
+      >
+        <svg width="10" height="1" viewBox="0 0 10 1" fill="currentColor" className="text-gray-400">
+          <rect width="10" height="1" />
+        </svg>
+      </button>
+      <button
+        onClick={() => window.api.windowMaximize()}
+        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
+        title="Maximize"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          className="text-gray-400"
+        >
+          <rect x="0.5" y="0.5" width="9" height="9" />
+        </svg>
+      </button>
+      <button
+        onClick={() => window.api.windowClose()}
+        className="w-[46px] h-[32px] flex items-center justify-center hover:bg-red-500/80 transition-colors group"
+        title="Close"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          className="text-gray-400 group-hover:text-white"
+        >
+          <path d="M1 1l8 8M9 1l-8 8" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -15,3 +15,5 @@ export const isMac =
   typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC')
 
 export const MOD = isMac ? '⌘' : 'Ctrl+'
+
+export const TRAFFIC_LIGHT_PAD_PX = 80

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -29,6 +29,21 @@ vi.mock('../src/renderer/components/GitChangesIndicator', () => ({
 vi.mock('../src/renderer/components/GridContextMenu', () => ({
   GridContextMenu: () => null
 }))
+vi.mock('../src/renderer/components/GridToolbar', () => ({
+  GridToolbar: () => <div data-testid="grid-toolbar" />
+}))
+vi.mock('../src/renderer/components/WindowControls', () => ({
+  WindowControls: () => <div data-testid="window-controls" />
+}))
+vi.mock('../src/renderer/components/SidebarToggleButton', () => ({
+  SidebarToggleButton: () => <button data-testid="sidebar-toggle">sidebar</button>
+}))
+vi.mock('../src/renderer/components/MainViewPills', () => ({
+  MainViewPills: () => <div data-testid="main-view-pills" />
+}))
+vi.mock('../src/renderer/components/RecentSessionsButton', () => ({
+  RecentSessionsButton: () => <button data-testid="recent-sessions">recent</button>
+}))
 let mockIsMobile = false
 vi.mock('../src/renderer/hooks/useIsMobile', () => ({
   useIsMobile: () => mockIsMobile
@@ -39,11 +54,14 @@ vi.mock('../src/renderer/hooks/useTerminalScrollButton', () => ({
 vi.mock('../src/renderer/hooks/useTerminalPinchZoom', () => ({
   useTerminalPinchZoom: vi.fn()
 }))
+let mockOrderedIds = ['term-1']
+let mockMinimizedIds: string[] = []
 vi.mock('../src/renderer/hooks/useVisibleTerminals', () => ({
-  useVisibleTerminals: () => ({ orderedIds: ['term-1'], minimizedIds: [] })
+  useVisibleTerminals: () => ({ orderedIds: mockOrderedIds, minimizedIds: mockMinimizedIds })
 }))
+let mockFilteredHeadless: unknown[] = []
 vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({
-  useFilteredHeadless: () => []
+  useFilteredHeadless: () => mockFilteredHeadless
 }))
 vi.mock('../src/renderer/lib/terminal-close', () => ({
   closeTerminalSession: vi.fn()
@@ -108,6 +126,9 @@ const initialState = useAppStore.getState()
 
 beforeEach(() => {
   mockIsMobile = false
+  mockOrderedIds = ['term-1']
+  mockMinimizedIds = []
+  mockFilteredHeadless = []
   const terminals = new Map()
   terminals.set('term-1', mockTerminal)
   act(() => {
@@ -446,5 +467,214 @@ describe('FocusedTerminal desktop title bar', () => {
     expect(titleBar).not.toBeNull()
     fireEvent.doubleClick(titleBar)
     expect(setFocused).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('TabView merged toolbar controls', () => {
+  it('shows sidebar toggle and view pills when sidebar is closed', () => {
+    act(() => {
+      useAppStore.setState({ isSidebarOpen: false })
+    })
+    render(<TabView />)
+    expect(screen.getByTestId('sidebar-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('main-view-pills')).toBeInTheDocument()
+  })
+
+  it('hides sidebar toggle and view pills when sidebar is open', () => {
+    act(() => {
+      useAppStore.setState({ isSidebarOpen: true })
+    })
+    render(<TabView />)
+    expect(screen.queryByTestId('sidebar-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('main-view-pills')).not.toBeInTheDocument()
+  })
+
+  it('always renders the right toolbar controls (GridToolbar, recent, window controls)', () => {
+    render(<TabView />)
+    expect(screen.getByTestId('grid-toolbar')).toBeInTheDocument()
+    expect(screen.getByTestId('recent-sessions')).toBeInTheDocument()
+    expect(screen.getByTestId('window-controls')).toBeInTheDocument()
+  })
+
+  it('renders empty state with PromptLauncher when no tabs and no background', () => {
+    mockOrderedIds = []
+    mockMinimizedIds = []
+    render(<TabView />)
+    // Toolbar still renders
+    expect(screen.getByTestId('grid-toolbar')).toBeInTheDocument()
+    // No terminal slot
+    expect(screen.queryByTestId('terminal-instance')).not.toBeInTheDocument()
+  })
+
+  it('renders "No matching agents" when filtered with no tabs', () => {
+    mockOrderedIds = []
+    act(() => {
+      useAppStore.setState({ statusFilter: 'running' })
+    })
+    render(<TabView />)
+    expect(screen.getByText('No matching agents')).toBeInTheDocument()
+  })
+
+  it('renders background tray when no tabs but has minimized sessions', () => {
+    mockOrderedIds = []
+    mockMinimizedIds = ['term-1']
+    render(<TabView />)
+    expect(screen.getByTestId('grid-toolbar')).toBeInTheDocument()
+  })
+
+  it('renders the new session button', () => {
+    render(<TabView />)
+    expect(screen.getByRole('button', { name: 'New session' })).toBeInTheDocument()
+  })
+
+  it('renders the more session options button', () => {
+    render(<TabView />)
+    expect(screen.getByRole('button', { name: 'More session options' })).toBeInTheDocument()
+  })
+
+  it('opens context menu on tab right-click', () => {
+    const { container } = render(<TabView />)
+    const tab = screen.getByRole('tab')
+    fireEvent.contextMenu(tab)
+    expect(container).toBeTruthy()
+  })
+
+  it('shows loading skeleton when terminal has no output yet', () => {
+    const terminals = new Map()
+    terminals.set('term-1', { ...mockTerminal, lastOutputTimestamp: 0 })
+    act(() => {
+      useAppStore.setState({ terminals })
+    })
+    const { container } = render(<TabView />)
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('renders tab with task-assigned display name', () => {
+    act(() => {
+      useAppStore.setState({
+        config: {
+          version: 1,
+          defaults: { shell: 'bash', fontSize: 14, theme: 'dark' as const },
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Fix auth bug',
+              status: 'in_progress' as const,
+              assignedSessionId: 'term-1',
+              createdAt: Date.now()
+            }
+          ]
+        }
+      })
+    })
+    render(<TabView />)
+    expect(screen.getByText('Fix auth bug')).toBeInTheDocument()
+  })
+
+  it('clicks new session button and opens dialog when no project', () => {
+    const setNewAgentDialogOpen = vi.fn()
+    act(() => {
+      useAppStore.setState({ setNewAgentDialogOpen })
+    })
+    render(<TabView />)
+    fireEvent.click(screen.getByRole('button', { name: 'New session' }))
+    expect(setNewAgentDialogOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('opens more session options dropdown on click', () => {
+    render(<TabView />)
+    const moreBtn = screen.getByRole('button', { name: 'More session options' })
+    fireEvent.click(moreBtn)
+    // Dropdown opens (GridContextMenu is mocked to null but state toggles)
+    expect(moreBtn).toBeInTheDocument()
+  })
+
+  it('renders tab in renaming mode', () => {
+    act(() => {
+      useAppStore.setState({ renamingTerminalId: 'term-1' })
+    })
+    render(<TabView />)
+    // InlineRename is not mocked, it renders an input
+    const input = screen.getByRole('textbox')
+    expect(input).toBeInTheDocument()
+  })
+
+  it('renders inactive tab styling for non-active tabs', () => {
+    const terminals = new Map()
+    terminals.set('term-1', mockTerminal)
+    terminals.set('term-2', {
+      ...mockTerminal,
+      id: 'term-2',
+      session: { ...mockTerminal.session, id: 'term-2' }
+    })
+    mockOrderedIds = ['term-1', 'term-2']
+    act(() => {
+      useAppStore.setState({ terminals, activeTabId: 'term-1' })
+    })
+    render(<TabView />)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0].className).toContain('text-white')
+    expect(tabs[1].className).toContain('text-gray-500')
+  })
+
+  it('clicks browse files button on a tab', () => {
+    const setDiffSidebar = vi.fn()
+    act(() => {
+      useAppStore.setState({ setDiffSidebarTerminalId: setDiffSidebar })
+    })
+    render(<TabView />)
+    fireEvent.click(screen.getByRole('button', { name: 'Browse files' }))
+    expect(setDiffSidebar).toHaveBeenCalledWith('term-1', 'all-files')
+  })
+
+  it('clicks rename button on a tab', () => {
+    const setRenamingTerminalId = vi.fn()
+    act(() => {
+      useAppStore.setState({ setRenamingTerminalId })
+    })
+    render(<TabView />)
+    fireEvent.click(screen.getByRole('button', { name: 'Rename session' }))
+    expect(setRenamingTerminalId).toHaveBeenCalledWith('term-1')
+  })
+
+  it('commits rename via InlineRename', async () => {
+    const renameTerminal = vi.fn()
+    const setRenamingTerminalId = vi.fn()
+    act(() => {
+      useAppStore.setState({
+        renamingTerminalId: 'term-1',
+        renameTerminal,
+        setRenamingTerminalId
+      })
+    })
+    render(<TabView />)
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'New Name' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(renameTerminal).toHaveBeenCalledWith('term-1', 'New Name')
+      expect(setRenamingTerminalId).toHaveBeenCalledWith(null)
+    })
+  })
+
+  it('cancels rename via Escape', () => {
+    const setRenamingTerminalId = vi.fn()
+    act(() => {
+      useAppStore.setState({ renamingTerminalId: 'term-1', setRenamingTerminalId })
+    })
+    render(<TabView />)
+    const input = screen.getByRole('textbox')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(setRenamingTerminalId).toHaveBeenCalledWith(null)
+  })
+
+  it('toggles more session options dropdown open and closed', () => {
+    render(<TabView />)
+    const moreBtn = screen.getByRole('button', { name: 'More session options' })
+    fireEvent.click(moreBtn)
+    // Click again to close
+    fireEvent.click(moreBtn)
+    expect(moreBtn).toBeInTheDocument()
   })
 })

--- a/tests/main-view-pills.test.tsx
+++ b/tests/main-view-pills.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+Object.defineProperty(window, 'api', {
+  value: { detectIDEs: vi.fn().mockResolvedValue([]) },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { MainViewPills } from '../src/renderer/components/MainViewPills'
+
+const setMainViewMode = vi.fn()
+
+beforeEach(() => {
+  setMainViewMode.mockClear()
+  useAppStore.setState({
+    config: {
+      version: 1,
+      defaults: {
+        shell: 'bash',
+        fontSize: 14,
+        theme: 'dark' as const,
+        mainViewMode: 'sessions' as const
+      }
+    },
+    setMainViewMode
+  })
+})
+
+describe('MainViewPills', () => {
+  it('renders Sessions, Tasks, and Workflows buttons', () => {
+    render(<MainViewPills />)
+    expect(screen.getByRole('button', { name: 'Sessions' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tasks' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Workflows' })).toBeInTheDocument()
+  })
+
+  it('marks the active view mode with aria-pressed', () => {
+    render(<MainViewPills />)
+    expect(screen.getByRole('button', { name: 'Sessions' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Tasks' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('calls setMainViewMode when a pill is clicked', () => {
+    render(<MainViewPills />)
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks' }))
+    expect(setMainViewMode).toHaveBeenCalledWith('tasks')
+  })
+
+  it('applies active styling to the current view mode', () => {
+    render(<MainViewPills />)
+    expect(screen.getByRole('button', { name: 'Sessions' }).className).toContain('text-white')
+    expect(screen.getByRole('button', { name: 'Workflows' }).className).toContain('text-gray-500')
+  })
+})

--- a/tests/recent-sessions-button.test.tsx
+++ b/tests/recent-sessions-button.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+let lastIsOpen = false
+vi.mock('../src/renderer/components/RecentSessionsPopover', () => ({
+  RecentSessionsPopover: ({ isOpen }: { isOpen: boolean }) => {
+    lastIsOpen = isOpen
+    return isOpen ? <div data-testid="popover">popover</div> : null
+  }
+}))
+
+Object.defineProperty(window, 'api', {
+  value: { detectIDEs: vi.fn().mockResolvedValue([]) },
+  writable: true
+})
+
+import { RecentSessionsButton } from '../src/renderer/components/RecentSessionsButton'
+
+describe('RecentSessionsButton', () => {
+  it('renders a button with accessible label', () => {
+    render(<RecentSessionsButton />)
+    expect(screen.getByRole('button', { name: 'Recent sessions' })).toBeInTheDocument()
+  })
+
+  it('toggles popover open/closed on click', () => {
+    render(<RecentSessionsButton />)
+    expect(lastIsOpen).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Recent sessions' }))
+    expect(screen.getByTestId('popover')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Recent sessions' }))
+    expect(screen.queryByTestId('popover')).not.toBeInTheDocument()
+  })
+})

--- a/tests/sidebar-toggle-button.test.tsx
+++ b/tests/sidebar-toggle-button.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+Object.defineProperty(window, 'api', {
+  value: { detectIDEs: vi.fn().mockResolvedValue([]) },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { SidebarToggleButton } from '../src/renderer/components/SidebarToggleButton'
+
+const toggleSidebar = vi.fn()
+
+beforeEach(() => {
+  toggleSidebar.mockClear()
+  useAppStore.setState({ toggleSidebar })
+})
+
+describe('SidebarToggleButton', () => {
+  it('renders a button with accessible label', () => {
+    render(<SidebarToggleButton />)
+    expect(screen.getByRole('button', { name: 'Toggle sidebar' })).toBeInTheDocument()
+  })
+
+  it('calls toggleSidebar on click', () => {
+    render(<SidebarToggleButton />)
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle sidebar' }))
+    expect(toggleSidebar).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/tab-icon-button.test.tsx
+++ b/tests/tab-icon-button.test.tsx
@@ -30,7 +30,7 @@ describe('TabIconButton', () => {
     expect(onParentClick).not.toHaveBeenCalled()
   })
 
-  it('still stops propagation when no onClick is provided', () => {
+  it('allows propagation when no onClick is provided (for ConfirmPopover wrapping)', () => {
     const onParentClick = vi.fn()
     render(
       <div onClick={onParentClick}>
@@ -38,7 +38,7 @@ describe('TabIconButton', () => {
       </div>
     )
     fireEvent.click(screen.getByRole('button', { name: 'Close session' }))
-    expect(onParentClick).not.toHaveBeenCalled()
+    expect(onParentClick).toHaveBeenCalledTimes(1)
   })
 
   it('applies a custom hover class', () => {

--- a/tests/window-controls.test.tsx
+++ b/tests/window-controls.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const windowMinimize = vi.fn()
+const windowMaximize = vi.fn()
+const windowClose = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    windowMinimize,
+    windowMaximize,
+    windowClose,
+    getAppVersion: () => 'test',
+    detectIDEs: vi.fn().mockResolvedValue([])
+  },
+  writable: true
+})
+
+// Force non-Mac + non-Web so WindowControls renders
+vi.mock('../src/renderer/lib/platform', () => ({
+  isMac: false,
+  isWeb: false
+}))
+
+import { WindowControls } from '../src/renderer/components/WindowControls'
+
+beforeEach(() => {
+  windowMinimize.mockClear()
+  windowMaximize.mockClear()
+  windowClose.mockClear()
+})
+
+describe('WindowControls', () => {
+  it('renders minimize, maximize, and close buttons', () => {
+    render(<WindowControls />)
+    expect(screen.getByRole('button', { name: 'Minimize' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Maximize' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('calls window.api.windowMinimize on minimize click', () => {
+    render(<WindowControls />)
+    fireEvent.click(screen.getByRole('button', { name: 'Minimize' }))
+    expect(windowMinimize).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls window.api.windowMaximize on maximize click', () => {
+    render(<WindowControls />)
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize' }))
+    expect(windowMaximize).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls window.api.windowClose on close click', () => {
+    render(<WindowControls />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(windowClose).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- **Fix keyboard hint overlap**: Tab names now truncate before reaching the ⌘N badge (added right padding)
- **Readable hover icons**: Tab action buttons (Browse/Rename/Close) show a solid background on hover so they're readable over text — no space permanently reserved
- **Merge toolbar into tab bar**: In tab mode, the top 52px toolbar is hidden and its controls are integrated into the tab bar:
  - Left: sidebar toggle + view mode toggles (when sidebar closed)
  - Middle: scrollable tabs + new session buttons
  - Right: GridToolbar + Recent sessions + WindowControls
- **Extract WindowControls**: Shared component used by both App.tsx and TabView.tsx
- **Always-rendered tab bar**: Toolbar controls render even in empty/background-only states

All 1084 tests pass. ESLint + Prettier clean.