### PR TITLE
refactor(sidebar): minimize footer to icon-only buttons

### DIFF
--- a/src/renderer/components/project-sidebar/SidebarFooter.tsx
+++ b/src/renderer/components/project-sidebar/SidebarFooter.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from '../../stores'
-import { KbdHint } from '../KbdHint'
+import { Tooltip } from '../Tooltip'
+import { getShortcut } from '../../lib/keyboard-shortcuts'
 import { CircleHelp, Settings } from 'lucide-react'
 
 export function SidebarFooter({
@@ -12,38 +13,33 @@ export function SidebarFooter({
   const setSettingsOpen = useAppStore((s) => s.setSettingsOpen)
   const setOnboardingOpen = useAppStore((s) => s.setOnboardingOpen)
 
-  const iconSize = isCollapsed ? 22 : 14
+  const settingsShortcut = getShortcut('settings')?.display
 
   return (
-    <div className={`p-3 border-t border-white/[0.06] space-y-0.5 ${isCollapsed ? 'p-1.5' : ''}`}>
-      <button
-        onClick={() => setOnboardingOpen(true)}
-        className={`w-full px-2.5 py-1.5 text-[13px] text-gray-400 hover:text-white
-                   hover:bg-white/[0.04] rounded-md transition-colors text-left flex items-center gap-2
-                   ${isCollapsed ? 'justify-center px-0' : ''}`}
-        title={isCollapsed ? 'Welcome Guide' : undefined}
-      >
-        <CircleHelp size={iconSize} strokeWidth={1.5} className="shrink-0" />
-        {!isCollapsed && 'Welcome Guide'}
-      </button>
-      <button
-        onClick={() => {
-          setSettingsOpen(true)
-          closeSidebarOnMobile()
-        }}
-        className={`w-full px-2.5 py-1.5 text-[13px] text-gray-300 hover:text-white
-                   hover:bg-white/[0.04] rounded-md transition-colors text-left flex items-center gap-2
-                   ${isCollapsed ? 'justify-center px-0' : ''}`}
-        title={isCollapsed ? 'Settings' : undefined}
-      >
-        <Settings size={iconSize} strokeWidth={1.5} className="shrink-0" />
-        {!isCollapsed && (
-          <>
-            Settings
-            <KbdHint shortcutId="settings" className="ml-auto" />
-          </>
-        )}
-      </button>
+    <div className={`flex items-center gap-0.5 ${isCollapsed ? 'flex-col p-1.5' : 'px-2 py-1.5'}`}>
+      <Tooltip label="Welcome Guide" position="right">
+        <button
+          onClick={() => setOnboardingOpen(true)}
+          aria-label="Welcome Guide"
+          className="p-1.5 text-gray-500 hover:text-gray-200 hover:bg-white/[0.04]
+                     rounded-md transition-colors"
+        >
+          <CircleHelp size={16} strokeWidth={1.5} />
+        </button>
+      </Tooltip>
+      <Tooltip label="Settings" shortcut={settingsShortcut} position="right">
+        <button
+          onClick={() => {
+            setSettingsOpen(true)
+            closeSidebarOnMobile()
+          }}
+          aria-label="Settings"
+          className="p-1.5 text-gray-500 hover:text-gray-200 hover:bg-white/[0.04]
+                     rounded-md transition-colors"
+        >
+          <Settings size={16} strokeWidth={1.5} />
+        </button>
+      </Tooltip>
     </div>
   )
 }

--- a/tests/sidebar-footer.test.tsx
+++ b/tests/sidebar-footer.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockStore = {
+  setSettingsOpen: vi.fn(),
+  setOnboardingOpen: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockStore) : mockStore
+  }
+}))
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+const { SidebarFooter } = await import('../src/renderer/components/project-sidebar/SidebarFooter')
+
+beforeEach(() => {
+  mockStore.setSettingsOpen.mockReset()
+  mockStore.setOnboardingOpen.mockReset()
+})
+
+describe('SidebarFooter', () => {
+  it('renders Welcome Guide and Settings icon buttons with accessible names', () => {
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Welcome Guide' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument()
+  })
+
+  it('opens the Welcome Guide when the help button is clicked', () => {
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Welcome Guide' }))
+    expect(mockStore.setOnboardingOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('opens Settings and dismisses the mobile sidebar when the settings button is clicked', () => {
+    const closeSidebarOnMobile = vi.fn()
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={closeSidebarOnMobile} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    expect(mockStore.setSettingsOpen).toHaveBeenCalledWith(true)
+    expect(closeSidebarOnMobile).toHaveBeenCalled()
+  })
+
+  it('still renders both buttons when the sidebar is collapsed', () => {
+    render(<SidebarFooter isCollapsed={true} closeSidebarOnMobile={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Welcome Guide' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Collapse the sidebar footer from two full-width labeled rows (Welcome Guide, Settings) to a compact cluster of two 16px icon buttons anchored bottom-left.
- Remove the footer's top border, labels, and inline `KbdHint`. Labels move into tooltips; the Settings shortcut renders inline inside its tooltip via the existing `Tooltip` `shortcut` prop.
- Tooltips open to the right so they clear the window's left edge regardless of sidebar width or collapsed state.

## Test plan
- [ ] Expanded sidebar: hover `?` → tooltip "Welcome Guide" opens to the right, fully visible.
- [ ] Expanded sidebar: hover ⚙ → tooltip "Settings  ⌘," opens to the right, fully visible.
- [ ] Click `?` opens the Welcome Guide; click ⚙ opens Settings.
- [ ] `⌘,` still opens Settings.
- [ ] Collapsed sidebar: icons stack vertically; tooltips still readable.
- [ ] No stray border between the project list and the footer.