### PR TITLE
feat: add connector system for external task sources (GitHub)

### DIFF
--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -1,0 +1,342 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type {
+  VornConnector,
+  ExternalItem,
+  PollResult,
+  ActionResult,
+  ConnectorManifest,
+  TaskStatus
+} from '@vornrun/shared/types'
+import log from '../logger'
+
+const execFileAsync = promisify(execFile)
+
+async function gh(args: string[], cwd?: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('gh', args, {
+      timeout: 30_000,
+      maxBuffer: 10 * 1024 * 1024,
+      ...(cwd && { cwd })
+    })
+    return stdout
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    log.error(`[github-connector] gh command failed: gh ${args.join(' ')} — ${msg}`)
+    throw new Error(`gh command failed: ${msg}`, { cause: err })
+  }
+}
+
+/** Detect owner/repo from a git repo path using gh CLI */
+export async function detectRepoSlug(
+  projectPath: string
+): Promise<{ owner: string; repo: string } | null> {
+  try {
+    const result = await gh(
+      ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+      projectPath
+    )
+    const slug = result.trim()
+    if (!slug.includes('/')) return null
+    const [owner, repo] = slug.split('/')
+    return { owner, repo }
+  } catch {
+    return null
+  }
+}
+
+async function ghApi(
+  endpoint: string,
+  method = 'GET',
+  body?: Record<string, unknown>
+): Promise<unknown> {
+  const args = ['api', endpoint]
+  if (method !== 'GET') {
+    args.push('-X', method)
+  }
+  if (body) {
+    for (const [key, value] of Object.entries(body)) {
+      args.push('-f', `${key}=${String(value)}`)
+    }
+  }
+  const result = await gh(args)
+  return result.trim() ? JSON.parse(result) : null
+}
+
+interface GitHubIssue {
+  number: number
+  title: string
+  body: string | null
+  state: string
+  html_url: string
+  updated_at: string
+  created_at: string
+  labels: Array<{ name: string }>
+  assignee: { login: string } | null
+  pull_request?: unknown
+}
+
+function issueToExternalItem(issue: GitHubIssue): ExternalItem {
+  return {
+    externalId: String(issue.number),
+    url: issue.html_url,
+    title: issue.title,
+    description: issue.body || '',
+    status: issue.state,
+    labels: issue.labels?.map((l) => l.name) ?? [],
+    assignee: issue.assignee?.login,
+    updatedAt: issue.updated_at,
+    metadata: { createdAt: issue.created_at }
+  }
+}
+
+export const githubConnector: VornConnector = {
+  id: 'github',
+  name: 'GitHub',
+  icon: 'github',
+  capabilities: ['tasks', 'triggers', 'actions'],
+
+  async listItems(filters: Record<string, unknown>): Promise<ExternalItem[]> {
+    const { owner, repo, state = 'open', labels, assignee, per_page = 50 } = filters
+    if (!owner || !repo) throw new Error('owner and repo are required')
+
+    let endpoint = `repos/${owner}/${repo}/issues?state=${state}&per_page=${per_page}`
+    if (labels) endpoint += `&labels=${labels}`
+    if (assignee) endpoint += `&assignee=${assignee}`
+    // Exclude pull requests (GitHub API returns PRs in issues endpoint)
+    const data = (await ghApi(endpoint)) as GitHubIssue[]
+    return data.filter((i) => !i.pull_request).map(issueToExternalItem)
+  },
+
+  async getItem(
+    externalId: string,
+    filters: Record<string, unknown>
+  ): Promise<ExternalItem | null> {
+    const { owner, repo } = filters
+    if (!owner || !repo) throw new Error('owner and repo are required')
+
+    try {
+      const issue = (await ghApi(`repos/${owner}/${repo}/issues/${externalId}`)) as GitHubIssue
+      return issueToExternalItem(issue)
+    } catch {
+      return null
+    }
+  },
+
+  async poll(
+    triggerType: string,
+    config: Record<string, unknown>,
+    cursor?: string
+  ): Promise<PollResult> {
+    const { owner, repo } = config
+    if (!owner || !repo) return { events: [] }
+
+    const since = cursor || new Date(Date.now() - 60_000).toISOString()
+
+    switch (triggerType) {
+      case 'issueCreated': {
+        const endpoint = `repos/${owner}/${repo}/issues?state=open&sort=created&direction=desc&since=${since}&per_page=30`
+        const issues = (await ghApi(endpoint)) as GitHubIssue[]
+        const newIssues = issues.filter((i) => !i.pull_request && i.created_at > since)
+        return {
+          events: newIssues.map((i) => ({
+            id: String(i.number),
+            type: 'issueCreated',
+            data: issueToExternalItem(i) as unknown as Record<string, unknown>,
+            timestamp: i.created_at
+          })),
+          nextCursor: new Date().toISOString()
+        }
+      }
+      case 'prOpened': {
+        const endpoint = `repos/${owner}/${repo}/pulls?state=open&sort=created&direction=desc&per_page=30`
+        const prs = (await ghApi(endpoint)) as Array<{
+          number: number
+          title: string
+          html_url: string
+          created_at: string
+          user: { login: string }
+        }>
+        const newPrs = prs.filter((pr) => pr.created_at > since)
+        return {
+          events: newPrs.map((pr) => ({
+            id: String(pr.number),
+            type: 'prOpened',
+            data: {
+              number: pr.number,
+              title: pr.title,
+              url: pr.html_url,
+              author: pr.user.login
+            },
+            timestamp: pr.created_at
+          })),
+          nextCursor: new Date().toISOString()
+        }
+      }
+      default:
+        return { events: [] }
+    }
+  },
+
+  async execute(actionType: string, args: Record<string, unknown>): Promise<ActionResult> {
+    const { owner, repo } = args
+    if (!owner || !repo) return { success: false, error: 'owner and repo are required' }
+
+    switch (actionType) {
+      case 'createIssue': {
+        const { title, body, labels: issueLabels } = args
+        if (!title) return { success: false, error: 'title is required' }
+        const bodyArgs: Record<string, unknown> = {
+          title: String(title)
+        }
+        if (body) bodyArgs.body = String(body)
+        if (issueLabels) {
+          bodyArgs.labels = String(issueLabels)
+        }
+        const result = await ghApi(`repos/${owner}/${repo}/issues`, 'POST', bodyArgs)
+        return { success: true, output: result as Record<string, unknown> }
+      }
+      case 'closeIssue': {
+        const { number: issueNumber } = args
+        if (!issueNumber) return { success: false, error: 'number is required' }
+        await ghApi(`repos/${owner}/${repo}/issues/${issueNumber}`, 'PATCH', { state: 'closed' })
+        return { success: true }
+      }
+      case 'commentOnIssue': {
+        const { number: num, body: comment } = args
+        if (!num || !comment) return { success: false, error: 'number and body are required' }
+        await ghApi(`repos/${owner}/${repo}/issues/${num}/comments`, 'POST', {
+          body: String(comment)
+        })
+        return { success: true }
+      }
+      case 'syncTasks': {
+        // This is handled by the sync engine at a higher level.
+        // The action node calls listItems() and does the upsert logic.
+        return { success: true }
+      }
+      default:
+        return { success: false, error: `Unknown action: ${actionType}` }
+    }
+  },
+
+  describe(): ConnectorManifest {
+    return {
+      auth: [], // gh CLI handles auth — no fields needed
+      taskFilters: [
+        {
+          key: 'state',
+          label: 'State',
+          type: 'select',
+          options: [
+            { value: 'open', label: 'Open' },
+            { value: 'closed', label: 'Closed' },
+            { value: 'all', label: 'All' }
+          ]
+        },
+        { key: 'labels', label: 'Labels', type: 'text', placeholder: 'bug,enhancement' },
+        { key: 'assignee', label: 'Assignee', type: 'text', placeholder: 'username or @me' }
+      ],
+      statusMapping: [
+        { upstream: 'open', suggestedLocal: 'todo' as TaskStatus },
+        { upstream: 'closed', suggestedLocal: 'done' as TaskStatus }
+      ],
+      triggers: [
+        {
+          type: 'issueCreated',
+          label: 'Issue Created',
+          description: 'Fires when a new issue is created',
+          configFields: [
+            { key: 'owner', label: 'Owner', type: 'text', required: true },
+            { key: 'repo', label: 'Repository', type: 'text', required: true },
+            { key: 'labels', label: 'Filter by labels', type: 'text' }
+          ],
+          defaultIntervalMs: 30_000
+        },
+        {
+          type: 'prOpened',
+          label: 'PR Opened',
+          description: 'Fires when a new pull request is opened',
+          configFields: [
+            { key: 'owner', label: 'Owner', type: 'text', required: true },
+            { key: 'repo', label: 'Repository', type: 'text', required: true }
+          ],
+          defaultIntervalMs: 30_000
+        }
+      ],
+      actions: [
+        {
+          type: 'syncTasks',
+          label: 'Sync Issues',
+          description: 'Pull GitHub issues into the task board',
+          configFields: []
+        },
+        {
+          type: 'createIssue',
+          label: 'Create Issue',
+          description: 'Create a new GitHub issue',
+          configFields: [
+            { key: 'owner', label: 'Owner', type: 'text', required: true },
+            { key: 'repo', label: 'Repository', type: 'text', required: true },
+            {
+              key: 'title',
+              label: 'Title',
+              type: 'text',
+              required: true,
+              supportsTemplates: true
+            },
+            { key: 'body', label: 'Body', type: 'textarea', supportsTemplates: true },
+            { key: 'labels', label: 'Labels', type: 'text' }
+          ]
+        },
+        {
+          type: 'closeIssue',
+          label: 'Close Issue',
+          description: 'Close a GitHub issue',
+          configFields: [
+            { key: 'owner', label: 'Owner', type: 'text', required: true },
+            { key: 'repo', label: 'Repository', type: 'text', required: true },
+            {
+              key: 'number',
+              label: 'Issue #',
+              type: 'text',
+              required: true,
+              supportsTemplates: true
+            }
+          ]
+        },
+        {
+          type: 'commentOnIssue',
+          label: 'Comment on Issue',
+          description: 'Add a comment to a GitHub issue',
+          configFields: [
+            { key: 'owner', label: 'Owner', type: 'text', required: true },
+            { key: 'repo', label: 'Repository', type: 'text', required: true },
+            {
+              key: 'number',
+              label: 'Issue #',
+              type: 'text',
+              required: true,
+              supportsTemplates: true
+            },
+            {
+              key: 'body',
+              label: 'Comment',
+              type: 'textarea',
+              required: true,
+              supportsTemplates: true
+            }
+          ]
+        }
+      ],
+      defaultWorkflows: [
+        {
+          name: 'Sync GitHub Issues',
+          trigger: 'recurring',
+          cron: '*/5 * * * *',
+          actionType: 'syncTasks'
+        }
+      ]
+    }
+  }
+}

--- a/packages/server/src/connectors/index.ts
+++ b/packages/server/src/connectors/index.ts
@@ -1,0 +1,2 @@
+export { connectorRegistry } from './registry'
+export { githubConnector, detectRepoSlug } from './github'

--- a/packages/server/src/connectors/registry.ts
+++ b/packages/server/src/connectors/registry.ts
@@ -1,0 +1,28 @@
+import type { VornConnector } from '@vornrun/shared/types'
+import log from '../logger'
+
+class ConnectorRegistry {
+  private connectors = new Map<string, VornConnector>()
+
+  register(connector: VornConnector): void {
+    if (this.connectors.has(connector.id)) {
+      log.warn(`Connector "${connector.id}" already registered, overwriting`)
+    }
+    this.connectors.set(connector.id, connector)
+    log.info(`Registered connector: ${connector.id} (${connector.capabilities.join(', ')})`)
+  }
+
+  get(id: string): VornConnector | undefined {
+    return this.connectors.get(id)
+  }
+
+  list(): VornConnector[] {
+    return [...this.connectors.values()]
+  }
+
+  has(id: string): boolean {
+    return this.connectors.has(id)
+  }
+}
+
+export const connectorRegistry = new ConnectorRegistry()

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -23,7 +23,9 @@ import {
   DEFAULT_WORKSPACE,
   SessionLog,
   SessionEvent,
-  SessionEventType
+  SessionEventType,
+  SourceConnection,
+  TaskSourceLink
 } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { DEFAULT_TASK_WORKFLOW_ID, buildDefaultTaskWorkflow } from './default-workflows'
@@ -586,6 +588,59 @@ function migrateSchema(d: Database.Database): void {
     })()
     log.info('[database] migrated schema to version 8 (approval gate timestamp)')
   }
+
+  if (version < 9) {
+    d.transaction(() => {
+      d.exec(`
+        CREATE TABLE IF NOT EXISTS source_connections (
+          id TEXT PRIMARY KEY,
+          connector_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          filters TEXT NOT NULL DEFAULT '{}',
+          sync_interval_minutes INTEGER NOT NULL DEFAULT 5,
+          status_mapping TEXT NOT NULL DEFAULT '{}',
+          execution_project TEXT,
+          last_sync_at TEXT,
+          last_sync_error TEXT,
+          sync_cursor TEXT,
+          created_at TEXT NOT NULL
+        )
+      `)
+
+      d.exec(`
+        CREATE TABLE IF NOT EXISTS task_source_links (
+          task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+          connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+          connector_id TEXT NOT NULL,
+          external_id TEXT NOT NULL,
+          external_url TEXT NOT NULL,
+          source_status_raw TEXT NOT NULL,
+          source_updated_at TEXT NOT NULL,
+          last_synced_at TEXT NOT NULL,
+          conflict_state TEXT NOT NULL DEFAULT 'none',
+          PRIMARY KEY (task_id),
+          UNIQUE (connection_id, external_id)
+        )
+      `)
+
+      // Add source columns to tasks table
+      const taskCols = d.prepare('PRAGMA table_info(tasks)').all() as Array<{ name: string }>
+      if (!taskCols.some((c) => c.name === 'source_connector_id')) {
+        d.exec('ALTER TABLE tasks ADD COLUMN source_connector_id TEXT')
+      }
+      if (!taskCols.some((c) => c.name === 'source_external_url')) {
+        d.exec('ALTER TABLE tasks ADD COLUMN source_external_url TEXT')
+      }
+      if (!taskCols.some((c) => c.name === 'source_external_id')) {
+        d.exec('ALTER TABLE tasks ADD COLUMN source_external_id TEXT')
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '9')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 9 (connector source connections)')
+  }
 }
 
 /**
@@ -642,6 +697,20 @@ function verifySchema(d: Database.Database): void {
         ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_path TEXT'
       },
       { column: 'approved_at', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN approved_at TEXT' }
+    ],
+    tasks: [
+      {
+        column: 'source_connector_id',
+        ddl: 'ALTER TABLE tasks ADD COLUMN source_connector_id TEXT'
+      },
+      {
+        column: 'source_external_url',
+        ddl: 'ALTER TABLE tasks ADD COLUMN source_external_url TEXT'
+      },
+      {
+        column: 'source_external_id',
+        ddl: 'ALTER TABLE tasks ADD COLUMN source_external_id TEXT'
+      }
     ]
   }
 
@@ -962,8 +1031,8 @@ export function saveConfig(config: AppConfig): void {
     // Tasks
     d.prepare('DELETE FROM tasks').run()
     const insertTask = d.prepare(
-      `INSERT INTO tasks (id, project_name, title, description, status, "order", assigned_session_id, assigned_agent, agent_session_id, branch, use_worktree, created_at, updated_at, completed_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO tasks (id, project_name, title, description, status, "order", assigned_session_id, assigned_agent, agent_session_id, branch, use_worktree, created_at, updated_at, completed_at, source_connector_id, source_external_url, source_external_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const t of config.tasks ?? []) {
       insertTask.run(
@@ -980,7 +1049,10 @@ export function saveConfig(config: AppConfig): void {
         t.useWorktree ? 1 : 0,
         t.createdAt,
         t.updatedAt,
-        t.completedAt ?? null
+        t.completedAt ?? null,
+        t.sourceConnectorId ?? null,
+        t.sourceExternalUrl ?? null,
+        t.sourceExternalId ?? null
       )
     }
 
@@ -1060,8 +1132,8 @@ export function dbGetTask(id: string): TaskConfig | null {
 export function dbInsertTask(task: TaskConfig): void {
   getDb()
     .prepare(
-      `INSERT INTO tasks (id, project_name, title, description, status, "order", assigned_session_id, assigned_agent, agent_session_id, branch, use_worktree, created_at, updated_at, completed_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO tasks (id, project_name, title, description, status, "order", assigned_session_id, assigned_agent, agent_session_id, branch, use_worktree, created_at, updated_at, completed_at, source_connector_id, source_external_url, source_external_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       task.id,
@@ -1077,7 +1149,10 @@ export function dbInsertTask(task: TaskConfig): void {
       task.useWorktree ? 1 : 0,
       task.createdAt,
       task.updatedAt,
-      task.completedAt ?? null
+      task.completedAt ?? null,
+      task.sourceConnectorId ?? null,
+      task.sourceExternalUrl ?? null,
+      task.sourceExternalId ?? null
     )
 }
 
@@ -1128,6 +1203,18 @@ export function dbUpdateTask(id: string, updates: Partial<TaskConfig>): void {
     sets.push('completed_at = ?')
     params.push(updates.completedAt ?? null)
   }
+  if (updates.sourceConnectorId !== undefined) {
+    sets.push('source_connector_id = ?')
+    params.push(updates.sourceConnectorId)
+  }
+  if (updates.sourceExternalUrl !== undefined) {
+    sets.push('source_external_url = ?')
+    params.push(updates.sourceExternalUrl)
+  }
+  if (updates.sourceExternalId !== undefined) {
+    sets.push('source_external_id = ?')
+    params.push(updates.sourceExternalId)
+  }
   if (sets.length === 0) return
   params.push(id)
   getDb()
@@ -1147,8 +1234,227 @@ export function dbGetMaxTaskOrder(projectName: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// Targeted CRUD: Projects
+// Targeted CRUD: Source Connections
 // ---------------------------------------------------------------------------
+
+interface SourceConnectionRow {
+  id: string
+  connector_id: string
+  name: string
+  filters: string
+  sync_interval_minutes: number
+  status_mapping: string
+  execution_project: string | null
+  last_sync_at: string | null
+  last_sync_error: string | null
+  sync_cursor: string | null
+  created_at: string
+}
+
+function rowToSourceConnection(r: SourceConnectionRow): SourceConnection {
+  return {
+    id: r.id,
+    connectorId: r.connector_id,
+    name: r.name,
+    filters: JSON.parse(r.filters),
+    syncIntervalMinutes: r.sync_interval_minutes,
+    statusMapping: JSON.parse(r.status_mapping),
+    ...(r.execution_project != null && { executionProject: r.execution_project }),
+    ...(r.last_sync_at != null && { lastSyncAt: r.last_sync_at }),
+    ...(r.last_sync_error != null && { lastSyncError: r.last_sync_error }),
+    ...(r.sync_cursor != null && { syncCursor: r.sync_cursor }),
+    createdAt: r.created_at
+  }
+}
+
+export function dbListSourceConnections(connectorId?: string): SourceConnection[] {
+  const d = getDb()
+  if (connectorId) {
+    const rows = d
+      .prepare('SELECT * FROM source_connections WHERE connector_id = ?')
+      .all(connectorId) as SourceConnectionRow[]
+    return rows.map(rowToSourceConnection)
+  }
+  const rows = d.prepare('SELECT * FROM source_connections').all() as SourceConnectionRow[]
+  return rows.map(rowToSourceConnection)
+}
+
+export function dbGetSourceConnection(id: string): SourceConnection | null {
+  const row = getDb().prepare('SELECT * FROM source_connections WHERE id = ?').get(id) as
+    | SourceConnectionRow
+    | undefined
+  return row ? rowToSourceConnection(row) : null
+}
+
+export function dbInsertSourceConnection(conn: SourceConnection): void {
+  getDb()
+    .prepare(
+      `INSERT INTO source_connections (id, connector_id, name, filters, sync_interval_minutes, status_mapping, execution_project, last_sync_at, last_sync_error, sync_cursor, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      conn.id,
+      conn.connectorId,
+      conn.name,
+      JSON.stringify(conn.filters),
+      conn.syncIntervalMinutes,
+      JSON.stringify(conn.statusMapping),
+      conn.executionProject ?? null,
+      conn.lastSyncAt ?? null,
+      conn.lastSyncError ?? null,
+      conn.syncCursor ?? null,
+      conn.createdAt
+    )
+}
+
+export function dbUpdateSourceConnection(id: string, updates: Partial<SourceConnection>): void {
+  const sets: string[] = []
+  const params: unknown[] = []
+  if (updates.name !== undefined) {
+    sets.push('name = ?')
+    params.push(updates.name)
+  }
+  if (updates.filters !== undefined) {
+    sets.push('filters = ?')
+    params.push(JSON.stringify(updates.filters))
+  }
+  if (updates.syncIntervalMinutes !== undefined) {
+    sets.push('sync_interval_minutes = ?')
+    params.push(updates.syncIntervalMinutes)
+  }
+  if (updates.statusMapping !== undefined) {
+    sets.push('status_mapping = ?')
+    params.push(JSON.stringify(updates.statusMapping))
+  }
+  if (updates.executionProject !== undefined) {
+    sets.push('execution_project = ?')
+    params.push(updates.executionProject)
+  }
+  if ('lastSyncAt' in updates) {
+    sets.push('last_sync_at = ?')
+    params.push(updates.lastSyncAt ?? null)
+  }
+  if ('lastSyncError' in updates) {
+    sets.push('last_sync_error = ?')
+    params.push(updates.lastSyncError ?? null)
+  }
+  if ('syncCursor' in updates) {
+    sets.push('sync_cursor = ?')
+    params.push(updates.syncCursor ?? null)
+  }
+  if (sets.length === 0) return
+  params.push(id)
+  getDb()
+    .prepare(`UPDATE source_connections SET ${sets.join(', ')} WHERE id = ?`)
+    .run(...params)
+}
+
+export function dbDeleteSourceConnection(id: string): void {
+  getDb().prepare('DELETE FROM source_connections WHERE id = ?').run(id)
+}
+
+// ---------------------------------------------------------------------------
+// Targeted CRUD: Task Source Links
+// ---------------------------------------------------------------------------
+
+interface TaskSourceLinkRow {
+  task_id: string
+  connection_id: string
+  connector_id: string
+  external_id: string
+  external_url: string
+  source_status_raw: string
+  source_updated_at: string
+  last_synced_at: string
+  conflict_state: string
+}
+
+function rowToTaskSourceLink(r: TaskSourceLinkRow): TaskSourceLink {
+  return {
+    taskId: r.task_id,
+    connectionId: r.connection_id,
+    connectorId: r.connector_id,
+    externalId: r.external_id,
+    externalUrl: r.external_url,
+    sourceStatusRaw: r.source_status_raw,
+    sourceUpdatedAt: r.source_updated_at,
+    lastSyncedAt: r.last_synced_at,
+    conflictState: r.conflict_state as TaskSourceLink['conflictState']
+  }
+}
+
+export function dbGetTaskSourceLink(taskId: string): TaskSourceLink | null {
+  const row = getDb().prepare('SELECT * FROM task_source_links WHERE task_id = ?').get(taskId) as
+    | TaskSourceLinkRow
+    | undefined
+  return row ? rowToTaskSourceLink(row) : null
+}
+
+export function dbGetTaskSourceLinkByExternalId(
+  connectionId: string,
+  externalId: string
+): TaskSourceLink | null {
+  const row = getDb()
+    .prepare('SELECT * FROM task_source_links WHERE connection_id = ? AND external_id = ?')
+    .get(connectionId, externalId) as TaskSourceLinkRow | undefined
+  return row ? rowToTaskSourceLink(row) : null
+}
+
+export function dbListTaskSourceLinks(connectionId: string): TaskSourceLink[] {
+  const rows = getDb()
+    .prepare('SELECT * FROM task_source_links WHERE connection_id = ?')
+    .all(connectionId) as TaskSourceLinkRow[]
+  return rows.map(rowToTaskSourceLink)
+}
+
+export function dbInsertTaskSourceLink(link: TaskSourceLink): void {
+  getDb()
+    .prepare(
+      `INSERT INTO task_source_links (task_id, connection_id, connector_id, external_id, external_url, source_status_raw, source_updated_at, last_synced_at, conflict_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      link.taskId,
+      link.connectionId,
+      link.connectorId,
+      link.externalId,
+      link.externalUrl,
+      link.sourceStatusRaw,
+      link.sourceUpdatedAt,
+      link.lastSyncedAt,
+      link.conflictState
+    )
+}
+
+export function dbUpdateTaskSourceLink(taskId: string, updates: Partial<TaskSourceLink>): void {
+  const sets: string[] = []
+  const params: unknown[] = []
+  if (updates.sourceStatusRaw !== undefined) {
+    sets.push('source_status_raw = ?')
+    params.push(updates.sourceStatusRaw)
+  }
+  if (updates.sourceUpdatedAt !== undefined) {
+    sets.push('source_updated_at = ?')
+    params.push(updates.sourceUpdatedAt)
+  }
+  if (updates.lastSyncedAt !== undefined) {
+    sets.push('last_synced_at = ?')
+    params.push(updates.lastSyncedAt)
+  }
+  if (updates.conflictState !== undefined) {
+    sets.push('conflict_state = ?')
+    params.push(updates.conflictState)
+  }
+  if (sets.length === 0) return
+  params.push(taskId)
+  getDb()
+    .prepare(`UPDATE task_source_links SET ${sets.join(', ')} WHERE task_id = ?`)
+    .run(...params)
+}
+
+export function dbDeleteTaskSourceLink(taskId: string): void {
+  getDb().prepare('DELETE FROM task_source_links WHERE task_id = ?').run(taskId)
+}
 
 export function dbListProjects(): ProjectConfig[] {
   const rows = getDb().prepare('SELECT * FROM projects').all() as Array<{
@@ -1473,6 +1779,9 @@ function rowToTask(r: {
   created_at: string
   updated_at: string
   completed_at: string | null
+  source_connector_id?: string | null
+  source_external_url?: string | null
+  source_external_id?: string | null
 }): TaskConfig {
   return {
     id: r.id,
@@ -1488,7 +1797,12 @@ function rowToTask(r: {
     ...(r.use_worktree != null && r.use_worktree !== 0 && { useWorktree: true }),
     createdAt: r.created_at,
     updatedAt: r.updated_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at })
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    ...(r.source_connector_id != null && { sourceConnectorId: r.source_connector_id }),
+    ...(r.source_external_url != null && { sourceExternalUrl: r.source_external_url }),
+    ...(r.source_external_id != null && {
+      sourceExternalId: r.source_external_id
+    })
   }
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,11 @@ export async function startServer(
   configManager.init()
   configManager.watchDb()
 
+  // Register built-in connectors
+  const { connectorRegistry } = await import('./connectors')
+  const { githubConnector } = await import('./connectors/github')
+  connectorRegistry.register(githubConnector)
+
   // Load initial config and wire up managers
   const config = configManager.loadConfig()
   ptyManager.setAgentCommands(config.agentCommands)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -26,6 +26,7 @@ import {
   RemoteHost,
   getProjectRemoteHostId
 } from '@vornrun/shared/types'
+import type { SourceConnection, TaskConfig, TaskStatus } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
 import { listDir, readFileContent } from './file-utils'
 import {
@@ -51,8 +52,23 @@ import {
   listSessionLogs,
   insertSessionEvent,
   listSessionEvents,
-  listSessionEventsBySession
+  listSessionEventsBySession,
+  dbListSourceConnections,
+  dbGetSourceConnection,
+  dbInsertSourceConnection,
+  dbUpdateSourceConnection,
+  dbDeleteSourceConnection,
+  dbGetTaskSourceLink,
+  dbGetTaskSourceLinkByExternalId,
+  dbInsertTaskSourceLink,
+  dbUpdateTaskSourceLink,
+  dbInsertTask,
+  dbUpdateTask,
+  dbGetMaxTaskOrder,
+  dbSignalChange
 } from './database'
+import { connectorRegistry } from './connectors'
+import { detectRepoSlug } from './connectors/github'
 import { stripAnsi } from './ansi-strip'
 import { executeScript, scriptRunnerEvents } from './script-runner'
 import { getTailscaleStatus, clearBinaryCache } from './tailscale'
@@ -486,6 +502,155 @@ export function registerAllMethods(): void {
       configManager.notifyChanged()
     }
   )
+
+  // Connectors
+  registerMethod('connector:list', () => {
+    return connectorRegistry.list().map((c) => ({
+      id: c.id,
+      name: c.name,
+      icon: c.icon,
+      capabilities: [...c.capabilities],
+      manifest: c.describe()
+    }))
+  })
+
+  registerMethod('connector:get', (id) => {
+    const c = connectorRegistry.get(id)
+    if (!c) return null
+    return {
+      id: c.id,
+      name: c.name,
+      icon: c.icon,
+      capabilities: [...c.capabilities],
+      manifest: c.describe()
+    }
+  })
+
+  registerMethod('connection:list', ({ connectorId }) => {
+    return dbListSourceConnections(connectorId)
+  })
+
+  registerMethod('connection:create', (params) => {
+    const id = crypto.randomUUID()
+    const conn: SourceConnection = {
+      id,
+      connectorId: params.connectorId,
+      name: params.name,
+      filters: params.filters,
+      syncIntervalMinutes: params.syncIntervalMinutes,
+      statusMapping: params.statusMapping,
+      ...(params.executionProject && { executionProject: params.executionProject }),
+      createdAt: new Date().toISOString()
+    }
+    dbInsertSourceConnection(conn)
+    dbSignalChange()
+    return conn
+  })
+
+  registerMethod('connection:update', ({ id, updates }) => {
+    dbUpdateSourceConnection(id, updates)
+    dbSignalChange()
+    return dbGetSourceConnection(id)
+  })
+
+  registerMethod('connection:delete', (id) => {
+    dbDeleteSourceConnection(id)
+    dbSignalChange()
+  })
+
+  registerMethod('connection:sync', async (connectionId) => {
+    const conn = dbGetSourceConnection(connectionId)
+    if (!conn) return { created: 0, updated: 0, error: 'Connection not found' }
+
+    const connector = connectorRegistry.get(conn.connectorId)
+    if (!connector?.listItems) {
+      return {
+        created: 0,
+        updated: 0,
+        error: `Connector "${conn.connectorId}" not found or has no task source`
+      }
+    }
+
+    try {
+      const items = await connector.listItems(conn.filters)
+      let created = 0
+      let updated = 0
+      const now = new Date().toISOString()
+      const projectName = conn.executionProject || conn.name
+
+      for (const item of items) {
+        const existingLink = dbGetTaskSourceLinkByExternalId(conn.id, item.externalId)
+
+        if (!existingLink) {
+          // Create new task + link
+          const mappedStatus = conn.statusMapping[item.status] || ('todo' as TaskStatus)
+          const maxOrder = dbGetMaxTaskOrder(projectName)
+          const task: TaskConfig = {
+            id: crypto.randomUUID(),
+            projectName,
+            title: item.title,
+            description: item.description,
+            status: mappedStatus,
+            order: maxOrder + 1,
+            createdAt: now,
+            updatedAt: now,
+            sourceConnectorId: conn.connectorId,
+            sourceExternalId: item.externalId,
+            sourceExternalUrl: item.url
+          }
+          dbInsertTask(task)
+          dbInsertTaskSourceLink({
+            taskId: task.id,
+            connectionId: conn.id,
+            connectorId: conn.connectorId,
+            externalId: item.externalId,
+            externalUrl: item.url,
+            sourceStatusRaw: item.status,
+            sourceUpdatedAt: item.updatedAt,
+            lastSyncedAt: now,
+            conflictState: 'none'
+          })
+          created++
+        } else {
+          // Update upstream-owned fields only (title, description)
+          dbUpdateTask(existingLink.taskId, {
+            title: item.title,
+            description: item.description,
+            updatedAt: now,
+            sourceExternalUrl: item.url,
+            sourceExternalId: item.externalId
+          })
+          dbUpdateTaskSourceLink(existingLink.taskId, {
+            sourceStatusRaw: item.status,
+            sourceUpdatedAt: item.updatedAt,
+            lastSyncedAt: now
+          })
+          updated++
+        }
+      }
+
+      dbUpdateSourceConnection(conn.id, {
+        lastSyncAt: now,
+        lastSyncError: undefined
+      })
+      dbSignalChange()
+      configManager.notifyChanged()
+
+      return { created, updated }
+    } catch (err: unknown) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      dbUpdateSourceConnection(conn.id, { lastSyncError: errorMsg })
+      return { created: 0, updated: 0, error: errorMsg }
+    }
+  })
+
+  registerMethod('connection:getSourceLink', (taskId) => {
+    return dbGetTaskSourceLink(taskId)
+  })
+
+  registerMethod('connector:detectRepo', (projectPath) => {
+    return detectRepoSlug(projectPath)
+  })
 
   // Wire manager events → broadcast to WS clients
   ptyManager.on('client-message', (channel: string, payload: unknown) => {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -18,7 +18,10 @@ import type {
   SSHKeyMeta,
   SessionLog,
   SessionEvent,
-  SessionEventType
+  SessionEventType,
+  SourceConnection,
+  TaskSourceLink,
+  ConnectorManifest
 } from './types'
 
 // ─── JSON-RPC 2.0 Envelope Types ────────────────────────────────
@@ -188,6 +191,59 @@ export interface RequestMethods {
   'file:readContent': {
     params: { filePath: string; maxBytes?: number; remoteHostId?: string }
     result: string | null
+  }
+
+  // Connectors
+  'connector:list': {
+    params: void
+    result: Array<{
+      id: string
+      name: string
+      icon: string
+      capabilities: string[]
+      manifest: ConnectorManifest
+    }>
+  }
+  'connector:get': {
+    params: string
+    result: {
+      id: string
+      name: string
+      icon: string
+      capabilities: string[]
+      manifest: ConnectorManifest
+    } | null
+  }
+  'connection:list': {
+    params: { connectorId?: string }
+    result: SourceConnection[]
+  }
+  'connection:create': {
+    params: Omit<
+      SourceConnection,
+      'id' | 'createdAt' | 'lastSyncAt' | 'lastSyncError' | 'syncCursor'
+    >
+    result: SourceConnection
+  }
+  'connection:update': {
+    params: { id: string; updates: Partial<SourceConnection> }
+    result: SourceConnection | null
+  }
+  'connection:delete': {
+    params: string
+    result: void
+  }
+  'connection:sync': {
+    params: string
+    result: { created: number; updated: number; error?: string }
+  }
+  'connection:getSourceLink': {
+    params: string
+    result: TaskSourceLink | null
+  }
+  'connector:detectRepo': {
+    params: string
+    result: { owner: string; repo: string } | null
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -178,6 +178,142 @@ export interface TaskConfig {
   createdAt: string
   updatedAt: string
   completedAt?: string
+  // Source connector fields (set when task originates from an external connector)
+  sourceConnectorId?: string // 'github' | 'linear' | custom connector id
+  sourceExternalId?: string // e.g. issue number "42"
+  sourceExternalUrl?: string // link to upstream item
+}
+
+// ─── Connector System ───────────────────────────────────────────
+
+/** Origin of a task mutation — only 'user' fires workflow triggers. */
+export type MutationOrigin = 'user' | 'sync' | 'system'
+
+// -- Connector interface --
+
+export interface ExternalItem {
+  externalId: string
+  url: string
+  title: string
+  description: string
+  status: string // raw upstream status
+  labels?: string[]
+  assignee?: string
+  priority?: string
+  updatedAt: string
+  metadata?: Record<string, unknown>
+}
+
+export interface PollResult {
+  events: TriggerEvent[]
+  nextCursor?: string
+}
+
+export interface TriggerEvent {
+  id: string // dedup key
+  type: string
+  data: Record<string, unknown>
+  timestamp: string
+}
+
+export interface ActionResult {
+  success: boolean
+  output?: Record<string, unknown>
+  error?: string
+}
+
+export interface ConnectorConfigField {
+  key: string
+  label: string
+  type: 'text' | 'select' | 'multiselect' | 'toggle' | 'textarea' | 'password'
+  required?: boolean
+  placeholder?: string
+  description?: string
+  options?: { value: string; label: string }[]
+  supportsTemplates?: boolean
+}
+
+export interface ConnectorTriggerDef {
+  type: string // e.g. 'issueCreated'
+  label: string
+  description?: string
+  configFields: ConnectorConfigField[]
+  defaultIntervalMs: number
+}
+
+export interface ConnectorActionDef {
+  type: string // e.g. 'createIssue'
+  label: string
+  description?: string
+  configFields: ConnectorConfigField[]
+}
+
+export interface ConnectorStatusOption {
+  upstream: string
+  suggestedLocal: TaskStatus
+}
+
+export interface ConnectorManifest {
+  auth: ConnectorConfigField[]
+  taskFilters?: ConnectorConfigField[]
+  statusMapping?: ConnectorStatusOption[]
+  triggers?: ConnectorTriggerDef[]
+  actions?: ConnectorActionDef[]
+  defaultWorkflows?: Array<{
+    name: string
+    trigger: 'recurring'
+    cron: string
+    actionType: string
+  }>
+}
+
+/**
+ * The core connector interface. A connector provides tasks, triggers, and/or
+ * actions for an external service. Implementations can use any transport:
+ * gh CLI, REST API, MCP server, shell script, etc.
+ */
+export interface VornConnector {
+  readonly id: string
+  readonly name: string
+  readonly icon: string
+  readonly capabilities: ('tasks' | 'triggers' | 'actions')[]
+
+  listItems?(filters: Record<string, unknown>): Promise<ExternalItem[]>
+  getItem?(externalId: string, filters: Record<string, unknown>): Promise<ExternalItem | null>
+  poll?(triggerType: string, config: Record<string, unknown>, cursor?: string): Promise<PollResult>
+  execute?(actionType: string, args: Record<string, unknown>): Promise<ActionResult>
+
+  describe(): ConnectorManifest
+}
+
+// -- Source connection (saved config for a linked connector) --
+
+export interface SourceConnection {
+  id: string
+  connectorId: string
+  name: string
+  filters: Record<string, unknown>
+  syncIntervalMinutes: number
+  statusMapping: Record<string, TaskStatus>
+  executionProject?: string // vorn project for tasks
+  lastSyncAt?: string
+  lastSyncError?: string
+  syncCursor?: string
+  createdAt: string
+}
+
+// -- Task source link (sync metadata, separate from TaskConfig) --
+
+export interface TaskSourceLink {
+  taskId: string
+  connectionId: string
+  connectorId: string
+  externalId: string
+  externalUrl: string
+  sourceStatusRaw: string
+  sourceUpdatedAt: string
+  lastSyncedAt: string
+  conflictState: 'none' | 'upstream_changed' | 'both_changed'
 }
 
 // Session event types (lifecycle activity log)
@@ -669,7 +805,16 @@ export const IPC = {
   SSH_TEST_CONNECTION: 'ssh:testConnection',
   OPEN_EXTERNAL: 'shell:openExternal',
   FILE_LIST_DIR: 'file:listDir',
-  FILE_READ_CONTENT: 'file:readContent'
+  FILE_READ_CONTENT: 'file:readContent',
+  CONNECTOR_LIST: 'connector:list',
+  CONNECTOR_GET: 'connector:get',
+  CONNECTION_LIST: 'connection:list',
+  CONNECTION_CREATE: 'connection:create',
+  CONNECTION_UPDATE: 'connection:update',
+  CONNECTION_DELETE: 'connection:delete',
+  CONNECTION_SYNC: 'connection:sync',
+  CONNECTION_GET_SOURCE_LINK: 'connection:getSourceLink',
+  CONNECTOR_DETECT_REPO: 'connector:detectRepo'
 } as const
 
 export interface PermissionSuggestion {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -165,6 +165,29 @@ export function registerIpcHandlers(): void {
     requireBridge().request(IPC.SSH_TEST_CONNECTION, host)
   )
 
+  // Connectors
+  safeHandle(IPC.CONNECTOR_LIST, () => requireBridge().request(IPC.CONNECTOR_LIST))
+  safeHandle(IPC.CONNECTOR_GET, (_, id) => requireBridge().request(IPC.CONNECTOR_GET, id))
+  safeHandle(IPC.CONNECTION_LIST, (_, params) =>
+    requireBridge().request(IPC.CONNECTION_LIST, params)
+  )
+  safeHandle(IPC.CONNECTION_CREATE, (_, params) =>
+    requireBridge().request(IPC.CONNECTION_CREATE, params)
+  )
+  safeHandle(IPC.CONNECTION_UPDATE, (_, params) =>
+    requireBridge().request(IPC.CONNECTION_UPDATE, params)
+  )
+  safeHandle(IPC.CONNECTION_DELETE, (_, id) => requireBridge().request(IPC.CONNECTION_DELETE, id))
+  safeHandle(IPC.CONNECTION_SYNC, (_, connectionId) =>
+    requireBridge().request(IPC.CONNECTION_SYNC, connectionId)
+  )
+  safeHandle(IPC.CONNECTION_GET_SOURCE_LINK, (_, taskId) =>
+    requireBridge().request(IPC.CONNECTION_GET_SOURCE_LINK, taskId)
+  )
+  safeHandle(IPC.CONNECTOR_DETECT_REPO, (_, projectPath) =>
+    requireBridge().request(IPC.CONNECTOR_DETECT_REPO, projectPath)
+  )
+
   // ─── Electron-only handlers (stay local) ───────────────────────
 
   safeHandle(IPC.DIALOG_OPEN_DIRECTORY, async (event) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,7 +19,10 @@ import {
   RemoteHost,
   TailscaleStatus,
   SessionLog,
-  FileEntry
+  FileEntry,
+  SourceConnection,
+  TaskSourceLink,
+  ConnectorManifest
 } from '../shared/types'
 
 const api = {
@@ -393,7 +396,56 @@ const api = {
   },
   installUpdate: () => ipcRenderer.send(IPC.UPDATE_INSTALL),
   setUpdateChannel: (channel: 'stable' | 'beta') =>
-    ipcRenderer.send(IPC.UPDATE_SET_CHANNEL, channel)
+    ipcRenderer.send(IPC.UPDATE_SET_CHANNEL, channel),
+
+  // Connectors
+  listConnectors: (): Promise<
+    Array<{
+      id: string
+      name: string
+      icon: string
+      capabilities: string[]
+      manifest: ConnectorManifest
+    }>
+  > => ipcRenderer.invoke(IPC.CONNECTOR_LIST),
+
+  getConnector: (
+    id: string
+  ): Promise<{
+    id: string
+    name: string
+    icon: string
+    capabilities: string[]
+    manifest: ConnectorManifest
+  } | null> => ipcRenderer.invoke(IPC.CONNECTOR_GET, id),
+
+  listConnections: (connectorId?: string): Promise<SourceConnection[]> =>
+    ipcRenderer.invoke(IPC.CONNECTION_LIST, { connectorId }),
+
+  createConnection: (
+    params: Omit<
+      SourceConnection,
+      'id' | 'createdAt' | 'lastSyncAt' | 'lastSyncError' | 'syncCursor'
+    >
+  ): Promise<SourceConnection> => ipcRenderer.invoke(IPC.CONNECTION_CREATE, params),
+
+  updateConnection: (
+    id: string,
+    updates: Partial<SourceConnection>
+  ): Promise<SourceConnection | null> => ipcRenderer.invoke(IPC.CONNECTION_UPDATE, { id, updates }),
+
+  deleteConnection: (id: string): Promise<void> => ipcRenderer.invoke(IPC.CONNECTION_DELETE, id),
+
+  syncConnection: (
+    connectionId: string
+  ): Promise<{ created: number; updated: number; error?: string }> =>
+    ipcRenderer.invoke(IPC.CONNECTION_SYNC, connectionId),
+
+  getTaskSourceLink: (taskId: string): Promise<TaskSourceLink | null> =>
+    ipcRenderer.invoke(IPC.CONNECTION_GET_SOURCE_LINK, taskId),
+
+  detectRepo: (projectPath: string): Promise<{ owner: string; repo: string } | null> =>
+    ipcRenderer.invoke(IPC.CONNECTOR_DETECT_REPO, projectPath)
 }
 
 contextBridge.exposeInMainWorld('api', api)

--- a/src/renderer/components/ConnectorIcon.tsx
+++ b/src/renderer/components/ConnectorIcon.tsx
@@ -1,0 +1,69 @@
+import { ExternalLink } from 'lucide-react'
+import { Tooltip } from './Tooltip'
+
+const CONNECTOR_ICONS: Record<string, React.FC<{ size: number; className?: string }>> = {
+  github: ({ size, className }) => (
+    <svg viewBox="0 0 16 16" width={size} height={size} className={className} fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  ),
+  linear: ({ size, className }) => (
+    <svg viewBox="0 0 16 16" width={size} height={size} className={className} fill="currentColor">
+      <path d="M0.856 8.972L7.028 15.144C3.291 14.618 0.382 11.709 0.856 8.972ZM0.254 7.396L8.604 15.746C12.758 15.09 15.09 12.758 15.746 8.604L7.396 0.254C3.242 0.91 0.91 3.242 0.254 7.396ZM8.972 0.856L15.144 7.028C14.618 3.291 11.709 0.382 8.972 0.856Z" />
+    </svg>
+  )
+}
+
+const DEFAULT_ICON: React.FC<{ size: number; className?: string }> = ({ size, className }) => (
+  <ExternalLink size={size} className={className} />
+)
+
+export function ConnectorIcon({
+  connectorId,
+  size = 12,
+  className = 'text-gray-500'
+}: {
+  connectorId: string
+  size?: number
+  className?: string
+}) {
+  const Icon = CONNECTOR_ICONS[connectorId] || DEFAULT_ICON
+  return <Icon size={size} className={className} />
+}
+
+export function SourceBadge({
+  connectorId,
+  url,
+  label
+}: {
+  connectorId: string
+  url?: string
+  label?: string
+}) {
+  const badge = (
+    <span className="inline-flex items-center gap-0.5">
+      <ConnectorIcon connectorId={connectorId} size={11} className="text-gray-500" />
+      {label && <span className="text-[10px] text-gray-500">{label}</span>}
+    </span>
+  )
+
+  if (url) {
+    return (
+      <Tooltip label={`Open in ${connectorId}`}>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            window.api.openExternal(url)
+          }}
+          className="inline-flex items-center hover:text-gray-300 transition-colors"
+        >
+          {badge}
+        </a>
+      </Tooltip>
+    )
+  }
+
+  return badge
+}

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { NotificationSettings } from './settings/NotificationSettings'
 import { AgentSettings } from './settings/AgentSettings'
 import { SSHSettings } from './settings/SSHSettings'
 import { McpSettings } from './settings/McpSettings'
+import { ConnectorSettings } from './settings/ConnectorSettings'
 import { NetworkSettings } from './settings/NetworkSettings'
 import { AboutSettings } from './settings/AboutSettings'
 
@@ -127,6 +128,24 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
           >
             <path d="M12 2v4m0 12v4M2 12h4m12 0h4" />
             <circle cx="12" cy="12" r="4" />
+          </svg>
+        )
+      },
+      {
+        key: 'connectors',
+        label: 'Connectors',
+        icon: (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path d="M9 17H7A5 5 0 017 7h2" />
+            <path d="M15 7h2a5 5 0 010 10h-2" />
+            <line x1="8" y1="12" x2="16" y2="12" />
           </svg>
         )
       },
@@ -260,6 +279,7 @@ export function SettingsPage() {
           {settingsCategory === 'agents' && <AgentSettings />}
           {settingsCategory === 'ssh' && <SSHSettings />}
           {settingsCategory === 'mcp' && <McpSettings />}
+          {settingsCategory === 'connectors' && <ConnectorSettings />}
           {settingsCategory === 'network' && <NetworkSettings />}
           {settingsCategory === 'about' && <AboutSettings />}
         </div>

--- a/src/renderer/components/TaskBoardView.tsx
+++ b/src/renderer/components/TaskBoardView.tsx
@@ -27,6 +27,7 @@ export function TaskBoardView() {
   const setSelectedTaskId = useAppStore((s) => s.setSelectedTaskId)
   const setTaskDialogOpen = useAppStore((s) => s.setTaskDialogOpen)
   const taskStatusFilter = useAppStore((s) => s.taskStatusFilter)
+  const taskSourceFilter = useAppStore((s) => s.taskSourceFilter)
 
   const viewMode = config?.defaults?.taskViewMode ?? 'list'
 
@@ -41,10 +42,18 @@ export function TaskBoardView() {
   )
 
   // Apply status filter
-  const allTasks =
+  const statusFiltered =
     taskStatusFilter === 'all'
       ? projectTasks
       : projectTasks.filter((t) => t.status === taskStatusFilter)
+
+  // Apply source filter
+  const allTasks =
+    taskSourceFilter === 'all'
+      ? statusFiltered
+      : taskSourceFilter === 'local'
+        ? statusFiltered.filter((t) => !t.sourceConnectorId)
+        : statusFiltered.filter((t) => t.sourceConnectorId === taskSourceFilter)
 
   const todoTasks = allTasks.filter((t) => t.status === 'todo').sort((a, b) => a.order - b.order)
   const inProgressTasks = allTasks.filter((t) => t.status === 'in_progress')

--- a/src/renderer/components/TaskDetailPanel.tsx
+++ b/src/renderer/components/TaskDetailPanel.tsx
@@ -43,6 +43,7 @@ import {
   Workflow,
   Activity
 } from 'lucide-react'
+import { ConnectorIcon } from './ConnectorIcon'
 import { RunEntry } from './workflow-editor/RunEntry'
 import { LogReplayModal } from './LogReplayModal'
 import { SessionActivityLog } from './SessionActivityLog'
@@ -732,6 +733,28 @@ export function TaskDetailPanel() {
                        focus:bg-white/[0.02] rounded px-1 -mx-1 py-0.5 transition-colors"
           />
         </div>
+
+        {/* Source reference */}
+        {task?.sourceConnectorId && task.sourceExternalUrl && (
+          <div className="px-4 pb-2">
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                window.api.openExternal(task.sourceExternalUrl!)
+              }}
+              className="inline-flex items-center gap-1.5 px-2 py-1 bg-white/[0.04] border border-white/[0.08] rounded-md text-xs text-gray-400 hover:text-white hover:bg-white/[0.08] transition-colors"
+            >
+              <ConnectorIcon
+                connectorId={task.sourceConnectorId}
+                size={13}
+                className="text-gray-400"
+              />
+              {task.sourceExternalId ? `#${task.sourceExternalId}` : task.sourceConnectorId}
+              <span className="text-gray-600">↗</span>
+            </a>
+          </div>
+        )}
 
         {/* Description */}
         <div className="px-4 pb-3">

--- a/src/renderer/components/TaskToolbar.tsx
+++ b/src/renderer/components/TaskToolbar.tsx
@@ -5,6 +5,7 @@ import { TaskViewMode } from '../../shared/types'
 import { SlidersHorizontal } from 'lucide-react'
 import { Tooltip } from './Tooltip'
 import { OptionRow } from './OptionRow'
+import { ConnectorIcon } from './ConnectorIcon'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
 
@@ -48,9 +49,16 @@ export function TaskToolbar() {
 
   const taskStatusFilter = useAppStore((s) => s.taskStatusFilter)
   const setTaskStatusFilter = useAppStore((s) => s.setTaskStatusFilter)
+  const taskSourceFilter = useAppStore((s) => s.taskSourceFilter)
+  const setTaskSourceFilter = useAppStore((s) => s.setTaskSourceFilter)
   const config = useAppStore((s) => s.config)
   const setConfig = useAppStore((s) => s.setConfig)
   const taskViewMode = (config?.defaults?.taskViewMode ?? 'list') as TaskViewMode
+
+  // Detect which connectors have tasks
+  const connectorIds = new Set(
+    (config?.tasks || []).map((t) => t.sourceConnectorId).filter(Boolean) as string[]
+  )
 
   const setViewMode = (mode: TaskViewMode): void => {
     if (!config || taskViewMode === mode) return
@@ -62,7 +70,8 @@ export function TaskToolbar() {
     setConfig(updated)
   }
 
-  const hasActiveFilters = taskStatusFilter !== 'all' || taskViewMode !== 'list'
+  const hasActiveFilters =
+    taskStatusFilter !== 'all' || taskViewMode !== 'list' || taskSourceFilter !== 'all'
 
   const toggle = useCallback(() => setOpen((o) => !o), [])
 
@@ -124,6 +133,59 @@ export function TaskToolbar() {
               />
             ))}
           </div>
+
+          {/* Source section (only show if connectors have tasks) */}
+          {connectorIds.size > 0 && (
+            <div className="py-1.5 border-t border-white/[0.06]">
+              <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
+                Source
+              </div>
+              <OptionRow
+                selected={taskSourceFilter === 'all'}
+                dot="bg-gray-400"
+                label="All Sources"
+                onClick={() => setTaskSourceFilter('all')}
+              />
+              <OptionRow
+                selected={taskSourceFilter === 'local'}
+                dot="bg-blue-400"
+                label="Local Only"
+                onClick={() => setTaskSourceFilter('local')}
+              />
+              {[...connectorIds].map((cid) => (
+                <button
+                  key={cid}
+                  onClick={() => setTaskSourceFilter(cid)}
+                  className={`w-full text-left px-3 py-1.5 text-[12px] transition-colors flex items-center gap-2 ${
+                    taskSourceFilter === cid
+                      ? 'text-white bg-white/[0.06]'
+                      : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+                  }`}
+                >
+                  {taskSourceFilter === cid ? (
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  ) : (
+                    <span className="w-[11px]" />
+                  )}
+                  <ConnectorIcon
+                    connectorId={cid}
+                    size={10}
+                    className={taskSourceFilter === cid ? 'text-white' : 'text-gray-500'}
+                  />
+                  {cid.charAt(0).toUpperCase() + cid.slice(1)}
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* View section */}
           <div className="py-1.5 border-t border-white/[0.06]">

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -1,0 +1,376 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useAppStore } from '../../stores'
+import { SettingsPageHeader } from './SettingsPageHeader'
+import { ConnectorIcon } from '../ConnectorIcon'
+import { Plus, RefreshCw, Trash2, Check, AlertCircle } from 'lucide-react'
+import type {
+  SourceConnection,
+  ConnectorManifest,
+  ConnectorConfigField,
+  TaskStatus
+} from '../../../shared/types'
+
+interface ConnectorInfo {
+  id: string
+  name: string
+  icon: string
+  capabilities: string[]
+  manifest: ConnectorManifest
+}
+
+export function ConnectorSettings() {
+  const [connectors, setConnectors] = useState<ConnectorInfo[]>([])
+  const [connections, setConnections] = useState<SourceConnection[]>([])
+  const [adding, setAdding] = useState<string | null>(null)
+  const [syncing, setSyncing] = useState<string | null>(null)
+  const [syncResult, setSyncResult] = useState<{
+    id: string
+    created: number
+    updated: number
+    error?: string
+  } | null>(null)
+
+  const load = useCallback(async () => {
+    const [c, conns] = await Promise.all([
+      window.api.listConnectors(),
+      window.api.listConnections()
+    ])
+    setConnectors(c)
+    setConnections(conns)
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleSync = async (connectionId: string) => {
+    setSyncing(connectionId)
+    setSyncResult(null)
+    try {
+      const result = await window.api.syncConnection(connectionId)
+      setSyncResult({ id: connectionId, ...result })
+    } finally {
+      setSyncing(null)
+      load()
+    }
+  }
+
+  const handleDelete = async (connectionId: string) => {
+    await window.api.deleteConnection(connectionId)
+    load()
+  }
+
+  return (
+    <div>
+      <SettingsPageHeader
+        title="Connectors"
+        description="Connect external task sources like GitHub and Linear"
+      />
+
+      {/* Available connectors */}
+      <div className="mb-8">
+        <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+          Available Connectors
+        </h3>
+        <div className="space-y-2">
+          {connectors.map((c) => {
+            const existingConns = connections.filter((conn) => conn.connectorId === c.id)
+            return (
+              <div
+                key={c.id}
+                className="flex items-center justify-between px-4 py-3 bg-white/[0.03] border border-white/[0.06] rounded-lg"
+              >
+                <div className="flex items-center gap-3">
+                  <ConnectorIcon connectorId={c.id} size={18} className="text-gray-400" />
+                  <div>
+                    <span className="text-sm text-gray-200 font-medium">{c.name}</span>
+                    <span className="text-xs text-gray-500 ml-2">{c.capabilities.join(' · ')}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {existingConns.length > 0 && (
+                    <span className="text-xs text-green-500 flex items-center gap-1">
+                      <Check size={12} /> {existingConns.length} connected
+                    </span>
+                  )}
+                  <button
+                    onClick={() => setAdding(c.id)}
+                    className="text-xs text-gray-400 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-md hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+                  >
+                    <Plus size={12} /> Add
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+          {connectors.length === 0 && (
+            <p className="text-sm text-gray-500">No connectors available.</p>
+          )}
+        </div>
+      </div>
+
+      {adding && (
+        <AddConnectionForm
+          connector={connectors.find((c) => c.id === adding)!}
+          onDone={() => {
+            setAdding(null)
+            load()
+          }}
+          onCancel={() => setAdding(null)}
+        />
+      )}
+
+      {connections.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+            Active Connections
+          </h3>
+          <div className="space-y-2">
+            {connections.map((conn) => {
+              const isSyncing = syncing === conn.id
+              const result = syncResult?.id === conn.id ? syncResult : null
+              return (
+                <div
+                  key={conn.id}
+                  className="px-4 py-3 bg-white/[0.03] border border-white/[0.06] rounded-lg"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <ConnectorIcon
+                        connectorId={conn.connectorId}
+                        size={16}
+                        className="text-gray-400"
+                      />
+                      <div>
+                        <span className="text-sm text-gray-200 font-medium">{conn.name}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        onClick={() => handleSync(conn.id)}
+                        disabled={isSyncing}
+                        className="p-1.5 text-gray-500 hover:text-white rounded transition-colors disabled:opacity-50"
+                        title="Sync now"
+                      >
+                        <RefreshCw size={14} className={isSyncing ? 'animate-spin' : ''} />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(conn.id)}
+                        className="p-1.5 text-gray-500 hover:text-red-400 rounded transition-colors"
+                        title="Remove connection"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </div>
+                  <div className="mt-2 flex items-center gap-2 text-[11px]">
+                    {conn.lastSyncAt && (
+                      <span className="text-gray-500">
+                        Last synced: {new Date(conn.lastSyncAt).toLocaleString()}
+                      </span>
+                    )}
+                    {conn.lastSyncError && (
+                      <span className="text-red-400 flex items-center gap-1">
+                        <AlertCircle size={10} /> {conn.lastSyncError}
+                      </span>
+                    )}
+                    {result && !result.error && (
+                      <span className="text-green-400">
+                        +{result.created} created, {result.updated} updated
+                      </span>
+                    )}
+                    {result?.error && <span className="text-red-400">{result.error}</span>}
+                  </div>
+                  {Object.keys(conn.filters).length > 0 && (
+                    <div className="mt-1.5 flex flex-wrap gap-1.5">
+                      {Object.entries(conn.filters).map(([k, v]) => (
+                        <span
+                          key={k}
+                          className="text-[10px] px-1.5 py-0.5 bg-white/[0.06] rounded text-gray-400"
+                        >
+                          {k}: {String(v)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AddConnectionForm({
+  connector,
+  onDone,
+  onCancel
+}: {
+  connector: ConnectorInfo
+  onDone: () => void
+  onCancel: () => void
+}) {
+  const projects = useAppStore((s) => s.config?.projects || [])
+  const manifest = connector.manifest
+
+  const [selectedProject, setSelectedProject] = useState(projects[0]?.name || '')
+  const [detectedRepo, setDetectedRepo] = useState<{
+    owner: string
+    repo: string
+  } | null>(null)
+  const [detecting, setDetecting] = useState(false)
+  const [filters, setFilters] = useState<Record<string, string>>({})
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    const project = projects.find((p) => p.name === selectedProject)
+    if (!project) return
+    setDetecting(true)
+    setDetectedRepo(null)
+    window.api.detectRepo(project.path).then((result) => {
+      setDetectedRepo(result)
+      setDetecting(false)
+    })
+  }, [selectedProject, projects])
+
+  const statusMapping: Record<string, TaskStatus> = {}
+  for (const opt of manifest.statusMapping || []) {
+    statusMapping[opt.upstream] = opt.suggestedLocal
+  }
+
+  const handleSave = async () => {
+    if (!detectedRepo) return
+    setSaving(true)
+    try {
+      const conn = await window.api.createConnection({
+        connectorId: connector.id,
+        name: `${detectedRepo.owner}/${detectedRepo.repo}`,
+        filters: { ...filters, owner: detectedRepo.owner, repo: detectedRepo.repo },
+        syncIntervalMinutes: 5,
+        statusMapping,
+        executionProject: selectedProject
+      })
+      await window.api.syncConnection(conn.id)
+      onDone()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mb-8 px-4 py-4 bg-white/[0.03] border border-white/[0.08] rounded-lg">
+      <div className="flex items-center gap-2 mb-4">
+        <ConnectorIcon connectorId={connector.id} size={16} className="text-gray-400" />
+        <h3 className="text-sm font-medium text-gray-200">Connect {connector.name}</h3>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Project</label>
+          <select
+            value={selectedProject}
+            onChange={(e) => setSelectedProject(e.target.value)}
+            className="w-full px-3 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-md text-sm text-gray-200 focus:border-white/[0.2] outline-none"
+          >
+            {projects.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="text-xs">
+          {detecting && <span className="text-gray-500">Detecting repository...</span>}
+          {detectedRepo && (
+            <span className="text-green-400 flex items-center gap-1">
+              <Check size={12} /> Detected: {detectedRepo.owner}/{detectedRepo.repo}
+            </span>
+          )}
+          {!detecting && !detectedRepo && selectedProject && (
+            <span className="text-amber-400">
+              No GitHub repo detected. Is this a git repo with a GitHub remote?
+            </span>
+          )}
+        </div>
+
+        {(manifest.taskFilters || []).map((field) => (
+          <DynamicField
+            key={field.key}
+            field={field}
+            value={filters[field.key] || ''}
+            onChange={(v) => setFilters((prev) => ({ ...prev, [field.key]: v }))}
+          />
+        ))}
+
+        <div className="flex gap-2 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={saving || !detectedRepo}
+            className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-md transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Connecting...' : 'Connect & Sync'}
+          </button>
+          <button
+            onClick={onCancel}
+            className="px-4 py-1.5 text-sm text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DynamicField({
+  field,
+  value,
+  onChange
+}: {
+  field: ConnectorConfigField
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div>
+      <label className="block text-xs text-gray-500 mb-1">
+        {field.label}
+        {field.required && <span className="text-red-400 ml-0.5">*</span>}
+      </label>
+      {field.type === 'select' ? (
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full px-3 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-md text-sm text-gray-200 focus:border-white/[0.2] outline-none"
+        >
+          <option value="">—</option>
+          {(field.options || []).map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      ) : field.type === 'textarea' ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          rows={3}
+          className="w-full px-3 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-md text-sm text-gray-200 focus:border-white/[0.2] outline-none"
+        />
+      ) : (
+        <input
+          type={field.type === 'password' ? 'password' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          className="w-full px-3 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-md text-sm text-gray-200 focus:border-white/[0.2] outline-none"
+        />
+      )}
+      {field.description && <p className="text-[10px] text-gray-600 mt-0.5">{field.description}</p>}
+    </div>
+  )
+}

--- a/src/renderer/components/task-board/TaskCard.tsx
+++ b/src/renderer/components/task-board/TaskCard.tsx
@@ -1,5 +1,6 @@
 import { TaskConfig } from '../../../shared/types'
 import { AgentIcon } from '../AgentIcon'
+import { SourceBadge, ConnectorIcon } from '../ConnectorIcon'
 import {
   STATUS_ICON,
   STATUS_ICON_COLOR,
@@ -58,9 +59,31 @@ export function TaskCard({
         onClick={onSelect}
       >
         <div className="px-3.5 py-3">
-          {/* Top row: short ID + menu */}
+          {/* Top row: short ID + source badge + menu */}
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-[10px] text-gray-500 font-medium">{shortId}</span>
+            <span className="flex items-center gap-1">
+              <span className="text-[10px] text-gray-500 font-medium">{shortId}</span>
+              {task.sourceConnectorId && task.sourceExternalId && (
+                <span className="flex items-center gap-0.5 text-[10px] text-gray-500">
+                  <ConnectorIcon
+                    connectorId={task.sourceConnectorId}
+                    size={10}
+                    className="text-gray-500"
+                  />
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      if (task.sourceExternalUrl) window.api.openExternal(task.sourceExternalUrl)
+                    }}
+                    className="hover:text-gray-300 transition-colors"
+                  >
+                    #{task.sourceExternalId}
+                  </a>
+                </span>
+              )}
+            </span>
             <div
               className="opacity-0 group-hover:opacity-100 transition-opacity"
               onClick={(e) => e.stopPropagation()}
@@ -126,8 +149,17 @@ export function TaskCard({
         )}
       </div>
 
-      {/* Task short ID */}
-      <span className="text-[11px] text-gray-500 font-medium w-14 shrink-0">{shortId}</span>
+      {/* Task short ID + source badge */}
+      <span className="flex items-center gap-1.5 text-[11px] text-gray-500 font-medium shrink-0">
+        {shortId}
+        {task.sourceConnectorId && task.sourceExternalId && (
+          <SourceBadge
+            connectorId={task.sourceConnectorId}
+            url={task.sourceExternalUrl}
+            label={`#${task.sourceExternalId}`}
+          />
+        )}
+      </span>
 
       {/* Status icon */}
       <StatusIcon size={14} className={`${iconColor} shrink-0`} />

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -29,6 +29,10 @@ export const MAIN_WORKTREE_SENTINEL = '__main__'
 export type SortMode = 'manual' | 'created' | 'recent'
 export type StatusFilter = AgentStatus | 'all'
 export type TaskStatusFilter = 'all' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'
+
+/** Filter tasks by source: 'all' shows everything, 'local' shows only local tasks,
+ *  or a connector ID (e.g. 'github') shows only tasks from that connector. */
+export type TaskSourceFilter = 'all' | 'local' | string
 export type ProjectSortMode = 'manual' | 'name' | 'recent'
 export type WorkflowFilter = 'all' | 'manual' | 'scheduled'
 export type WorktreeSortMode = 'name' | 'recent'
@@ -104,6 +108,7 @@ export type SettingsCategory =
   | 'agents'
   | 'ssh'
   | 'mcp'
+  | 'connectors'
   | 'network'
   | 'about'
 
@@ -143,6 +148,7 @@ export interface UISlice {
   mainViewMode: 'sessions' | 'tasks' | 'workflows'
   selectedTaskId: string | null
   taskStatusFilter: TaskStatusFilter
+  taskSourceFilter: TaskSourceFilter
   isTaskDialogOpen: boolean
   taskDialogDefaultStatus: TaskStatus
   editingTask: TaskConfig | null
@@ -183,6 +189,7 @@ export interface UISlice {
   setMainViewMode: (mode: 'sessions' | 'tasks' | 'workflows') => void
   setSelectedTaskId: (id: string | null) => void
   setTaskStatusFilter: (filter: TaskStatusFilter) => void
+  setTaskSourceFilter: (filter: TaskSourceFilter) => void
   setTaskDialogOpen: (open: boolean, defaultStatus?: TaskStatus) => void
   setEditingTask: (task: TaskConfig | null) => void
   setActiveTabId: (id: string | null) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand'
 import { TerminalSession } from '../../shared/types'
-import { AppStore, UISlice, SidebarViewMode, FlexibleLayoutRect } from './types'
+import { AppStore, UISlice, SidebarViewMode, FlexibleLayoutRect, TaskSourceFilter } from './types'
 
 const EMPTY_SESSIONS: TerminalSession[] = []
 const WORKTREE_CACHE_TTL = 5_000
@@ -102,6 +102,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   mainViewMode: 'sessions' as const,
   selectedTaskId: null,
   taskStatusFilter: 'all' as const,
+  taskSourceFilter: 'all' as TaskSourceFilter,
   isTaskDialogOpen: false,
   taskDialogDefaultStatus: 'todo' as const,
   editingTask: null,
@@ -260,6 +261,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   },
   setSelectedTaskId: (id) => set({ selectedTaskId: id }),
   setTaskStatusFilter: (filter) => set({ taskStatusFilter: filter }),
+  setTaskSourceFilter: (filter) => set({ taskSourceFilter: filter }),
   setTaskDialogOpen: (open, defaultStatus) =>
     set({ isTaskDialogOpen: open, taskDialogDefaultStatus: defaultStatus ?? 'todo' }),
   setEditingTask: (task) => set({ editingTask: task }),


### PR DESCRIPTION
Add a pluggable connector system that imports tasks from external services into the unified task board. Ships with a built-in GitHub connector using the `gh` CLI.

## Connector Interface
- `VornConnector`: 4 methods (`listItems`, `poll`, `execute`, `describe`) + manifest
- `ConnectorRegistry` for registering/discovering connectors
- Self-describing manifests drive dynamic UI (auth, filters, actions)

## GitHub Connector
- Built-in at `packages/server/src/connectors/github.ts`
- Uses `gh` CLI — zero auth config, leverages existing `gh auth`
- Tasks: list/get issues via `gh api`
- Triggers: `issueCreated`, `prOpened` (polling)
- Actions: `createIssue`, `closeIssue`, `commentOnIssue`
- Auto-detects `owner/repo` from project path via `gh repo view`

## Database
- Migration v9: `source_connections` + `task_source_links` tables
- `TaskConfig` extended with `sourceConnectorId`, `sourceExternalId`, `sourceExternalUrl`

## Protocol & IPC
- 9 new RPCs: `connector:list/get/detectRepo`, `connection:list/create/update/delete/sync/getSourceLink`
- Sync logic: upserts tasks with field ownership (upstream owns title/desc, local owns status/agent/session)

## UI
- `ConnectorIcon`: GitHub/Linear SVG icons + `SourceBadge` component
- `TaskCard`: issue number badge (`#42`) with click-to-open-upstream
- `TaskDetailPanel`: source reference link below title
- `TaskToolbar`: source filter (All Sources / Local Only / GitHub)
- Settings → Connectors: add/sync/remove connections with dynamic forms