### PR TITLE
fix: window control maximize/restore state + mac focused drag strip

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -623,6 +623,8 @@ export const IPC = {
   WINDOW_MINIMIZE: 'window:minimize',
   WINDOW_MAXIMIZE: 'window:maximize',
   WINDOW_CLOSE: 'window:close',
+  WINDOW_IS_MAXIMIZED: 'window:isMaximized',
+  WINDOW_MAXIMIZED_CHANGED: 'window:maximizedChanged',
   WIDGET_STATUS_UPDATE: 'widget:status-update',
   WIDGET_FOCUS_TERMINAL: 'widget:focus-terminal',
   WIDGET_HIDE: 'widget:hide',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,7 @@ function createWindow(): void {
     frame: false,
     ...(isMac
       ? {
-          trafficLightPosition: { x: 16, y: 16 }
+          trafficLightPosition: { x: 16, y: 13 }
         }
       : {}),
     backgroundColor: '#1a1a1e',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,6 +69,13 @@ function createWindow(): void {
     mainWindow?.show()
   })
 
+  mainWindow.on('maximize', () => {
+    mainWindow?.webContents.send(IPC.WINDOW_MAXIMIZED_CHANGED, true)
+  })
+  mainWindow.on('unmaximize', () => {
+    mainWindow?.webContents.send(IPC.WINDOW_MAXIMIZED_CHANGED, false)
+  })
+
   // Set dock icon on macOS (needed in dev mode since there's no app bundle)
   if (process.platform === 'darwin') {
     const iconPath = path.join(__dirname, '../../resources/icon.png')
@@ -311,6 +318,7 @@ app.whenReady().then(async () => {
     else mainWindow?.maximize()
   })
   ipcMain.on(IPC.WINDOW_CLOSE, () => mainWindow?.close())
+  ipcMain.handle(IPC.WINDOW_IS_MAXIMIZED, () => mainWindow?.isMaximized() ?? false)
 
   createMenu(toggleWidget)
   createWindow()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -305,6 +305,14 @@ const api = {
   windowMinimize: () => ipcRenderer.send(IPC.WINDOW_MINIMIZE),
   windowMaximize: () => ipcRenderer.send(IPC.WINDOW_MAXIMIZE),
   windowClose: () => ipcRenderer.send(IPC.WINDOW_CLOSE),
+  isWindowMaximized: (): Promise<boolean> => ipcRenderer.invoke(IPC.WINDOW_IS_MAXIMIZED),
+  onWindowMaximizedChange: (callback: (maximized: boolean) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, maximized: boolean): void => callback(maximized)
+    ipcRenderer.on(IPC.WINDOW_MAXIMIZED_CHANGED, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.WINDOW_MAXIMIZED_CHANGED, listener)
+    }
+  },
 
   // Widget
   notifyWidgetStatus: () => ipcRenderer.send(IPC.WIDGET_RENDERER_STATUS),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -394,7 +394,7 @@ export function App() {
         {!isInlineWorkflowEditor && !isTabToolbarMerged && !isFocusedFullScreen && (
           <div
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
-                        flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} h-[52px]`}
+                        flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} ${isMobile ? 'h-[52px]' : 'h-[40px]'}`}
             style={
               !isSidebarOpen && !isWeb && !isMobile
                 ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -396,7 +396,7 @@ export function App() {
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} ${isMobile ? 'h-[52px]' : 'h-[40px]'}`}
             style={
-              isMac && !isSidebarOpen && !isMobile
+              isMac && !isWeb && !isSidebarOpen && !isMobile
                 ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
                 : undefined
             }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -396,7 +396,7 @@ export function App() {
             className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} ${isMobile ? 'h-[52px]' : 'h-[40px]'}`}
             style={
-              !isSidebarOpen && !isWeb && !isMobile
+              isMac && !isSidebarOpen && !isMobile
                 ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
                 : undefined
             }

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -149,18 +149,15 @@ export function FocusedTerminal() {
             </div>
           </div>
         ) : (
-          <>
-            {isMac && <div className="titlebar-drag h-6 shrink-0" />}
-            <div
-              className="group/card titlebar-no-drag"
-              onDoubleClick={(e) => {
-                if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
-                handleContract()
-              }}
-            >
-              <CardHeader terminalId={effectiveId} variant="focused" />
-            </div>
-          </>
+          <div
+            className={`group/card ${isMac ? 'titlebar-drag' : 'titlebar-no-drag'}`}
+            onDoubleClick={(e) => {
+              if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
+              handleContract()
+            }}
+          >
+            <CardHeader terminalId={effectiveId} variant="focused" />
+          </div>
         )}
 
         {/* Terminal */}

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -12,6 +12,7 @@ import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { useTerminalScrollButton } from '../hooks/useTerminalScrollButton'
 import { useTerminalPinchZoom } from '../hooks/useTerminalPinchZoom'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { isMac } from '../lib/platform'
 import { ArrowDown, FolderGit2, GitBranch, Minimize2, Pencil } from 'lucide-react'
 
 export function FocusedTerminal() {
@@ -148,15 +149,18 @@ export function FocusedTerminal() {
             </div>
           </div>
         ) : (
-          <div
-            className="group/card titlebar-no-drag"
-            onDoubleClick={(e) => {
-              if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
-              handleContract()
-            }}
-          >
-            <CardHeader terminalId={effectiveId} variant="focused" />
-          </div>
+          <>
+            {isMac && <div className="titlebar-drag h-6 shrink-0" />}
+            <div
+              className="group/card titlebar-no-drag"
+              onDoubleClick={(e) => {
+                if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
+                handleContract()
+              }}
+            >
+              <CardHeader terminalId={effectiveId} variant="focused" />
+            </div>
+          </>
         )}
 
         {/* Terminal */}

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -281,7 +281,7 @@ export function TabView() {
         )}
 
         <div
-          className="flex-1 flex items-end gap-1 px-1 overflow-x-auto min-w-0 titlebar-no-drag"
+          className="flex-1 flex items-end gap-1 px-1 overflow-x-auto min-w-0"
           style={{ minHeight: 40 }}
         >
           {orderedIds.map((id, index) => {
@@ -327,7 +327,7 @@ export function TabView() {
                   e.stopPropagation()
                   setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
                 }}
-                className={`group relative flex items-center gap-2 pl-3 pr-10 h-[36px] text-[13px] cursor-pointer
+                className={`titlebar-no-drag group relative flex items-center gap-2 pl-3 pr-10 h-[36px] text-[13px] cursor-pointer
                            transition-colors flex-1 min-w-[120px] max-w-[260px] select-none border-b
                            ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                            ${isDragging ? 'opacity-50' : ''}
@@ -418,7 +418,7 @@ export function TabView() {
             )
           })}
 
-          <div className="shrink-0 flex items-center">
+          <div className="titlebar-no-drag shrink-0 flex items-center">
             <button
               onClick={() => {
                 const project = resolveActiveProject()

--- a/src/renderer/components/TaskBoardView.tsx
+++ b/src/renderer/components/TaskBoardView.tsx
@@ -12,6 +12,8 @@ import { ListTodo } from 'lucide-react'
 import { toast } from './Toast'
 import { useWorkspaceProjects } from '../hooks/useWorkspaceProjects'
 
+const ROOT_STYLE = { background: '#141416' }
+
 export function TaskBoardView() {
   const activeProject = useAppStore((s) => s.activeProject)
   const config = useAppStore((s) => s.config)
@@ -152,7 +154,7 @@ export function TaskBoardView() {
   const totalTasks = allTasks.length
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 min-w-0">
+    <div className="flex-1 flex flex-col min-h-0 min-w-0" style={ROOT_STYLE}>
       {/* Content */}
       <div
         className={`flex-1 p-4 ${viewMode === 'kanban' ? 'flex flex-col min-h-0 overflow-hidden' : 'overflow-auto'}`}

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,13 +1,20 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { isMac, isWeb } from '../lib/platform'
 
 export function WindowControls() {
   const [isMaximized, setIsMaximized] = useState(false)
+  const eventReceivedRef = useRef(false)
 
   useEffect(() => {
     if (isMac || isWeb) return
-    window.api.isWindowMaximized().then(setIsMaximized)
-    return window.api.onWindowMaximizedChange(setIsMaximized)
+    const unsubscribe = window.api.onWindowMaximizedChange((m) => {
+      eventReceivedRef.current = true
+      setIsMaximized(m)
+    })
+    window.api.isWindowMaximized().then((m) => {
+      if (!eventReceivedRef.current) setIsMaximized(m)
+    })
+    return unsubscribe
   }, [])
 
   if (isMac || isWeb) return null
@@ -39,8 +46,8 @@ export function WindowControls() {
             strokeWidth="1"
             className="text-gray-400"
           >
-            <rect x="2.5" y="0.5" width="7" height="7" />
-            <rect x="0.5" y="2.5" width="7" height="7" fill="#1a1a1e" />
+            <path d="M3 1 h6 v6 h-2 M3 1 v2" />
+            <rect x="1" y="3" width="6" height="6" />
           </svg>
         ) : (
           <svg

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,6 +1,15 @@
+import { useEffect, useState } from 'react'
 import { isMac, isWeb } from '../lib/platform'
 
 export function WindowControls() {
+  const [isMaximized, setIsMaximized] = useState(false)
+
+  useEffect(() => {
+    if (isMac || isWeb) return
+    window.api.isWindowMaximized().then(setIsMaximized)
+    return window.api.onWindowMaximizedChange(setIsMaximized)
+  }, [])
+
   if (isMac || isWeb) return null
   return (
     <div className="flex items-center titlebar-no-drag ml-2">
@@ -17,20 +26,35 @@ export function WindowControls() {
       <button
         onClick={() => window.api.windowMaximize()}
         className="w-[46px] h-[32px] flex items-center justify-center hover:bg-white/[0.08] transition-colors"
-        title="Maximize"
-        aria-label="Maximize"
+        title={isMaximized ? 'Restore' : 'Maximize'}
+        aria-label={isMaximized ? 'Restore' : 'Maximize'}
       >
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          className="text-gray-400"
-        >
-          <rect x="0.5" y="0.5" width="9" height="9" />
-        </svg>
+        {isMaximized ? (
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1"
+            className="text-gray-400"
+          >
+            <rect x="2.5" y="0.5" width="7" height="7" />
+            <rect x="0.5" y="2.5" width="7" height="7" fill="#1a1a1e" />
+          </svg>
+        ) : (
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1"
+            className="text-gray-400"
+          >
+            <rect x="0.5" y="0.5" width="9" height="9" />
+          </svg>
+        )}
       </button>
       <button
         onClick={() => window.api.windowClose()}

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -60,7 +60,7 @@ export function CardHeader({
           status={terminal.status}
           size={18}
         />
-        <div className="min-w-0 flex items-center gap-1 group/rename">
+        <div className="titlebar-no-drag min-w-0 flex items-center gap-1 group/rename">
           {isRenaming ? (
             <InlineRename
               value={displayName}
@@ -87,7 +87,7 @@ export function CardHeader({
                   e.stopPropagation()
                   setRenamingTerminalId(terminalId)
                 }}
-                className="opacity-0 group-hover/rename:opacity-100 text-gray-500 hover:text-gray-300 transition-opacity shrink-0"
+                className="titlebar-no-drag opacity-0 group-hover/rename:opacity-100 text-gray-500 hover:text-gray-300 transition-opacity shrink-0"
                 aria-label="Rename session"
               >
                 <Pencil size={10} />
@@ -110,7 +110,7 @@ export function CardHeader({
             {index + 1}
           </span>
         )}
-        <div className={revealClass}>
+        <div className={`titlebar-no-drag ${revealClass}`}>
           <CardActionCluster terminalId={terminalId} variant={variant} />
         </div>
       </div>

--- a/src/renderer/components/project-sidebar/SidebarHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { isMac, MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
+import { isMac, isWeb, MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { useAppStore } from '../../stores'
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
 import { PanelLeft, Monitor, ListTodo, Zap } from 'lucide-react'
@@ -19,7 +19,9 @@ export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
     <div className="shrink-0 border-b border-white/[0.06]">
       <div
         className="titlebar-drag h-[40px] pr-3 flex items-center"
-        style={isMac ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : { paddingLeft: '12px' }}
+        style={
+          isMac && !isWeb ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : { paddingLeft: '12px' }
+        }
       >
         {!isCollapsed && (
           <div className="flex-1 titlebar-no-drag min-w-0">

--- a/src/renderer/components/project-sidebar/SidebarHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { isElectron, MOD } from '../../lib/platform'
+import { isElectron, MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { useAppStore } from '../../stores'
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
 import { PanelLeft, Monitor, ListTodo, Zap } from 'lucide-react'
@@ -18,7 +18,8 @@ export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
   return (
     <div className="shrink-0 border-b border-white/[0.06]">
       <div
-        className={`titlebar-drag h-[52px] pr-3 flex items-center ${isElectron ? 'pl-[78px]' : 'pl-3'}`}
+        className="titlebar-drag h-[40px] pr-3 flex items-center"
+        style={isElectron ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : { paddingLeft: '12px' }}
       >
         {!isCollapsed && (
           <div className="flex-1 titlebar-no-drag min-w-0">

--- a/src/renderer/components/project-sidebar/SidebarHeader.tsx
+++ b/src/renderer/components/project-sidebar/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { isElectron, MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
+import { isMac, MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { useAppStore } from '../../stores'
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
 import { PanelLeft, Monitor, ListTodo, Zap } from 'lucide-react'
@@ -19,7 +19,7 @@ export function SidebarHeader({ isCollapsed }: { isCollapsed: boolean }) {
     <div className="shrink-0 border-b border-white/[0.06]">
       <div
         className="titlebar-drag h-[40px] pr-3 flex items-center"
-        style={isElectron ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : { paddingLeft: '12px' }}
+        style={isMac ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : { paddingLeft: '12px' }}
       >
         {!isCollapsed && (
           <div className="flex-1 titlebar-no-drag min-w-0">

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -5,7 +5,7 @@ import { ICON_MAP } from '../project-sidebar/icon-map'
 import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../../lib/project-icons'
 import { Tooltip } from '../Tooltip'
 import { useAppStore } from '../../stores'
-import { isMac, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
+import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { SidebarToggleButton } from '../SidebarToggleButton'
 import { MainViewPills } from '../MainViewPills'
 import { WindowControls } from '../WindowControls'
@@ -434,14 +434,14 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       <div
         className={`shrink-0 h-[40px] flex items-center justify-between px-3 border-b border-white/[0.08] titlebar-drag`}
         style={
-          inline && !isSidebarOpen && isMac
+          inline && !isSidebarOpen && isMac && !isWeb
             ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
             : undefined
         }
       >
         <div
           className="flex items-center gap-1 titlebar-no-drag"
-          style={!inline ? { paddingLeft: '70px' } : undefined}
+          style={!inline && isMac && !isWeb ? { paddingLeft: '70px' } : undefined}
         >
           {inline && !isSidebarOpen && (
             <>

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -5,7 +5,7 @@ import { ICON_MAP } from '../project-sidebar/icon-map'
 import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../../lib/project-icons'
 import { Tooltip } from '../Tooltip'
 import { useAppStore } from '../../stores'
-import { isWeb, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
+import { isMac, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { SidebarToggleButton } from '../SidebarToggleButton'
 import { MainViewPills } from '../MainViewPills'
 import { WindowControls } from '../WindowControls'
@@ -434,7 +434,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       <div
         className={`shrink-0 h-[40px] flex items-center justify-between px-3 border-b border-white/[0.08] titlebar-drag`}
         style={
-          inline && !isSidebarOpen && !isWeb
+          inline && !isSidebarOpen && isMac
             ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
             : undefined
         }

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -5,7 +5,10 @@ import { ICON_MAP } from '../project-sidebar/icon-map'
 import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../../lib/project-icons'
 import { Tooltip } from '../Tooltip'
 import { useAppStore } from '../../stores'
-import { isWeb } from '../../lib/platform'
+import { isWeb, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
+import { SidebarToggleButton } from '../SidebarToggleButton'
+import { MainViewPills } from '../MainViewPills'
+import { WindowControls } from '../WindowControls'
 import {
   WorkflowDefinition,
   WorkflowNode,
@@ -429,13 +432,25 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     <>
       {/* Top bar */}
       <div
-        className={`shrink-0 h-[52px] flex items-center justify-between px-4 border-b border-white/[0.08] titlebar-drag`}
-        style={inline && !isSidebarOpen && !isWeb ? { paddingLeft: '80px' } : undefined}
+        className={`shrink-0 h-[40px] flex items-center justify-between px-3 border-b border-white/[0.08] titlebar-drag`}
+        style={
+          inline && !isSidebarOpen && !isWeb
+            ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` }
+            : undefined
+        }
       >
         <div
-          className="flex items-center gap-3 titlebar-no-drag"
+          className="flex items-center gap-1 titlebar-no-drag"
           style={!inline ? { paddingLeft: '70px' } : undefined}
         >
+          {inline && !isSidebarOpen && (
+            <>
+              <SidebarToggleButton />
+              <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
+              <MainViewPills />
+              <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
+            </>
+          )}
           {!inline && (
             <button
               onClick={handleClose}
@@ -611,6 +626,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
               </div>
             )}
           </div>
+          {inline && <WindowControls />}
         </div>
       </div>
 

--- a/tests/task-board-view.test.tsx
+++ b/tests/task-board-view.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockState = {
+  activeProject: null,
+  config: { tasks: [], projects: [] },
+  removeTask: vi.fn(),
+  addTerminal: vi.fn(),
+  startTask: vi.fn(),
+  completeTask: vi.fn(),
+  cancelTask: vi.fn(),
+  reopenTask: vi.fn(),
+  updateTask: vi.fn(),
+  terminals: new Map(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  setTaskDialogOpen: vi.fn(),
+  taskStatusFilter: 'all',
+  activeWorkspace: 'personal'
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+
+vi.mock('../src/renderer/hooks/useWorkspaceProjects', () => ({
+  useWorkspaceProjects: () => []
+}))
+
+vi.mock('../src/renderer/components/task-board/TaskKanbanBoard', () => ({
+  TaskKanbanBoard: () => <div data-testid="kanban" />
+}))
+
+vi.mock('../src/renderer/components/task-board/TaskListView', () => ({
+  TaskListView: () => <div data-testid="list" />
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() }
+}))
+
+const { TaskBoardView } = await import('../src/renderer/components/TaskBoardView')
+
+describe('TaskBoardView', () => {
+  it('renders the empty state when there are no tasks', () => {
+    const { container, getByText } = render(<TaskBoardView />)
+    expect(getByText(/No tasks yet/i)).toBeInTheDocument()
+    const root = container.firstElementChild as HTMLElement
+    expect(root.style.background).toBe('rgb(20, 20, 22)')
+  })
+})

--- a/tests/window-controls.test.tsx
+++ b/tests/window-controls.test.tsx
@@ -1,17 +1,21 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 const windowMinimize = vi.fn()
 const windowMaximize = vi.fn()
 const windowClose = vi.fn()
+const isWindowMaximized = vi.fn().mockResolvedValue(false)
+const onWindowMaximizedChange = vi.fn(() => () => {})
 
 Object.defineProperty(window, 'api', {
   value: {
     windowMinimize,
     windowMaximize,
     windowClose,
+    isWindowMaximized,
+    onWindowMaximizedChange,
     getAppVersion: () => 'test',
     detectIDEs: vi.fn().mockResolvedValue([])
   },
@@ -56,5 +60,27 @@ describe('WindowControls', () => {
     render(<WindowControls />)
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(windowClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows Restore label when the window is already maximized on mount', async () => {
+    isWindowMaximized.mockResolvedValueOnce(true)
+    render(<WindowControls />)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument())
+  })
+
+  it('flips the glyph when the main process reports a state change', async () => {
+    let notify: ((maximized: boolean) => void) | undefined
+    onWindowMaximizedChange.mockImplementationOnce((cb: (m: boolean) => void) => {
+      notify = cb
+      return () => {}
+    })
+    render(<WindowControls />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Maximize' })).toBeInTheDocument()
+    )
+    await act(async () => {
+      notify?.(true)
+    })
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument()
   })
 })

--- a/tests/window-controls.test.tsx
+++ b/tests/window-controls.test.tsx
@@ -75,11 +75,35 @@ describe('WindowControls', () => {
       return () => {}
     })
     render(<WindowControls />)
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Maximize' })).toBeInTheDocument()
-    )
+    await waitFor(() => expect(notify).toBeDefined())
+    expect(screen.getByRole('button', { name: 'Maximize' })).toBeInTheDocument()
     await act(async () => {
       notify?.(true)
+    })
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument()
+  })
+
+  it('ignores initial isWindowMaximized() result when an event has already fired', async () => {
+    let notify: ((maximized: boolean) => void) | undefined
+    let resolveInitial: ((m: boolean) => void) | undefined
+    isWindowMaximized.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveInitial = resolve
+        })
+    )
+    onWindowMaximizedChange.mockImplementationOnce((cb: (m: boolean) => void) => {
+      notify = cb
+      return () => {}
+    })
+    render(<WindowControls />)
+    await waitFor(() => expect(notify).toBeDefined())
+    await act(async () => {
+      notify?.(true)
+    })
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument()
+    await act(async () => {
+      resolveInitial?.(false)
     })
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument()
   })

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -66,7 +66,12 @@ vi.mock('../src/renderer/stores', () => {
 ;(global as unknown as { window: object }).window = {
   api: {
     listWorkflowRuns: vi.fn().mockResolvedValue([]),
-    createTerminal: vi.fn()
+    createTerminal: vi.fn(),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {}),
+    windowMinimize: vi.fn(),
+    windowMaximize: vi.fn(),
+    windowClose: vi.fn()
   }
 }
 


### PR DESCRIPTION
## Summary
Polish pass on Vorn's window chrome — covers the two original items from the audit plus a handful of follow-ups the UI testing surfaced.

### Window buttons (Win/Linux)
- Maximize button now reflects the actual window state. Added `window:maximizedChanged` event (main → renderer) plus a `window:isMaximized` invoke handler for initial state. `WindowControls` subscribes and swaps between the single-square "Maximize" glyph and the offset-two-rects "Restore" glyph.

### macOS focused-session drag
- Focused panel's `CardHeader` row is now the drag region on mac (instead of adding a separate 24px strip). Interactive children in `CardHeader` (rename input, pencil button, action cluster) are explicitly marked `titlebar-no-drag` so clicks still work.

### Tab bar drag
- Moved `titlebar-no-drag` off the tabs container and onto each tab pill + the new-session cluster. Empty space between the last tab and the right-side controls is now draggable.

### Toolbar alignment across views
- Unified desktop toolbar height: `h-[40px]` for the main toolbar, sidebar header, and workflow editor top bar. Mobile stays at `h-[52px]`.
- Traffic lights re-centered: `trafficLightPosition.y` 16 → 13.
- Workflow editor inline top-bar now matches the main toolbar: same `gap-1`, `px-3`, uses `TRAFFIC_LIGHT_PAD_PX`.

### Inline WorkflowEditor chrome
- When the sidebar is collapsed, the inline editor now shows `SidebarToggleButton` + `MainViewPills` so users can re-open the sidebar or jump back to Sessions/Tasks.
- `WindowControls` added to the right cluster for Win/Linux.

### Theming
- `TaskBoardView` background set to `#141416` to match the session/workflow content areas.

## Test plan
- [x] `yarn test` — 1140 pass (added 2 new tests for maximize-state behavior; updated workflow-editor test mock for new `window.api` methods)
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean on changed files
- [x] `yarn build:server` bundle clean
- [x] Ran `/simplify`: addressed in-scope findings (reconciled `pl-[78px]` → `TRAFFIC_LIGHT_PAD_PX`, stabilized TaskBoardView style object ref). Deferred broader refactors (extracting `ToolbarSeparator`/`LeftChromeCluster`, CSS color tokens) as out of scope.
- [ ] Manual: Windows — click maximize/unmaximize, double-click drag region, OS shortcut (Win+Up); glyph should track state
- [ ] Manual: macOS — drag focused session from header row; controls/buttons inside still clickable
- [ ] Manual: switch Sessions ↔ Tasks ↔ Workflows; chrome aligns across the transitions