### PR TITLE
fix(connectors): gh PATH resolution + Linear actions

### DIFF
--- a/packages/server/src/connectors/gh-cli.ts
+++ b/packages/server/src/connectors/gh-cli.ts
@@ -1,0 +1,24 @@
+import { resolveExecutable } from '../resolve-executable'
+
+export function resolveGhPath(): string | null {
+  return resolveExecutable('gh')
+}
+
+export function ghInstallHint(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return 'Install with Homebrew: `brew install gh`'
+    case 'win32':
+      return 'Install with winget: `winget install --id GitHub.cli` (or download from https://cli.github.com)'
+    default:
+      return 'Install from https://cli.github.com (Debian/Ubuntu: `sudo apt install gh`)'
+  }
+}
+
+export class GhNotFoundError extends Error {
+  readonly code = 'GH_NOT_FOUND'
+  constructor() {
+    super(`GitHub CLI (gh) not found on PATH. ${ghInstallHint()}`)
+    this.name = 'GhNotFoundError'
+  }
+}

--- a/packages/server/src/connectors/gh-cli.ts
+++ b/packages/server/src/connectors/gh-cli.ts
@@ -1,7 +1,23 @@
 import { resolveExecutable } from '../resolve-executable'
+import { getSafeEnv } from '../process-utils'
 
 export function resolveGhPath(): string | null {
   return resolveExecutable('gh')
+}
+
+/**
+ * Env for invoking `gh`. Starts from `getSafeEnv()` for the login-shell PATH
+ * but re-adds `GH_TOKEN` / `GITHUB_TOKEN` from the raw process env — `gh`
+ * supports non-interactive auth via those, and `getSafeEnv()` strips them by
+ * default as a general precaution.
+ */
+export function getGhEnv(): Record<string, string> {
+  const env = getSafeEnv()
+  for (const key of ['GH_TOKEN', 'GITHUB_TOKEN']) {
+    const val = process.env[key]
+    if (val) env[key] = val
+  }
+  return env
 }
 
 export function ghInstallHint(): string {

--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -9,6 +9,8 @@ import type {
   TaskStatus
 } from '@vornrun/shared/types'
 import log from '../logger'
+import { getSafeEnv } from '../process-utils'
+import { resolveGhPath, GhNotFoundError } from './gh-cli'
 
 const execFileAsync = promisify(execFile)
 
@@ -26,13 +28,17 @@ function isTransientErr(err: unknown): boolean {
  * so gh's non-zero exit reasons (e.g. rate limiting, auth) surface in logs.
  */
 async function gh(args: string[], cwd?: string, input?: string): Promise<string> {
+  const ghPath = resolveGhPath()
+  if (!ghPath) throw new GhNotFoundError()
+  const env = getSafeEnv()
   const run = async () => {
     if (input !== undefined) {
-      return runWithStdin(args, input, cwd)
+      return runWithStdin(ghPath, args, input, cwd, env)
     }
-    const { stdout } = await execFileAsync('gh', args, {
+    const { stdout } = await execFileAsync(ghPath, args, {
       timeout: 15_000,
       maxBuffer: 10 * 1024 * 1024,
+      env,
       ...(cwd && { cwd })
     })
     return stdout
@@ -58,9 +64,15 @@ async function gh(args: string[], cwd?: string, input?: string): Promise<string>
 
 /** Run `gh` feeding `input` on stdin. Used by `gh api --input -` paths so we
  *  never interpolate untrusted body values into shell arguments. */
-function runWithStdin(args: string[], input: string, cwd?: string): Promise<string> {
+function runWithStdin(
+  ghPath: string,
+  args: string[],
+  input: string,
+  cwd: string | undefined,
+  env: Record<string, string>
+): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn('gh', args, { cwd, timeout: 15_000 })
+    const child = spawn(ghPath, args, { cwd, timeout: 15_000, env })
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', (d) => {

--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -9,8 +9,7 @@ import type {
   TaskStatus
 } from '@vornrun/shared/types'
 import log from '../logger'
-import { getSafeEnv } from '../process-utils'
-import { resolveGhPath, GhNotFoundError } from './gh-cli'
+import { resolveGhPath, GhNotFoundError, getGhEnv } from './gh-cli'
 
 const execFileAsync = promisify(execFile)
 
@@ -30,7 +29,7 @@ function isTransientErr(err: unknown): boolean {
 async function gh(args: string[], cwd?: string, input?: string): Promise<string> {
   const ghPath = resolveGhPath()
   if (!ghPath) throw new GhNotFoundError()
-  const env = getSafeEnv()
+  const env = getGhEnv()
   const run = async () => {
     if (input !== undefined) {
       return runWithStdin(ghPath, args, input, cwd, env)
@@ -72,17 +71,39 @@ function runWithStdin(
   env: Record<string, string>
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(ghPath, args, { cwd, timeout: 15_000, env })
+    // Note: child_process.spawn doesn't honor `timeout` (unlike execFile), so
+    // we enforce it with an explicit timer. Without this, a `gh` subprocess
+    // blocking on e.g. a hung credential helper would hang poll/exec forever.
+    const child = spawn(ghPath, args, { cwd, env })
     let stdout = ''
     let stderr = ''
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        /* already exited */
+      }
+      reject(new Error('gh command timed out after 15s'))
+    }, 15_000)
     child.stdout.on('data', (d) => {
       stdout += d.toString()
     })
     child.stderr.on('data', (d) => {
       stderr += d.toString()
     })
-    child.on('error', reject)
+    child.on('error', (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      reject(err)
+    })
     child.on('close', (code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
       if (code === 0) return resolve(stdout)
       reject(new Error(`gh exited with code ${code}: ${stderr.trim() || 'no stderr'}`))
     })

--- a/packages/server/src/connectors/linear.ts
+++ b/packages/server/src/connectors/linear.ts
@@ -78,6 +78,67 @@ const ISSUE_FIELDS = `
   team { key }
 `
 
+async function resolveIssueId(apiKey: string, identifier: string): Promise<string | null> {
+  const data = await linearGraphQL<{ issues: { nodes: Array<{ id: string }> } }>(
+    apiKey,
+    `query IssueIdByIdentifier($identifier: String!) {
+       issues(filter: { identifier: { eq: $identifier } }, first: 1) { nodes { id } }
+     }`,
+    { identifier }
+  )
+  return data.issues.nodes[0]?.id ?? null
+}
+
+async function resolveIssueWithTeam(
+  apiKey: string,
+  identifier: string
+): Promise<{ id: string; teamId: string; teamKey: string } | null> {
+  const data = await linearGraphQL<{
+    issues: { nodes: Array<{ id: string; team: { id: string; key: string } }> }
+  }>(
+    apiKey,
+    `query IssueWithTeam($identifier: String!) {
+       issues(filter: { identifier: { eq: $identifier } }, first: 1) {
+         nodes { id team { id key } }
+       }
+     }`,
+    { identifier }
+  )
+  const node = data.issues.nodes[0]
+  return node ? { id: node.id, teamId: node.team.id, teamKey: node.team.key } : null
+}
+
+async function resolveTeamId(apiKey: string, teamKey: string): Promise<string | null> {
+  const data = await linearGraphQL<{ teams: { nodes: Array<{ id: string }> } }>(
+    apiKey,
+    `query TeamIdByKey($key: String!) {
+       teams(filter: { key: { eq: $key } }, first: 1) { nodes { id } }
+     }`,
+    { key: teamKey }
+  )
+  return data.teams.nodes[0]?.id ?? null
+}
+
+async function resolveCompletedStateId(apiKey: string, teamId: string): Promise<string | null> {
+  const data = await linearGraphQL<{
+    workflowStates: { nodes: Array<{ id: string; type: string; position: number }> }
+  }>(
+    apiKey,
+    `query CompletedStates($teamId: ID!) {
+       workflowStates(
+         filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }
+         first: 5
+       ) { nodes { id type position } }
+     }`,
+    { teamId }
+  )
+  const nodes = data.workflowStates.nodes
+  if (!nodes.length) return null
+  // Prefer the lowest-position completed state (Linear orders "Done" before
+  // post-done states like "Merged" / "Released").
+  return nodes.slice().sort((a, b) => a.position - b.position)[0].id
+}
+
 function requireAuth(filters: Record<string, unknown>): string {
   const key = filters.apiKey
   if (typeof key !== 'string' || !key.trim()) {
@@ -92,7 +153,7 @@ export const linearConnector: VornConnector = {
   id: 'linear',
   name: 'Linear',
   icon: 'linear',
-  capabilities: ['tasks', 'triggers'],
+  capabilities: ['tasks', 'triggers', 'actions'],
 
   async listItems(filters: Record<string, unknown>): Promise<ExternalItem[]> {
     const apiKey = requireAuth(filters)
@@ -189,10 +250,107 @@ export const linearConnector: VornConnector = {
     }
   },
 
-  async execute(actionType: string, _args: Record<string, unknown>): Promise<ActionResult> {
-    // Linear actions (createIssue, updateIssue) not yet implemented — the
-    // connector is read-only for polling tasks into the board.
-    return { success: false, error: `Linear action "${actionType}" not implemented yet` }
+  async execute(actionType: string, args: Record<string, unknown>): Promise<ActionResult> {
+    const apiKey = requireAuth(args)
+
+    switch (actionType) {
+      case 'commentOnIssue': {
+        const identifier = typeof args.identifier === 'string' ? args.identifier : ''
+        const body = typeof args.body === 'string' ? args.body : ''
+        if (!identifier) return { success: false, error: 'identifier is required (e.g. ENG-123)' }
+        if (!body) return { success: false, error: 'body is required' }
+        const issueId = await resolveIssueId(apiKey, identifier)
+        if (!issueId) return { success: false, error: `Issue ${identifier} not found` }
+        const data = await linearGraphQL<{
+          commentCreate: { success: boolean; comment: { id: string; url: string } }
+        }>(
+          apiKey,
+          `mutation CreateComment($input: CommentCreateInput!) {
+             commentCreate(input: $input) { success comment { id url } }
+           }`,
+          { input: { issueId, body } }
+        )
+        if (!data.commentCreate.success) {
+          return { success: false, error: 'Linear commentCreate returned success=false' }
+        }
+        return { success: true, output: { url: data.commentCreate.comment.url } }
+      }
+
+      case 'createIssue': {
+        const title = typeof args.title === 'string' ? args.title : ''
+        if (!title) return { success: false, error: 'title is required' }
+        const description = typeof args.description === 'string' ? args.description : undefined
+        const teamKey = typeof args.teamKey === 'string' ? args.teamKey : undefined
+        if (!teamKey) {
+          return {
+            success: false,
+            error: 'teamKey is required (set it on the connection or per-action)'
+          }
+        }
+        const teamId = await resolveTeamId(apiKey, teamKey)
+        if (!teamId) return { success: false, error: `Team ${teamKey} not found` }
+        const input: Record<string, unknown> = { teamId, title }
+        if (description) input.description = description
+        const data = await linearGraphQL<{
+          issueCreate: {
+            success: boolean
+            issue: { id: string; identifier: string; url: string }
+          }
+        }>(
+          apiKey,
+          `mutation CreateIssue($input: IssueCreateInput!) {
+             issueCreate(input: $input) { success issue { id identifier url } }
+           }`,
+          { input }
+        )
+        if (!data.issueCreate.success) {
+          return { success: false, error: 'Linear issueCreate returned success=false' }
+        }
+        return {
+          success: true,
+          output: {
+            identifier: data.issueCreate.issue.identifier,
+            url: data.issueCreate.issue.url
+          }
+        }
+      }
+
+      case 'closeIssue': {
+        const identifier = typeof args.identifier === 'string' ? args.identifier : ''
+        if (!identifier) return { success: false, error: 'identifier is required (e.g. ENG-123)' }
+        const issue = await resolveIssueWithTeam(apiKey, identifier)
+        if (!issue) return { success: false, error: `Issue ${identifier} not found` }
+        // Pick a "completed"-type workflow state on the issue's team. Linear
+        // doesn't have a single canonical "Done" — each team configures its
+        // own, so we grab the first completed-type state.
+        const stateId = await resolveCompletedStateId(apiKey, issue.teamId)
+        if (!stateId) {
+          return { success: false, error: `No completed-type state on team ${issue.teamKey}` }
+        }
+        const data = await linearGraphQL<{
+          issueUpdate: { success: boolean; issue: { id: string; state: { name: string } } }
+        }>(
+          apiKey,
+          `mutation CloseIssue($id: String!, $input: IssueUpdateInput!) {
+             issueUpdate(id: $id, input: $input) { success issue { id state { name } } }
+           }`,
+          { id: issue.id, input: { stateId } }
+        )
+        if (!data.issueUpdate.success) {
+          return { success: false, error: 'Linear issueUpdate returned success=false' }
+        }
+        return { success: true, output: { state: data.issueUpdate.issue.state.name } }
+      }
+
+      case 'syncTasks': {
+        // Handled by the sync engine at a higher level; the action node
+        // calls listItems() and does upsert logic.
+        return { success: true }
+      }
+
+      default:
+        return { success: false, error: `Unknown action: ${actionType}` }
+    }
   },
 
   describe(): ConnectorManifest {
@@ -243,7 +401,75 @@ export const linearConnector: VornConnector = {
           defaultIntervalMs: 60_000
         }
       ],
-      actions: [],
+      actions: [
+        // teamKey / apiKey come from the connection's filters/auth and are
+        // merged server-side before execute() runs, so they're not duplicated
+        // in these configFields.
+        {
+          type: 'commentOnIssue',
+          label: 'Comment on Issue',
+          description: 'Post a comment on a Linear issue',
+          configFields: [
+            {
+              key: 'identifier',
+              label: 'Issue',
+              type: 'text',
+              required: true,
+              placeholder: '{{connectorItem.externalId}}',
+              supportsTemplates: true
+            },
+            {
+              key: 'body',
+              label: 'Comment',
+              type: 'textarea',
+              required: true,
+              supportsTemplates: true
+            }
+          ]
+        },
+        {
+          type: 'createIssue',
+          label: 'Create Issue',
+          description: 'Create a new Linear issue',
+          configFields: [
+            {
+              key: 'title',
+              label: 'Title',
+              type: 'text',
+              required: true,
+              supportsTemplates: true
+            },
+            {
+              key: 'description',
+              label: 'Description',
+              type: 'textarea',
+              supportsTemplates: true
+            },
+            {
+              key: 'teamKey',
+              label: 'Team Key',
+              type: 'text',
+              placeholder: 'ENG (defaults to connection team)',
+              description: 'Override the connection team for this action.'
+            }
+          ]
+        },
+        {
+          type: 'closeIssue',
+          label: 'Close Issue',
+          description: "Move an issue to the team's default completed state",
+          configFields: [
+            {
+              key: 'identifier',
+              label: 'Issue',
+              type: 'text',
+              required: true,
+              placeholder: '{{connectorItem.externalId}}',
+              supportsTemplates: true
+            }
+          ]
+        }
+      ],
       defaultWorkflows: [
         {
           name: 'Linear: Issue Created',

--- a/packages/server/src/connectors/linear.ts
+++ b/packages/server/src/connectors/linear.ts
@@ -120,6 +120,9 @@ async function resolveTeamId(apiKey: string, teamKey: string): Promise<string | 
 }
 
 async function resolveCompletedStateId(apiKey: string, teamId: string): Promise<string | null> {
+  // orderBy: position so the lowest-position completed state ("Done" in
+  // Linear's defaults) is at index 0. Fetch a generous page so we don't miss
+  // it if a team has many post-done states (Merged, Released, Shipped, etc.).
   const data = await linearGraphQL<{
     workflowStates: { nodes: Array<{ id: string; type: string; position: number }> }
   }>(
@@ -127,15 +130,15 @@ async function resolveCompletedStateId(apiKey: string, teamId: string): Promise<
     `query CompletedStates($teamId: ID!) {
        workflowStates(
          filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }
-         first: 5
+         orderBy: position
+         first: 50
        ) { nodes { id type position } }
      }`,
     { teamId }
   )
   const nodes = data.workflowStates.nodes
   if (!nodes.length) return null
-  // Prefer the lowest-position completed state (Linear orders "Done" before
-  // post-done states like "Merged" / "Released").
+  // Defensive client-side sort in case the server ever returns out of order.
   return nodes.slice().sort((a, b) => a.position - b.position)[0].id
 }
 

--- a/packages/server/src/file-utils.ts
+++ b/packages/server/src/file-utils.ts
@@ -3,9 +3,12 @@ import path from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { FileEntry, RemoteHost } from '@vornrun/shared/types'
-import { sshExecSync, shellEscape } from './process-utils'
+import { sshExecSync, shellEscape, getSafeEnv } from './process-utils'
+import { resolveExecutable } from './resolve-executable'
 
 const execFileAsync = promisify(execFile)
+
+const gitBin = (): string => resolveExecutable('git') ?? 'git'
 
 const ALWAYS_EXCLUDE = new Set(['.git', '.DS_Store', 'Thumbs.db'])
 const MAX_READ_BYTES = 512 * 1024 // 512 KB default
@@ -16,9 +19,10 @@ const IGNORE_CACHE_TTL = 30_000
 
 async function getRepoRoot(cwd: string): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync('git', ['rev-parse', '--show-toplevel'], {
+    const { stdout } = await execFileAsync(gitBin(), ['rev-parse', '--show-toplevel'], {
       cwd,
       encoding: 'utf-8',
+      env: getSafeEnv(),
       timeout: 3000
     })
     return stdout.trim()
@@ -38,9 +42,15 @@ async function getGitIgnored(cwd: string): Promise<Set<string> | null> {
 
   try {
     const { stdout } = await execFileAsync(
-      'git',
+      gitBin(),
       ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
-      { cwd: root, encoding: 'utf-8', timeout: 5000, maxBuffer: 1024 * 1024 }
+      {
+        cwd: root,
+        encoding: 'utf-8',
+        env: getSafeEnv(),
+        timeout: 5000,
+        maxBuffer: 1024 * 1024
+      }
     )
     const lines = stdout.trim()
     const ignored = lines

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -3,7 +3,16 @@ import path from 'node:path'
 import fs from 'node:fs'
 import crypto from 'node:crypto'
 import type { RemoteHost } from '@vornrun/shared/types'
-import { sshExecSync, shellEscape } from './process-utils'
+import { sshExecSync, shellEscape, getSafeEnv } from './process-utils'
+import { resolveExecutable } from './resolve-executable'
+
+// Resolve `git` from the login-shell PATH so packaged Electron finds the
+// same binary the user would from their terminal (e.g. a newer Homebrew git
+// rather than the Xcode stub). Falls back to the bare name so callers still
+// work if resolution fails.
+function gitBin(): string {
+  return resolveExecutable('git') ?? 'git'
+}
 
 /**
  * Run a git command locally or via SSH depending on whether a remote host is provided.
@@ -18,9 +27,10 @@ function gitExec(
     const cmd = `cd ${shellEscape(cwd, 'posix')} && git ${args.map((a) => shellEscape(a, 'posix')).join(' ')}`
     return sshExecSync(opts.remote, cmd, { timeout: opts?.timeout ?? 10000 })
   }
-  return execFileSync('git', args, {
+  return execFileSync(gitBin(), args, {
     cwd,
     ...EXEC_OPTS,
+    env: getSafeEnv(),
     timeout: opts?.timeout ?? 10000,
     maxBuffer: opts?.maxBuffer
   }).trim()
@@ -34,9 +44,10 @@ const EXEC_OPTS = {
 export function isGitRepo(projectPath: string): boolean {
   try {
     return (
-      execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      execFileSync(gitBin(), ['rev-parse', '--is-inside-work-tree'], {
         cwd: projectPath,
         ...EXEC_OPTS,
+        env: getSafeEnv(),
         timeout: 3000
       }).trim() === 'true'
     )

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -845,8 +845,7 @@ export function registerAllMethods(): void {
     const results: Array<{ connectorId: string; authed: boolean; message?: string }> = []
     for (const c of connectorRegistry.list()) {
       if (c.id === 'github') {
-        const { resolveGhPath, ghInstallHint } = await import('./connectors/gh-cli')
-        const { getSafeEnv } = await import('./process-utils')
+        const { resolveGhPath, ghInstallHint, getGhEnv } = await import('./connectors/gh-cli')
         const ghPath = resolveGhPath()
         if (!ghPath) {
           results.push({
@@ -862,11 +861,15 @@ export function registerAllMethods(): void {
           const execFileAsync = promisify(execFile)
           await execFileAsync(ghPath, ['auth', 'status'], {
             timeout: 5_000,
-            env: getSafeEnv()
+            env: getGhEnv()
           })
           results.push({ connectorId: c.id, authed: true })
-        } catch {
-          // gh is installed but not authenticated (or auth expired).
+        } catch (err) {
+          // gh is installed but the status probe failed. The common case is
+          // "not signed in"; anything else we surface in logs so it's not
+          // silently lost.
+          const msg = err instanceof Error ? err.message : String(err)
+          log.warn(`[connector:status] gh auth status failed: ${msg}`)
           results.push({
             connectorId: c.id,
             authed: false,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -845,19 +845,32 @@ export function registerAllMethods(): void {
     const results: Array<{ connectorId: string; authed: boolean; message?: string }> = []
     for (const c of connectorRegistry.list()) {
       if (c.id === 'github') {
-        // Probe gh auth status non-interactively.
+        const { resolveGhPath, ghInstallHint } = await import('./connectors/gh-cli')
+        const { getSafeEnv } = await import('./process-utils')
+        const ghPath = resolveGhPath()
+        if (!ghPath) {
+          results.push({
+            connectorId: c.id,
+            authed: false,
+            message: `GitHub CLI (gh) is not installed or not on PATH.\n${ghInstallHint()}\nAfter installing, run: \`gh auth login\``
+          })
+          continue
+        }
         try {
           const { execFile } = await import('node:child_process')
           const { promisify } = await import('node:util')
           const execFileAsync = promisify(execFile)
-          await execFileAsync('gh', ['auth', 'status'], { timeout: 5_000 })
+          await execFileAsync(ghPath, ['auth', 'status'], {
+            timeout: 5_000,
+            env: getSafeEnv()
+          })
           results.push({ connectorId: c.id, authed: true })
-        } catch (err) {
+        } catch {
+          // gh is installed but not authenticated (or auth expired).
           results.push({
             connectorId: c.id,
             authed: false,
-            message:
-              err instanceof Error ? err.message : 'gh auth status failed — run `gh auth login`'
+            message: 'Sign in by running `gh auth login` in your terminal.'
           })
         }
       } else {

--- a/packages/server/src/resolve-executable.ts
+++ b/packages/server/src/resolve-executable.ts
@@ -7,7 +7,10 @@ import { getSafeEnv } from './process-utils'
 // aren't visible to `spawn('name', …)`. We resolve the absolute path once
 // from the user's resolved shell env and reuse it.
 
-const cache = new Map<string, string | null>()
+// Cache only successful lookups — if the user installs `gh` or `git` mid-
+// session, we want the next probe to discover it rather than reporting
+// "not found" until app restart.
+const cache = new Map<string, string>()
 
 function find(name: string): string | null {
   const env = getSafeEnv()
@@ -33,12 +36,16 @@ function find(name: string): string | null {
 
 /**
  * Look up an executable by name on the user's PATH (login-shell PATH via
- * `getSafeEnv()`). On Windows also tries `.exe` and `.cmd` suffixes. Result
- * is cached per-name until `resetResolveCache()` is called.
+ * `getSafeEnv()`). On Windows also tries `.exe` and `.cmd` suffixes.
+ * Successful lookups are cached; misses are re-probed so a fresh install
+ * is picked up without an app restart.
  */
 export function resolveExecutable(name: string): string | null {
-  if (!cache.has(name)) cache.set(name, find(name))
-  return cache.get(name) ?? null
+  const hit = cache.get(name)
+  if (hit) return hit
+  const found = find(name)
+  if (found) cache.set(name, found)
+  return found
 }
 
 export function resetResolveCache(name?: string): void {

--- a/packages/server/src/resolve-executable.ts
+++ b/packages/server/src/resolve-executable.ts
@@ -14,8 +14,7 @@ function find(name: string): string | null {
   const pathEnv = env.PATH || env.Path || process.env.PATH || ''
   if (!pathEnv) return null
   const sep = process.platform === 'win32' ? ';' : ':'
-  const candidates =
-    process.platform === 'win32' ? [`${name}.exe`, `${name}.cmd`, name] : [name]
+  const candidates = process.platform === 'win32' ? [`${name}.exe`, `${name}.cmd`, name] : [name]
   for (const rawDir of pathEnv.split(sep)) {
     const dir = rawDir.trim()
     if (!dir) continue

--- a/packages/server/src/resolve-executable.ts
+++ b/packages/server/src/resolve-executable.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { getSafeEnv } from './process-utils'
+
+// Packaged Electron apps on macOS don't inherit the login-shell PATH, so
+// user-installed binaries (Homebrew at /opt/homebrew/bin, /usr/local/bin)
+// aren't visible to `spawn('name', …)`. We resolve the absolute path once
+// from the user's resolved shell env and reuse it.
+
+const cache = new Map<string, string | null>()
+
+function find(name: string): string | null {
+  const env = getSafeEnv()
+  const pathEnv = env.PATH || env.Path || process.env.PATH || ''
+  if (!pathEnv) return null
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const candidates =
+    process.platform === 'win32' ? [`${name}.exe`, `${name}.cmd`, name] : [name]
+  for (const rawDir of pathEnv.split(sep)) {
+    const dir = rawDir.trim()
+    if (!dir) continue
+    for (const candidate of candidates) {
+      const full = path.join(dir, candidate)
+      try {
+        fs.accessSync(full, fs.constants.X_OK)
+        return full
+      } catch {
+        /* not here */
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Look up an executable by name on the user's PATH (login-shell PATH via
+ * `getSafeEnv()`). On Windows also tries `.exe` and `.cmd` suffixes. Result
+ * is cached per-name until `resetResolveCache()` is called.
+ */
+export function resolveExecutable(name: string): string | null {
+  if (!cache.has(name)) cache.set(name, find(name))
+  return cache.get(name) ?? null
+}
+
+export function resetResolveCache(name?: string): void {
+  if (name) cache.delete(name)
+  else cache.clear()
+}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, type ReactNode } from 'react'
 import { useAppStore } from '../../stores'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { ConnectorIcon } from '../ConnectorIcon'
@@ -40,6 +40,24 @@ function humanCron(cron: string): string {
   if (m) return `every ${m[1]} minute${m[1] === '1' ? '' : 's'}`
   if (cron === '* * * * *') return 'every minute'
   return cron
+}
+
+/** Render text with `backtick` spans styled as inline code. */
+function renderMessageWithCode(text: string): ReactNode {
+  const parts = text.split(/(`[^`]+`)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith('`') && part.endsWith('`') && part.length >= 2) {
+      return (
+        <code
+          key={i}
+          className="px-1 py-[1px] bg-black/30 border border-white/[0.08] rounded-sm text-amber-100 font-mono text-[11px]"
+        >
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    return <span key={i}>{part}</span>
+  })
 }
 
 export function ConnectorSettings() {
@@ -140,8 +158,10 @@ export function ConnectorSettings() {
                 {connectors.find((c) => c.id === s.connectorId)?.name || s.connectorId} not signed
                 in
               </div>
-              <div className="text-amber-300/70 mt-0.5">
-                {s.message || 'Run `gh auth login` in your terminal to sign in.'}
+              <div className="text-amber-300/70 mt-0.5 whitespace-pre-line">
+                {renderMessageWithCode(
+                  s.message || 'Run `gh auth login` in your terminal to sign in.'
+                )}
               </div>
             </div>
           </div>

--- a/tests/gh-cli.test.ts
+++ b/tests/gh-cli.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../packages/server/src/process-utils', () => ({
+  getSafeEnv: () => ({ PATH: '/usr/bin' })
+}))
+
+const importGhCli = async () => import('../packages/server/src/connectors/gh-cli')
+
+const origPlatform = process.platform
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true })
+}
+
+afterEach(() => {
+  setPlatform(origPlatform)
+})
+
+describe('gh-cli — ghInstallHint()', () => {
+  it('gives the Homebrew hint on darwin', async () => {
+    setPlatform('darwin')
+    const { ghInstallHint } = await importGhCli()
+    expect(ghInstallHint()).toMatch(/brew install gh/)
+  })
+
+  it('gives the winget / cli.github.com hint on win32', async () => {
+    setPlatform('win32')
+    const { ghInstallHint } = await importGhCli()
+    expect(ghInstallHint()).toMatch(/winget.*GitHub\.cli/)
+    expect(ghInstallHint()).toMatch(/cli\.github\.com/)
+  })
+
+  it('gives a generic hint on linux', async () => {
+    setPlatform('linux')
+    const { ghInstallHint } = await importGhCli()
+    expect(ghInstallHint()).toMatch(/apt install gh/)
+  })
+})
+
+describe('gh-cli — GhNotFoundError', () => {
+  it('has a GH_NOT_FOUND code and embeds the install hint in its message', async () => {
+    setPlatform('darwin')
+    const { GhNotFoundError } = await importGhCli()
+    const err = new GhNotFoundError()
+    expect(err.code).toBe('GH_NOT_FOUND')
+    expect(err.name).toBe('GhNotFoundError')
+    expect(err.message).toMatch(/GitHub CLI .* not found/)
+    expect(err.message).toMatch(/brew install gh/)
+  })
+})
+
+describe('gh-cli — getGhEnv()', () => {
+  const origGhToken = process.env.GH_TOKEN
+  const origGithubToken = process.env.GITHUB_TOKEN
+
+  beforeEach(() => {
+    delete process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+  })
+
+  afterEach(() => {
+    if (origGhToken !== undefined) process.env.GH_TOKEN = origGhToken
+    else delete process.env.GH_TOKEN
+    if (origGithubToken !== undefined) process.env.GITHUB_TOKEN = origGithubToken
+    else delete process.env.GITHUB_TOKEN
+  })
+
+  it('starts from the safe env (login-shell PATH)', async () => {
+    const { getGhEnv } = await importGhCli()
+    const env = getGhEnv()
+    expect(env.PATH).toBe('/usr/bin')
+  })
+
+  it('preserves GH_TOKEN and GITHUB_TOKEN from process.env', async () => {
+    process.env.GH_TOKEN = 'gh-secret'
+    process.env.GITHUB_TOKEN = 'gha-secret'
+    const { getGhEnv } = await importGhCli()
+    const env = getGhEnv()
+    expect(env.GH_TOKEN).toBe('gh-secret')
+    expect(env.GITHUB_TOKEN).toBe('gha-secret')
+  })
+
+  it('omits GH_TOKEN / GITHUB_TOKEN entirely when they are not set', async () => {
+    const { getGhEnv } = await importGhCli()
+    const env = getGhEnv()
+    expect(env.GH_TOKEN).toBeUndefined()
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+  })
+})

--- a/tests/github-connector.test.ts
+++ b/tests/github-connector.test.ts
@@ -122,7 +122,9 @@ describe('github connector — listItems()', () => {
       assignee: 'user+alias'
     })
     const [cmd, args] = execFileMock.mock.calls[0]
-    expect(cmd).toBe('gh')
+    // resolveGhPath() may return an absolute path (/usr/bin/gh, /opt/homebrew/bin/gh)
+    // or the bare name when not on PATH in the test runner.
+    expect(cmd).toMatch(/(?:^|[/\\])gh(?:\.(?:exe|cmd))?$/)
     const endpoint = args[1] as string
     expect(endpoint).toContain(encodeURIComponent('owner with space'))
     expect(endpoint).toContain(encodeURIComponent('repo/has/slash'))
@@ -278,7 +280,10 @@ describe('github connector — poll()', () => {
       ])
     )
     const gh = await importGithub()
-    const result = await gh.poll!('prOpened', { owner: 'o', repo: 'r' })
+    // Explicit cursor before created_at so the test isn't time-of-day dependent
+    // (default cursor is `Date.now() - 60s`, which flakes once real time passes
+    // the hardcoded PR timestamp).
+    const result = await gh.poll!('prOpened', { owner: 'o', repo: 'r' }, '2026-04-24T10:59:00Z')
     expect(result.events).toHaveLength(1)
     expect(result.events[0].data).toMatchObject({
       number: 7,

--- a/tests/linear-connector.test.ts
+++ b/tests/linear-connector.test.ts
@@ -37,9 +37,16 @@ const importLinear = async () =>
   (await import('../packages/server/src/connectors/linear')).linearConnector
 
 describe('linear connector — describe()', () => {
-  it('advertises tasks + triggers (no actions)', async () => {
+  it('advertises tasks, triggers, and actions', async () => {
     const linear = await importLinear()
-    expect(linear.capabilities).toEqual(['tasks', 'triggers'])
+    expect(linear.capabilities).toEqual(['tasks', 'triggers', 'actions'])
+  })
+
+  it('declares commentOnIssue / createIssue / closeIssue actions', async () => {
+    const linear = await importLinear()
+    const manifest = linear.describe()
+    const types = manifest.actions?.map((a) => a.type)
+    expect(types).toEqual(['commentOnIssue', 'createIssue', 'closeIssue'])
   })
 
   it('declares apiKey as a required password auth field', async () => {
@@ -184,10 +191,121 @@ describe('linear connector — poll()', () => {
 })
 
 describe('linear connector — execute()', () => {
-  it('returns success:false for any action (not implemented yet)', async () => {
+  it('createIssue: resolves teamKey to teamId then calls issueCreate', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ teams: { nodes: [{ id: 'team-uuid' }] } }))
+      .mockResolvedValueOnce(
+        okResponse({
+          issueCreate: {
+            success: true,
+            issue: { id: 'i', identifier: 'ENG-42', url: 'https://linear.app/i/ENG-42' }
+          }
+        })
+      )
     const linear = await importLinear()
-    const result = await linear.execute!('createIssue', { apiKey: 'k' })
+    const result = await linear.execute!('createIssue', {
+      apiKey: 'k',
+      teamKey: 'ENG',
+      title: 'New bug',
+      description: 'desc'
+    })
+    expect(result.success).toBe(true)
+    expect(result.output).toEqual({
+      identifier: 'ENG-42',
+      url: 'https://linear.app/i/ENG-42'
+    })
+    const createBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)
+    expect(createBody.variables.input).toEqual({
+      teamId: 'team-uuid',
+      title: 'New bug',
+      description: 'desc'
+    })
+  })
+
+  it('createIssue: fails when title is missing', async () => {
+    const linear = await importLinear()
+    const result = await linear.execute!('createIssue', { apiKey: 'k', teamKey: 'ENG' })
     expect(result.success).toBe(false)
-    expect(result.error).toMatch(/not implemented/)
+    expect(result.error).toMatch(/title is required/)
+  })
+
+  it('createIssue: fails when teamKey is missing (not on connection or call)', async () => {
+    const linear = await importLinear()
+    const result = await linear.execute!('createIssue', { apiKey: 'k', title: 't' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/teamKey is required/)
+  })
+
+  it('commentOnIssue: resolves identifier to UUID then calls commentCreate', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ issues: { nodes: [{ id: 'issue-uuid' }] } }))
+      .mockResolvedValueOnce(
+        okResponse({
+          commentCreate: { success: true, comment: { id: 'c', url: 'https://linear.app/c/1' } }
+        })
+      )
+    const linear = await importLinear()
+    const result = await linear.execute!('commentOnIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-1',
+      body: 'thanks'
+    })
+    expect(result.success).toBe(true)
+    const commentBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)
+    expect(commentBody.variables.input).toEqual({ issueId: 'issue-uuid', body: 'thanks' })
+  })
+
+  it('commentOnIssue: fails when issue identifier not found', async () => {
+    fetchMock.mockResolvedValue(okResponse({ issues: { nodes: [] } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('commentOnIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-999',
+      body: 'hi'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/)
+  })
+
+  it('closeIssue: picks lowest-position completed state on the issue team', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({
+          issues: {
+            nodes: [{ id: 'issue-uuid', team: { id: 'team-uuid', key: 'ENG' } }]
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        okResponse({
+          workflowStates: {
+            nodes: [
+              { id: 'state-released', type: 'completed', position: 200 },
+              { id: 'state-done', type: 'completed', position: 100 }
+            ]
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        okResponse({
+          issueUpdate: { success: true, issue: { id: 'issue-uuid', state: { name: 'Done' } } }
+        })
+      )
+    const linear = await importLinear()
+    const result = await linear.execute!('closeIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-1'
+    })
+    expect(result.success).toBe(true)
+    const updateBody = JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)
+    expect(updateBody.variables.id).toBe('issue-uuid')
+    expect(updateBody.variables.input).toEqual({ stateId: 'state-done' })
+  })
+
+  it('returns an error for unknown action types', async () => {
+    const linear = await importLinear()
+    const result = await linear.execute!('noSuchAction', { apiKey: 'k' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Unknown action/)
   })
 })

--- a/tests/linear-connector.test.ts
+++ b/tests/linear-connector.test.ts
@@ -308,4 +308,82 @@ describe('linear connector — execute()', () => {
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/Unknown action/)
   })
+
+  it('commentOnIssue: surfaces success:false from Linear', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ issues: { nodes: [{ id: 'issue-uuid' }] } }))
+      .mockResolvedValueOnce(okResponse({ commentCreate: { success: false, comment: null } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('commentOnIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-1',
+      body: 'hi'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/success=false/)
+  })
+
+  it('createIssue: fails when teamKey has no matching team', async () => {
+    fetchMock.mockResolvedValue(okResponse({ teams: { nodes: [] } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('createIssue', {
+      apiKey: 'k',
+      teamKey: 'NOPE',
+      title: 't'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Team NOPE not found/)
+  })
+
+  it('createIssue: surfaces success:false from Linear', async () => {
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ teams: { nodes: [{ id: 'team-uuid' }] } }))
+      .mockResolvedValueOnce(okResponse({ issueCreate: { success: false, issue: null } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('createIssue', {
+      apiKey: 'k',
+      teamKey: 'ENG',
+      title: 't'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/success=false/)
+  })
+
+  it('closeIssue: fails when the team has no completed-type workflow state', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({
+          issues: { nodes: [{ id: 'issue-uuid', team: { id: 'team-uuid', key: 'ENG' } }] }
+        })
+      )
+      .mockResolvedValueOnce(okResponse({ workflowStates: { nodes: [] } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('closeIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-1'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/No completed-type state/)
+  })
+
+  it('closeIssue: fails when identifier not found', async () => {
+    fetchMock.mockResolvedValue(okResponse({ issues: { nodes: [] } }))
+    const linear = await importLinear()
+    const result = await linear.execute!('closeIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-999'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/)
+  })
+
+  it('commentOnIssue: fails when body is missing', async () => {
+    const linear = await importLinear()
+    const result = await linear.execute!('commentOnIssue', {
+      apiKey: 'k',
+      identifier: 'ENG-1'
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/body is required/)
+  })
 })

--- a/tests/resolve-executable.test.ts
+++ b/tests/resolve-executable.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+
+// We swap in a custom safe-env per test so we can drive the PATH search.
+const safeEnvMock = vi.fn()
+vi.mock('../packages/server/src/process-utils', () => ({
+  getSafeEnv: () => safeEnvMock()
+}))
+
+const importResolver = async () => {
+  // Reset module state so the per-name cache starts fresh each test.
+  vi.resetModules()
+  return import('../packages/server/src/resolve-executable')
+}
+
+const origPlatform = process.platform
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true })
+}
+
+beforeEach(() => {
+  safeEnvMock.mockReset()
+})
+
+afterEach(() => {
+  setPlatform(origPlatform)
+  vi.restoreAllMocks()
+})
+
+describe('resolveExecutable()', () => {
+  it('returns null and re-probes on subsequent calls when not found', async () => {
+    safeEnvMock.mockReturnValue({ PATH: '/nope' })
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    const { resolveExecutable } = await importResolver()
+    expect(resolveExecutable('nothing')).toBeNull()
+    expect(resolveExecutable('nothing')).toBeNull()
+    // Missing-lookups are NOT cached, so we re-probe each call.
+    expect(accessSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('caches successful lookups', async () => {
+    safeEnvMock.mockReturnValue({ PATH: '/usr/bin' })
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementation((p) => {
+      if (String(p).endsWith('/usr/bin/thing')) return undefined
+      throw new Error('ENOENT')
+    })
+    const { resolveExecutable } = await importResolver()
+    const first = resolveExecutable('thing')
+    const callsAfterFirst = accessSpy.mock.calls.length
+    const second = resolveExecutable('thing')
+    expect(second).toBe(first)
+    // No additional probes on the second call.
+    expect(accessSpy.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it('returns null when PATH is empty', async () => {
+    safeEnvMock.mockReturnValue({})
+    const { resolveExecutable } = await importResolver()
+    expect(resolveExecutable('anything')).toBeNull()
+  })
+
+  it('tries .exe and .cmd suffixes on Windows', async () => {
+    setPlatform('win32')
+    safeEnvMock.mockReturnValue({ PATH: 'C:\\bin' })
+    const checked: string[] = []
+    vi.spyOn(fs, 'accessSync').mockImplementation((p) => {
+      checked.push(String(p))
+      if (String(p).endsWith('gh.cmd')) return undefined
+      throw new Error('ENOENT')
+    })
+    const { resolveExecutable } = await importResolver()
+    const resolved = resolveExecutable('gh')
+    expect(resolved).toMatch(/gh\.cmd$/)
+    expect(checked.some((c) => c.endsWith('gh.exe'))).toBe(true)
+  })
+
+  it('resetResolveCache(name) clears a specific entry', async () => {
+    safeEnvMock.mockReturnValue({ PATH: '/usr/bin' })
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementation((p) => {
+      if (String(p).endsWith('/usr/bin/thing')) return undefined
+      throw new Error('ENOENT')
+    })
+    const { resolveExecutable, resetResolveCache } = await importResolver()
+    resolveExecutable('thing')
+    const before = accessSpy.mock.calls.length
+    resetResolveCache('thing')
+    resolveExecutable('thing')
+    expect(accessSpy.mock.calls.length).toBeGreaterThan(before)
+  })
+
+  it('resetResolveCache() with no arg clears all entries', async () => {
+    safeEnvMock.mockReturnValue({ PATH: '/usr/bin' })
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementation((p) => {
+      if (String(p).endsWith('/usr/bin/a') || String(p).endsWith('/usr/bin/b')) return undefined
+      throw new Error('ENOENT')
+    })
+    const { resolveExecutable, resetResolveCache } = await importResolver()
+    resolveExecutable('a')
+    resolveExecutable('b')
+    const before = accessSpy.mock.calls.length
+    resetResolveCache()
+    resolveExecutable('a')
+    resolveExecutable('b')
+    expect(accessSpy.mock.calls.length).toBeGreaterThan(before)
+  })
+})


### PR DESCRIPTION
## Summary

- **Fix**: packaged Electron on macOS couldn't find Homebrew-installed `gh`, surfacing as "spawn gh ENOENT" in Settings → Connectors. New `resolveExecutable()` resolves binaries against the login-shell PATH (via `getSafeEnv()`) with Windows `.exe`/`.cmd` support, and the GitHub connector + `connector:status` handler use it. Also generalized to `git` (fallback-safe) so nothing regresses.
- **UX**: the banner now shows distinct, actionable messages — "GitHub CLI not installed" with the platform install command, vs "Sign in by running \`gh auth login\`" when installed but unauthed. Multi-line messages preserved and inline commands rendered as code.
- **Feature**: Linear gains three basic actions — `commentOnIssue`, `createIssue`, `closeIssue` — so it can be a downstream target in workflows the same way GitHub is. UUID resolvers wrap the human identifiers / team keys / completed states users actually see.

## Test plan

- [ ] Settings → Connectors: with `gh` installed + signed in, banner is gone and `jcanizalez/vorn` row shows no error on next poll.
- [ ] Uninstall or unPATH `gh`: banner shows "GitHub CLI (gh) is not installed or not on PATH. Install with Homebrew: \`brew install gh\`. After installing, run: \`gh auth login\`".
- [ ] `gh auth logout`: banner shows "Sign in by running \`gh auth login\` in your terminal."
- [ ] Linear row shows `tasks · triggers · actions`; workflow editor surfaces Comment / Create / Close Issue actions with the `{{connectorItem.externalId}}` placeholder prefilled.
- [ ] Run a workflow that calls `Linear → Comment on Issue` on a real issue — comment lands on Linear.
- [ ] `Linear → Close Issue` moves the issue to the team's "Done"-type state.