### PR TITLE
feat: project-scoped focused-mode nav, grid-only minimize, defensive AgentIcon

### DIFF
--- a/src/renderer/components/AgentIcon.tsx
+++ b/src/renderer/components/AgentIcon.tsx
@@ -153,5 +153,6 @@ const ICON_COMPONENTS: Record<AiAgentType, React.FC<{ size: number }>> = {
 export function AgentIcon({ agentType, size = 16 }: Props) {
   if (agentType === 'shell') return <ShellIcon size={size} />
   const IconComponent = ICON_COMPONENTS[agentType]
+  if (!IconComponent) return <ShellIcon size={size} />
   return <IconComponent size={size} />
 }

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -112,6 +112,18 @@ function PlusDropdown({
 
 export function TabView() {
   const { orderedIds, minimizedIds } = useVisibleTerminals()
+  const terminalOrder = useAppStore((s) => s.terminalOrder)
+  // Tab mode treats minimize as a no-op: every session shows as a tab. The
+  // minimizedTerminals Set is preserved so switching back to grid restores
+  // the BackgroundTray pills.
+  const allTabIds = useMemo(() => {
+    const merged = [...orderedIds, ...minimizedIds]
+    return merged.sort((a, b) => {
+      const ia = terminalOrder.indexOf(a)
+      const ib = terminalOrder.indexOf(b)
+      return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
+    })
+  }, [orderedIds, minimizedIds, terminalOrder])
   const terminals = useAppStore((s) => s.terminals)
   const activeTabId = useAppStore((s) => s.activeTabId)
   const setActiveTabId = useAppStore((s) => s.setActiveTabId)
@@ -152,14 +164,14 @@ export function TabView() {
   }, [tasks])
 
   useEffect(() => {
-    if (orderedIds.length === 0) {
+    if (allTabIds.length === 0) {
       if (activeTabId !== null) setActiveTabId(null)
       return
     }
-    if (!activeTabId || !orderedIds.includes(activeTabId)) {
-      setActiveTabId(orderedIds[0])
+    if (!activeTabId || !allTabIds.includes(activeTabId)) {
+      setActiveTabId(allTabIds[0])
     }
-  }, [orderedIds, activeTabId, setActiveTabId])
+  }, [allTabIds, activeTabId, setActiveTabId])
 
   const handleSelectTab = (id: string): void => {
     setActiveTabId(id)
@@ -175,8 +187,8 @@ export function TabView() {
 
     // Auto-select adjacent tab before removing
     if (activeTabId === id) {
-      const idx = orderedIds.indexOf(id)
-      const nextId = orderedIds[idx + 1] ?? orderedIds[idx - 1] ?? null
+      const idx = allTabIds.indexOf(id)
+      const nextId = allTabIds[idx + 1] ?? allTabIds[idx - 1] ?? null
       setActiveTabId(nextId)
     }
 
@@ -218,26 +230,26 @@ export function TabView() {
           prev ? { ...prev, pointerX: e.clientX, pointerY: e.clientY } : prev
         )
       }
-      const targetIndex = getHorizontalDropIndex(e.clientX, orderedIds, tabRefs.current)
+      const targetIndex = getHorizontalDropIndex(e.clientX, allTabIds, tabRefs.current)
       setDropTargetIndex(targetIndex)
     },
-    [dragState, orderedIds]
+    [dragState, allTabIds]
   )
 
   const handlePointerUp = useCallback(() => {
     if (dragState?.isDragging && dropTargetIndex !== null) {
-      const fromIndex = orderedIds.indexOf(dragState.draggingId)
+      const fromIndex = allTabIds.indexOf(dragState.draggingId)
       if (
         fromIndex !== -1 &&
         fromIndex !== dropTargetIndex &&
-        orderedIds.includes(dragState.draggingId)
+        allTabIds.includes(dragState.draggingId)
       ) {
         reorderTerminals(fromIndex, dropTargetIndex)
       }
     }
     setDragState(null)
     setDropTargetIndex(null)
-  }, [dragState, dropTargetIndex, orderedIds, reorderTerminals])
+  }, [dragState, dropTargetIndex, allTabIds, reorderTerminals])
 
   const handlePointerCancel = useCallback(() => {
     setDragState(null)
@@ -246,9 +258,10 @@ export function TabView() {
 
   /* ── Render ─────────────────────────────────────────────────── */
 
-  const hasBackground =
-    minimizedIds.length > 0 || filteredHeadless.length > 0 || waitingApprovals.length > 0
-  const hasTabs = orderedIds.length > 0
+  // Minimize is a grid-only concept, so don't surface minimized sessions in
+  // the tab-mode background tray. Headless + waiting approvals still do.
+  const hasBackground = filteredHeadless.length > 0 || waitingApprovals.length > 0
+  const hasTabs = allTabIds.length > 0
   const activeTerminal = activeTabId ? terminals.get(activeTabId) : null
 
   return (
@@ -256,7 +269,7 @@ export function TabView() {
       {hasTabs && (
         <BackgroundTray
           headlessSessions={filteredHeadless}
-          minimizedIds={minimizedIds}
+          minimizedIds={[]}
           waitingApprovals={waitingApprovals}
           variant="tabs"
         />
@@ -285,7 +298,7 @@ export function TabView() {
           className="flex-1 flex items-end gap-1 px-1 overflow-x-auto min-w-0"
           style={{ minHeight: 40 }}
         >
-          {orderedIds.map((id, index) => {
+          {allTabIds.map((id, index) => {
             const terminal = terminals.get(id)
             if (!terminal) return null
             const isActive = id === activeTabId
@@ -515,7 +528,7 @@ export function TabView() {
         <div className="flex-1 overflow-auto p-4">
           <BackgroundTray
             headlessSessions={filteredHeadless}
-            minimizedIds={minimizedIds}
+            minimizedIds={[]}
             waitingApprovals={waitingApprovals}
             variant="grid"
           />

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
-import { useVisibleTerminals } from '../hooks/useVisibleTerminals'
+import { useVisibleTerminals, compareTerminalIds } from '../hooks/useVisibleTerminals'
 import { useFilteredHeadless } from '../hooks/useFilteredHeadless'
 import { AgentStatusIcon } from './AgentStatusIcon'
 import { useWaitingApprovals } from '../hooks/useWaitingApprovals'
@@ -113,18 +113,16 @@ function PlusDropdown({
 export function TabView() {
   const { orderedIds, minimizedIds } = useVisibleTerminals()
   const terminalOrder = useAppStore((s) => s.terminalOrder)
+  const terminals = useAppStore((s) => s.terminals)
+  const sortMode = useAppStore((s) => s.sortMode)
   // Tab mode treats minimize as a no-op: every session shows as a tab. The
   // minimizedTerminals Set is preserved so switching back to grid restores
-  // the BackgroundTray pills.
+  // the BackgroundTray pills. The merged list honors the active sortMode so
+  // tabs follow the same order as the grid.
   const allTabIds = useMemo(() => {
     const merged = [...orderedIds, ...minimizedIds]
-    return merged.sort((a, b) => {
-      const ia = terminalOrder.indexOf(a)
-      const ib = terminalOrder.indexOf(b)
-      return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
-    })
-  }, [orderedIds, minimizedIds, terminalOrder])
-  const terminals = useAppStore((s) => s.terminals)
+    return merged.sort((a, b) => compareTerminalIds(a, b, terminals, sortMode, terminalOrder))
+  }, [orderedIds, minimizedIds, terminalOrder, terminals, sortMode])
   const activeTabId = useAppStore((s) => s.activeTabId)
   const setActiveTabId = useAppStore((s) => s.setActiveTabId)
   const setSelected = useAppStore((s) => s.setSelectedTerminal)
@@ -132,7 +130,6 @@ export function TabView() {
   const renamingTerminalId = useAppStore((s) => s.renamingTerminalId)
   const setRenamingTerminalId = useAppStore((s) => s.setRenamingTerminalId)
   const renameTerminal = useAppStore((s) => s.renameTerminal)
-  const sortMode = useAppStore((s) => s.sortMode)
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
   const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
   const tasks = useAppStore((s) => s.config?.tasks)

--- a/src/renderer/components/card/FocusedNavHint.tsx
+++ b/src/renderer/components/card/FocusedNavHint.tsx
@@ -9,21 +9,21 @@ interface Props {
 }
 
 export function FocusedNavHint({ terminalId }: Props) {
-  const { visibleTerminalIds, setFocusedTerminal } = useAppStore(
+  const { focusableTerminalIds, setFocusedTerminal } = useAppStore(
     useShallow((s) => ({
-      visibleTerminalIds: s.visibleTerminalIds,
+      focusableTerminalIds: s.focusableTerminalIds,
       setFocusedTerminal: s.setFocusedTerminal
     }))
   )
 
-  if (visibleTerminalIds.length < 2) return null
+  if (focusableTerminalIds.length < 2) return null
 
-  const index = visibleTerminalIds.indexOf(terminalId)
+  const index = focusableTerminalIds.indexOf(terminalId)
   if (index === -1) return null
 
-  const total = visibleTerminalIds.length
-  const prevId = visibleTerminalIds[(index - 1 + total) % total]
-  const nextId = visibleTerminalIds[(index + 1) % total]
+  const total = focusableTerminalIds.length
+  const prevId = focusableTerminalIds[(index - 1 + total) % total]
+  const nextId = focusableTerminalIds[(index + 1) % total]
 
   const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -119,12 +119,17 @@ export function useKeyboardShortcuts() {
       if (modKey(e) && e.key === ']') {
         e.preventDefault()
         const ids = state.visibleTerminalIds
-        if (ids.length === 0) return
         const layoutMode = state.config?.defaults?.layoutMode ?? 'grid'
         if (state.focusedTerminalId) {
-          const current = ids.indexOf(state.focusedTerminalId)
-          const next = current === -1 ? 0 : (current + 1) % ids.length
-          state.setFocusedTerminal(ids[next])
+          // Focused mode spans the whole project (across worktrees), not just
+          // the worktree-filtered grid view.
+          const focusable = state.focusableTerminalIds
+          if (focusable.length === 0) return
+          const current = focusable.indexOf(state.focusedTerminalId)
+          const next = current === -1 ? 0 : (current + 1) % focusable.length
+          state.setFocusedTerminal(focusable[next])
+        } else if (ids.length === 0) {
+          return
         } else if (layoutMode === 'tabs') {
           const currentTab = state.activeTabId
           const current = currentTab ? ids.indexOf(currentTab) : -1
@@ -147,12 +152,18 @@ export function useKeyboardShortcuts() {
       if (modKey(e) && e.key === '[') {
         e.preventDefault()
         const ids = state.visibleTerminalIds
-        if (ids.length === 0) return
         const layoutMode = state.config?.defaults?.layoutMode ?? 'grid'
         if (state.focusedTerminalId) {
-          const current = ids.indexOf(state.focusedTerminalId)
-          const prev = current === -1 ? ids.length - 1 : (current - 1 + ids.length) % ids.length
-          state.setFocusedTerminal(ids[prev])
+          const focusable = state.focusableTerminalIds
+          if (focusable.length === 0) return
+          const current = focusable.indexOf(state.focusedTerminalId)
+          const prev =
+            current === -1
+              ? focusable.length - 1
+              : (current - 1 + focusable.length) % focusable.length
+          state.setFocusedTerminal(focusable[prev])
+        } else if (ids.length === 0) {
+          return
         } else if (layoutMode === 'tabs') {
           const currentTab = state.activeTabId
           const current = currentTab ? ids.indexOf(currentTab) : -1

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -1,7 +1,7 @@
 import { useMemo, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
-import { MAIN_WORKTREE_SENTINEL } from '../stores/types'
+import { MAIN_WORKTREE_SENTINEL, type TerminalState } from '../stores/types'
 
 export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: string[] } {
   const {
@@ -14,7 +14,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     statusFilter,
     terminalOrder,
     minimizedTerminals,
-    setVisibleTerminalIds
+    setVisibleTerminalIds,
+    setFocusableTerminalIds
   } = useAppStore(
     useShallow((s) => ({
       terminals: s.terminals,
@@ -26,7 +27,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
       statusFilter: s.statusFilter,
       terminalOrder: s.terminalOrder,
       minimizedTerminals: s.minimizedTerminals,
-      setVisibleTerminalIds: s.setVisibleTerminalIds
+      setVisibleTerminalIds: s.setVisibleTerminalIds,
+      setFocusableTerminalIds: s.setFocusableTerminalIds
     }))
   )
 
@@ -37,12 +39,34 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     )
   }, [projects, activeWorkspace])
 
-  const { orderedIds, minimizedIds } = useMemo(() => {
-    const filtered = Array.from(terminals.entries())
+  const { orderedIds, minimizedIds, focusableIds } = useMemo(() => {
+    const inActiveScope = (t: TerminalState): boolean => {
+      if (activeProject && t.session.projectName !== activeProject) return false
+      if (!activeProject && workspaceProjects && !workspaceProjects.has(t.session.projectName))
+        return false
+      return true
+    }
+    const sortFn = (
+      [aId, aState]: [string, TerminalState],
+      [bId, bState]: [string, TerminalState]
+    ): number => {
+      switch (sortMode) {
+        case 'created':
+          return bState.session.createdAt - aState.session.createdAt
+        case 'recent':
+          return bState.lastOutputTimestamp - aState.lastOutputTimestamp
+        case 'manual':
+        default: {
+          const ia = terminalOrder.indexOf(aId)
+          const ib = terminalOrder.indexOf(bId)
+          return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
+        }
+      }
+    }
+    const all = Array.from(terminals.entries())
+    const filtered = all
       .filter(([, t]) => {
-        if (activeProject && t.session.projectName !== activeProject) return false
-        if (!activeProject && workspaceProjects && !workspaceProjects.has(t.session.projectName))
-          return false
+        if (!inActiveScope(t)) return false
         if (activeWorktreePath) {
           if (activeWorktreePath === MAIN_WORKTREE_SENTINEL) {
             if (t.session.worktreePath) return false
@@ -51,20 +75,7 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
         if (statusFilter !== 'all' && t.status !== statusFilter) return false
         return true
       })
-      .sort(([aId, aState], [bId, bState]) => {
-        switch (sortMode) {
-          case 'created':
-            return bState.session.createdAt - aState.session.createdAt
-          case 'recent':
-            return bState.lastOutputTimestamp - aState.lastOutputTimestamp
-          case 'manual':
-          default: {
-            const ia = terminalOrder.indexOf(aId)
-            const ib = terminalOrder.indexOf(bId)
-            return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
-          }
-        }
-      })
+      .sort(sortFn)
 
     const ordered: string[] = []
     const minimized: string[] = []
@@ -75,7 +86,15 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
         ordered.push(id)
       }
     }
-    return { orderedIds: ordered, minimizedIds: minimized }
+
+    // Focused-mode nav spans the active project (or workspace) regardless of
+    // worktree filter or status filter, so cycling sessions reaches all of them.
+    const focusable = all
+      .filter(([, t]) => inActiveScope(t))
+      .sort(sortFn)
+      .map(([id]) => id)
+
+    return { orderedIds: ordered, minimizedIds: minimized, focusableIds: focusable }
   }, [
     terminals,
     activeProject,
@@ -94,6 +113,10 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
       useAppStore.getState().setSelectedTerminal(null)
     }
   }, [orderedIds, setVisibleTerminalIds])
+
+  useEffect(() => {
+    setFocusableTerminalIds(focusableIds)
+  }, [focusableIds, setFocusableTerminalIds])
 
   return { orderedIds, minimizedIds }
 }

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -1,7 +1,42 @@
 import { useMemo, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
-import { MAIN_WORKTREE_SENTINEL, type TerminalState } from '../stores/types'
+import { MAIN_WORKTREE_SENTINEL, type SortMode, type TerminalState } from '../stores/types'
+
+/**
+ * Stable comparator for terminal ids under the active sortMode. Manual mode
+ * pushes ids missing from `terminalOrder` to the end (rather than producing
+ * `Infinity - Infinity = NaN`, which is undefined behavior for Array#sort).
+ */
+export function compareTerminalIds(
+  aId: string,
+  bId: string,
+  terminals: Map<string, TerminalState>,
+  sortMode: SortMode,
+  terminalOrder: string[]
+): number {
+  const aState = terminals.get(aId)
+  const bState = terminals.get(bId)
+  if (!aState || !bState) {
+    if (!aState && !bState) return 0
+    return aState ? -1 : 1
+  }
+  switch (sortMode) {
+    case 'created':
+      return bState.session.createdAt - aState.session.createdAt
+    case 'recent':
+      return bState.lastOutputTimestamp - aState.lastOutputTimestamp
+    case 'manual':
+    default: {
+      const ia = terminalOrder.indexOf(aId)
+      const ib = terminalOrder.indexOf(bId)
+      if (ia === -1 && ib === -1) return 0
+      if (ia === -1) return 1
+      if (ib === -1) return -1
+      return ia - ib
+    }
+  }
+}
 
 export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: string[] } {
   const {
@@ -46,23 +81,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
         return false
       return true
     }
-    const sortFn = (
-      [aId, aState]: [string, TerminalState],
-      [bId, bState]: [string, TerminalState]
-    ): number => {
-      switch (sortMode) {
-        case 'created':
-          return bState.session.createdAt - aState.session.createdAt
-        case 'recent':
-          return bState.lastOutputTimestamp - aState.lastOutputTimestamp
-        case 'manual':
-        default: {
-          const ia = terminalOrder.indexOf(aId)
-          const ib = terminalOrder.indexOf(bId)
-          return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
-        }
-      }
-    }
+    const sortFn = ([aId]: [string, TerminalState], [bId]: [string, TerminalState]): number =>
+      compareTerminalIds(aId, bId, terminals, sortMode, terminalOrder)
     const all = Array.from(terminals.entries())
     const filtered = all
       .filter(([, t]) => {

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -139,6 +139,7 @@ export interface UISlice {
   statusFilter: StatusFilter
   terminalOrder: string[]
   visibleTerminalIds: string[]
+  focusableTerminalIds: string[]
   minimizedTerminals: Set<string>
   backgroundTrayCollapsed: boolean
   isOnboardingOpen: boolean
@@ -178,6 +179,7 @@ export interface UISlice {
   setFlexibleLayouts: (layouts: Record<string, FlexibleLayoutRect>) => void
   setTerminalOrder: (order: string[]) => void
   setVisibleTerminalIds: (ids: string[]) => void
+  setFocusableTerminalIds: (ids: string[]) => void
   reorderTerminals: (fromIndex: number, toIndex: number) => void
   toggleMinimized: (id: string) => void
   toggleBackgroundTray: () => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -91,6 +91,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
     (savedGrid.statusFilter as 'all' | 'running' | 'waiting' | 'idle' | 'error') ?? 'all',
   terminalOrder: [],
   visibleTerminalIds: [],
+  focusableTerminalIds: [],
   minimizedTerminals: new Set(),
   backgroundTrayCollapsed: false,
   isOnboardingOpen: false,
@@ -184,6 +185,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   setTerminalOrder: (order) => set({ terminalOrder: order }),
   setVisibleTerminalIds: (ids) => set({ visibleTerminalIds: ids }),
+  setFocusableTerminalIds: (ids) => set({ focusableTerminalIds: ids }),
 
   reorderTerminals: (fromIndex, toIndex) =>
     set((state) => {

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -57,7 +57,8 @@ vi.mock('../src/renderer/hooks/useTerminalPinchZoom', () => ({
 let mockOrderedIds = ['term-1']
 let mockMinimizedIds: string[] = []
 vi.mock('../src/renderer/hooks/useVisibleTerminals', () => ({
-  useVisibleTerminals: () => ({ orderedIds: mockOrderedIds, minimizedIds: mockMinimizedIds })
+  useVisibleTerminals: () => ({ orderedIds: mockOrderedIds, minimizedIds: mockMinimizedIds }),
+  compareTerminalIds: (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 }))
 let mockFilteredHeadless: unknown[] = []
 vi.mock('../src/renderer/hooks/useFilteredHeadless', () => ({

--- a/tests/compare-terminal-ids.test.ts
+++ b/tests/compare-terminal-ids.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { compareTerminalIds } from '../src/renderer/hooks/useVisibleTerminals'
+import type { TerminalState } from '../src/renderer/stores/types'
+
+function termState(createdAt: number, lastOutput: number): TerminalState {
+  return {
+    session: {
+      id: 'irrelevant',
+      projectName: 'p',
+      createdAt
+    },
+    status: 'idle',
+    lastOutputTimestamp: lastOutput
+  } as unknown as TerminalState
+}
+
+const TERMS = new Map<string, TerminalState>([
+  ['a', termState(1000, 5000)],
+  ['b', termState(2000, 4000)],
+  ['c', termState(3000, 3000)]
+])
+
+describe('compareTerminalIds', () => {
+  it('manual mode orders ids by their position in terminalOrder', () => {
+    const order = ['b', 'a', 'c']
+    const ids = ['c', 'a', 'b']
+      .slice()
+      .sort((x, y) => compareTerminalIds(x, y, TERMS, 'manual', order))
+    expect(ids).toEqual(['b', 'a', 'c'])
+  })
+
+  it('manual mode pushes ids missing from terminalOrder to the end (no NaN)', () => {
+    const order = ['a']
+    const ids = ['c', 'b', 'a']
+      .slice()
+      .sort((x, y) => compareTerminalIds(x, y, TERMS, 'manual', order))
+    // 'a' is in the order list, 'b' and 'c' are not — they keep relative order
+    // (Array#sort in V8 is stable since ES2019).
+    expect(ids[0]).toBe('a')
+    expect(ids.slice(1).sort()).toEqual(['b', 'c'])
+  })
+
+  it('manual mode treats two missing ids as equal (no Infinity - Infinity)', () => {
+    const order: string[] = []
+    expect(compareTerminalIds('a', 'b', TERMS, 'manual', order)).toBe(0)
+    expect(compareTerminalIds('b', 'a', TERMS, 'manual', order)).toBe(0)
+  })
+
+  it('created mode orders newest first by session.createdAt', () => {
+    const ids = ['a', 'b', 'c']
+      .slice()
+      .sort((x, y) => compareTerminalIds(x, y, TERMS, 'created', []))
+    expect(ids).toEqual(['c', 'b', 'a'])
+  })
+
+  it('recent mode orders most-recently-active first by lastOutputTimestamp', () => {
+    const ids = ['a', 'b', 'c']
+      .slice()
+      .sort((x, y) => compareTerminalIds(x, y, TERMS, 'recent', []))
+    expect(ids).toEqual(['a', 'b', 'c'])
+  })
+
+  it('treats unknown terminal ids as last while keeping known ids ordered', () => {
+    const ids = ['a', 'ghost', 'c']
+      .slice()
+      .sort((x, y) => compareTerminalIds(x, y, TERMS, 'created', []))
+    expect(ids[ids.length - 1]).toBe('ghost')
+    expect(ids.slice(0, 2)).toEqual(['c', 'a'])
+  })
+
+  it('merging visible + minimized ids produces a sortMode-correct list (TabView allTabIds)', () => {
+    // Simulates TabView merging orderedIds + minimizedIds and re-sorting via
+    // the shared comparator under the active sortMode.
+    const visible = ['a', 'c']
+    const minimized = ['b']
+    const merged = [...visible, ...minimized].sort((x, y) =>
+      compareTerminalIds(x, y, TERMS, 'created', [])
+    )
+    expect(merged).toEqual(['c', 'b', 'a'])
+  })
+})

--- a/tests/focused-nav-hint.test.tsx
+++ b/tests/focused-nav-hint.test.tsx
@@ -12,7 +12,7 @@ import { FocusedNavHint } from '../src/renderer/components/card/FocusedNavHint'
 
 beforeEach(() => {
   useAppStore.setState({
-    visibleTerminalIds: ['a', 'b', 'c']
+    focusableTerminalIds: ['a', 'b', 'c']
   })
 })
 
@@ -24,13 +24,13 @@ describe('FocusedNavHint', () => {
     expect(container.textContent).toMatch(/2\s*\/\s*3/)
   })
 
-  it('returns nothing when fewer than 2 sessions are visible', () => {
-    useAppStore.setState({ visibleTerminalIds: ['a'] })
+  it('returns nothing when fewer than 2 sessions are focusable', () => {
+    useAppStore.setState({ focusableTerminalIds: ['a'] })
     const { container } = render(<FocusedNavHint terminalId="a" />)
     expect(container.firstChild).toBeNull()
   })
 
-  it('returns nothing when the current terminal is not in the visible list', () => {
+  it('returns nothing when the current terminal is not in the focusable list', () => {
     const { container } = render(<FocusedNavHint terminalId="gone" />)
     expect(container.firstChild).toBeNull()
   })


### PR DESCRIPTION
## Summary
- Focused-mode hint and `⌘[` / `⌘]` now span every session in the active project (not just the worktree-filtered grid view); the indicator reads N/total across worktrees and the shortcut cycles through all of them. New `focusableTerminalIds` derived state powers both call sites.
- `TabView` treats minimize as a no-op: every session renders as a tab and `BackgroundTray` stops surfacing minimized pills in tab mode. Switching back to grid restores the tray — the `minimizedTerminals` Set is preserved.
- `AgentIcon` falls back to `ShellIcon` for unknown `agentType` values so a stale or future-typed session does not crash the renderer.

## Test plan
- [ ] In a project with sessions across multiple worktrees, enter focused mode and confirm `⌘[` / `⌘]` cycles through all of them and the hint shows the full count.
- [ ] In tab view, minimize a session and confirm no `BackgroundTray` pill appears; switch to grid view and confirm the pill returns.
- [ ] Force an unknown `agentType` on a session and confirm the renderer stays up with the shell icon.