### PR TITLE
fix(mcp): use two-arg z.record so tools/list doesn't crash

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -57,7 +57,7 @@ const nodeSchema = z.object({
   id: V.id,
   type: z.enum(['trigger', 'launchAgent']),
   label: V.shortText,
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
   position: z.object({ x: z.number(), y: z.number() })
 })
 


### PR DESCRIPTION
## Summary
- `packages/mcp/src/tools/workflows.ts` used `z.record(z.unknown())`. Zod v4 treats that single arg as the **key** type with no value type, so when the MCP SDK walked the schema to build the `tools/list` response it hit `valueType._zod` on `undefined` and threw.
- That one exception made `tools/list` return a JSON-RPC error and zero tools — the MCP server showed as connected but exposed nothing to the client.
- Fix: `z.record(z.string(), z.unknown())`.

## Test plan
- [x] All 30 tool schemas convert to JSON schema without throwing
- [x] End-to-end stdio `initialize` → `tools/list` returns 30 tools (incl. `create_workflow` / `update_workflow`)
- [x] Live `tools/call` on `list_tasks` and `list_workflows` returns real data
- [ ] Reviewer spot-checks `workflows.ts` diff