### PR TITLE
feat(grid): smart adaptive Auto layout + focused-mode nav hint

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -77,9 +77,8 @@ export const AgentCard = memo(
     return (
       <div
         ref={ref}
-        className={`group/card relative border overflow-hidden flex flex-col
+        className={`group/card relative border overflow-hidden flex flex-col h-full
                    transition-colors
-                   ${flexible ? 'h-full' : ''}
                    ${
                      isFocused
                        ? 'border-blue-500/60 ring-1 ring-blue-500/30'

--- a/src/renderer/components/GridToolbar.tsx
+++ b/src/renderer/components/GridToolbar.tsx
@@ -23,8 +23,12 @@ const SORT_OPTIONS: { value: SortMode; label: string }[] = [
   { value: 'recent', label: 'Recent' }
 ]
 
-const COLUMN_OPTIONS: { value: string; label: string }[] = [
-  { value: '0', label: 'Auto' },
+const COLUMN_OPTIONS: { value: string; label: string; title?: string }[] = [
+  {
+    value: '0',
+    label: 'Auto',
+    title: 'Adapts columns and rows to viewport and card count'
+  },
   { value: '1', label: '1 Column' },
   { value: '2', label: '2 Columns' },
   { value: '3', label: '3 Columns' },
@@ -197,6 +201,7 @@ export function GridToolbar() {
                   key={opt.value}
                   selected={String(gridColumns) === opt.value}
                   label={opt.label}
+                  title={opt.title}
                   onClick={() => setGridColumns(Number(opt.value))}
                 />
               ))}

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -20,6 +20,7 @@ import { resolveActiveProject } from '../lib/session-utils'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import type { TerminalState, FlexibleLayoutRect } from '../stores/types'
 import { GitBranch, FolderGit2 } from 'lucide-react'
+import { pickAutoLayout, AUTO_MIN_CARD_H, fitMaxRows } from '../lib/auto-grid-layout'
 
 interface DragState {
   draggingId: string
@@ -31,6 +32,43 @@ interface DragState {
   pointerX: number
   pointerY: number
   width: number
+}
+
+function useContainerSize(): {
+  size: { width: number; height: number } | null
+  setNode: (el: HTMLElement | null) => void
+} {
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
+  // Round to integer px and skip state updates when dimensions haven't
+  // actually changed — ResizeObserver fires on every subpixel shift, which
+  // would otherwise thrash pickAutoLayout downstream.
+  const updateSize = useCallback((w: number, h: number) => {
+    if (w <= 0 || h <= 0) return
+    const width = Math.round(w)
+    const height = Math.round(h)
+    setSize((prev) =>
+      prev && prev.width === width && prev.height === height ? prev : { width, height }
+    )
+  }, [])
+  const setNode = useCallback(
+    (el: HTMLElement | null) => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+      if (!el) return
+      const observer = new ResizeObserver((entries) => {
+        const rect = entries[0]?.contentRect
+        if (rect) updateSize(rect.width, rect.height)
+      })
+      observer.observe(el)
+      observerRef.current = observer
+      const r = el.getBoundingClientRect()
+      updateSize(r.width, r.height)
+    },
+    [updateSize]
+  )
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+  return { size, setNode }
 }
 
 export const GridView = memo(function GridView() {
@@ -50,6 +88,7 @@ export const GridView = memo(function GridView() {
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null)
   const [gridContextMenu, setGridContextMenu] = useState<{ x: number; y: number } | null>(null)
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const { size: wrapperSize, setNode: setGridWrapperNode } = useContainerSize()
 
   const terminals = useAppStore((s) => s.terminals)
   const { orderedIds, minimizedIds } = useVisibleTerminals()
@@ -58,14 +97,54 @@ export const GridView = memo(function GridView() {
 
   const isFiltered = statusFilter !== 'all'
 
-  const gridStyle: React.CSSProperties = {
-    ...(isMobile
-      ? { gridTemplateColumns: '1fr' }
-      : gridColumns > 0
-        ? { gridTemplateColumns: `repeat(${gridColumns}, 1fr)` }
-        : { gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))' }),
-    gridAutoRows: isMobile ? 'auto' : `${rowHeight + 42}px`
-  }
+  const isSmartAuto = !isMobile && gridColumns === 0
+  const autoLayout = useMemo(
+    () =>
+      isSmartAuto && wrapperSize
+        ? pickAutoLayout(orderedIds.length, wrapperSize.width, wrapperSize.height)
+        : null,
+    [isSmartAuto, wrapperSize, orderedIds.length]
+  )
+
+  // For the first paint before the ResizeObserver fires we still want a
+  // sensible column layout so cards don't flash stacked-in-one-column.
+  // Use n cards wide (capped at 4) — close to the final smart choice for
+  // small n and prevents the "single column" flicker.
+  const firstPaintCols = Math.max(1, Math.min(4, orderedIds.length || 1))
+
+  const gridStyle: React.CSSProperties = isMobile
+    ? { gridTemplateColumns: '1fr', gridAutoRows: 'auto' }
+    : gridColumns > 0
+      ? {
+          gridTemplateColumns: `repeat(${gridColumns}, 1fr)`,
+          gridAutoRows: `${rowHeight + 42}px`
+        }
+      : autoLayout?.mode === 'fit'
+        ? {
+            gridTemplateColumns: `repeat(${autoLayout.cols}, 1fr)`,
+            gridTemplateRows: `repeat(${autoLayout.rows}, 1fr)`
+          }
+        : autoLayout?.mode === 'scroll'
+          ? {
+              gridTemplateColumns: `repeat(${autoLayout.cols}, 1fr)`,
+              // Scroll-mode row height = viewport / (fit-mode max rows).
+              // This makes the first N rows exactly fill the viewport so the
+              // "above the fold" looks identical to fit mode — card N+1 is
+              // then a clean scroll-down away, not a half-visible slice.
+              gridAutoRows: `${
+                wrapperSize?.height
+                  ? Math.max(
+                      AUTO_MIN_CARD_H,
+                      Math.floor(wrapperSize.height / fitMaxRows(wrapperSize.height))
+                    )
+                  : rowHeight + 42
+              }px`,
+              overflowY: 'auto'
+            }
+          : {
+              gridTemplateColumns: `repeat(${firstPaintCols}, 1fr)`,
+              gridTemplateRows: '1fr'
+            }
 
   const DRAG_THRESHOLD = 5
 
@@ -160,7 +239,7 @@ export const GridView = memo(function GridView() {
 
   return (
     <div
-      className="h-full overflow-auto"
+      className={`h-full flex flex-col ${isSmartAuto ? 'overflow-hidden' : 'overflow-auto'}`}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
@@ -170,7 +249,7 @@ export const GridView = memo(function GridView() {
     >
       {/* Background tray: headless + minimized */}
       {backgroundTrayHasItems(filteredHeadless, minimizedIds, waitingApprovals) && (
-        <div className="px-4 pt-4">
+        <div className="px-4 pt-4 shrink-0">
           <BackgroundTray
             headlessSessions={filteredHeadless}
             minimizedIds={minimizedIds}
@@ -212,7 +291,8 @@ export const GridView = memo(function GridView() {
           />
         ) : (
           <div
-            className="grid gap-0"
+            ref={setGridWrapperNode}
+            className={`grid gap-0 ${isSmartAuto ? 'flex-1 min-h-0' : ''}`}
             style={gridStyle}
             onDoubleClick={handleGridDoubleClick}
             onContextMenu={handleGridContextMenu}
@@ -264,8 +344,8 @@ function FlexibleGrid({
   onCreateSession: () => void
   onShowContextMenu: (pos: { x: number; y: number } | null) => void
 }) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(0)
+  const { size: containerSize, setNode: setContainerNode } = useContainerSize()
+  const containerWidth = containerSize?.width ?? 0
 
   // Narrow selector: only extract the stable keys we need, not the full terminals Map
   const stableKeys = useAppStore(
@@ -280,17 +360,6 @@ function FlexibleGrid({
   )
   const flexibleLayouts = useAppStore((s) => s.flexibleLayouts)
   const setFlexibleLayouts = useAppStore((s) => s.setFlexibleLayouts)
-
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const observer = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width
-      if (w && w > 0) setContainerWidth(w)
-    })
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [])
 
   const layout = useMemo(() => {
     // Stack new items below all previously-placed cards so they don't overlap
@@ -363,11 +432,11 @@ function FlexibleGrid({
   )
 
   if (containerWidth === 0) {
-    return <div ref={containerRef} className="w-full min-h-[200px]" />
+    return <div ref={setContainerNode} className="w-full min-h-[200px]" />
   }
 
   return (
-    <div ref={containerRef} onDoubleClick={handleDoubleClick} onContextMenu={handleContextMenu}>
+    <div ref={setContainerNode} onDoubleClick={handleDoubleClick} onContextMenu={handleContextMenu}>
       <GridLayout
         className="flexible-grid"
         layout={layout}

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -56,14 +56,18 @@ function useContainerSize(): {
       observerRef.current?.disconnect()
       observerRef.current = null
       if (!el) return
+      const r = el.getBoundingClientRect()
+      updateSize(r.width, r.height)
+      // Older runtimes (and some test environments) don't ship ResizeObserver.
+      // The one-shot getBoundingClientRect above is enough to kick off smart
+      // Auto; live resize updates are best-effort.
+      if (typeof ResizeObserver === 'undefined') return
       const observer = new ResizeObserver((entries) => {
         const rect = entries[0]?.contentRect
         if (rect) updateSize(rect.width, rect.height)
       })
       observer.observe(el)
       observerRef.current = observer
-      const r = el.getBoundingClientRect()
-      updateSize(r.width, r.height)
     },
     [updateSize]
   )
@@ -98,6 +102,13 @@ export const GridView = memo(function GridView() {
   const isFiltered = statusFilter !== 'all'
 
   const isSmartAuto = !isMobile && gridColumns === 0
+  // Only wire the ResizeObserver when smart-auto is active. In fixed-column
+  // or mobile modes the wrapper size isn't used, so there's no reason to
+  // trigger re-renders on every window resize.
+  const attachWrapperRef = useCallback(
+    (el: HTMLElement | null) => setGridWrapperNode(isSmartAuto ? el : null),
+    [isSmartAuto, setGridWrapperNode]
+  )
   const autoLayout = useMemo(
     () =>
       isSmartAuto && wrapperSize
@@ -291,7 +302,7 @@ export const GridView = memo(function GridView() {
           />
         ) : (
           <div
-            ref={setGridWrapperNode}
+            ref={attachWrapperRef}
             className={`grid gap-0 ${isSmartAuto ? 'flex-1 min-h-0' : ''}`}
             style={gridStyle}
             onDoubleClick={handleGridDoubleClick}

--- a/src/renderer/components/OptionRow.tsx
+++ b/src/renderer/components/OptionRow.tsx
@@ -2,16 +2,19 @@ export function OptionRow({
   selected,
   dot,
   label,
+  title,
   onClick
 }: {
   selected: boolean
   dot?: string
   label: string
+  title?: string
   onClick: () => void
 }) {
   return (
     <button
       onClick={onClick}
+      title={title}
       className={`w-full text-left px-3 py-1.5 text-[12px] transition-colors flex items-center gap-2 ${
         selected
           ? 'text-white bg-white/[0.06]'

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -55,12 +55,15 @@ export function CardActionCluster({ terminalId, variant }: Props) {
 
   const showMinimize = variant === 'mini'
   const isFocused = variant === 'focused'
+  // In focused mode the header sits at the top of the window, so top-positioned
+  // tooltips get clipped off-screen. Drop them below the buttons instead.
+  const tooltipPos = isFocused ? 'bottom' : 'top'
 
   const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
 
   return (
     <div className="flex items-center gap-0.5 shrink-0">
-      <Tooltip label="Browse files" position="top">
+      <Tooltip label="Browse files" position={tooltipPos}>
         <button
           type="button"
           onClick={handleBrowseFiles}
@@ -73,7 +76,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
       </Tooltip>
 
       {showMinimize && (
-        <Tooltip label="Minimize" position="top">
+        <Tooltip label="Minimize" position={tooltipPos}>
           <button
             type="button"
             onClick={handleMinimize}
@@ -89,7 +92,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
       <Tooltip
         label={isFocused ? 'Collapse to grid' : 'Expand'}
         shortcut={isFocused ? `${MOD}W` : `${MOD}O`}
-        position="top"
+        position={tooltipPos}
       >
         <button
           type="button"
@@ -107,7 +110,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
       </Tooltip>
 
       <ConfirmPopover message="Close this session?" confirmLabel="Close" onConfirm={handleClose}>
-        <Tooltip label="Close session" position="top">
+        <Tooltip label="Close session" position={tooltipPos}>
           <button
             type="button"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '../../stores'
 import { AgentStatusIcon } from '../AgentStatusIcon'
 import { InlineRename } from '../InlineRename'
 import { CardActionCluster, type CardVariant } from './CardActionCluster'
+import { FocusedNavHint } from './FocusedNavHint'
 import { getDisplayName } from '../../lib/terminal-display'
 import { Pencil } from 'lucide-react'
 import { MOD } from '../../lib/platform'
@@ -96,6 +97,12 @@ export function CardHeader({
           )}
         </div>
       </div>
+
+      {variant === 'focused' && (
+        <div className="titlebar-no-drag">
+          <FocusedNavHint terminalId={terminalId} />
+        </div>
+      )}
 
       {/* ⌘N badge and action cluster share this slot so the badge sits flush right when idle. */}
       <div className="relative flex items-center shrink-0">

--- a/src/renderer/components/card/FocusedNavHint.tsx
+++ b/src/renderer/components/card/FocusedNavHint.tsx
@@ -1,0 +1,61 @@
+import { useShallow } from 'zustand/react/shallow'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { Tooltip } from '../Tooltip'
+import { MOD } from '../../lib/platform'
+
+interface Props {
+  terminalId: string
+}
+
+export function FocusedNavHint({ terminalId }: Props) {
+  const { visibleTerminalIds, setFocusedTerminal } = useAppStore(
+    useShallow((s) => ({
+      visibleTerminalIds: s.visibleTerminalIds,
+      setFocusedTerminal: s.setFocusedTerminal
+    }))
+  )
+
+  if (visibleTerminalIds.length < 2) return null
+
+  const index = visibleTerminalIds.indexOf(terminalId)
+  if (index === -1) return null
+
+  const total = visibleTerminalIds.length
+  const prevId = visibleTerminalIds[(index - 1 + total) % total]
+  const nextId = visibleTerminalIds[(index + 1) % total]
+
+  const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
+
+  return (
+    <div className="flex items-center gap-1 shrink-0 pr-1">
+      <span className="text-[11px] font-mono text-gray-500 tabular-nums select-none">
+        {index + 1}
+        <span className="text-gray-700"> / </span>
+        {total}
+      </span>
+      <Tooltip label="Previous session" shortcut={`${MOD}[`} position="bottom">
+        <button
+          type="button"
+          onClick={() => setFocusedTerminal(prevId)}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={btn}
+          aria-label="Previous session"
+        >
+          <ChevronLeft size={14} strokeWidth={2} />
+        </button>
+      </Tooltip>
+      <Tooltip label="Next session" shortcut={`${MOD}]`} position="bottom">
+        <button
+          type="button"
+          onClick={() => setFocusedTerminal(nextId)}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={btn}
+          aria-label="Next session"
+        >
+          <ChevronRight size={14} strokeWidth={2} />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -118,16 +118,17 @@ select,
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 ::-webkit-scrollbar-track {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: #374151;
+  background: rgba(255, 255, 255, 0.08);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #4b5563;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 /* Focus-visible ring for keyboard navigation */

--- a/src/renderer/lib/auto-grid-layout.ts
+++ b/src/renderer/lib/auto-grid-layout.ts
@@ -1,0 +1,68 @@
+import { clamp } from './math'
+
+export const AUTO_MIN_CARD_W = 320
+export const AUTO_MIN_CARD_H = 200
+// Row cap threshold: rows only keep getting added if each row has at least
+// this many px. Higher than MIN_CARD_H so cards don't get squashed short
+// just because a viewport technically fits 4 rows. Asymmetric with cols on
+// purpose — we want wider layouts, not taller ones.
+export const AUTO_ROW_FIT_MIN_H = 280
+
+// Target a roughly square card. Terminals need vertical room for output —
+// wide-short cards (e.g. 2 cols × 3 rows) leave each card too short to read,
+// so we bias toward more columns / squarer tiles.
+export const AUTO_TARGET_ASPECT = 1
+// Hard upper bound regardless of monitor — past 4×4 (16 cards) the benefit of
+// seeing more at once is outweighed by the harm of small tiles.
+export const AUTO_HARD_MAX_COLS = 4
+export const AUTO_HARD_MAX_ROWS = 4
+
+// How many rows fit comfortably on this viewport. Used to size scroll-mode
+// rows so the first "page" of cards looks identical to the fit-mode grid.
+export function fitMaxRows(H: number): number {
+  return clamp(Math.floor(H / AUTO_ROW_FIT_MIN_H), 1, AUTO_HARD_MAX_ROWS)
+}
+
+export type AutoLayout = { cols: number; rows: number; mode: 'fit' | 'scroll' }
+
+// Pure function: given card count and viewport, pick the best (cols, rows, mode).
+// Fit mode is capped dynamically (3×3 on laptops, up to 4×4 on large monitors);
+// beyond the cap we scroll so cards stay readable.
+export function pickAutoLayout(n: number, W: number, H: number): AutoLayout {
+  if (n <= 0) return { cols: 1, rows: 1, mode: 'fit' }
+  if (n === 1) return { cols: 1, rows: 1, mode: 'fit' }
+  if (n === 2) return { cols: 2, rows: 1, mode: 'fit' }
+  if (n === 3) return { cols: 3, rows: 1, mode: 'fit' }
+
+  const maxCols = clamp(Math.floor(W / AUTO_MIN_CARD_W), 1, AUTO_HARD_MAX_COLS)
+  const maxRows = clamp(Math.floor(H / AUTO_ROW_FIT_MIN_H), 1, AUTO_HARD_MAX_ROWS)
+
+  const scrollFallback = (): AutoLayout => {
+    const cols = clamp(Math.floor(W / AUTO_MIN_CARD_W), 1, maxCols)
+    return { cols, rows: Math.ceil(n / cols), mode: 'scroll' }
+  }
+
+  if (n > maxCols * maxRows) return scrollFallback()
+
+  let best: { cols: number; rows: number; score: number; fits: boolean } | null = null
+  for (let cols = 1; cols <= Math.min(n, maxCols); cols++) {
+    const rows = Math.ceil(n / cols)
+    if (rows > maxRows) continue
+    const cardW = W / cols
+    const cardH = H / rows
+    const fits = cardW >= AUTO_MIN_CARD_W && cardH >= AUTO_MIN_CARD_H
+    const aspectPenalty = Math.abs(Math.log(cardW / cardH / AUTO_TARGET_ASPECT))
+    const emptyPenalty = (cols * rows - n) * 0.25
+    const score = -aspectPenalty - emptyPenalty
+    if (
+      best === null ||
+      (fits && !best.fits) ||
+      (fits === best.fits && (score > best.score || (score === best.score && cols > best.cols)))
+    ) {
+      best = { cols, rows, score, fits }
+    }
+  }
+
+  if (best && best.fits) return { cols: best.cols, rows: best.rows, mode: 'fit' }
+  return scrollFallback()
+}

--- a/src/renderer/lib/auto-grid-layout.ts
+++ b/src/renderer/lib/auto-grid-layout.ts
@@ -48,25 +48,22 @@ export function pickAutoLayout(n: number, W: number, H: number): AutoLayout {
 
   if (n > maxCols * maxRows) return scrollFallback()
 
-  let best: { cols: number; rows: number; score: number; fits: boolean } | null = null
+  // Pick the best candidate by aspect-ratio proximity to target, breaking ties
+  // toward fewer empty cells and then more columns. The gate above guarantees
+  // at least one candidate fits the min-card-size floor, so we can seed `best`
+  // with the first non-skipped iteration and drop a defensive post-loop branch.
+  let best = { cols: 1, rows: n, score: -Infinity }
   for (let cols = 1; cols <= Math.min(n, maxCols); cols++) {
     const rows = Math.ceil(n / cols)
     if (rows > maxRows) continue
     const cardW = W / cols
     const cardH = H / rows
-    const fits = cardW >= AUTO_MIN_CARD_W && cardH >= AUTO_MIN_CARD_H
     const aspectPenalty = Math.abs(Math.log(cardW / cardH / AUTO_TARGET_ASPECT))
     const emptyPenalty = (cols * rows - n) * 0.25
     const score = -aspectPenalty - emptyPenalty
-    if (
-      best === null ||
-      (fits && !best.fits) ||
-      (fits === best.fits && (score > best.score || (score === best.score && cols > best.cols)))
-    ) {
-      best = { cols, rows, score, fits }
+    if (score > best.score || (score === best.score && cols > best.cols)) {
+      best = { cols, rows, score }
     }
   }
-
-  if (best && best.fits) return { cols: best.cols, rows: best.rows, mode: 'fit' }
-  return scrollFallback()
+  return { cols: best.cols, rows: best.rows, mode: 'fit' }
 }

--- a/src/renderer/lib/auto-grid-layout.ts
+++ b/src/renderer/lib/auto-grid-layout.ts
@@ -31,8 +31,12 @@ export type AutoLayout = { cols: number; rows: number; mode: 'fit' | 'scroll' }
 export function pickAutoLayout(n: number, W: number, H: number): AutoLayout {
   if (n <= 0) return { cols: 1, rows: 1, mode: 'fit' }
   if (n === 1) return { cols: 1, rows: 1, mode: 'fit' }
-  if (n === 2) return { cols: 2, rows: 1, mode: 'fit' }
-  if (n === 3) return { cols: 3, rows: 1, mode: 'fit' }
+  // Prefer a single row for 2 and 3 cards — but only when the viewport is
+  // wide enough that each card still meets the usable-width floor. On a
+  // narrow viewport we fall through to the scoring loop, which may stack
+  // vertically or spill to scroll instead of producing unreadably thin tiles.
+  if (n === 2 && W / 2 >= AUTO_MIN_CARD_W) return { cols: 2, rows: 1, mode: 'fit' }
+  if (n === 3 && W / 3 >= AUTO_MIN_CARD_W) return { cols: 3, rows: 1, mode: 'fit' }
 
   const maxCols = clamp(Math.floor(W / AUTO_MIN_CARD_W), 1, AUTO_HARD_MAX_COLS)
   const maxRows = clamp(Math.floor(H / AUTO_ROW_FIT_MIN_H), 1, AUTO_HARD_MAX_ROWS)

--- a/src/renderer/lib/math.ts
+++ b/src/renderer/lib/math.ts
@@ -1,0 +1,3 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}

--- a/src/renderer/lib/popover-position.ts
+++ b/src/renderer/lib/popover-position.ts
@@ -23,12 +23,10 @@ export interface PopoverPosition {
   placement: 'top' | 'bottom'
 }
 
+import { clamp } from './math'
+
 const VIEWPORT_MARGIN = 8
 const POPOVER_GAP = 6
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max)
-}
 
 export function calculatePopoverPosition(
   anchor: AnchorRect,

--- a/src/renderer/lib/popover-position.ts
+++ b/src/renderer/lib/popover-position.ts
@@ -1,3 +1,5 @@
+import { clamp } from './math'
+
 export interface AnchorRect {
   top: number
   left: number
@@ -22,8 +24,6 @@ export interface PopoverPosition {
   left: number
   placement: 'top' | 'bottom'
 }
-
-import { clamp } from './math'
 
 const VIEWPORT_MARGIN = 8
 const POPOVER_GAP = 6

--- a/tests/focused-nav-hint.test.tsx
+++ b/tests/focused-nav-hint.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { FocusedNavHint } from '../src/renderer/components/card/FocusedNavHint'
+
+beforeEach(() => {
+  useAppStore.setState({
+    visibleTerminalIds: ['a', 'b', 'c']
+  })
+})
+
+describe('FocusedNavHint', () => {
+  it('renders "N / total" with the 1-based index of the current terminal', () => {
+    const { container } = render(<FocusedNavHint terminalId="b" />)
+    expect(container.textContent).toContain('2')
+    expect(container.textContent).toContain('3')
+    expect(container.textContent).toMatch(/2\s*\/\s*3/)
+  })
+
+  it('returns nothing when fewer than 2 sessions are visible', () => {
+    useAppStore.setState({ visibleTerminalIds: ['a'] })
+    const { container } = render(<FocusedNavHint terminalId="a" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns nothing when the current terminal is not in the visible list', () => {
+    const { container } = render(<FocusedNavHint terminalId="gone" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('Next button focuses the following terminal', () => {
+    const setFocusedTerminal = vi.fn()
+    useAppStore.setState({ setFocusedTerminal })
+    render(<FocusedNavHint terminalId="a" />)
+    fireEvent.click(screen.getByLabelText('Next session'))
+    expect(setFocusedTerminal).toHaveBeenCalledWith('b')
+  })
+
+  it('Next button wraps around from the last terminal to the first', () => {
+    const setFocusedTerminal = vi.fn()
+    useAppStore.setState({ setFocusedTerminal })
+    render(<FocusedNavHint terminalId="c" />)
+    fireEvent.click(screen.getByLabelText('Next session'))
+    expect(setFocusedTerminal).toHaveBeenCalledWith('a')
+  })
+
+  it('Previous button focuses the preceding terminal', () => {
+    const setFocusedTerminal = vi.fn()
+    useAppStore.setState({ setFocusedTerminal })
+    render(<FocusedNavHint terminalId="c" />)
+    fireEvent.click(screen.getByLabelText('Previous session'))
+    expect(setFocusedTerminal).toHaveBeenCalledWith('b')
+  })
+
+  it('Previous button wraps from the first terminal to the last', () => {
+    const setFocusedTerminal = vi.fn()
+    useAppStore.setState({ setFocusedTerminal })
+    render(<FocusedNavHint terminalId="a" />)
+    fireEvent.click(screen.getByLabelText('Previous session'))
+    expect(setFocusedTerminal).toHaveBeenCalledWith('c')
+  })
+})

--- a/tests/focused-nav-hint.test.tsx
+++ b/tests/focused-nav-hint.test.tsx
@@ -66,4 +66,16 @@ describe('FocusedNavHint', () => {
     fireEvent.click(screen.getByLabelText('Previous session'))
     expect(setFocusedTerminal).toHaveBeenCalledWith('c')
   })
+
+  it('button pointerDown does not bubble (prevents drag interference)', () => {
+    const parentPointerDown = vi.fn()
+    render(
+      <div onPointerDown={parentPointerDown}>
+        <FocusedNavHint terminalId="b" />
+      </div>
+    )
+    fireEvent.pointerDown(screen.getByLabelText('Next session'))
+    fireEvent.pointerDown(screen.getByLabelText('Previous session'))
+    expect(parentPointerDown).not.toHaveBeenCalled()
+  })
 })

--- a/tests/github-connector.test.ts
+++ b/tests/github-connector.test.ts
@@ -278,7 +278,11 @@ describe('github connector — poll()', () => {
       ])
     )
     const gh = await importGithub()
-    const result = await gh.poll!('prOpened', { owner: 'o', repo: 'r' })
+    // Pin the `since` cursor so the test stays deterministic regardless of
+    // when it runs — without a cursor the connector uses `now - 60s`, which
+    // filters out the fixture PR whenever wall-clock time is past its
+    // hard-coded `created_at`.
+    const result = await gh.poll!('prOpened', { owner: 'o', repo: 'r' }, '2026-04-24T10:59:00Z')
     expect(result.events).toHaveLength(1)
     expect(result.events[0].data).toMatchObject({
       number: 7,

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -14,6 +14,14 @@ Object.defineProperty(window, 'api', {
   writable: true
 })
 
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+;(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+  MockResizeObserver
+
 // Stub AgentCard with forwardRef so GridView's ref callback (which calls
 // cardRefs.current.set(id, el)) actually fires.
 vi.mock('../src/renderer/components/AgentCard', () => ({
@@ -54,6 +62,7 @@ vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({
 
 import { useAppStore } from '../src/renderer/stores'
 import { GridView } from '../src/renderer/components/GridView'
+import { pickAutoLayout } from '../src/renderer/lib/auto-grid-layout'
 
 const mockConfig = {
   projects: [
@@ -128,5 +137,118 @@ describe('GridView', () => {
     useAppStore.setState({ sortMode: 'created' })
     render(<GridView />)
     expect(screen.getByTestId('card-term-a').dataset.dragTarget).toBe('no')
+  })
+})
+
+describe('pickAutoLayout', () => {
+  const W = 1920
+  const H = 1080
+
+  it('n=0 returns 1x1 fit', () => {
+    expect(pickAutoLayout(0, W, H)).toEqual({ cols: 1, rows: 1, mode: 'fit' })
+  })
+
+  it('n=1 is a single fullscreen card', () => {
+    expect(pickAutoLayout(1, W, H)).toEqual({ cols: 1, rows: 1, mode: 'fit' })
+    expect(pickAutoLayout(1, 800, 600)).toEqual({ cols: 1, rows: 1, mode: 'fit' })
+  })
+
+  it('n=2 splits the screen into two columns', () => {
+    expect(pickAutoLayout(2, W, H)).toEqual({ cols: 2, rows: 1, mode: 'fit' })
+  })
+
+  it('n=3 splits into three columns', () => {
+    expect(pickAutoLayout(3, W, H)).toEqual({ cols: 3, rows: 1, mode: 'fit' })
+  })
+
+  it('n=4 on 1920x1080 prefers 2x2 over 4x1', () => {
+    const layout = pickAutoLayout(4, W, H)
+    expect(layout.mode).toBe('fit')
+    expect(layout.cols).toBe(2)
+    expect(layout.rows).toBe(2)
+  })
+
+  it('n=6 on 1920x1080 picks 3x2', () => {
+    expect(pickAutoLayout(6, W, H)).toEqual({ cols: 3, rows: 2, mode: 'fit' })
+  })
+
+  it('n=6 on MacBook Pro retina (~2200x1400) picks 3x2, not 2x3', () => {
+    // Regression: earlier aspect target 16:10 picked 2 cols × 3 rows (wide-short
+    // cards) on this viewport. Squarer target should give 3 cols × 2 rows.
+    expect(pickAutoLayout(6, 2200, 1400)).toEqual({ cols: 3, rows: 2, mode: 'fit' })
+  })
+
+  it('n=9 on 1920x1080 packs into 3x3 fit', () => {
+    expect(pickAutoLayout(9, W, H)).toEqual({ cols: 3, rows: 3, mode: 'fit' })
+  })
+
+  it('n=10 on 1920x1080 fits in 4x3 (4-col cap on landscape)', () => {
+    const layout = pickAutoLayout(10, W, H)
+    expect(layout.mode).toBe('fit')
+    expect(layout.cols).toBe(4)
+    expect(layout.rows).toBe(3)
+  })
+
+  it('n=6 on a small-ish laptop window (1230x860) picks 3x2', () => {
+    // Regression: earlier comfy threshold 480px blocked 3 cols here, forcing 2x3.
+    // With the hard min (320), 1230/320=3 cols is allowed, and 3x2 wins.
+    expect(pickAutoLayout(6, 1230, 860)).toEqual({ cols: 3, rows: 2, mode: 'fit' })
+  })
+
+  it('n=10 on a laptop window (1230x860) spills to scroll — 4 rows too short', () => {
+    // Row cap: 860/280=3 rows, cols cap: 1230/320=3 cols → 3x3=9 fit cap.
+    // Prevents the 3x4 layout where each row would be ~215px tall.
+    const layout = pickAutoLayout(10, 1230, 860)
+    expect(layout.mode).toBe('scroll')
+  })
+
+  it('n=10 on a small window (1000x700) scrolls (cap is lower)', () => {
+    // 1000/320=3 cols, 700/280=2 rows → 3x2 = 6 cap; n=10 spills.
+    const layout = pickAutoLayout(10, 1000, 700)
+    expect(layout.mode).toBe('scroll')
+  })
+
+  it('n=16 on a 4K monitor packs into 4x4 fit', () => {
+    // 2560x1440 is comfortable for 4 cols (640 wide) and 4 rows (360 tall)
+    const layout = pickAutoLayout(16, 2560, 1440)
+    expect(layout).toEqual({ cols: 4, rows: 4, mode: 'fit' })
+  })
+
+  it('n=12 on a 4K monitor packs into 4x3 fit', () => {
+    const layout = pickAutoLayout(12, 2560, 1440)
+    expect(layout.mode).toBe('fit')
+    expect(layout.cols).toBe(4)
+    expect(layout.rows).toBe(3)
+  })
+
+  it('n=17 on a 4K monitor spills to scroll (fit cap is 16)', () => {
+    const layout = pickAutoLayout(17, 2560, 1440)
+    expect(layout.mode).toBe('scroll')
+  })
+
+  it('fit mode never exceeds 4x4 even on huge viewports', () => {
+    for (let n = 1; n <= 16; n++) {
+      const layout = pickAutoLayout(n, 5120, 2880)
+      if (layout.mode === 'fit') {
+        expect(layout.cols).toBeLessThanOrEqual(4)
+        expect(layout.rows).toBeLessThanOrEqual(4)
+      }
+    }
+  })
+
+  it('falls back to scroll when cards would be unusably small', () => {
+    const layout = pickAutoLayout(20, 1280, 720)
+    expect(layout.mode).toBe('scroll')
+    expect(layout.cols).toBeGreaterThanOrEqual(1)
+    expect(layout.cols).toBeLessThanOrEqual(4)
+    expect(layout.rows).toBe(Math.ceil(20 / layout.cols))
+  })
+
+  it('never exceeds the card count in columns', () => {
+    for (let n = 1; n <= 12; n++) {
+      const layout = pickAutoLayout(n, W, H)
+      expect(layout.cols).toBeLessThanOrEqual(n)
+      expect(layout.cols * layout.rows).toBeGreaterThanOrEqual(n)
+    }
   })
 })

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -14,16 +14,40 @@ Object.defineProperty(window, 'api', {
   writable: true
 })
 
+type ResizeCb = (entries: Array<{ contentRect: DOMRectReadOnly }>, ob: ResizeObserver) => void
 class MockResizeObserver {
-  observe() {}
+  constructor(public cb: ResizeCb) {}
+  observe(el: Element) {
+    // Fire once synchronously with the element's "measured" rect so
+    // useContainerSize() receives a real size (jsdom defaults to 0×0).
+    const r = el.getBoundingClientRect()
+    this.cb([{ contentRect: r as unknown as DOMRectReadOnly }], this as unknown as ResizeObserver)
+  }
   unobserve() {}
   disconnect() {}
 }
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
 beforeAll(() => {
   vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  // Stub getBoundingClientRect so measured sizes are non-zero in jsdom.
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      width: 1920,
+      height: 1080,
+      top: 0,
+      left: 0,
+      right: 1920,
+      bottom: 1080,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }
+  }
 })
 afterAll(() => {
   vi.unstubAllGlobals()
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
 })
 
 // Stub AgentCard with forwardRef so GridView's ref callback (which calls
@@ -141,6 +165,47 @@ describe('GridView', () => {
     useAppStore.setState({ sortMode: 'created' })
     render(<GridView />)
     expect(screen.getByTestId('card-term-a').dataset.dragTarget).toBe('no')
+  })
+})
+
+describe('GridView smart Auto mode', () => {
+  it('fit mode on 1920x1080 with 2 cards produces a 2×1 grid-template', () => {
+    useAppStore.setState({ gridColumns: 0 })
+    const { container } = render(<GridView />)
+    const grid = container.querySelector('.grid') as HTMLElement | null
+    expect(grid).not.toBeNull()
+    expect(grid!.style.gridTemplateColumns).toBe('repeat(2, 1fr)')
+    expect(grid!.style.gridTemplateRows).toBe('repeat(1, 1fr)')
+  })
+
+  it('scroll mode kicks in once the card count exceeds the fit cap', () => {
+    // On 1920×1080 maxCols=4, maxRows=3 → fit cap is 12. Render 14 cards to spill.
+    const terminals = new Map()
+    const order: string[] = []
+    for (let i = 0; i < 14; i++) {
+      const id = `t-${i}`
+      terminals.set(id, {
+        id,
+        session: {
+          id,
+          agentType: 'claude' as const,
+          projectName: 'Vorn',
+          projectPath: '/tmp/vorn',
+          isWorktree: false,
+          branch: 'main',
+          createdAt: Date.now()
+        },
+        status: 'idle',
+        lastOutputTimestamp: Date.now()
+      })
+      order.push(id)
+    }
+    useAppStore.setState({ gridColumns: 0, terminals, terminalOrder: order })
+    const { container } = render(<GridView />)
+    const grid = container.querySelector('.grid') as HTMLElement | null
+    expect(grid).not.toBeNull()
+    expect(grid!.style.overflowY).toBe('auto')
+    expect(grid!.style.gridAutoRows).toMatch(/\d+px/)
   })
 })
 

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({
 
 import { useAppStore } from '../src/renderer/stores'
 import { GridView } from '../src/renderer/components/GridView'
-import { pickAutoLayout } from '../src/renderer/lib/auto-grid-layout'
+import { pickAutoLayout, fitMaxRows } from '../src/renderer/lib/auto-grid-layout'
 
 const mockConfig = {
   projects: [
@@ -254,5 +254,28 @@ describe('pickAutoLayout', () => {
       expect(layout.cols).toBeLessThanOrEqual(n)
       expect(layout.cols * layout.rows).toBeGreaterThanOrEqual(n)
     }
+  })
+
+  it('narrow viewport falls through n=2 single-row shortcut', () => {
+    // W=500: 500/2=250 < AUTO_MIN_CARD_W(320), so we bypass the shortcut
+    // and the scoring loop picks a 1-col, 2-row layout.
+    const layout = pickAutoLayout(2, 500, 900)
+    expect(layout.cols).toBe(1)
+    expect(layout.rows).toBe(2)
+  })
+})
+
+describe('fitMaxRows', () => {
+  it('clamps to 1 on very short viewports', () => {
+    expect(fitMaxRows(100)).toBe(1)
+  })
+
+  it('scales with viewport height', () => {
+    expect(fitMaxRows(600)).toBe(2)
+    expect(fitMaxRows(900)).toBe(3)
+  })
+
+  it('caps at the hard max (4) on very tall viewports', () => {
+    expect(fitMaxRows(5000)).toBe(4)
   })
 })

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { forwardRef } from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -19,8 +19,12 @@ class MockResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-;(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
-  MockResizeObserver
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+})
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
 
 // Stub AgentCard with forwardRef so GridView's ref callback (which calls
 // cardRefs.current.set(id, el)) actually fires.


### PR DESCRIPTION
## Summary

- **Smart Auto grid**: the Auto column option now adapts columns, rows, and mode to the card count and viewport. 1 card fills the screen, 2/3 cards share a single row, 4+ cards pick an aspect-optimal grid up to a 4×4 cap; beyond the cap it spills to a scrollable grid sized so the first page looks identical to the fit layout.
- **Focused-mode nav hint**: when 2+ sessions are open, the focused header shows `N / total` with prev/next chevrons (shortcuts ⌘[ / ⌘], already bound in `useKeyboardShortcuts`).
- **UI polish**: scrollbars are now 6 px with a translucent white thumb (visible on hover, recedes at rest). Horizontal scrollbars pick up the same thickness. Tooltips in focused-mode card headers flip to `position="bottom"` so they don't clip off the top of the window. AgentCard always gets `h-full` so it reliably stretches to its grid cell.

## Notable internals

- `pickAutoLayout(n, W, H)` lives in `src/renderer/lib/auto-grid-layout.ts` as a pure function — easy to unit-test and to tweak without touching render code. 20 unit tests cover the decision table (n=1..16, various viewports, scroll spill, hard cap).
- `useContainerSize` is a ref-callback + ResizeObserver hook with change-detection (rounds to integer px and skips setState when dimensions match), shared between the main grid and `FlexibleGrid`.
- `clamp` factored out to `src/renderer/lib/math.ts`; `popover-position.ts` now imports it instead of its own copy.

## Test plan

- [ ] With 1 session open, Auto renders a single fullscreen card.
- [ ] With 2 sessions, side-by-side (2 cols × 1 row); with 3, three-across.
- [ ] With 6 sessions on a laptop viewport, renders 3×2 (wider/squarer cards), not 2×3.
- [ ] With 10 sessions on a laptop viewport, grid scrolls and first 9 look like a 3×3.
- [ ] On a large monitor, up to 4×4 packs in fit mode.
- [ ] Resize the window — grid reflows live.
- [ ] Switch to fixed 1/2/3/4 Columns, Flexible, and Tabs — all unchanged from before.
- [ ] In focused mode with ≥2 sessions: `N / total` shows in the header; ⌘[ / ⌘] and the arrow buttons move between sessions; action-cluster tooltips appear below the buttons (not clipped).
- [ ] Scroll anywhere in the app — scrollbars are thin and translucent.
- [ ] `yarn typecheck` clean, `yarn vitest run tests/grid-view.test.tsx` passes (21 tests).