### PR TITLE
feat(workflows): runs landing view with all-runs table and needs-review tab

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2278,6 +2278,10 @@ export function listWorkflowRunsByTask(
   }))
 }
 
+// Surfaces every run that has at least one waiting node — small in practice
+// because gates pause execution. No LIMIT is intentional so the badge count
+// matches the real backlog. If this ever grows, cap with a LIMIT here and
+// chunk `fetchNodesByRunIds` to stay under SQLite's IN-clause variable cap.
 export function listRunsWithWaitingGates(): WorkflowExecution[] {
   const d = getDb()
 
@@ -2338,7 +2342,12 @@ export function listAllWorkflowRuns(
     trigger_task_id: string | null
     workflow_name: string | null
   }
-  const where = workspaceId ? `WHERE COALESCE(w.workspace_id, 'personal') = ?` : ''
+  // When filtering by workspace, exclude orphaned runs (workflow deleted, the
+  // LEFT JOIN nulls everything on `w`). Without `w.id IS NOT NULL`, the
+  // COALESCE would silently bucket every orphan into 'personal'.
+  const where = workspaceId
+    ? `WHERE w.id IS NOT NULL AND COALESCE(w.workspace_id, 'personal') = ?`
+    : ''
   const sql = `SELECT wr.*, w.name as workflow_name
                FROM workflow_runs wr
                LEFT JOIN workflows w ON w.id = wr.workflow_id

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2151,62 +2151,88 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
   run()
 }
 
+type WorkflowRunNodeRow = {
+  run_id: string
+  node_id: string
+  status: string
+  started_at: string | null
+  completed_at: string | null
+  session_id: string | null
+  error: string | null
+  logs: string | null
+  task_id: string | null
+  agent_session_id: string | null
+  agent_type: string | null
+  project_name: string | null
+  project_path: string | null
+  approved_at: string | null
+}
+
+function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
+  return {
+    nodeId: n.node_id,
+    status: n.status as NodeExecutionState['status'],
+    ...(n.started_at != null && { startedAt: n.started_at }),
+    ...(n.completed_at != null && { completedAt: n.completed_at }),
+    ...(n.session_id != null && { sessionId: n.session_id }),
+    ...(n.error != null && { error: n.error }),
+    ...(n.logs != null && { logs: n.logs }),
+    ...(n.task_id != null && { taskId: n.task_id }),
+    ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
+    ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
+    ...(n.project_name != null && { projectName: n.project_name }),
+    ...(n.project_path != null && { projectPath: n.project_path }),
+    ...(n.approved_at != null && { approvedAt: n.approved_at })
+  }
+}
+
+function fetchNodesByRunIds(
+  d: Database.Database,
+  runIds: string[]
+): Map<string, NodeExecutionState[]> {
+  if (runIds.length === 0) return new Map()
+  const placeholders = runIds.map(() => '?').join(',')
+  const rows = d
+    .prepare(`SELECT * FROM workflow_run_nodes WHERE run_id IN (${placeholders})`)
+    .all(...runIds) as WorkflowRunNodeRow[]
+  const out = new Map<string, NodeExecutionState[]>()
+  for (const r of rows) {
+    const bucket = out.get(r.run_id)
+    const node = mapNodeRow(r)
+    if (bucket) bucket.push(node)
+    else out.set(r.run_id, [node])
+  }
+  return out
+}
+
 export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecution[] {
   const d = getDb()
 
-  const rows = d
-    .prepare('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?')
-    .all(workflowId, limit) as Array<{
+  type RunRow = {
     id: string
     workflow_id: string
     started_at: string
     completed_at: string | null
     status: string
     trigger_task_id: string | null
-  }>
+  }
+  const rows = d
+    .prepare('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?')
+    .all(workflowId, limit) as RunRow[]
 
-  return rows.map((r) => {
-    const nodeRows = d
-      .prepare('SELECT * FROM workflow_run_nodes WHERE run_id = ?')
-      .all(r.id) as Array<{
-      node_id: string
-      status: string
-      started_at: string | null
-      completed_at: string | null
-      session_id: string | null
-      error: string | null
-      logs: string | null
-      task_id: string | null
-      agent_session_id: string | null
-      agent_type: string | null
-      project_name: string | null
-      project_path: string | null
-      approved_at: string | null
-    }>
+  const nodesByRun = fetchNodesByRunIds(
+    d,
+    rows.map((r) => r.id)
+  )
 
-    return {
-      workflowId: r.workflow_id,
-      startedAt: r.started_at,
-      ...(r.completed_at != null && { completedAt: r.completed_at }),
-      status: r.status as WorkflowExecution['status'],
-      ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-      nodeStates: nodeRows.map((n) => ({
-        nodeId: n.node_id,
-        status: n.status as NodeExecutionState['status'],
-        ...(n.started_at != null && { startedAt: n.started_at }),
-        ...(n.completed_at != null && { completedAt: n.completed_at }),
-        ...(n.session_id != null && { sessionId: n.session_id }),
-        ...(n.error != null && { error: n.error }),
-        ...(n.logs != null && { logs: n.logs }),
-        ...(n.task_id != null && { taskId: n.task_id }),
-        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
-        ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
-        ...(n.project_name != null && { projectName: n.project_name }),
-        ...(n.project_path != null && { projectPath: n.project_path }),
-        ...(n.approved_at != null && { approvedAt: n.approved_at })
-      }))
-    }
-  })
+  return rows.map((r) => ({
+    workflowId: r.workflow_id,
+    startedAt: r.started_at,
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    status: r.status as WorkflowExecution['status'],
+    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+    nodeStates: nodesByRun.get(r.id) ?? []
+  }))
 }
 
 export function listWorkflowRunsByTask(
@@ -2215,20 +2241,7 @@ export function listWorkflowRunsByTask(
 ): (WorkflowExecution & { workflowName?: string })[] {
   const d = getDb()
 
-  // Find runs where the task triggered the workflow OR a node executed the task
-  const rows = d
-    .prepare(
-      `
-    SELECT DISTINCT wr.*, w.name as workflow_name
-    FROM workflow_runs wr
-    LEFT JOIN workflows w ON w.id = wr.workflow_id
-    WHERE wr.trigger_task_id = ?
-       OR wr.id IN (SELECT run_id FROM workflow_run_nodes WHERE task_id = ?)
-    ORDER BY wr.started_at DESC
-    LIMIT ?
-  `
-    )
-    .all(taskId, taskId, limit) as Array<{
+  type RunRow = {
     id: string
     workflow_id: string
     started_at: string
@@ -2236,50 +2249,46 @@ export function listWorkflowRunsByTask(
     status: string
     trigger_task_id: string | null
     workflow_name: string | null
-  }>
+  }
+  const rows = d
+    .prepare(
+      `SELECT DISTINCT wr.*, w.name as workflow_name
+       FROM workflow_runs wr
+       LEFT JOIN workflows w ON w.id = wr.workflow_id
+       WHERE wr.trigger_task_id = ?
+          OR wr.id IN (SELECT run_id FROM workflow_run_nodes WHERE task_id = ?)
+       ORDER BY wr.started_at DESC
+       LIMIT ?`
+    )
+    .all(taskId, taskId, limit) as RunRow[]
 
-  return rows.map((r) => {
-    const nodeRows = d
-      .prepare('SELECT * FROM workflow_run_nodes WHERE run_id = ?')
-      .all(r.id) as Array<{
-      node_id: string
-      status: string
-      started_at: string | null
-      completed_at: string | null
-      session_id: string | null
-      error: string | null
-      logs: string | null
-      task_id: string | null
-      agent_session_id: string | null
-      approved_at: string | null
-    }>
+  const nodesByRun = fetchNodesByRunIds(
+    d,
+    rows.map((r) => r.id)
+  )
 
-    return {
-      workflowId: r.workflow_id,
-      startedAt: r.started_at,
-      ...(r.completed_at != null && { completedAt: r.completed_at }),
-      status: r.status as WorkflowExecution['status'],
-      ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-      ...(r.workflow_name != null && { workflowName: r.workflow_name }),
-      nodeStates: nodeRows.map((n) => ({
-        nodeId: n.node_id,
-        status: n.status as NodeExecutionState['status'],
-        ...(n.started_at != null && { startedAt: n.started_at }),
-        ...(n.completed_at != null && { completedAt: n.completed_at }),
-        ...(n.session_id != null && { sessionId: n.session_id }),
-        ...(n.error != null && { error: n.error }),
-        ...(n.logs != null && { logs: n.logs }),
-        ...(n.task_id != null && { taskId: n.task_id }),
-        ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
-        ...(n.approved_at != null && { approvedAt: n.approved_at })
-      }))
-    }
-  })
+  return rows.map((r) => ({
+    workflowId: r.workflow_id,
+    startedAt: r.started_at,
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    status: r.status as WorkflowExecution['status'],
+    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+    ...(r.workflow_name != null && { workflowName: r.workflow_name }),
+    nodeStates: nodesByRun.get(r.id) ?? []
+  }))
 }
 
 export function listRunsWithWaitingGates(): WorkflowExecution[] {
   const d = getDb()
 
+  type RunRow = {
+    id: string
+    workflow_id: string
+    started_at: string
+    completed_at: string | null
+    status: string
+    trigger_task_id: string | null
+  }
   const rows = d
     .prepare(
       `SELECT DISTINCT wr.*
@@ -2288,43 +2297,12 @@ export function listRunsWithWaitingGates(): WorkflowExecution[] {
        WHERE wrn.status = 'waiting'
        ORDER BY wr.started_at DESC`
     )
-    .all() as Array<{
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-  }>
+    .all() as RunRow[]
 
-  if (rows.length === 0) return []
-
-  const placeholders = rows.map(() => '?').join(',')
-  const allNodeRows = d
-    .prepare(`SELECT * FROM workflow_run_nodes WHERE run_id IN (${placeholders})`)
-    .all(...rows.map((r) => r.id)) as Array<{
-    run_id: string
-    node_id: string
-    status: string
-    started_at: string | null
-    completed_at: string | null
-    session_id: string | null
-    error: string | null
-    logs: string | null
-    task_id: string | null
-    agent_session_id: string | null
-    agent_type: string | null
-    project_name: string | null
-    project_path: string | null
-    approved_at: string | null
-  }>
-
-  const nodesByRun = new Map<string, typeof allNodeRows>()
-  for (const n of allNodeRows) {
-    const bucket = nodesByRun.get(n.run_id)
-    if (bucket) bucket.push(n)
-    else nodesByRun.set(n.run_id, [n])
-  }
+  const nodesByRun = fetchNodesByRunIds(
+    d,
+    rows.map((r) => r.id)
+  )
 
   return rows.map((r) => ({
     workflowId: r.workflow_id,
@@ -2332,21 +2310,57 @@ export function listRunsWithWaitingGates(): WorkflowExecution[] {
     ...(r.completed_at != null && { completedAt: r.completed_at }),
     status: r.status as WorkflowExecution['status'],
     ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    nodeStates: (nodesByRun.get(r.id) ?? []).map((n) => ({
-      nodeId: n.node_id,
-      status: n.status as NodeExecutionState['status'],
-      ...(n.started_at != null && { startedAt: n.started_at }),
-      ...(n.completed_at != null && { completedAt: n.completed_at }),
-      ...(n.session_id != null && { sessionId: n.session_id }),
-      ...(n.error != null && { error: n.error }),
-      ...(n.logs != null && { logs: n.logs }),
-      ...(n.task_id != null && { taskId: n.task_id }),
-      ...(n.agent_session_id != null && { agentSessionId: n.agent_session_id }),
-      ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
-      ...(n.project_name != null && { projectName: n.project_name }),
-      ...(n.project_path != null && { projectPath: n.project_path }),
-      ...(n.approved_at != null && { approvedAt: n.approved_at })
-    }))
+    nodeStates: nodesByRun.get(r.id) ?? []
+  }))
+}
+
+/**
+ * Cross-workflow run history for the Workflows → All runs view. Joins on
+ * the workflows table so the renderer can display the workflow name without
+ * a second lookup. When `workspaceId` is provided, restricts to workflows
+ * in that workspace; otherwise returns runs across every workflow.
+ */
+export function listAllWorkflowRuns(
+  workspaceId?: string,
+  limit = 50
+): (WorkflowExecution & { workflowName?: string })[] {
+  const d = getDb()
+  // Clamp to keep the IN-clause below SQLite's default 999-variable cap
+  // when fetching node rows for each run.
+  const cappedLimit = Math.max(1, Math.min(limit, 500))
+
+  type RunRow = {
+    id: string
+    workflow_id: string
+    started_at: string
+    completed_at: string | null
+    status: string
+    trigger_task_id: string | null
+    workflow_name: string | null
+  }
+  const where = workspaceId ? `WHERE COALESCE(w.workspace_id, 'personal') = ?` : ''
+  const sql = `SELECT wr.*, w.name as workflow_name
+               FROM workflow_runs wr
+               LEFT JOIN workflows w ON w.id = wr.workflow_id
+               ${where}
+               ORDER BY wr.started_at DESC
+               LIMIT ?`
+  const params = workspaceId ? [workspaceId, cappedLimit] : [cappedLimit]
+  const rows = d.prepare(sql).all(...params) as RunRow[]
+
+  const nodesByRun = fetchNodesByRunIds(
+    d,
+    rows.map((r) => r.id)
+  )
+
+  return rows.map((r) => ({
+    workflowId: r.workflow_id,
+    startedAt: r.started_at,
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    status: r.status as WorkflowExecution['status'],
+    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+    ...(r.workflow_name != null && { workflowName: r.workflow_name }),
+    nodeStates: nodesByRun.get(r.id) ?? []
   }))
 }
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -40,6 +40,7 @@ import {
   saveWorkflowRun,
   listWorkflowRuns,
   listWorkflowRunsByTask,
+  listAllWorkflowRuns,
   listRunsWithWaitingGates,
   updateWorkflowRunStatus,
   dbSaveSSHKey,
@@ -539,6 +540,9 @@ export function registerAllMethods(): void {
     listWorkflowRunsByTask(taskId, limit)
   )
   registerMethod('workflowRun:listWaiting', () => listRunsWithWaitingGates())
+  registerMethod('workflowRun:listAll', ({ workspaceId, limit }) =>
+    listAllWorkflowRuns(workspaceId, limit)
+  )
 
   // Session logs
   registerMethod('sessionLog:list', ({ taskId }) => listSessionLogs(taskId))

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -905,6 +905,7 @@ export const IPC = {
   WORKFLOW_RUN_LIST: 'workflowRun:list',
   WORKFLOW_RUN_LIST_BY_TASK: 'workflowRun:listByTask',
   WORKFLOW_RUN_LIST_WAITING: 'workflowRun:listWaiting',
+  WORKFLOW_RUN_LIST_ALL: 'workflowRun:listAll',
   SESSION_LOG_LIST: 'sessionLog:list',
   SESSION_LOG_UPDATE: 'sessionLog:update',
   SESSION_EVENT_LIST: 'sessionEvent:list',

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -129,6 +129,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.WORKFLOW_RUN_LIST_WAITING, () =>
     requireBridge().request(IPC.WORKFLOW_RUN_LIST_WAITING, {})
   )
+  safeHandle(IPC.WORKFLOW_RUN_LIST_ALL, (_, workspaceId, limit) =>
+    requireBridge().request(IPC.WORKFLOW_RUN_LIST_ALL, { workspaceId, limit })
+  )
 
   // Session logs
   safeHandle(IPC.SESSION_LOG_LIST, (_, taskId) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -357,6 +357,12 @@ const api = {
   listRunsWithWaitingGates: (): Promise<WorkflowExecution[]> =>
     ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_WAITING),
 
+  listAllWorkflowRuns: (
+    workspaceId?: string,
+    limit?: number
+  ): Promise<(WorkflowExecution & { workflowName?: string })[]> =>
+    ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_ALL, workspaceId, limit),
+
   listSessionLogs: (taskId: string): Promise<SessionLog[]> =>
     ipcRenderer.invoke(IPC.SESSION_LOG_LIST, taskId),
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,11 @@ import { AddProjectDialog } from './components/AddProjectDialog'
 const WorkflowEditor = lazy(() =>
   import('./components/workflow-editor/WorkflowEditor').then((m) => ({ default: m.WorkflowEditor }))
 )
+const WorkflowsLandingView = lazy(() =>
+  import('./components/workflow-runs/WorkflowsLandingView').then((m) => ({
+    default: m.WorkflowsLandingView
+  }))
+)
 import {
   executeWorkflow as runWorkflow,
   rescheduleWaitingGateTimers
@@ -30,6 +35,7 @@ import { Tooltip } from './components/Tooltip'
 import { Plus, Menu } from 'lucide-react'
 import { MobileBottomTabs } from './components/MobileBottomTabs'
 import { TaskToolbar } from './components/TaskToolbar'
+import { WorkflowsLandingHeader } from './components/workflow-runs/WorkflowsLandingHeader'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useVirtualKeyboard } from './hooks/useVirtualKeyboard'
 import { useGitDiffPolling } from './hooks/useGitDiffPolling'
@@ -434,7 +440,11 @@ export function App() {
               </div>
             )}
             <div className={`flex items-center titlebar-no-drag ${isMobile ? 'gap-1.5' : 'gap-1'}`}>
-              {mainViewMode === 'workflows' && !isMobile ? null : mainViewMode !== 'tasks' ? (
+              {mainViewMode === 'workflows' && !isMobile ? (
+                editingWorkflowId === null && !isWorkflowEditorOpen ? (
+                  <WorkflowsLandingHeader />
+                ) : null
+              ) : mainViewMode !== 'tasks' ? (
                 <>
                   {!isMobile && (
                     <>
@@ -522,9 +532,7 @@ export function App() {
                 {editingWorkflowId !== null || isWorkflowEditorOpen ? (
                   <WorkflowEditor inline />
                 ) : (
-                  <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">
-                    Select a workflow from the sidebar to edit it
-                  </div>
+                  <WorkflowsLandingView />
                 )}
               </Suspense>
             ) : mainViewMode === 'workflows' && isMobile ? (

--- a/src/renderer/components/MainViewPills.tsx
+++ b/src/renderer/components/MainViewPills.tsx
@@ -1,16 +1,18 @@
 import { Monitor, ListTodo, Zap } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { Tooltip } from './Tooltip'
+import { useWaitingApprovals } from '../hooks/useWaitingApprovals'
 import { isMac } from '../lib/platform'
 
 const pillClass = (active: boolean): string =>
-  `px-2.5 py-1 rounded-md transition-colors ${
+  `relative px-2.5 py-1 rounded-md transition-colors ${
     active ? 'bg-white/[0.1] text-white' : 'text-gray-500 hover:text-gray-300'
   }`
 
 export function MainViewPills() {
   const mainViewMode = useAppStore((s) => s.config?.defaults?.mainViewMode ?? 'sessions')
   const setMainViewMode = useAppStore((s) => s.setMainViewMode)
+  const waitingCount = useWaitingApprovals().length
 
   return (
     <div className="flex bg-white/[0.04] rounded-lg p-0.5 gap-0.5">
@@ -34,7 +36,11 @@ export function MainViewPills() {
           <ListTodo size={14} strokeWidth={2} />
         </button>
       </Tooltip>
-      <Tooltip label="Workflows" shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`} position="bottom">
+      <Tooltip
+        label={waitingCount > 0 ? `Workflows · ${waitingCount} awaiting review` : 'Workflows'}
+        shortcut={`${isMac ? '⌘⇧' : 'Ctrl+Shift+'}W`}
+        position="bottom"
+      >
         <button
           onClick={() => setMainViewMode('workflows')}
           className={pillClass(mainViewMode === 'workflows')}
@@ -42,6 +48,17 @@ export function MainViewPills() {
           aria-pressed={mainViewMode === 'workflows'}
         >
           <Zap size={14} strokeWidth={2} />
+          {waitingCount > 0 && (
+            <span
+              aria-hidden
+              className="absolute -top-0.5 -right-0.5 min-w-[12px] h-[12px] px-[3px]
+                         flex items-center justify-center
+                         rounded-full bg-amber-400 text-[#1a1a1e]
+                         text-[9px] font-mono leading-none tabular-nums"
+            >
+              {waitingCount > 9 ? '9+' : waitingCount}
+            </span>
+          )}
         </button>
       </Tooltip>
     </div>

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -6,8 +6,9 @@ import { WorkflowFilterToolbar } from './WorkflowFilterToolbar'
 import { WorkflowContextMenu } from './WorkflowContextMenu'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { isScheduledWorkflow } from '../../lib/workflow-helpers'
-import { Zap } from 'lucide-react'
+import { Zap, Activity } from 'lucide-react'
 import type { WorkflowDefinition } from '../../../shared/types'
+import { useWaitingApprovals } from '../../hooks/useWaitingApprovals'
 
 type ContextMenuState = { id: string; x: number; y: number } | null
 
@@ -24,6 +25,10 @@ export function WorkflowsSection({
   const updateWorkflow = useAppStore((s) => s.updateWorkflow)
   const reorderWorkflows = useAppStore((s) => s.reorderWorkflows)
   const workflowFilter = useAppStore((s) => s.sidebarWorkflowFilter)
+  const editingWorkflowId = useAppStore((s) => s.editingWorkflowId)
+  const isWorkflowEditorOpen = useAppStore((s) => s.isWorkflowEditorOpen)
+  const allRunsSelected = editingWorkflowId === null && !isWorkflowEditorOpen
+  const waitingCount = useWaitingApprovals().length
 
   const [sectionCollapsed, setSectionCollapsed] = useState(false)
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
@@ -101,6 +106,37 @@ export function WorkflowsSection({
           </>
         }
       />
+
+      {!sectionCollapsed && (
+        <button
+          type="button"
+          onClick={() => {
+            setEditingWorkflowId(null)
+            setWorkflowEditorOpen(false)
+          }}
+          title={isCollapsed ? 'All runs' : undefined}
+          aria-label="All runs"
+          aria-pressed={allRunsSelected}
+          className={`group/all relative w-full text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+            allRunsSelected ? 'text-white' : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+          } ${isCollapsed ? 'justify-center px-0' : ''}`}
+        >
+          {allRunsSelected && !isCollapsed && (
+            <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />
+          )}
+          <Activity size={iconSize} strokeWidth={1.5} className="text-gray-400 shrink-0" />
+          {!isCollapsed && (
+            <>
+              <span className="min-w-0 flex-1 truncate">All runs</span>
+              {waitingCount > 0 && (
+                <span className="font-mono text-[10px] text-amber-400 tabular-nums">
+                  {waitingCount}
+                </span>
+              )}
+            </>
+          )}
+        </button>
+      )}
 
       {!isCollapsed && !sectionCollapsed && filteredWorkflows.length === 0 && (
         <p className="text-[13px] text-gray-600 px-2.5 py-1">No workflows</p>

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -10,18 +10,10 @@ import {
   supportsExactSessionResume
 } from '../../../shared/types'
 
-import { formatRelativeTime } from '../../lib/format-time'
+import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import { STATUS_DOT_CLASSES as SHARED_STATUS_DOTS } from './statusDot'
 import { Tooltip } from '../Tooltip'
 import { approveWorkflowGate, rejectWorkflowGate } from '../../lib/workflow-execution'
-
-function formatDuration(start: string, end?: string): string {
-  if (!end) return 'running...'
-  const ms = new Date(end).getTime() - new Date(start).getTime()
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
-}
 
 const STATUS_LABELS: Record<WorkflowExecution['status'] | NodeExecutionState['status'], string> = {
   success: 'Success',
@@ -48,9 +40,227 @@ export function StatusDot({
   )
 }
 
-function NodeLabel({ nodeId, nodes }: { nodeId: string; nodes: WorkflowNode[] }) {
+export function NodeLabel({ nodeId, nodes }: { nodeId: string; nodes: WorkflowNode[] }) {
   const node = nodes.find((n) => n.id === nodeId)
   return <span>{node?.label || nodeId.slice(0, 8)}</span>
+}
+
+interface RunStepsListProps {
+  execution: WorkflowExecution
+  nodes: WorkflowNode[]
+  tasks?: TaskConfig[]
+  onViewFullOutput?: (logs: string) => void
+  onClickTask?: (taskId: string) => void
+  onResumeSession?: (
+    agentSessionId: string,
+    agentType: AiAgentType,
+    projectName: string,
+    projectPath: string,
+    branch?: string,
+    useWorktree?: boolean
+  ) => void
+}
+
+export function RunStepsList({
+  execution,
+  nodes,
+  tasks,
+  onViewFullOutput,
+  onClickTask,
+  onResumeSession
+}: RunStepsListProps) {
+  const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null)
+
+  const actionStates = execution.nodeStates.filter((ns) => {
+    const node = nodes.find((n) => n.id === ns.nodeId)
+    return node?.type !== 'trigger'
+  })
+
+  const triggerTask =
+    execution.triggerTaskId && tasks
+      ? tasks.find((t) => t.id === execution.triggerTaskId)
+      : undefined
+
+  return (
+    <div className="border-t border-white/[0.06]">
+      {actionStates.map((ns, i) => {
+        const nodeTask = ns.taskId && tasks ? tasks.find((t) => t.id === ns.taskId) : undefined
+        const node = nodes.find((n) => n.id === ns.nodeId)
+        const nodeConfig = node?.config as
+          | {
+              agentType?: AiAgentType | 'fromTask'
+              projectName?: string
+              projectPath?: string
+              branch?: string
+              useWorktree?: boolean
+            }
+          | undefined
+
+        const configAgent =
+          nodeConfig?.agentType && nodeConfig.agentType !== 'fromTask'
+            ? nodeConfig.agentType
+            : undefined
+        const resumeAiAgentType: AiAgentType | undefined = ns.agentType ?? configAgent
+        const resumeProjectName =
+          ns.projectName ||
+          nodeConfig?.projectName ||
+          nodeTask?.projectName ||
+          triggerTask?.projectName ||
+          ''
+        const resumeProjectPath = ns.projectPath || nodeConfig?.projectPath || ''
+        const resumeBranch = nodeConfig?.branch ?? nodeTask?.branch ?? triggerTask?.branch
+        const resumeUseWorktree =
+          nodeConfig?.useWorktree ?? nodeTask?.useWorktree ?? triggerTask?.useWorktree
+        const canResume =
+          !!ns.agentSessionId &&
+          !!onResumeSession &&
+          !!resumeAiAgentType &&
+          !!resumeProjectName &&
+          supportsExactSessionResume(resumeAiAgentType)
+        const handleResume = (): void =>
+          onResumeSession!(
+            ns.agentSessionId!,
+            resumeAiAgentType!,
+            resumeProjectName,
+            resumeProjectPath,
+            resumeBranch,
+            resumeUseWorktree
+          )
+
+        const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
+        const approvalMessage =
+          node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
+
+        return (
+          <div key={ns.nodeId} className="border-b border-white/[0.04] last:border-b-0">
+            <button
+              onClick={() => setExpandedNodeId(expandedNodeId === ns.nodeId ? null : ns.nodeId)}
+              className="w-full flex items-center gap-2 px-4 py-2 text-left hover:bg-white/[0.03] transition-colors"
+            >
+              <div className="flex flex-col items-center w-4 shrink-0">
+                <StatusDot status={ns.status} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] text-gray-500 font-mono">#{i + 1}</span>
+                  <span className="text-[12px] text-gray-300 truncate">
+                    <NodeLabel nodeId={ns.nodeId} nodes={nodes} />
+                  </span>
+                  {nodeTask && (
+                    <span
+                      className="text-[10px] px-1.5 py-0.5 bg-blue-500/10 border border-blue-500/20 rounded text-blue-400 truncate max-w-[80px] cursor-pointer hover:bg-blue-500/20 transition-colors"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onClickTask?.(nodeTask.id)
+                      }}
+                      title={nodeTask.title}
+                    >
+                      {nodeTask.title}
+                    </span>
+                  )}
+                </div>
+                {ns.startedAt && ns.completedAt && (
+                  <span className="text-[10px] text-gray-600">
+                    {formatRunDuration(ns.startedAt, ns.completedAt)}
+                  </span>
+                )}
+              </div>
+              {(ns.logs || ns.error) && (
+                <span className="text-[10px] text-gray-600">
+                  {expandedNodeId === ns.nodeId ? 'hide' : 'logs'}
+                </span>
+              )}
+            </button>
+
+            {isWaitingGate && (
+              <div className="px-4 pb-3 -mt-0.5 flex items-start gap-2">
+                <div className="flex-1 min-w-0 text-[11px] text-amber-300/90">
+                  {approvalMessage || 'Waiting for approval.'}
+                </div>
+                <button
+                  onClick={() => {
+                    void approveWorkflowGate(execution, ns.nodeId)
+                  }}
+                  className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
+                             text-green-300 hover:text-green-200 hover:bg-green-500/10
+                             border border-green-500/30 transition-colors shrink-0"
+                >
+                  <Check size={11} strokeWidth={2.5} />
+                  Approve
+                </button>
+                <button
+                  onClick={() => {
+                    void rejectWorkflowGate(execution, ns.nodeId)
+                  }}
+                  className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
+                             text-red-300 hover:text-red-200 hover:bg-red-500/10
+                             border border-red-500/30 transition-colors shrink-0"
+                >
+                  <X size={11} strokeWidth={2.5} />
+                  Reject
+                </button>
+              </div>
+            )}
+
+            {expandedNodeId === ns.nodeId && ns.logs && (
+              <div className="px-4 pb-2">
+                <pre
+                  className="text-[11px] text-gray-400 bg-black/30 rounded-md p-2 max-h-[200px] overflow-auto
+                                font-mono whitespace-pre-wrap break-all leading-relaxed"
+                >
+                  {ns.logs.length > 2000 ? ns.logs.slice(0, 2000) + '\n...' : ns.logs}
+                </pre>
+                <div className="flex items-center gap-1 mt-1.5">
+                  {onViewFullOutput && (
+                    <Tooltip label="View full output">
+                      <button
+                        onClick={() => onViewFullOutput(ns.logs!)}
+                        aria-label="View full output"
+                        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                      >
+                        <Maximize2 size={12} strokeWidth={2} />
+                      </button>
+                    </Tooltip>
+                  )}
+                  {canResume && (
+                    <Tooltip label="Resume session">
+                      <button
+                        onClick={handleResume}
+                        aria-label="Resume session"
+                        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                      >
+                        <RotateCcw size={12} strokeWidth={2} />
+                      </button>
+                    </Tooltip>
+                  )}
+                </div>
+                {ns.error && <p className="text-[11px] text-red-400 mt-1">{ns.error}</p>}
+              </div>
+            )}
+
+            {expandedNodeId === ns.nodeId && !ns.logs && ns.error && (
+              <div className="px-4 pb-2">
+                <p className="text-[11px] text-red-400">{ns.error}</p>
+                {canResume && (
+                  <div className="mt-1.5">
+                    <Tooltip label="Resume session">
+                      <button
+                        onClick={handleResume}
+                        aria-label="Resume session"
+                        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                      >
+                        <RotateCcw size={12} strokeWidth={2} />
+                      </button>
+                    </Tooltip>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 interface RunEntryProps {
@@ -81,18 +291,11 @@ export function RunEntry({
 }: RunEntryProps) {
   const hasWaitingGate = execution.nodeStates.some((ns) => ns.status === 'waiting')
   const [expanded, setExpanded] = useState(hasWaitingGate)
-  const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null)
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     if (hasWaitingGate) setExpanded(true)
   }, [hasWaitingGate])
-
-  // Filter to non-trigger nodes for display
-  const actionStates = execution.nodeStates.filter((ns) => {
-    const node = nodes.find((n) => n.id === ns.nodeId)
-    return node?.type !== 'trigger'
-  })
 
   const triggerTask =
     execution.triggerTaskId && tasks
@@ -129,197 +332,19 @@ export function RunEntry({
           </span>
         )}
         <span className="text-[11px] text-gray-500 shrink-0">
-          {formatDuration(execution.startedAt, execution.completedAt)}
+          {formatRunDuration(execution.startedAt, execution.completedAt)}
         </span>
       </button>
 
-      {/* Expanded: step-by-step view */}
       {expanded && (
-        <div className="border-t border-white/[0.06]">
-          {actionStates.map((ns, i) => {
-            const nodeTask = ns.taskId && tasks ? tasks.find((t) => t.id === ns.taskId) : undefined
-            const node = nodes.find((n) => n.id === ns.nodeId)
-            const nodeConfig = node?.config as
-              | {
-                  agentType?: AiAgentType | 'fromTask'
-                  projectName?: string
-                  projectPath?: string
-                  branch?: string
-                  useWorktree?: boolean
-                }
-              | undefined
-
-            // Prefer the concrete values the engine recorded at launch
-            // (ns.agentType/projectName/projectPath) over node config, which
-            // may hold the 'fromTask' sentinel or be blank for task-driven nodes.
-            const configAgent =
-              nodeConfig?.agentType && nodeConfig.agentType !== 'fromTask'
-                ? nodeConfig.agentType
-                : undefined
-            const resumeAiAgentType: AiAgentType | undefined = ns.agentType ?? configAgent
-            const resumeProjectName =
-              ns.projectName ||
-              nodeConfig?.projectName ||
-              nodeTask?.projectName ||
-              triggerTask?.projectName ||
-              ''
-            const resumeProjectPath = ns.projectPath || nodeConfig?.projectPath || ''
-            const resumeBranch = nodeConfig?.branch ?? nodeTask?.branch ?? triggerTask?.branch
-            const resumeUseWorktree =
-              nodeConfig?.useWorktree ?? nodeTask?.useWorktree ?? triggerTask?.useWorktree
-            const canResume =
-              !!ns.agentSessionId &&
-              !!onResumeSession &&
-              !!resumeAiAgentType &&
-              !!resumeProjectName &&
-              supportsExactSessionResume(resumeAiAgentType)
-            const handleResume = (): void =>
-              onResumeSession!(
-                ns.agentSessionId!,
-                resumeAiAgentType!,
-                resumeProjectName,
-                resumeProjectPath,
-                resumeBranch,
-                resumeUseWorktree
-              )
-
-            const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
-            const approvalMessage =
-              node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
-
-            return (
-              <div key={ns.nodeId} className="border-b border-white/[0.04] last:border-b-0">
-                {/* Step header */}
-                <button
-                  onClick={() => setExpandedNodeId(expandedNodeId === ns.nodeId ? null : ns.nodeId)}
-                  className="w-full flex items-center gap-2 px-4 py-2 text-left hover:bg-white/[0.03] transition-colors"
-                >
-                  <div className="flex flex-col items-center w-4 shrink-0">
-                    <StatusDot status={ns.status} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[11px] text-gray-500 font-mono">#{i + 1}</span>
-                      <span className="text-[12px] text-gray-300 truncate">
-                        <NodeLabel nodeId={ns.nodeId} nodes={nodes} />
-                      </span>
-                      {nodeTask && (
-                        <span
-                          className="text-[10px] px-1.5 py-0.5 bg-blue-500/10 border border-blue-500/20 rounded text-blue-400 truncate max-w-[80px] cursor-pointer hover:bg-blue-500/20 transition-colors"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            onClickTask?.(nodeTask.id)
-                          }}
-                          title={nodeTask.title}
-                        >
-                          {nodeTask.title}
-                        </span>
-                      )}
-                    </div>
-                    {ns.startedAt && ns.completedAt && (
-                      <span className="text-[10px] text-gray-600">
-                        {formatDuration(ns.startedAt, ns.completedAt)}
-                      </span>
-                    )}
-                  </div>
-                  {(ns.logs || ns.error) && (
-                    <span className="text-[10px] text-gray-600">
-                      {expandedNodeId === ns.nodeId ? 'hide' : 'logs'}
-                    </span>
-                  )}
-                </button>
-
-                {/* Approval gate controls */}
-                {isWaitingGate && (
-                  <div className="px-4 pb-3 -mt-0.5 flex items-start gap-2">
-                    <div className="flex-1 min-w-0 text-[11px] text-amber-300/90">
-                      {approvalMessage || 'Waiting for approval.'}
-                    </div>
-                    <button
-                      onClick={() => {
-                        void approveWorkflowGate(execution, ns.nodeId)
-                      }}
-                      className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
-                                 text-green-300 hover:text-green-200 hover:bg-green-500/10
-                                 border border-green-500/30 transition-colors shrink-0"
-                    >
-                      <Check size={11} strokeWidth={2.5} />
-                      Approve
-                    </button>
-                    <button
-                      onClick={() => {
-                        void rejectWorkflowGate(execution, ns.nodeId)
-                      }}
-                      className="flex items-center gap-1 px-2 py-1 rounded text-[11px]
-                                 text-red-300 hover:text-red-200 hover:bg-red-500/10
-                                 border border-red-500/30 transition-colors shrink-0"
-                    >
-                      <X size={11} strokeWidth={2.5} />
-                      Reject
-                    </button>
-                  </div>
-                )}
-
-                {/* Expanded logs */}
-                {expandedNodeId === ns.nodeId && ns.logs && (
-                  <div className="px-4 pb-2">
-                    <pre
-                      className="text-[11px] text-gray-400 bg-black/30 rounded-md p-2 max-h-[200px] overflow-auto
-                                    font-mono whitespace-pre-wrap break-all leading-relaxed"
-                    >
-                      {ns.logs.length > 2000 ? ns.logs.slice(0, 2000) + '\n...' : ns.logs}
-                    </pre>
-                    <div className="flex items-center gap-1 mt-1.5">
-                      {onViewFullOutput && (
-                        <Tooltip label="View full output">
-                          <button
-                            onClick={() => onViewFullOutput(ns.logs!)}
-                            aria-label="View full output"
-                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
-                          >
-                            <Maximize2 size={12} strokeWidth={2} />
-                          </button>
-                        </Tooltip>
-                      )}
-                      {canResume && (
-                        <Tooltip label="Resume session">
-                          <button
-                            onClick={handleResume}
-                            aria-label="Resume session"
-                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
-                          >
-                            <RotateCcw size={12} strokeWidth={2} />
-                          </button>
-                        </Tooltip>
-                      )}
-                    </div>
-                    {ns.error && <p className="text-[11px] text-red-400 mt-1">{ns.error}</p>}
-                  </div>
-                )}
-
-                {/* Error without logs */}
-                {expandedNodeId === ns.nodeId && !ns.logs && ns.error && (
-                  <div className="px-4 pb-2">
-                    <p className="text-[11px] text-red-400">{ns.error}</p>
-                    {canResume && (
-                      <div className="mt-1.5">
-                        <Tooltip label="Resume session">
-                          <button
-                            onClick={handleResume}
-                            aria-label="Resume session"
-                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
-                          >
-                            <RotateCcw size={12} strokeWidth={2} />
-                          </button>
-                        </Tooltip>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
+        <RunStepsList
+          execution={execution}
+          nodes={nodes}
+          tasks={tasks}
+          onViewFullOutput={onViewFullOutput}
+          onClickTask={onClickTask}
+          onResumeSession={onResumeSession}
+        />
       )}
     </div>
   )

--- a/src/renderer/components/workflow-editor/statusDot.ts
+++ b/src/renderer/components/workflow-editor/statusDot.ts
@@ -1,10 +1,16 @@
 import type { NodeExecutionStatus } from '../../../shared/types'
 
-export const STATUS_DOT_CLASSES: Record<NodeExecutionStatus | 'running', string> = {
+export const STATUS_DOT_STATIC: Record<NodeExecutionStatus | 'running', string> = {
   success: 'bg-green-400',
   error: 'bg-red-500',
-  running: 'bg-yellow-400 animate-pulse',
+  running: 'bg-yellow-400',
   pending: 'bg-gray-600',
   skipped: 'bg-gray-600',
-  waiting: 'bg-amber-400 animate-pulse'
+  waiting: 'bg-amber-400'
+}
+
+export const STATUS_DOT_CLASSES: Record<NodeExecutionStatus | 'running', string> = {
+  ...STATUS_DOT_STATIC,
+  running: `${STATUS_DOT_STATIC.running} animate-pulse`,
+  waiting: `${STATUS_DOT_STATIC.waiting} animate-pulse`
 }

--- a/src/renderer/components/workflow-runs/AllRunsTable.tsx
+++ b/src/renderer/components/workflow-runs/AllRunsTable.tsx
@@ -1,0 +1,191 @@
+import { useState, useMemo } from 'react'
+import { ChevronRight } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { formatRelativeTime, formatCompactDuration } from '../../lib/format-time'
+import { StatusDot, NodeLabel, RunStepsList } from '../workflow-editor/RunEntry'
+import { LogReplayModal } from '../LogReplayModal'
+import type { NodeExecutionState, WorkflowExecution, WorkflowNode } from '../../../shared/types'
+import type { RunListEntry } from '../../hooks/useAllWorkflowRuns'
+import type { RunBucket } from '../../stores/types'
+
+type Bucket = RunBucket
+
+const NODE_PILL_CLASS: Partial<Record<NodeExecutionState['status'], string>> = {
+  waiting: 'text-amber-400 border-amber-500/30',
+  error: 'text-red-400 border-red-500/30'
+}
+const NODE_PILL_DEFAULT = 'text-gray-300 border-white/[0.08]'
+
+const GRID_COLS = '14px minmax(180px,1.4fr) 110px 90px minmax(140px,1.1fr) 110px 16px'
+
+function bucketOf(execution: WorkflowExecution): Bucket {
+  if (execution.status === 'running') {
+    return execution.nodeStates.some((n) => n.status === 'waiting') ? 'waiting' : 'running'
+  }
+  return execution.status === 'success' ? 'success' : 'error'
+}
+
+function lastNodeOf(execution: WorkflowExecution): NodeExecutionState | undefined {
+  const waiting = execution.nodeStates.find((n) => n.status === 'waiting')
+  if (waiting) return waiting
+  const sortable = execution.nodeStates.filter(
+    (n): n is NodeExecutionState & { startedAt: string } => typeof n.startedAt === 'string'
+  )
+  sortable.sort((a, b) => (a.startedAt > b.startedAt ? -1 : 1))
+  return sortable[0]
+}
+
+interface Row {
+  run: RunListEntry
+  bucket: Bucket
+  last: NodeExecutionState | undefined
+}
+
+interface Props {
+  runs: RunListEntry[]
+  workflowsById: Map<string, { name?: string; nodes: WorkflowNode[] }>
+  filter: Bucket
+}
+
+export function AllRunsTable({ runs, workflowsById, filter }: Props) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [logModal, setLogModal] = useState<string | null>(null)
+  const setMainViewMode = useAppStore((s) => s.setMainViewMode)
+  const setEditingWorkflowId = useAppStore((s) => s.setEditingWorkflowId)
+
+  const rows: Row[] = useMemo(
+    () => runs.map((run) => ({ run, bucket: bucketOf(run), last: lastNodeOf(run) })),
+    [runs]
+  )
+
+  const visible = useMemo(
+    () => (filter === 'all' ? rows : rows.filter((r) => r.bucket === filter)),
+    [filter, rows]
+  )
+
+  const openInEditor = (workflowId: string): void => {
+    setEditingWorkflowId(workflowId)
+    setMainViewMode('workflows')
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="text-[12px]">
+        <div
+          className="grid items-center px-3 py-2 border-b border-white/[0.04]
+                     text-[10px] uppercase tracking-wider text-gray-600"
+          style={{ gridTemplateColumns: GRID_COLS }}
+        >
+          <span></span>
+          <span>Workflow</span>
+          <span>Started</span>
+          <span>Duration</span>
+          <span>Trigger</span>
+          <span>Last node</span>
+          <span></span>
+        </div>
+
+        {visible.length === 0 ? (
+          <div className="text-center py-10 text-gray-600 text-[12px]">No runs to show</div>
+        ) : (
+          visible.map(({ run, bucket, last }) => {
+            const id = `${run.workflowId}-${run.startedAt}`
+            const expanded = expandedId === id
+            const wf = workflowsById.get(run.workflowId)
+            const wfNodes = wf?.nodes ?? []
+            const liveName = wf?.name?.trim() || run.workflowName?.trim()
+            const isDeleted = !wf
+            return (
+              <div key={id}>
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(expanded ? null : id)}
+                  onDoubleClick={() => openInEditor(run.workflowId)}
+                  className={`w-full grid items-center px-3 py-2.5 text-left
+                              border-b border-white/[0.04]
+                              ${expanded ? 'bg-white/[0.04] text-white' : 'text-gray-300 hover:bg-white/[0.04] hover:text-white'}`}
+                  style={{ gridTemplateColumns: GRID_COLS }}
+                >
+                  <StatusDot status={bucket === 'waiting' ? 'waiting' : run.status} />
+                  <span
+                    className="min-w-0 truncate flex items-center gap-1.5"
+                    title={
+                      liveName
+                        ? `${liveName} · ${run.workflowId}`
+                        : `${run.workflowId} (workflow deleted)`
+                    }
+                  >
+                    {liveName ? (
+                      <span className="text-white truncate">{liveName}</span>
+                    ) : (
+                      <span className="font-mono text-[12px] text-gray-500 truncate">
+                        {run.workflowId.slice(0, 8)}
+                      </span>
+                    )}
+                    {isDeleted && (
+                      <span className="text-[10px] uppercase tracking-wide text-gray-600 shrink-0">
+                        deleted
+                      </span>
+                    )}
+                  </span>
+                  <span className="font-mono tabular-nums text-gray-500">
+                    {formatRelativeTime(run.startedAt)}
+                  </span>
+                  <span className="font-mono tabular-nums text-gray-500">
+                    {formatCompactDuration(run.startedAt, run.completedAt)}
+                  </span>
+                  <span className="min-w-0 truncate">
+                    {run.triggerTaskId ? (
+                      <span
+                        className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono
+                                   text-violet-400 bg-violet-500/10 border border-violet-500/20"
+                      >
+                        task · {run.triggerTaskId.slice(0, 6)}
+                      </span>
+                    ) : (
+                      <span className="text-gray-500 text-[11px]">manual</span>
+                    )}
+                  </span>
+                  <span className="min-w-0 truncate font-mono text-[11px]">
+                    {last ? (
+                      <span
+                        className={`inline-block px-1.5 py-0.5 rounded border ${
+                          NODE_PILL_CLASS[last.status] ?? NODE_PILL_DEFAULT
+                        }`}
+                      >
+                        <NodeLabel nodeId={last.nodeId} nodes={wfNodes} />
+                      </span>
+                    ) : (
+                      <span className="text-gray-600">—</span>
+                    )}
+                  </span>
+                  <ChevronRight
+                    size={12}
+                    className={`text-gray-600 transition-transform ${expanded ? 'rotate-90 text-white' : ''}`}
+                  />
+                </button>
+
+                {expanded && (
+                  <div className="bg-[#141416] border-b border-white/[0.04]">
+                    <RunStepsList execution={run} nodes={wfNodes} onViewFullOutput={setLogModal} />
+                    <div className="px-4 py-2 flex items-center justify-end">
+                      <button
+                        type="button"
+                        onClick={() => openInEditor(run.workflowId)}
+                        className="px-2 py-1 text-[11px] text-gray-400 border border-white/[0.08] rounded hover:bg-white/[0.04] hover:text-white"
+                      >
+                        Open workflow
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      {logModal !== null && <LogReplayModal logs={logModal} onClose={() => setLogModal(null)} />}
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-runs/AllRunsTable.tsx
+++ b/src/renderer/components/workflow-runs/AllRunsTable.tsx
@@ -100,7 +100,7 @@ export function AllRunsTable({ runs, workflowsById, filter }: Props) {
                 <button
                   type="button"
                   onClick={() => setExpandedId(expanded ? null : id)}
-                  onDoubleClick={() => openInEditor(run.workflowId)}
+                  onDoubleClick={isDeleted ? undefined : () => openInEditor(run.workflowId)}
                   className={`w-full grid items-center px-3 py-2.5 text-left
                               border-b border-white/[0.04]
                               ${expanded ? 'bg-white/[0.04] text-white' : 'text-gray-300 hover:bg-white/[0.04] hover:text-white'}`}
@@ -171,8 +171,10 @@ export function AllRunsTable({ runs, workflowsById, filter }: Props) {
                     <div className="px-4 py-2 flex items-center justify-end">
                       <button
                         type="button"
+                        disabled={isDeleted}
                         onClick={() => openInEditor(run.workflowId)}
-                        className="px-2 py-1 text-[11px] text-gray-400 border border-white/[0.08] rounded hover:bg-white/[0.04] hover:text-white"
+                        title={isDeleted ? 'Workflow no longer exists' : undefined}
+                        className="px-2 py-1 text-[11px] text-gray-400 border border-white/[0.08] rounded hover:bg-white/[0.04] hover:text-white disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
                       >
                         Open workflow
                       </button>

--- a/src/renderer/components/workflow-runs/NeedsReviewList.tsx
+++ b/src/renderer/components/workflow-runs/NeedsReviewList.tsx
@@ -1,0 +1,39 @@
+import { useAppStore } from '../../stores'
+import { useWaitingApprovals } from '../../hooks/useWaitingApprovals'
+import { RunEntry } from '../workflow-editor/RunEntry'
+
+export function NeedsReviewList() {
+  const waiting = useWaitingApprovals()
+  const tasks = useAppStore((s) => s.config?.tasks)
+
+  if (waiting.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-600 text-[12px]">
+        No runs waiting on approval.
+      </div>
+    )
+  }
+
+  // Group by execution so each paused run renders once with all its waiting
+  // gates expanded inline. RunEntry already auto-expands when a gate is
+  // waiting, so we just hand it the executions.
+  const byExecution = new Map<string, (typeof waiting)[number]>()
+  for (const w of waiting) {
+    const key = `${w.execution.workflowId}-${w.execution.startedAt}`
+    if (!byExecution.has(key)) byExecution.set(key, w)
+  }
+
+  return (
+    <div className="flex flex-col gap-2 px-3.5 py-4">
+      {[...byExecution.values()].map((w) => (
+        <RunEntry
+          key={`${w.execution.workflowId}-${w.execution.startedAt}`}
+          execution={w.execution}
+          nodes={w.workflow?.nodes ?? []}
+          workflowName={w.workflow?.name}
+          tasks={tasks}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-runs/RunsToolbar.tsx
+++ b/src/renderer/components/workflow-runs/RunsToolbar.tsx
@@ -51,6 +51,9 @@ export function RunsToolbar({ filter, setFilter }: Props) {
       <Tooltip label="View options" position="bottom">
         <button
           onClick={toggle}
+          aria-label="Filter runs"
+          aria-haspopup="menu"
+          aria-expanded={open}
           className={`relative p-1 rounded-md transition-colors ${
             open
               ? 'text-white bg-white/[0.1]'

--- a/src/renderer/components/workflow-runs/RunsToolbar.tsx
+++ b/src/renderer/components/workflow-runs/RunsToolbar.tsx
@@ -1,0 +1,96 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { SlidersHorizontal } from 'lucide-react'
+import { Tooltip } from '../Tooltip'
+import { OptionRow } from '../OptionRow'
+import { STATUS_DOT_STATIC } from '../workflow-editor/statusDot'
+import type { RunBucket } from '../../stores/types'
+
+const RUN_FILTERS: { key: RunBucket; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'running', label: 'Running' },
+  { key: 'waiting', label: 'Waiting' },
+  { key: 'error', label: 'Failed' },
+  { key: 'success', label: 'Succeeded' }
+]
+
+const RUN_FILTER_DOT: Record<RunBucket, string> = {
+  all: 'bg-gray-400',
+  running: STATUS_DOT_STATIC.running,
+  waiting: STATUS_DOT_STATIC.waiting,
+  error: STATUS_DOT_STATIC.error,
+  success: STATUS_DOT_STATIC.success
+}
+
+interface Props {
+  filter: RunBucket
+  setFilter: (b: RunBucket) => void
+}
+
+export function RunsToolbar({ filter, setFilter }: Props) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  const hasActiveFilters = filter !== 'all'
+
+  const toggle = useCallback(() => setOpen((o) => !o), [])
+
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const id = setTimeout(() => document.addEventListener('mousedown', handleClick), 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [open])
+
+  return (
+    <div className="relative flex items-center" ref={ref}>
+      <Tooltip label="View options" position="bottom">
+        <button
+          onClick={toggle}
+          className={`relative p-1 rounded-md transition-colors ${
+            open
+              ? 'text-white bg-white/[0.1]'
+              : hasActiveFilters
+                ? 'text-white bg-white/[0.08] hover:bg-white/[0.12]'
+                : 'text-gray-400 hover:text-white hover:bg-white/[0.06]'
+          }`}
+        >
+          <SlidersHorizontal size={16} strokeWidth={1.5} />
+          {hasActiveFilters && !open && (
+            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+          )}
+        </button>
+      </Tooltip>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 z-50 w-[200px]
+                     border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
+          style={{ background: '#1a1a1e' }}
+        >
+          <div className="py-1.5">
+            <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
+              Status
+            </div>
+            {RUN_FILTERS.map((opt) => (
+              <OptionRow
+                key={opt.key}
+                selected={filter === opt.key}
+                dot={RUN_FILTER_DOT[opt.key]}
+                label={opt.label}
+                onClick={() => {
+                  setFilter(opt.key)
+                  setOpen(false)
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-runs/WorkflowsLandingHeader.tsx
+++ b/src/renderer/components/workflow-runs/WorkflowsLandingHeader.tsx
@@ -9,7 +9,7 @@ export function WorkflowsLandingHeader() {
   const setTab = useAppStore((s) => s.setWorkflowsLandingTab)
   const filter = useAppStore((s) => s.workflowsRunFilter)
   const setFilter = useAppStore((s) => s.setWorkflowsRunFilter)
-  const loading = useAppStore((s) => s.workflowsRunsLoading)
+  const loading = useAppStore((s) => s.workflowsRunsInflight > 0)
   const bumpReload = useAppStore((s) => s.bumpWorkflowsRunsReload)
   const waiting = useWaitingApprovals()
 

--- a/src/renderer/components/workflow-runs/WorkflowsLandingHeader.tsx
+++ b/src/renderer/components/workflow-runs/WorkflowsLandingHeader.tsx
@@ -1,0 +1,62 @@
+import { RefreshCw } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { useWaitingApprovals } from '../../hooks/useWaitingApprovals'
+import { Tooltip } from '../Tooltip'
+import { RunsToolbar } from './RunsToolbar'
+
+export function WorkflowsLandingHeader() {
+  const tab = useAppStore((s) => s.workflowsLandingTab)
+  const setTab = useAppStore((s) => s.setWorkflowsLandingTab)
+  const filter = useAppStore((s) => s.workflowsRunFilter)
+  const setFilter = useAppStore((s) => s.setWorkflowsRunFilter)
+  const loading = useAppStore((s) => s.workflowsRunsLoading)
+  const bumpReload = useAppStore((s) => s.bumpWorkflowsRunsReload)
+  const waiting = useWaitingApprovals()
+
+  return (
+    <div className="flex items-center gap-1 titlebar-no-drag">
+      <button
+        type="button"
+        onClick={() => setTab('runs')}
+        className={`px-2.5 py-1 rounded-md text-[12px] transition-colors ${
+          tab === 'runs'
+            ? 'text-white bg-white/[0.08]'
+            : 'text-gray-400 hover:text-white hover:bg-white/[0.06]'
+        }`}
+      >
+        All runs
+      </button>
+      <button
+        type="button"
+        onClick={() => setTab('review')}
+        className={`px-2.5 py-1 rounded-md text-[12px] transition-colors flex items-center gap-1.5 ${
+          tab === 'review'
+            ? 'text-white bg-white/[0.08]'
+            : 'text-gray-400 hover:text-white hover:bg-white/[0.06]'
+        }`}
+      >
+        Needs review
+        {waiting.length > 0 && (
+          <span className="font-mono text-[10px] text-amber-400 tabular-nums">
+            {waiting.length}
+          </span>
+        )}
+      </button>
+
+      <div className="w-px h-4 bg-white/[0.06] mx-1" />
+
+      {tab === 'runs' && <RunsToolbar filter={filter} setFilter={setFilter} />}
+
+      <Tooltip label="Refresh" position="bottom">
+        <button
+          type="button"
+          onClick={bumpReload}
+          aria-label="Refresh"
+          className="p-1 rounded-md text-gray-400 hover:text-white hover:bg-white/[0.06] transition-colors"
+        >
+          <RefreshCw size={14} strokeWidth={1.5} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-runs/WorkflowsLandingView.tsx
+++ b/src/renderer/components/workflow-runs/WorkflowsLandingView.tsx
@@ -1,0 +1,28 @@
+import { useMemo } from 'react'
+import { useAllWorkflowRuns } from '../../hooks/useAllWorkflowRuns'
+import { useAppStore } from '../../stores'
+import { AllRunsTable } from './AllRunsTable'
+import { NeedsReviewList } from './NeedsReviewList'
+
+export function WorkflowsLandingView() {
+  const tab = useAppStore((s) => s.workflowsLandingTab)
+  const filter = useAppStore((s) => s.workflowsRunFilter)
+  const { runs } = useAllWorkflowRuns(50)
+  const workflows = useAppStore((s) => s.config?.workflows)
+  const workflowsById = useMemo(
+    () => new Map((workflows ?? []).map((w) => [w.id, { name: w.name, nodes: w.nodes ?? [] }])),
+    [workflows]
+  )
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'runs' ? (
+          <AllRunsTable runs={runs} workflowsById={workflowsById} filter={filter} />
+        ) : (
+          <NeedsReviewList />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/useAllWorkflowRuns.ts
+++ b/src/renderer/hooks/useAllWorkflowRuns.ts
@@ -20,13 +20,17 @@ export function useAllWorkflowRuns(limit = 50): {
   const workflowExecutions = useAppStore((s) => s.workflowExecutions)
   const workflows = useAppStore((s) => s.config?.workflows)
   const reloadToken = useAppStore((s) => s.workflowsRunsReloadToken)
-  const setStoreLoading = useAppStore((s) => s.setWorkflowsRunsLoading)
+  const beginLoad = useAppStore((s) => s.beginWorkflowsRunsLoad)
+  const endLoad = useAppStore((s) => s.endWorkflowsRunsLoad)
   const [persisted, setPersisted] = useState<RunListEntry[]>([])
   const [loading, setLoading] = useState(true)
 
+  // Store-side loader uses an in-flight counter (not a boolean) so the
+  // header spinner stays on while initial load, manual refresh, and the
+  // debounced live-completion refetch overlap.
   const reload = useCallback(async () => {
     setLoading(true)
-    setStoreLoading(true)
+    beginLoad()
     try {
       const rows = await window.api.listAllWorkflowRuns(activeWorkspace, limit)
       setPersisted(rows)
@@ -34,9 +38,9 @@ export function useAllWorkflowRuns(limit = 50): {
       console.error('[useAllWorkflowRuns] load failed', err)
     } finally {
       setLoading(false)
-      setStoreLoading(false)
+      endLoad()
     }
-  }, [activeWorkspace, limit, setStoreLoading])
+  }, [activeWorkspace, limit, beginLoad, endLoad])
 
   useEffect(() => {
     void reload()

--- a/src/renderer/hooks/useAllWorkflowRuns.ts
+++ b/src/renderer/hooks/useAllWorkflowRuns.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
+import { useAppStore } from '../stores'
+import type { WorkflowExecution } from '../../shared/types'
+
+export type RunListEntry = WorkflowExecution & { workflowName?: string }
+
+/**
+ * Loads recent workflow runs across the active workspace from the persistent
+ * SQLite store. Live in-memory `workflowExecutions` override the snapshot for
+ * matching workflows so an in-flight run shows fresh node states without a
+ * reload, and `reload()` is debounced when an active run completes so the
+ * snapshot doesn't go stale once it leaves the live Map.
+ */
+export function useAllWorkflowRuns(limit = 50): {
+  runs: RunListEntry[]
+  loading: boolean
+  reload: () => Promise<void>
+} {
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  const workflowExecutions = useAppStore((s) => s.workflowExecutions)
+  const workflows = useAppStore((s) => s.config?.workflows)
+  const reloadToken = useAppStore((s) => s.workflowsRunsReloadToken)
+  const setStoreLoading = useAppStore((s) => s.setWorkflowsRunsLoading)
+  const [persisted, setPersisted] = useState<RunListEntry[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setStoreLoading(true)
+    try {
+      const rows = await window.api.listAllWorkflowRuns(activeWorkspace, limit)
+      setPersisted(rows)
+    } catch (err) {
+      console.error('[useAllWorkflowRuns] load failed', err)
+    } finally {
+      setLoading(false)
+      setStoreLoading(false)
+    }
+  }, [activeWorkspace, limit, setStoreLoading])
+
+  useEffect(() => {
+    void reload()
+  }, [reload, reloadToken])
+
+  // When an in-memory run completes (status flips to success/error), the
+  // persisted snapshot is stale — schedule a debounced refetch so the row's
+  // final state survives a navigation away from the view.
+  const liveActiveCount = useMemo(() => {
+    let n = 0
+    for (const exec of workflowExecutions.values()) if (exec.status === 'running') n++
+    return n
+  }, [workflowExecutions])
+  const prevLiveActive = useRef(liveActiveCount)
+  useEffect(() => {
+    if (liveActiveCount < prevLiveActive.current) {
+      const t = setTimeout(() => void reload(), 500)
+      prevLiveActive.current = liveActiveCount
+      return () => clearTimeout(t)
+    }
+    prevLiveActive.current = liveActiveCount
+    return undefined
+  }, [liveActiveCount, reload])
+
+  const runs = useMemo<RunListEntry[]>(() => {
+    const out: RunListEntry[] = []
+    const live = new Map<string, WorkflowExecution>()
+    for (const [wfId, exec] of workflowExecutions) live.set(wfId, exec)
+
+    for (const r of persisted) {
+      const liveExec = live.get(r.workflowId)
+      if (liveExec && liveExec.startedAt === r.startedAt) {
+        out.push({ ...liveExec, workflowName: r.workflowName })
+        live.delete(r.workflowId)
+      } else {
+        out.push(r)
+      }
+    }
+    for (const [wfId, exec] of live) {
+      const wf = workflows?.find((w) => w.id === wfId)
+      if (wf && (wf.workspaceId ?? 'personal') !== activeWorkspace) continue
+      out.push({ ...exec, workflowName: wf?.name })
+    }
+    out.sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1))
+    return out
+  }, [persisted, workflowExecutions, workflows, activeWorkspace])
+
+  return { runs, loading, reload }
+}

--- a/src/renderer/lib/format-time.ts
+++ b/src/renderer/lib/format-time.ts
@@ -1,10 +1,12 @@
 /**
  * Workflow-run duration in the verbose RunEntry format
- * (e.g. "1.4s", "2m 13s"). Returns "running..." when `end` is absent.
+ * (e.g. "1.4s", "2m 13s"). Returns "running..." when `end` is absent and
+ * "—" when either timestamp is unparseable or `end` is before `start`.
  */
 export function formatRunDuration(start: string, end?: string): string {
   if (!end) return 'running...'
   const ms = new Date(end).getTime() - new Date(start).getTime()
+  if (Number.isNaN(ms) || ms < 0) return '—'
   if (ms < 1000) return `${ms}ms`
   if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
   return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
@@ -13,7 +15,7 @@ export function formatRunDuration(start: string, end?: string): string {
 /** Compact "MM:SS" or "Ns" for table cells. Counts up to now when `end` is absent. */
 export function formatCompactDuration(start: string, end?: string): string {
   const ms = (end ? new Date(end).getTime() : Date.now()) - new Date(start).getTime()
-  if (ms < 0) return '—'
+  if (Number.isNaN(ms) || ms < 0) return '—'
   if (ms < 60_000) return `${Math.floor(ms / 1000)}s`
   const mins = Math.floor(ms / 60_000)
   const secs = Math.floor((ms % 60_000) / 1000)

--- a/src/renderer/lib/format-time.ts
+++ b/src/renderer/lib/format-time.ts
@@ -1,3 +1,25 @@
+/**
+ * Workflow-run duration in the verbose RunEntry format
+ * (e.g. "1.4s", "2m 13s"). Returns "running..." when `end` is absent.
+ */
+export function formatRunDuration(start: string, end?: string): string {
+  if (!end) return 'running...'
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
+}
+
+/** Compact "MM:SS" or "Ns" for table cells. Counts up to now when `end` is absent. */
+export function formatCompactDuration(start: string, end?: string): string {
+  const ms = (end ? new Date(end).getTime() : Date.now()) - new Date(start).getTime()
+  if (ms < 0) return '—'
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s`
+  const mins = Math.floor(ms / 60_000)
+  const secs = Math.floor((ms % 60_000) / 1000)
+  return `${mins}:${String(secs).padStart(2, '0')}`
+}
+
 export function formatRelativeTime(iso: string): string {
   const time = new Date(iso).getTime()
   if (Number.isNaN(time)) return 'Unknown'

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -152,7 +152,7 @@ export interface UISlice {
   mainViewMode: 'sessions' | 'tasks' | 'workflows'
   workflowsLandingTab: 'runs' | 'review'
   workflowsRunFilter: RunBucket
-  workflowsRunsLoading: boolean
+  workflowsRunsInflight: number
   workflowsRunsReloadToken: number
   selectedTaskId: string | null
   taskStatusFilter: TaskStatusFilter
@@ -198,7 +198,8 @@ export interface UISlice {
   setMainViewMode: (mode: 'sessions' | 'tasks' | 'workflows') => void
   setWorkflowsLandingTab: (tab: 'runs' | 'review') => void
   setWorkflowsRunFilter: (filter: RunBucket) => void
-  setWorkflowsRunsLoading: (loading: boolean) => void
+  beginWorkflowsRunsLoad: () => void
+  endWorkflowsRunsLoad: () => void
   bumpWorkflowsRunsReload: () => void
   setSelectedTaskId: (id: string | null) => void
   setTaskStatusFilter: (filter: TaskStatusFilter) => void

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -37,6 +37,7 @@ export type TaskStatusFilter = 'all' | 'todo' | 'in_progress' | 'in_review' | 'd
 export type TaskSourceFilter = 'all' | 'local' | (string & {})
 export type ProjectSortMode = 'manual' | 'name' | 'recent'
 export type WorkflowFilter = 'all' | 'manual' | 'scheduled'
+export type RunBucket = 'all' | 'running' | 'waiting' | 'success' | 'error'
 export type WorktreeSortMode = 'name' | 'recent'
 export type WorktreeFilter = 'all' | 'active'
 export type SidebarViewMode = 'worktrees' | 'worktrees-sessions' | 'sessions' | 'sessions-flat'
@@ -139,6 +140,7 @@ export interface UISlice {
   statusFilter: StatusFilter
   terminalOrder: string[]
   visibleTerminalIds: string[]
+  focusableTerminalIds: string[]
   minimizedTerminals: Set<string>
   backgroundTrayCollapsed: boolean
   isOnboardingOpen: boolean
@@ -148,6 +150,10 @@ export interface UISlice {
   isDiffPanelMaximized: boolean
   diffPanelWidth: number
   mainViewMode: 'sessions' | 'tasks' | 'workflows'
+  workflowsLandingTab: 'runs' | 'review'
+  workflowsRunFilter: RunBucket
+  workflowsRunsLoading: boolean
+  workflowsRunsReloadToken: number
   selectedTaskId: string | null
   taskStatusFilter: TaskStatusFilter
   taskSourceFilter: TaskSourceFilter
@@ -178,6 +184,7 @@ export interface UISlice {
   setFlexibleLayouts: (layouts: Record<string, FlexibleLayoutRect>) => void
   setTerminalOrder: (order: string[]) => void
   setVisibleTerminalIds: (ids: string[]) => void
+  setFocusableTerminalIds: (ids: string[]) => void
   reorderTerminals: (fromIndex: number, toIndex: number) => void
   toggleMinimized: (id: string) => void
   toggleBackgroundTray: () => void
@@ -189,6 +196,10 @@ export interface UISlice {
   setDiffPanelMaximized: (maximized: boolean) => void
   setDiffPanelWidth: (width: number) => void
   setMainViewMode: (mode: 'sessions' | 'tasks' | 'workflows') => void
+  setWorkflowsLandingTab: (tab: 'runs' | 'review') => void
+  setWorkflowsRunFilter: (filter: RunBucket) => void
+  setWorkflowsRunsLoading: (loading: boolean) => void
+  bumpWorkflowsRunsReload: () => void
   setSelectedTaskId: (id: string | null) => void
   setTaskStatusFilter: (filter: TaskStatusFilter) => void
   setTaskSourceFilter: (filter: TaskSourceFilter) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -91,6 +91,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
     (savedGrid.statusFilter as 'all' | 'running' | 'waiting' | 'idle' | 'error') ?? 'all',
   terminalOrder: [],
   visibleTerminalIds: [],
+  focusableTerminalIds: [],
   minimizedTerminals: new Set(),
   backgroundTrayCollapsed: false,
   isOnboardingOpen: false,
@@ -100,6 +101,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   isDiffPanelMaximized: false,
   diffPanelWidth: 480,
   mainViewMode: 'sessions' as const,
+  workflowsLandingTab: 'runs' as const,
+  workflowsRunFilter: 'all' as const,
+  workflowsRunsLoading: false,
+  workflowsRunsReloadToken: 0,
   selectedTaskId: null,
   taskStatusFilter: 'all' as const,
   taskSourceFilter: 'all' as TaskSourceFilter,
@@ -184,6 +189,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   setTerminalOrder: (order) => set({ terminalOrder: order }),
   setVisibleTerminalIds: (ids) => set({ visibleTerminalIds: ids }),
+  setFocusableTerminalIds: (ids) => set({ focusableTerminalIds: ids }),
 
   reorderTerminals: (fromIndex, toIndex) =>
     set((state) => {
@@ -259,6 +265,11 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
       set({ mainViewMode: mode, ...extra })
     }
   },
+  setWorkflowsLandingTab: (tab) => set({ workflowsLandingTab: tab }),
+  setWorkflowsRunFilter: (filter) => set({ workflowsRunFilter: filter }),
+  setWorkflowsRunsLoading: (loading) => set({ workflowsRunsLoading: loading }),
+  bumpWorkflowsRunsReload: () =>
+    set((s) => ({ workflowsRunsReloadToken: s.workflowsRunsReloadToken + 1 })),
   setSelectedTaskId: (id) => set({ selectedTaskId: id }),
   setTaskStatusFilter: (filter) => set({ taskStatusFilter: filter }),
   setTaskSourceFilter: (filter) => set({ taskSourceFilter: filter }),

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -103,7 +103,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   mainViewMode: 'sessions' as const,
   workflowsLandingTab: 'runs' as const,
   workflowsRunFilter: 'all' as const,
-  workflowsRunsLoading: false,
+  workflowsRunsInflight: 0,
   workflowsRunsReloadToken: 0,
   selectedTaskId: null,
   taskStatusFilter: 'all' as const,
@@ -267,7 +267,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   },
   setWorkflowsLandingTab: (tab) => set({ workflowsLandingTab: tab }),
   setWorkflowsRunFilter: (filter) => set({ workflowsRunFilter: filter }),
-  setWorkflowsRunsLoading: (loading) => set({ workflowsRunsLoading: loading }),
+  beginWorkflowsRunsLoad: () =>
+    set((s) => ({ workflowsRunsInflight: s.workflowsRunsInflight + 1 })),
+  endWorkflowsRunsLoad: () =>
+    set((s) => ({ workflowsRunsInflight: Math.max(0, s.workflowsRunsInflight - 1) })),
   bumpWorkflowsRunsReload: () =>
     set((s) => ({ workflowsRunsReloadToken: s.workflowsRunsReloadToken + 1 })),
   setSelectedTaskId: (id) => set({ selectedTaskId: id }),

--- a/tests/all-runs-table.test.tsx
+++ b/tests/all-runs-table.test.tsx
@@ -198,4 +198,23 @@ describe('AllRunsTable', () => {
     expect(mockState.setEditingWorkflowId).toHaveBeenCalledWith('wf-a')
     expect(mockState.setMainViewMode).toHaveBeenCalledWith('workflows')
   })
+
+  it('does not open the editor on double-click of a deleted-workflow row', () => {
+    const runs = [makeRun('wf-gone', 'success', { workflowName: 'Gone' })]
+    render(<AllRunsTable runs={runs} workflowsById={new Map()} filter="all" />)
+    fireEvent.doubleClick(screen.getByText('Gone'))
+    expect(mockState.setEditingWorkflowId).not.toHaveBeenCalled()
+    expect(mockState.setMainViewMode).not.toHaveBeenCalled()
+  })
+
+  it('disables the "Open workflow" button on a deleted-workflow row', () => {
+    const runs = [makeRun('wf-gone', 'success', { workflowName: 'Gone' })]
+    render(<AllRunsTable runs={runs} workflowsById={new Map()} filter="all" />)
+    fireEvent.click(screen.getByText('Gone'))
+    const openBtn = screen.getByRole('button', { name: 'Open workflow' })
+    expect(openBtn).toBeDisabled()
+    expect(openBtn.title).toBe('Workflow no longer exists')
+    fireEvent.click(openBtn)
+    expect(mockState.setEditingWorkflowId).not.toHaveBeenCalled()
+  })
 })

--- a/tests/all-runs-table.test.tsx
+++ b/tests/all-runs-table.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowExecution, WorkflowNode } from '../src/shared/types'
+import type { RunListEntry } from '../src/renderer/hooks/useAllWorkflowRuns'
+
+const mockState = {
+  setMainViewMode: vi.fn(),
+  setEditingWorkflowId: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockState) : mockState
+  }
+}))
+
+vi.mock('../src/renderer/components/LogReplayModal', () => ({
+  LogReplayModal: ({ logs, onClose }: { logs: string; onClose: () => void }) => (
+    <div data-testid="log-replay-modal" onClick={onClose}>
+      {logs}
+    </div>
+  )
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/RunEntry', () => ({
+  StatusDot: ({ status }: { status: string }) => <span data-testid="status-dot">{status}</span>,
+  NodeLabel: ({ nodeId }: { nodeId: string }) => <span data-testid="node-label">{nodeId}</span>,
+  RunStepsList: () => <div data-testid="run-steps-list" />
+}))
+
+const NOW = new Date('2026-04-20T12:00:00Z').getTime()
+
+beforeAll(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterAll(() => {
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  mockState.setMainViewMode.mockReset()
+  mockState.setEditingWorkflowId.mockReset()
+})
+
+const { AllRunsTable } = await import('../src/renderer/components/workflow-runs/AllRunsTable')
+
+function makeNode(id: string, label: string): WorkflowNode {
+  return {
+    id,
+    type: 'launchAgent',
+    label,
+    config: {},
+    position: { x: 0, y: 0 }
+  } as WorkflowNode
+}
+
+function makeRun(
+  workflowId: string,
+  status: WorkflowExecution['status'],
+  overrides: Partial<RunListEntry> = {}
+): RunListEntry {
+  const startedAt = overrides.startedAt ?? new Date(NOW - 60_000).toISOString()
+  const completedAt =
+    'completedAt' in overrides ? overrides.completedAt : new Date(NOW - 30_000).toISOString()
+  return {
+    workflowId,
+    startedAt,
+    ...(completedAt !== undefined && { completedAt }),
+    status,
+    nodeStates: overrides.nodeStates ?? [
+      {
+        nodeId: 'n1',
+        status: status === 'success' ? 'success' : status === 'error' ? 'error' : 'running',
+        startedAt
+      }
+    ],
+    ...overrides
+  } as RunListEntry
+}
+
+describe('AllRunsTable', () => {
+  it('renders an empty-state row when there are no runs', () => {
+    render(<AllRunsTable runs={[]} workflowsById={new Map()} filter="all" />)
+    expect(screen.getByText('No runs to show')).toBeInTheDocument()
+  })
+
+  it('renders the live workflow name and surfaces the column headers', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha Flow', nodes: [makeNode('n1', 'Step 1')] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    expect(screen.getByText('Workflow')).toBeInTheDocument()
+    expect(screen.getByText('Started')).toBeInTheDocument()
+    expect(screen.getByText('Duration')).toBeInTheDocument()
+    expect(screen.getByText('Trigger')).toBeInTheDocument()
+    expect(screen.getByText('Last node')).toBeInTheDocument()
+    expect(screen.getByText('Alpha Flow')).toBeInTheDocument()
+  })
+
+  it('falls back to the short id with a "deleted" tag when the workflow is missing', () => {
+    const runs = [makeRun('407f59ea-1234-5678', 'success')]
+    render(<AllRunsTable runs={runs} workflowsById={new Map()} filter="all" />)
+    expect(screen.getByText('407f59ea')).toBeInTheDocument()
+    expect(screen.getByText('deleted')).toBeInTheDocument()
+  })
+
+  it('shows the persisted name when only the run row carries it (workflow deleted)', () => {
+    const runs = [makeRun('wf-gone', 'success', { workflowName: 'Old Name' })]
+    render(<AllRunsTable runs={runs} workflowsById={new Map()} filter="all" />)
+    // wfById lookup misses → still flagged as deleted, but liveName uses the persisted name.
+    expect(screen.getByText('Old Name')).toBeInTheDocument()
+    expect(screen.getByText('deleted')).toBeInTheDocument()
+  })
+
+  it('filters rows by bucket', () => {
+    const runs = [
+      makeRun('wf-a', 'success'),
+      makeRun('wf-b', 'error'),
+      makeRun('wf-c', 'running', { completedAt: undefined })
+    ]
+    const wfById = new Map([
+      ['wf-a', { name: 'Alpha', nodes: [] }],
+      ['wf-b', { name: 'Beta', nodes: [] }],
+      ['wf-c', { name: 'Gamma', nodes: [] }]
+    ])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="error" />)
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(screen.queryByText('Gamma')).not.toBeInTheDocument()
+  })
+
+  it('classifies a running execution with a waiting node as the waiting bucket', () => {
+    const runs = [
+      makeRun('wf-w', 'running', {
+        completedAt: undefined,
+        nodeStates: [
+          { nodeId: 'n1', status: 'waiting', startedAt: new Date(NOW - 5000).toISOString() }
+        ]
+      })
+    ]
+    const wfById = new Map([['wf-w', { name: 'Wait', nodes: [makeNode('n1', 'Step 1')] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="waiting" />)
+    expect(screen.getByText('Wait')).toBeInTheDocument()
+  })
+
+  it('renders a "task · …" pill when the run was triggered by a task', () => {
+    const runs = [makeRun('wf-a', 'success', { triggerTaskId: 'task-abc1234567' })]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    expect(screen.getByText(/task · task-a/)).toBeInTheDocument()
+  })
+
+  it('shows "manual" when there is no triggering task', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    expect(screen.getByText('manual')).toBeInTheDocument()
+  })
+
+  it('expands the row to show the run-steps list and renders an "Open workflow" button', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [makeNode('n1', 'Step 1')] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    fireEvent.click(screen.getByText('Alpha'))
+    expect(screen.getByTestId('run-steps-list')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Open workflow' })).toBeInTheDocument()
+  })
+
+  it('routes "Open workflow" to the editor for that workflow', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [makeNode('n1', 'Step 1')] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    fireEvent.click(screen.getByText('Alpha'))
+    fireEvent.click(screen.getByRole('button', { name: 'Open workflow' }))
+    expect(mockState.setEditingWorkflowId).toHaveBeenCalledWith('wf-a')
+    expect(mockState.setMainViewMode).toHaveBeenCalledWith('workflows')
+  })
+
+  it('collapses an expanded row when clicked again', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    const row = screen.getByText('Alpha')
+    fireEvent.click(row)
+    expect(screen.getByTestId('run-steps-list')).toBeInTheDocument()
+    fireEvent.click(row)
+    expect(screen.queryByTestId('run-steps-list')).not.toBeInTheDocument()
+  })
+
+  it('opens the editor on double-click of a row', () => {
+    const runs = [makeRun('wf-a', 'success')]
+    const wfById = new Map([['wf-a', { name: 'Alpha', nodes: [] }]])
+    render(<AllRunsTable runs={runs} workflowsById={wfById} filter="all" />)
+    fireEvent.doubleClick(screen.getByText('Alpha'))
+    expect(mockState.setEditingWorkflowId).toHaveBeenCalledWith('wf-a')
+    expect(mockState.setMainViewMode).toHaveBeenCalledWith('workflows')
+  })
+})

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -11,9 +11,11 @@ vi.mock('node:fs', async (importOriginal) => {
 import {
   initTestDatabase,
   saveWorkflowRun,
-  listWorkflowRuns
+  listWorkflowRuns,
+  listAllWorkflowRuns,
+  saveConfig
 } from '../packages/server/src/database'
-import type { WorkflowExecution } from '@vornrun/shared/types'
+import type { AppConfig, WorkflowExecution } from '@vornrun/shared/types'
 
 let teardown: () => void
 
@@ -70,5 +72,124 @@ describe('workflow run persistence', () => {
     expect(state.agentType).toBeUndefined()
     expect(state.projectName).toBeUndefined()
     expect(state.projectPath).toBeUndefined()
+  })
+})
+
+function configWithWorkflows(
+  workflows: { id: string; name: string; workspaceId?: string }[]
+): AppConfig {
+  return {
+    version: 1,
+    defaults: { shell: 'bash', fontSize: 14, theme: 'dark' },
+    projects: [],
+    workflows: workflows.map((w) => ({
+      id: w.id,
+      name: w.name,
+      icon: 'Zap',
+      iconColor: '#fff',
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          label: 'T',
+          config: { triggerType: 'manual' },
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: [],
+      enabled: true,
+      ...(w.workspaceId !== undefined && { workspaceId: w.workspaceId })
+    }))
+  }
+}
+
+describe('listAllWorkflowRuns', () => {
+  it('returns runs across every workflow in started-desc order with workflow names attached', () => {
+    saveConfig(
+      configWithWorkflows([
+        { id: 'wf-a', name: 'Alpha' },
+        { id: 'wf-b', name: 'Beta' }
+      ])
+    )
+    saveWorkflowRun({
+      workflowId: 'wf-a',
+      startedAt: '2026-04-20T10:00:00Z',
+      completedAt: '2026-04-20T10:00:05Z',
+      status: 'success',
+      nodeStates: [{ nodeId: 'n', status: 'success' }]
+    })
+    saveWorkflowRun({
+      workflowId: 'wf-b',
+      startedAt: '2026-04-20T10:01:00Z',
+      completedAt: '2026-04-20T10:01:09Z',
+      status: 'error',
+      nodeStates: [{ nodeId: 'n', status: 'error' }]
+    })
+
+    const runs = listAllWorkflowRuns()
+    expect(runs.map((r) => r.workflowId)).toEqual(['wf-b', 'wf-a'])
+    expect(runs.map((r) => r.workflowName)).toEqual(['Beta', 'Alpha'])
+  })
+
+  it('restricts to workflows in the given workspace', () => {
+    saveConfig(
+      configWithWorkflows([
+        { id: 'wf-personal', name: 'P', workspaceId: 'personal' },
+        { id: 'wf-team', name: 'T', workspaceId: 'team' }
+      ])
+    )
+    saveWorkflowRun({
+      workflowId: 'wf-personal',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      nodeStates: []
+    })
+    saveWorkflowRun({
+      workflowId: 'wf-team',
+      startedAt: '2026-04-20T10:00:30Z',
+      status: 'success',
+      nodeStates: []
+    })
+
+    const personal = listAllWorkflowRuns('personal')
+    expect(personal.map((r) => r.workflowId)).toEqual(['wf-personal'])
+
+    const team = listAllWorkflowRuns('team')
+    expect(team.map((r) => r.workflowId)).toEqual(['wf-team'])
+  })
+
+  it('honors the limit and clamps it to 500', () => {
+    saveConfig(configWithWorkflows([{ id: 'wf-x', name: 'X' }]))
+    for (let i = 0; i < 5; i++) {
+      saveWorkflowRun({
+        workflowId: 'wf-x',
+        startedAt: `2026-04-20T10:0${i}:00Z`,
+        status: 'success',
+        nodeStates: []
+      })
+    }
+    expect(listAllWorkflowRuns(undefined, 2)).toHaveLength(2)
+    expect(listAllWorkflowRuns(undefined, 99999)).toHaveLength(5)
+  })
+
+  it('returns triggerTaskId only when present, and survives orphaned runs', () => {
+    saveConfig(configWithWorkflows([{ id: 'wf-orphan', name: 'O' }]))
+    saveWorkflowRun({
+      workflowId: 'wf-orphan',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      triggerTaskId: 'task-7',
+      nodeStates: []
+    })
+    // Now wipe the workflow from config — the run row stays, name should be null.
+    saveConfig({
+      version: 1,
+      defaults: { shell: 'bash', fontSize: 14, theme: 'dark' },
+      projects: []
+    })
+    const runs = listAllWorkflowRuns()
+    expect(runs).toHaveLength(1)
+    expect(runs[0].triggerTaskId).toBe('task-7')
+    expect(runs[0].workflowName).toBeUndefined()
   })
 })

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -192,4 +192,22 @@ describe('listAllWorkflowRuns', () => {
     expect(runs[0].triggerTaskId).toBe('task-7')
     expect(runs[0].workflowName).toBeUndefined()
   })
+
+  it('excludes orphaned runs from workspace-filtered listings (no silent personal bucket)', () => {
+    saveConfig(configWithWorkflows([{ id: 'wf-orphan', name: 'O', workspaceId: 'team' }]))
+    saveWorkflowRun({
+      workflowId: 'wf-orphan',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      nodeStates: []
+    })
+    saveConfig({
+      version: 1,
+      defaults: { shell: 'bash', fontSize: 14, theme: 'dark' },
+      projects: []
+    })
+    expect(listAllWorkflowRuns('personal')).toEqual([])
+    expect(listAllWorkflowRuns('team')).toEqual([])
+    expect(listAllWorkflowRuns()).toHaveLength(1)
+  })
 })

--- a/tests/format-time.test.ts
+++ b/tests/format-time.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
-import { formatRelativeTime } from '../src/renderer/lib/format-time'
+import {
+  formatRelativeTime,
+  formatRunDuration,
+  formatCompactDuration
+} from '../src/renderer/lib/format-time'
 
 const NOW = new Date('2026-04-16T12:00:00Z').getTime()
 
@@ -48,5 +52,48 @@ describe('formatRelativeTime', () => {
     const result = formatRelativeTime(future)
     expect(result).not.toBe('Just now')
     expect(result).not.toContain('ago')
+  })
+})
+
+describe('formatRunDuration', () => {
+  it('returns "running..." when end is undefined', () => {
+    expect(formatRunDuration('2026-04-20T10:00:00Z')).toBe('running...')
+  })
+
+  it('formats sub-second durations as ms', () => {
+    expect(formatRunDuration('2026-04-20T10:00:00.000Z', '2026-04-20T10:00:00.250Z')).toBe('250ms')
+  })
+
+  it('formats seconds with one decimal place under a minute', () => {
+    expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T10:00:01.400Z')).toBe('1.4s')
+    expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T10:00:45Z')).toBe('45.0s')
+  })
+
+  it('formats minutes and seconds at or above one minute', () => {
+    expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T10:02:13Z')).toBe('2m 13s')
+    expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T11:00:05Z')).toBe('60m 5s')
+  })
+})
+
+describe('formatCompactDuration', () => {
+  it('returns "—" for negative durations', () => {
+    expect(formatCompactDuration('2026-04-20T10:00:05Z', '2026-04-20T10:00:00Z')).toBe('—')
+  })
+
+  it('formats seconds-only durations as "Ns"', () => {
+    expect(formatCompactDuration('2026-04-20T10:00:00Z', '2026-04-20T10:00:30Z')).toBe('30s')
+  })
+
+  it('formats one-minute durations as "MM:SS"', () => {
+    expect(formatCompactDuration('2026-04-20T10:00:00Z', '2026-04-20T10:01:08Z')).toBe('1:08')
+  })
+
+  it('zero-pads the seconds component', () => {
+    expect(formatCompactDuration('2026-04-20T10:00:00Z', '2026-04-20T10:02:03Z')).toBe('2:03')
+  })
+
+  it('counts up to now when end is omitted', () => {
+    const start = new Date(NOW - 75_000).toISOString()
+    expect(formatCompactDuration(start)).toBe('1:15')
   })
 })

--- a/tests/format-time.test.ts
+++ b/tests/format-time.test.ts
@@ -73,6 +73,15 @@ describe('formatRunDuration', () => {
     expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T10:02:13Z')).toBe('2m 13s')
     expect(formatRunDuration('2026-04-20T10:00:00Z', '2026-04-20T11:00:05Z')).toBe('60m 5s')
   })
+
+  it('returns "—" for unparseable timestamps instead of "NaNms"', () => {
+    expect(formatRunDuration('not-a-date', '2026-04-20T10:00:01Z')).toBe('—')
+    expect(formatRunDuration('2026-04-20T10:00:00Z', 'still-not')).toBe('—')
+  })
+
+  it('returns "—" when end is before start instead of a negative duration', () => {
+    expect(formatRunDuration('2026-04-20T10:00:05Z', '2026-04-20T10:00:00Z')).toBe('—')
+  })
 })
 
 describe('formatCompactDuration', () => {
@@ -95,5 +104,11 @@ describe('formatCompactDuration', () => {
   it('counts up to now when end is omitted', () => {
     const start = new Date(NOW - 75_000).toISOString()
     expect(formatCompactDuration(start)).toBe('1:15')
+  })
+
+  it('returns "—" for unparseable timestamps instead of "NaN:NaN"', () => {
+    expect(formatCompactDuration('not-a-date')).toBe('—')
+    expect(formatCompactDuration('not-a-date', '2026-04-20T10:00:00Z')).toBe('—')
+    expect(formatCompactDuration('2026-04-20T10:00:00Z', 'still-not')).toBe('—')
   })
 })

--- a/tests/main-view-pills.test.tsx
+++ b/tests/main-view-pills.test.tsx
@@ -5,7 +5,14 @@ import '@testing-library/jest-dom/vitest'
 import type { ReactNode } from 'react'
 
 vi.mock('../src/renderer/components/Tooltip', () => ({
-  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+  Tooltip: ({ children, label }: { children: ReactNode; label: string }) => (
+    <span data-tooltip-label={label}>{children}</span>
+  )
+}))
+
+const waitingMock = vi.fn(() => [] as unknown[])
+vi.mock('../src/renderer/hooks/useWaitingApprovals', () => ({
+  useWaitingApprovals: () => waitingMock()
 }))
 
 Object.defineProperty(window, 'api', {
@@ -20,6 +27,8 @@ const setMainViewMode = vi.fn()
 
 beforeEach(() => {
   setMainViewMode.mockClear()
+  waitingMock.mockReset()
+  waitingMock.mockReturnValue([])
   useAppStore.setState({
     config: {
       version: 1,
@@ -58,5 +67,24 @@ describe('MainViewPills', () => {
     render(<MainViewPills />)
     expect(screen.getByRole('button', { name: 'Sessions' }).className).toContain('text-white')
     expect(screen.getByRole('button', { name: 'Workflows' }).className).toContain('text-gray-500')
+  })
+
+  it('renders no waiting badge when no approvals are pending', () => {
+    const { container } = render(<MainViewPills />)
+    expect(container.querySelector('.bg-amber-400')).not.toBeInTheDocument()
+  })
+
+  it('renders the waiting count on the Workflows pill when approvals are pending', () => {
+    waitingMock.mockReturnValue([{}, {}, {}])
+    render(<MainViewPills />)
+    expect(screen.getByText('3')).toBeInTheDocument()
+    const tooltip = screen.getByText('3').closest('[data-tooltip-label]')
+    expect(tooltip?.getAttribute('data-tooltip-label')).toContain('3 awaiting review')
+  })
+
+  it('caps the waiting badge at "9+"', () => {
+    waitingMock.mockReturnValue(new Array(15).fill({}))
+    render(<MainViewPills />)
+    expect(screen.getByText('9+')).toBeInTheDocument()
   })
 })

--- a/tests/needs-review-list.test.tsx
+++ b/tests/needs-review-list.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockState = {
+  config: { tasks: [] as unknown[] }
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockState) : mockState
+  }
+}))
+
+const waitingMock = vi.fn(
+  () =>
+    [] as Array<{
+      execution: { workflowId: string; startedAt: string }
+      workflow?: { name?: string }
+    }>
+)
+vi.mock('../src/renderer/hooks/useWaitingApprovals', () => ({
+  useWaitingApprovals: () => waitingMock()
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/RunEntry', () => ({
+  RunEntry: ({ workflowName }: { workflowName?: string }) => (
+    <div data-testid="run-entry" data-name={workflowName} />
+  )
+}))
+
+const { NeedsReviewList } = await import('../src/renderer/components/workflow-runs/NeedsReviewList')
+
+beforeEach(() => {
+  waitingMock.mockReset()
+  waitingMock.mockReturnValue([])
+})
+
+describe('NeedsReviewList', () => {
+  it('renders the empty state when no executions are waiting', () => {
+    render(<NeedsReviewList />)
+    expect(screen.getByText('No runs waiting on approval.')).toBeInTheDocument()
+  })
+
+  it('renders one RunEntry per unique waiting execution', () => {
+    const exec1 = { workflowId: 'wf-1', startedAt: '2026-04-20T10:00:00Z' }
+    const exec2 = { workflowId: 'wf-2', startedAt: '2026-04-20T10:01:00Z' }
+    waitingMock.mockReturnValue([
+      { execution: exec1, workflow: { name: 'One' } },
+      { execution: exec1, workflow: { name: 'One' } },
+      { execution: exec2, workflow: { name: 'Two' } }
+    ])
+    render(<NeedsReviewList />)
+    expect(screen.getAllByTestId('run-entry')).toHaveLength(2)
+  })
+})

--- a/tests/runs-toolbar.test.tsx
+++ b/tests/runs-toolbar.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import type { RunBucket } from '../src/renderer/stores/types'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+import { RunsToolbar } from '../src/renderer/components/workflow-runs/RunsToolbar'
+
+const setFilter = vi.fn()
+
+beforeEach(() => {
+  setFilter.mockReset()
+})
+
+describe('RunsToolbar', () => {
+  it('renders the filter button', () => {
+    const { container } = render(<RunsToolbar filter="all" setFilter={setFilter} />)
+    expect(container.querySelector('button')).toBeInTheDocument()
+  })
+
+  it('does not show the active-state indicator when filter is "all"', () => {
+    const { container } = render(<RunsToolbar filter="all" setFilter={setFilter} />)
+    expect(container.querySelector('.bg-blue-500')).not.toBeInTheDocument()
+  })
+
+  it('shows the active-state indicator when a non-default filter is active', () => {
+    const { container } = render(<RunsToolbar filter="running" setFilter={setFilter} />)
+    expect(container.querySelector('.bg-blue-500')).toBeInTheDocument()
+  })
+
+  it('opens the dropdown with All / Running / Waiting / Failed / Succeeded', () => {
+    render(<RunsToolbar filter="all" setFilter={setFilter} />)
+    fireEvent.click(screen.getByLabelText('Filter runs'))
+    expect(screen.getByText('All')).toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Waiting')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Succeeded')).toBeInTheDocument()
+  })
+
+  it('calls setFilter with the chosen bucket and closes the dropdown', () => {
+    render(<RunsToolbar filter="all" setFilter={setFilter} />)
+    fireEvent.click(screen.getByLabelText('Filter runs'))
+    fireEvent.click(screen.getByText('Failed'))
+    const expected: RunBucket = 'error'
+    expect(setFilter).toHaveBeenCalledWith(expected)
+    expect(screen.queryByText('Running')).not.toBeInTheDocument()
+  })
+
+  it('toggles the dropdown closed when the trigger button is clicked again', () => {
+    render(<RunsToolbar filter="all" setFilter={setFilter} />)
+    const trigger = screen.getByLabelText('Filter runs')
+    fireEvent.click(trigger)
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    fireEvent.click(trigger)
+    expect(screen.queryByText('Running')).not.toBeInTheDocument()
+  })
+})

--- a/tests/workflows-landing-header.test.tsx
+++ b/tests/workflows-landing-header.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import type { RunBucket } from '../src/renderer/stores/types'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+const mockState = {
+  workflowsLandingTab: 'runs' as 'runs' | 'review',
+  setWorkflowsLandingTab: vi.fn(),
+  workflowsRunFilter: 'all' as RunBucket,
+  setWorkflowsRunFilter: vi.fn(),
+  workflowsRunsLoading: false,
+  bumpWorkflowsRunsReload: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockState) : mockState
+  }
+}))
+
+const waitingMock = vi.fn(() => [] as unknown[])
+vi.mock('../src/renderer/hooks/useWaitingApprovals', () => ({
+  useWaitingApprovals: () => waitingMock()
+}))
+
+const { WorkflowsLandingHeader } =
+  await import('../src/renderer/components/workflow-runs/WorkflowsLandingHeader')
+
+beforeEach(() => {
+  mockState.workflowsLandingTab = 'runs'
+  mockState.workflowsRunFilter = 'all'
+  mockState.workflowsRunsLoading = false
+  mockState.setWorkflowsLandingTab.mockReset()
+  mockState.setWorkflowsRunFilter.mockReset()
+  mockState.bumpWorkflowsRunsReload.mockReset()
+  waitingMock.mockReset()
+  waitingMock.mockReturnValue([])
+})
+
+describe('WorkflowsLandingHeader', () => {
+  it('renders both tabs and the refresh control', () => {
+    render(<WorkflowsLandingHeader />)
+    expect(screen.getByRole('button', { name: 'All runs' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Needs review/ })).toBeInTheDocument()
+    expect(screen.getByLabelText('Refresh')).toBeInTheDocument()
+  })
+
+  it('shows the filter toolbar only on the All runs tab', () => {
+    const { rerender } = render(<WorkflowsLandingHeader />)
+    expect(screen.getByLabelText('Filter runs')).toBeInTheDocument()
+
+    mockState.workflowsLandingTab = 'review'
+    rerender(<WorkflowsLandingHeader />)
+    expect(screen.queryByLabelText('Filter runs')).not.toBeInTheDocument()
+  })
+
+  it('switches tabs via the store actions', () => {
+    render(<WorkflowsLandingHeader />)
+    fireEvent.click(screen.getByRole('button', { name: /Needs review/ }))
+    expect(mockState.setWorkflowsLandingTab).toHaveBeenCalledWith('review')
+
+    mockState.workflowsLandingTab = 'review'
+    fireEvent.click(screen.getByRole('button', { name: 'All runs' }))
+    expect(mockState.setWorkflowsLandingTab).toHaveBeenCalledWith('runs')
+  })
+
+  it('triggers the store reload on refresh click', () => {
+    render(<WorkflowsLandingHeader />)
+    fireEvent.click(screen.getByLabelText('Refresh'))
+    expect(mockState.bumpWorkflowsRunsReload).toHaveBeenCalled()
+  })
+
+  it('spins the refresh icon while loading is true', () => {
+    mockState.workflowsRunsLoading = true
+    const { container } = render(<WorkflowsLandingHeader />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('renders the waiting count next to Needs review when approvals are pending', () => {
+    waitingMock.mockReturnValue([{}, {}, {}])
+    render(<WorkflowsLandingHeader />)
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('omits the waiting count when no approvals are pending', () => {
+    render(<WorkflowsLandingHeader />)
+    const reviewButton = screen.getByRole('button', { name: /Needs review/ })
+    expect(reviewButton.querySelector('.text-amber-400')).not.toBeInTheDocument()
+  })
+})

--- a/tests/workflows-landing-header.test.tsx
+++ b/tests/workflows-landing-header.test.tsx
@@ -14,7 +14,7 @@ const mockState = {
   setWorkflowsLandingTab: vi.fn(),
   workflowsRunFilter: 'all' as RunBucket,
   setWorkflowsRunFilter: vi.fn(),
-  workflowsRunsLoading: false,
+  workflowsRunsInflight: 0,
   bumpWorkflowsRunsReload: vi.fn()
 }
 
@@ -35,7 +35,7 @@ const { WorkflowsLandingHeader } =
 beforeEach(() => {
   mockState.workflowsLandingTab = 'runs'
   mockState.workflowsRunFilter = 'all'
-  mockState.workflowsRunsLoading = false
+  mockState.workflowsRunsInflight = 0
   mockState.setWorkflowsLandingTab.mockReset()
   mockState.setWorkflowsRunFilter.mockReset()
   mockState.bumpWorkflowsRunsReload.mockReset()
@@ -77,7 +77,7 @@ describe('WorkflowsLandingHeader', () => {
   })
 
   it('spins the refresh icon while loading is true', () => {
-    mockState.workflowsRunsLoading = true
+    mockState.workflowsRunsInflight = 2
     const { container } = render(<WorkflowsLandingHeader />)
     expect(container.querySelector('.animate-spin')).toBeInTheDocument()
   })

--- a/tests/workflows-landing-view.test.tsx
+++ b/tests/workflows-landing-view.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { RunBucket } from '../src/renderer/stores/types'
+
+const mockState = {
+  workflowsLandingTab: 'runs' as 'runs' | 'review',
+  workflowsRunFilter: 'all' as RunBucket,
+  config: { workflows: [] as Array<{ id: string; name: string; nodes: unknown[] }> }
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    return selector ? selector(mockState) : mockState
+  }
+}))
+
+const runsHookMock = vi.fn(() => ({ runs: [], loading: false, reload: vi.fn() }))
+vi.mock('../src/renderer/hooks/useAllWorkflowRuns', () => ({
+  useAllWorkflowRuns: (...args: unknown[]) => runsHookMock(...(args as []))
+}))
+
+vi.mock('../src/renderer/components/workflow-runs/AllRunsTable', () => ({
+  AllRunsTable: (props: { filter: string }) => (
+    <div data-testid="all-runs-table" data-filter={props.filter} />
+  )
+}))
+
+vi.mock('../src/renderer/components/workflow-runs/NeedsReviewList', () => ({
+  NeedsReviewList: () => <div data-testid="needs-review-list" />
+}))
+
+const { WorkflowsLandingView } =
+  await import('../src/renderer/components/workflow-runs/WorkflowsLandingView')
+
+beforeEach(() => {
+  mockState.workflowsLandingTab = 'runs'
+  mockState.workflowsRunFilter = 'all'
+  mockState.config = { workflows: [] }
+  runsHookMock.mockReset()
+  runsHookMock.mockReturnValue({ runs: [], loading: false, reload: vi.fn() })
+})
+
+describe('WorkflowsLandingView', () => {
+  it('renders the All Runs table for the runs tab', () => {
+    render(<WorkflowsLandingView />)
+    expect(screen.getByTestId('all-runs-table')).toBeInTheDocument()
+    expect(screen.queryByTestId('needs-review-list')).not.toBeInTheDocument()
+  })
+
+  it('renders the Needs Review list for the review tab', () => {
+    mockState.workflowsLandingTab = 'review'
+    render(<WorkflowsLandingView />)
+    expect(screen.getByTestId('needs-review-list')).toBeInTheDocument()
+    expect(screen.queryByTestId('all-runs-table')).not.toBeInTheDocument()
+  })
+
+  it('threads the current filter into AllRunsTable', () => {
+    mockState.workflowsRunFilter = 'error'
+    render(<WorkflowsLandingView />)
+    expect(screen.getByTestId('all-runs-table').getAttribute('data-filter')).toBe('error')
+  })
+})

--- a/tests/workflows-section.test.tsx
+++ b/tests/workflows-section.test.tsx
@@ -12,13 +12,20 @@ const mockStore = {
   reorderWorkflows: vi.fn(),
   sidebarWorkflowFilter: 'all' as 'all' | 'manual' | 'scheduled',
   setSidebarWorkflowFilter: vi.fn(),
-  workflowExecutions: new Map<string, unknown>()
+  workflowExecutions: new Map<string, unknown>(),
+  editingWorkflowId: null as string | null,
+  isWorkflowEditorOpen: false
 }
 
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: (selector?: (state: unknown) => unknown) => {
     return selector ? selector(mockStore) : mockStore
   }
+}))
+
+const waitingMock = vi.fn(() => [] as unknown[])
+vi.mock('../src/renderer/hooks/useWaitingApprovals', () => ({
+  useWaitingApprovals: () => waitingMock()
 }))
 
 vi.mock('../src/renderer/lib/workflow-execution', () => ({
@@ -58,6 +65,10 @@ beforeEach(() => {
   mockStore.reorderWorkflows.mockReset()
   mockStore.setSidebarWorkflowFilter.mockReset()
   mockStore.sidebarWorkflowFilter = 'all'
+  mockStore.editingWorkflowId = null
+  mockStore.isWorkflowEditorOpen = false
+  waitingMock.mockReset()
+  waitingMock.mockReturnValue([])
 })
 
 describe('WorkflowsSection', () => {
@@ -145,6 +156,42 @@ describe('WorkflowsSection', () => {
     render(<WorkflowsSection isCollapsed={true} workspaceWorkflows={workflows} />)
     expect(screen.queryByText('Workflows')).not.toBeInTheDocument()
     expect(screen.queryByText('Flow a')).not.toBeInTheDocument()
+  })
+
+  it('renders the "All runs" entry above the workflow list', () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[]} />)
+    expect(screen.getByRole('button', { name: 'All runs' })).toBeInTheDocument()
+  })
+
+  it('marks "All runs" as selected when no workflow is being edited', () => {
+    mockStore.editingWorkflowId = null
+    mockStore.isWorkflowEditorOpen = false
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[]} />)
+    expect(screen.getByRole('button', { name: 'All runs' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('does not mark "All runs" as selected when a workflow is being edited', () => {
+    mockStore.editingWorkflowId = 'a'
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[makeWorkflow('a')]} />)
+    expect(screen.getByRole('button', { name: 'All runs' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  it('clears editor selection when "All runs" is clicked', () => {
+    mockStore.editingWorkflowId = 'a'
+    mockStore.isWorkflowEditorOpen = true
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[makeWorkflow('a')]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'All runs' }))
+    expect(mockStore.setEditingWorkflowId).toHaveBeenCalledWith(null)
+    expect(mockStore.setWorkflowEditorOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('shows the waiting count next to "All runs" when approvals are pending', () => {
+    waitingMock.mockReturnValue([{}, {}])
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[]} />)
+    expect(screen.getByRole('button', { name: 'All runs' })).toContainElement(screen.getByText('2'))
   })
 
   it('Edit Workflow menu item opens the editor for the right workflow', () => {


### PR DESCRIPTION
## Summary
- New **Workflows landing screen** that takes over the right pane when no workflow is being edited, replacing the empty area users saw when they switched to the Workflows tab without selecting a workflow.
- **All runs** table — recent executions across the active workspace with status, started, duration, trigger, and last-node columns. Rows expand inline to show the same step-by-step view as the workflow editor's Run History panel, factored out into a reusable `RunStepsList` so both surfaces stay in sync.
- **Needs review** tab surfaces paused-on-approval executions; reuses `RunEntry` auto-expanded.
- Live workflow names resolve via the in-memory store; runs for deleted workflows render a short id with a `deleted` tag and a tooltip showing the full id.
- **Top-bar integration** mirrors the Tasks toolbar pattern: tabs + status filter + refresh sit in the existing 40px title bar, so there is no second header row.
- **Sidebar** gets an `All runs` entry above the workflow list so the landing screen is always reachable, including after closing a workflow editor.
- **Server**: new `listAllWorkflowRuns` IPC method backed by SQLite, merged with in-memory `workflowExecutions` so in-flight runs render fresh state without a manual refresh.

State (tab, status filter, refresh token, loading flag) lives in the UI store, so the refresh icon reflects real loading state from the runs hook and the controls in the title bar drive the table below them through normal store subscriptions.

## Test plan
- [ ] Open the Workflows section without an active workflow → confirm All runs table renders.
- [ ] Click `All runs` in the sidebar after opening a workflow → confirm the landing view returns.
- [ ] Filter by `Running` / `Waiting` / `Failed` / `Succeeded` → confirm row counts and row visibility match.
- [ ] Expand a row → confirm the step list shows status dots, durations, and per-step logs/error/resume affordances.
- [ ] Trigger a workflow run → confirm the row appears live without refresh and the badge on the Workflows pill increments while a gate is waiting.
- [ ] Approve a waiting gate from the `Needs review` tab → confirm the row leaves the tab and the badge clears.
- [ ] Delete a workflow that has historical runs → confirm those rows render the short id with a `deleted` tag.
- [ ] Click the refresh icon → confirm the spinner reflects the actual fetch and the table updates.