### PR TITLE
fix: show CardStatusBar in tab mode

### DIFF
--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -11,6 +11,7 @@ import { PromptLauncher } from './PromptLauncher'
 import { InlineRename } from './InlineRename'
 import { CardContextMenu } from './CardContextMenu'
 import { BackgroundTray } from './BackgroundTray'
+import { CardStatusBar } from './card/CardStatusBar'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { buildTooltip } from '../lib/tab-tooltip'
@@ -520,35 +521,38 @@ export function TabView() {
           />
         </div>
       ) : (
-        <div className="relative flex-1 min-h-0" style={{ background: '#141416' }}>
-          {activeTabId && activeTerminal && (
-            <TerminalSlot
-              key={activeTabId}
-              terminalId={activeTabId}
-              isFocused={true}
-              className="w-full h-full"
-            />
-          )}
-          {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
-            <div
-              className="absolute inset-0 p-3 space-y-2 pointer-events-none"
-              style={{ background: '#141416' }}
-            >
-              <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
-              <div
-                className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
-                style={{ animationDelay: '0.15s' }}
+        <div className="flex-1 min-h-0 flex flex-col" style={{ background: '#141416' }}>
+          <div className="relative flex-1 min-h-0">
+            {activeTabId && activeTerminal && (
+              <TerminalSlot
+                key={activeTabId}
+                terminalId={activeTabId}
+                isFocused={true}
+                className="w-full h-full"
               />
+            )}
+            {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
               <div
-                className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
-                style={{ animationDelay: '0.3s' }}
-              />
-              <div
-                className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
-                style={{ animationDelay: '0.45s' }}
-              />
-            </div>
-          )}
+                className="absolute inset-0 p-3 space-y-2 pointer-events-none"
+                style={{ background: '#141416' }}
+              >
+                <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
+                <div
+                  className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
+                  style={{ animationDelay: '0.15s' }}
+                />
+                <div
+                  className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
+                  style={{ animationDelay: '0.3s' }}
+                />
+                <div
+                  className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
+                  style={{ animationDelay: '0.45s' }}
+                />
+              </div>
+            )}
+          </div>
+          {activeTabId && activeTerminal && <CardStatusBar terminalId={activeTabId} />}
         </div>
       )}
 

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -259,11 +259,11 @@ describe('CardStatusBar — bottom VS Code style strip', () => {
   })
 })
 
-describe('TabView no longer renders CardStatusBar (unified sessions panel)', () => {
-  it('omits the bottom branch chip — metadata lives in the tab tooltip instead', () => {
+describe('TabView renders CardStatusBar below the active terminal', () => {
+  it('renders the bottom branch chip so it matches grid and focused views', () => {
     render(<TabView />)
-    // The "Switch branch" button only exists inside CardStatusBar, so none should render.
-    expect(screen.queryByRole('button', { name: /Switch branch/ })).not.toBeInTheDocument()
+    // The "Switch branch" button only exists inside CardStatusBar.
+    expect(screen.getByRole('button', { name: /Switch branch/ })).toBeInTheDocument()
     // The tab itself still carries the branch in its `title` tooltip attribute.
     const tab = screen.getByRole('tab')
     expect(tab.querySelector('[title*="Branch: main"]')).toBeTruthy()
@@ -568,7 +568,11 @@ describe('TabView merged toolbar controls', () => {
       })
     })
     render(<TabView />)
-    expect(screen.getByText('Fix auth bug')).toBeInTheDocument()
+    // Title appears both in the tab label and in the CardStatusBar task pill.
+    const matches = screen.getAllByText('Fix auth bug')
+    expect(matches.length).toBeGreaterThan(0)
+    const tab = screen.getByRole('tab')
+    expect(tab.textContent).toContain('Fix auth bug')
   })
 
   it('clicks new session button and opens dialog when no project', () => {


### PR DESCRIPTION
## Summary
- Tab mode's terminal view was missing the bottom status bar (branch chip, diff indicator, Open In) that grid mode and focused view already render.
- Wrapped the `TerminalSlot` in a flex column and rendered `CardStatusBar` below it so behaviour matches the other layouts.

## Test plan
- [ ] Open a session in tab mode, verify branch chip + diff + Open In appear at the bottom
- [ ] Confirm loading skeleton still renders over the terminal area (not overlapping the status bar)
- [ ] Confirm grid mode and focused view are unchanged