### PR TITLE
fix(worktrees): replace last-session cleanup modal with toast

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -46,6 +46,7 @@ import {
   disposeGlobalDataListener
 } from './lib/terminal-registry'
 import { WorktreeCleanupDialog } from './components/WorktreeCleanupDialog'
+import { WorktreeCleanupToastBridge } from './components/WorktreeCleanupToastBridge'
 import { RightPanel } from './components/RightPanel'
 import { TaskBoardView } from './components/TaskBoardView'
 import { TaskDetailPanel } from './components/TaskDetailPanel'
@@ -576,6 +577,7 @@ export function App() {
       <CommandPalette />
       <AddTaskDialog />
       <WorktreeCleanupDialog />
+      <WorktreeCleanupToastBridge />
       <MissedScheduleDialog />
       <AnimatePresence>{isShortcutsPanelOpen && <KeyboardShortcutsPanel />}</AnimatePresence>
 

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -120,6 +120,27 @@ toast.dismiss = (id: string): void => {
   notify()
 }
 
+/**
+ * Like `toast.update`, but bails out (returns null) if the toast no longer exists.
+ * Use when an async update may race with the user dismissing the toast — without
+ * this guard, `toast.update` would resurrect the dismissed toast.
+ */
+toast.updateIfExists = (
+  id: string,
+  message: string,
+  type: ToastType,
+  opts: ToastUpdateOptions = {}
+): string | null => {
+  const existing = toasts.find((t) => t.id === id)
+  if (!existing) return null
+  const duration = opts.duration ?? DEFAULT_DURATIONS[type]
+  const actions = opts.actions === null ? undefined : (opts.actions ?? existing.actions)
+  toasts = toasts.map((t) => (t.id === id ? { ...t, message, type, duration, actions } : t))
+  notify()
+  scheduleDismiss(id, duration)
+  return id
+}
+
 /* ------------------------------------------------------------------ */
 /*  Icons & colors per type                                           */
 /* ------------------------------------------------------------------ */

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -10,11 +10,23 @@ import { useIsMobile } from '../hooks/useIsMobile'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info' | 'loading'
 
+export interface ToastAction {
+  label: string
+  onClick: (toastId: string) => void
+  tone?: 'default' | 'danger'
+}
+
+export interface ToastOptions {
+  duration?: number
+  actions?: ToastAction[]
+}
+
 interface Toast {
   id: string
   message: string
   type: ToastType
-  duration?: number
+  duration: number
+  actions?: ToastAction[]
 }
 
 const DEFAULT_DURATIONS: Record<ToastType, number> = {
@@ -55,10 +67,15 @@ function scheduleDismiss(id: string, duration: number) {
 export function toast(
   message: string,
   type: ToastType = 'success',
-  duration: number = DEFAULT_DURATIONS[type]
+  durationOrOptions?: number | ToastOptions
 ): string {
+  const opts: ToastOptions =
+    typeof durationOrOptions === 'number'
+      ? { duration: durationOrOptions }
+      : (durationOrOptions ?? {})
+  const duration = opts.duration ?? DEFAULT_DURATIONS[type]
   const id = crypto.randomUUID()
-  toasts = [...toasts, { id, message, type, duration }]
+  toasts = [...toasts, { id, message, type, duration, actions: opts.actions }]
   notify()
   scheduleDismiss(id, duration)
   return id
@@ -70,14 +87,28 @@ toast.warning = (msg: string) => toast(msg, 'warning', 3500)
 toast.info = (msg: string) => toast(msg, 'info')
 toast.loading = (msg: string) => toast(msg, 'loading')
 
-toast.update = (id: string, message: string, type: ToastType): string => {
+interface ToastUpdateOptions {
+  duration?: number
+  actions?: ToastAction[] | null
+}
+
+toast.update = (
+  id: string,
+  message: string,
+  type: ToastType,
+  opts: ToastUpdateOptions = {}
+): string => {
   const existing = toasts.find((t) => t.id === id)
   if (!existing) {
     // Toast was dismissed manually — fall back to a fresh one so feedback isn't lost
-    return toast(message, type)
+    return toast(message, type, {
+      duration: opts.duration,
+      actions: opts.actions ?? undefined
+    })
   }
-  const duration = DEFAULT_DURATIONS[type]
-  toasts = toasts.map((t) => (t.id === id ? { ...t, message, type, duration } : t))
+  const duration = opts.duration ?? DEFAULT_DURATIONS[type]
+  const actions = opts.actions === null ? undefined : (opts.actions ?? existing.actions)
+  toasts = toasts.map((t) => (t.id === id ? { ...t, message, type, duration, actions } : t))
   notify()
   scheduleDismiss(id, duration)
   return id
@@ -189,6 +220,19 @@ export function ToastContainer() {
                 className={`shrink-0 ${style.text} ${t.type === 'loading' ? 'animate-spin' : ''}`}
               />
               <span className="text-sm text-gray-200 flex-1">{t.message}</span>
+              {t.actions?.map((action, i) => (
+                <button
+                  key={i}
+                  onClick={() => action.onClick(t.id)}
+                  className={`shrink-0 px-2 py-0.5 text-xs rounded transition-colors hover:bg-white/[0.06] ${
+                    action.tone === 'danger'
+                      ? 'text-red-400 hover:text-red-300'
+                      : 'text-gray-300 hover:text-white'
+                  }`}
+                >
+                  {action.label}
+                </button>
+              ))}
               <button
                 onClick={() => dismiss(t.id)}
                 className="shrink-0 p-0.5 text-gray-500 hover:text-gray-300 transition-colors"

--- a/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -1,14 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { FolderGit2, Trash2, FolderOpen, AlertTriangle } from 'lucide-react'
-import { useAppStore } from '../stores'
-import { withProgressToast } from '../lib/progress-toast'
-
-interface WorktreeCleanupInfo {
-  id: string
-  projectPath: string
-  worktreePath: string
-}
+import { FolderGit2, Trash2, AlertTriangle } from 'lucide-react'
+import { removeWorktreeWithProgress } from '../lib/remove-worktree'
 
 interface ExplicitDeleteInfo {
   projectPath: string
@@ -16,7 +9,6 @@ interface ExplicitDeleteInfo {
   sessionIds: string[]
 }
 
-type DialogMode = 'session-exit' | 'explicit-delete'
 type DirtyState = 'checking' | 'clean' | 'dirty' | 'unknown'
 
 type ExplicitDeleteCallback = (info: ExplicitDeleteInfo) => void
@@ -42,99 +34,57 @@ function useExplicitDeleteSubscription(cb: ExplicitDeleteCallback): void {
 }
 
 export function WorktreeCleanupDialog() {
-  const [pending, setPending] = useState<WorktreeCleanupInfo | null>(null)
-  const [explicitDelete, setExplicitDelete] = useState<ExplicitDeleteInfo | null>(null)
+  const [info, setInfo] = useState<ExplicitDeleteInfo | null>(null)
   const [dirtyState, setDirtyState] = useState<DirtyState>('checking')
   const checkIdRef = useRef(0)
   const removingLock = useRef(false)
 
-  const dialogMode: DialogMode = explicitDelete ? 'explicit-delete' : 'session-exit'
-  const activePath = explicitDelete?.worktreePath ?? pending?.worktreePath
-  const activeProjectPath = explicitDelete?.projectPath ?? pending?.projectPath
-  const isVisible = !!(pending || explicitDelete)
+  const isVisible = info !== null
 
-  // Check dirty state when dialog info changes
-  const checkDirty = useCallback((worktreePath: string) => {
-    const id = ++checkIdRef.current
-    setDirtyState('checking')
-    window.api
-      .isWorktreeDirty(worktreePath)
-      .then((dirty) => {
-        if (checkIdRef.current === id) setDirtyState(dirty ? 'dirty' : 'clean')
-      })
-      .catch(() => {
-        if (checkIdRef.current === id) setDirtyState('unknown')
-      })
-  }, [])
-
-  // Session-exit mode listener
-  useEffect(() => {
-    const unsub = window.api.onWorktreeCleanup((session) => {
-      setPending(session)
-      checkDirty(session.worktreePath)
-    })
-    return unsub
-  }, [checkDirty])
-
-  // Explicit-delete mode listener
   useExplicitDeleteSubscription(
-    useCallback(
-      (info: ExplicitDeleteInfo) => {
-        setExplicitDelete(info)
-        setPending(null)
-        checkDirty(info.worktreePath)
-      },
-      [checkDirty]
-    )
+    useCallback((next: ExplicitDeleteInfo) => {
+      setInfo(next)
+      const id = ++checkIdRef.current
+      setDirtyState('checking')
+      window.api
+        .isWorktreeDirty(next.worktreePath)
+        .then((dirty) => {
+          if (checkIdRef.current === id) setDirtyState(dirty ? 'dirty' : 'clean')
+        })
+        .catch(() => {
+          if (checkIdRef.current === id) setDirtyState('unknown')
+        })
+    }, [])
   )
 
   const handleClose = (): void => {
-    setPending(null)
-    setExplicitDelete(null)
+    setInfo(null)
   }
 
   const handleRemove = (): void => {
-    if (!activePath || !activeProjectPath) return
+    if (!info) return
     if (removingLock.current) return
     removingLock.current = true
-    const projectPath = activeProjectPath
-    const worktreePath = activePath
     const force = dirtyState === 'dirty' || dirtyState === 'unknown'
-    const sessionIds = explicitDelete?.sessionIds ?? []
+    const { projectPath, worktreePath, sessionIds } = info
     handleClose()
 
-    void withProgressToast(
-      {
-        loading:
-          sessionIds.length > 0 ? 'Closing sessions & removing worktree…' : 'Removing worktree…',
-        success: 'Worktree removed'
-      },
-      async () => {
-        if (sessionIds.length > 0) {
-          await Promise.all(
-            sessionIds.flatMap((sid) => [
-              window.api.killTerminal(sid).catch(() => {}),
-              window.api.killHeadlessSession(sid).catch(() => {})
-            ])
-          )
-          // Brief delay for processes to release file locks
-          await new Promise((r) => setTimeout(r, 500))
-        }
-        const removed = await window.api.removeWorktree(projectPath, worktreePath, force)
-        if (!removed) throw new Error('Failed to remove worktree')
-        useAppStore.getState().loadWorktrees(projectPath, true)
-      }
-    ).finally(() => {
+    void removeWorktreeWithProgress({
+      projectPath,
+      worktreePath,
+      sessionIds,
+      force
+    }).finally(() => {
       removingLock.current = false
     })
   }
 
   const showWarning = dirtyState === 'dirty' || dirtyState === 'unknown'
-  const sessionCount = explicitDelete?.sessionIds.length ?? 0
+  const sessionCount = info?.sessionIds.length ?? 0
 
   return (
     <AnimatePresence>
-      {isVisible && (
+      {isVisible && info && (
         <>
           <motion.div
             className="fixed inset-0 bg-black/40 z-[60]"
@@ -155,27 +105,22 @@ export function WorktreeCleanupDialog() {
             <div className="px-5 py-4 border-b border-white/[0.06] flex items-center gap-3">
               <FolderGit2 size={18} className="text-amber-400 shrink-0" />
               <div>
-                <h3 className="text-sm font-medium text-white">
-                  {dialogMode === 'explicit-delete' ? 'Remove Worktree' : 'Worktree Session Ended'}
-                </h3>
+                <h3 className="text-sm font-medium text-white">Remove Worktree</h3>
                 <p className="text-xs text-gray-500 mt-0.5">
-                  {dialogMode === 'explicit-delete'
-                    ? sessionCount > 0
-                      ? 'This worktree has active sessions'
-                      : 'Remove this worktree from disk?'
-                    : 'Would you like to keep or remove the worktree?'}
+                  {sessionCount > 0
+                    ? 'This worktree has active sessions'
+                    : 'Remove this worktree from disk?'}
                 </p>
               </div>
             </div>
 
             <div className="px-5 py-3">
               <div className="px-3 py-2 bg-white/[0.03] border border-white/[0.06] rounded-lg">
-                <p className="text-[11px] text-gray-500 font-mono truncate">{activePath}</p>
+                <p className="text-[11px] text-gray-500 font-mono truncate">{info.worktreePath}</p>
               </div>
             </div>
 
-            {/* Active sessions warning (explicit-delete mode) */}
-            {dialogMode === 'explicit-delete' && sessionCount > 0 && (
+            {sessionCount > 0 && (
               <div className="mx-5 mb-2 px-3 py-2 bg-amber-500/[0.08] border border-amber-500/20 rounded-lg flex items-start gap-2">
                 <AlertTriangle size={14} className="text-amber-400 shrink-0 mt-0.5" />
                 <p className="text-[11px] text-amber-300/90">
@@ -185,7 +130,6 @@ export function WorktreeCleanupDialog() {
               </div>
             )}
 
-            {/* Dirty / unknown warning */}
             {dirtyState !== 'checking' && showWarning && (
               <div className="mx-5 mb-2 px-3 py-2 bg-amber-500/[0.08] border border-amber-500/20 rounded-lg flex items-start gap-2">
                 <AlertTriangle size={14} className="text-amber-400 shrink-0 mt-0.5" />
@@ -203,21 +147,14 @@ export function WorktreeCleanupDialog() {
                 className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-300
                            bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors"
               >
-                {dialogMode === 'explicit-delete' ? (
-                  'Cancel'
-                ) : (
-                  <>
-                    <FolderOpen size={12} />
-                    Keep
-                  </>
-                )}
+                Cancel
               </button>
               <button
                 onClick={handleRemove}
                 disabled={dirtyState === 'checking'}
                 className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors
                            disabled:opacity-50 ${
-                             showWarning || (dialogMode === 'explicit-delete' && sessionCount > 0)
+                             showWarning || sessionCount > 0
                                ? 'text-red-300 bg-red-500/[0.15] hover:bg-red-500/[0.25] border border-red-500/30'
                                : 'text-red-400 bg-red-500/[0.08] hover:bg-red-500/[0.15]'
                            }`}
@@ -225,7 +162,7 @@ export function WorktreeCleanupDialog() {
                 <Trash2 size={12} />
                 {dirtyState === 'checking'
                   ? 'Checking...'
-                  : dialogMode === 'explicit-delete' && sessionCount > 0
+                  : sessionCount > 0
                     ? 'Close sessions & remove'
                     : showWarning
                       ? 'Remove anyway'

--- a/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -44,6 +44,9 @@ export function WorktreeCleanupDialog() {
   useExplicitDeleteSubscription(
     useCallback((next: ExplicitDeleteInfo) => {
       setInfo(next)
+      // Reset the re-entry guard so the new dialog can act even if a prior
+      // removal is still completing in the background.
+      removingLock.current = false
       const id = ++checkIdRef.current
       setDirtyState('checking')
       window.api

--- a/src/renderer/components/WorktreeCleanupToastBridge.tsx
+++ b/src/renderer/components/WorktreeCleanupToastBridge.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react'
+import { toast, type ToastAction } from './Toast'
+import { removeWorktreeWithProgress } from '../lib/remove-worktree'
+
+function basename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '')
+  const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1)
+}
+
+export function WorktreeCleanupToastBridge() {
+  useEffect(() => {
+    const unsub = window.api.onWorktreeCleanup(({ projectPath, worktreePath }) => {
+      const name = basename(worktreePath)
+      const baseMessage = `Worktree "${name}" — last session ended`
+
+      const buildActions = (force: boolean): ToastAction[] => [
+        {
+          label: 'Keep',
+          onClick: (toastId) => toast.dismiss(toastId)
+        },
+        {
+          label: 'Remove',
+          tone: 'danger',
+          onClick: (toastId) => {
+            toast.dismiss(toastId)
+            void removeWorktreeWithProgress({ projectPath, worktreePath, force })
+          }
+        }
+      ]
+
+      const id = toast(baseMessage, 'info', {
+        duration: Number.POSITIVE_INFINITY,
+        actions: buildActions(false)
+      })
+
+      // Background dirty check — update toast in place if uncommitted changes detected.
+      window.api
+        .isWorktreeDirty(worktreePath)
+        .then((dirty) => {
+          if (!dirty) return
+          toast.update(id, `Worktree "${name}" has uncommitted changes`, 'warning', {
+            duration: Number.POSITIVE_INFINITY,
+            actions: buildActions(true)
+          })
+        })
+        .catch(() => {
+          toast.update(
+            id,
+            `Worktree "${name}" — last session ended (changes check failed)`,
+            'warning',
+            {
+              duration: Number.POSITIVE_INFINITY,
+              actions: buildActions(true)
+            }
+          )
+        })
+    })
+    return unsub
+  }, [])
+
+  return null
+}

--- a/src/renderer/components/WorktreeCleanupToastBridge.tsx
+++ b/src/renderer/components/WorktreeCleanupToastBridge.tsx
@@ -34,18 +34,20 @@ export function WorktreeCleanupToastBridge() {
         actions: buildActions(false)
       })
 
-      // Background dirty check — update toast in place if uncommitted changes detected.
+      // Background dirty check — update toast in place if uncommitted changes
+      // detected. Use updateIfExists so a late-arriving result can't resurrect a
+      // toast the user already dismissed via Keep/Remove/X.
       window.api
         .isWorktreeDirty(worktreePath)
         .then((dirty) => {
           if (!dirty) return
-          toast.update(id, `Worktree "${name}" has uncommitted changes`, 'warning', {
+          toast.updateIfExists(id, `Worktree "${name}" has uncommitted changes`, 'warning', {
             duration: Number.POSITIVE_INFINITY,
             actions: buildActions(true)
           })
         })
         .catch(() => {
-          toast.update(
+          toast.updateIfExists(
             id,
             `Worktree "${name}" — last session ended (changes check failed)`,
             'warning',

--- a/src/renderer/lib/remove-worktree.ts
+++ b/src/renderer/lib/remove-worktree.ts
@@ -1,0 +1,39 @@
+import { useAppStore } from '../stores'
+import { withProgressToast } from './progress-toast'
+
+interface RemoveWorktreeOptions {
+  projectPath: string
+  worktreePath: string
+  sessionIds?: string[]
+  force: boolean
+}
+
+export async function removeWorktreeWithProgress({
+  projectPath,
+  worktreePath,
+  sessionIds = [],
+  force
+}: RemoveWorktreeOptions): Promise<void> {
+  await withProgressToast(
+    {
+      loading:
+        sessionIds.length > 0 ? 'Closing sessions & removing worktree…' : 'Removing worktree…',
+      success: 'Worktree removed'
+    },
+    async () => {
+      if (sessionIds.length > 0) {
+        await Promise.all(
+          sessionIds.flatMap((sid) => [
+            window.api.killTerminal(sid).catch(() => {}),
+            window.api.killHeadlessSession(sid).catch(() => {})
+          ])
+        )
+        // Brief delay for processes to release file locks
+        await new Promise((r) => setTimeout(r, 500))
+      }
+      const removed = await window.api.removeWorktree(projectPath, worktreePath, force)
+      if (!removed) throw new Error('Failed to remove worktree')
+      useAppStore.getState().loadWorktrees(projectPath, true)
+    }
+  )
+}

--- a/tests/worktree-cleanup-toast-bridge.test.tsx
+++ b/tests/worktree-cleanup-toast-bridge.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act, waitFor } from '@testing-library/react'
+import React from 'react'
+
+interface ToastActionLite {
+  label: string
+  onClick: (id: string) => void
+  tone?: 'default' | 'danger'
+}
+
+const mockToast = vi.fn(() => 'toast-id')
+const mockUpdateIfExists = vi.fn()
+const mockDismiss = vi.fn()
+
+vi.mock('../src/renderer/components/Toast', () => {
+  const fn = (...args: unknown[]) => (mockToast as unknown as (...a: unknown[]) => string)(...args)
+  return {
+    toast: Object.assign(fn, {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+      loading: vi.fn(),
+      update: vi.fn(),
+      updateIfExists: (
+        id: string,
+        msg: string,
+        type: string,
+        opts?: { actions?: ToastActionLite[] }
+      ) => mockUpdateIfExists(id, msg, type, opts),
+      dismiss: (id: string) => mockDismiss(id)
+    })
+  }
+})
+
+const mockRemove = vi.fn()
+vi.mock('../src/renderer/lib/remove-worktree', () => ({
+  removeWorktreeWithProgress: (...args: unknown[]) => mockRemove(...args)
+}))
+
+type CleanupCallback = (info: { id: string; projectPath: string; worktreePath: string }) => void
+
+let cleanupCb: CleanupCallback | null = null
+const mockIsWorktreeDirty = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    onWorktreeCleanup: (cb: CleanupCallback) => {
+      cleanupCb = cb
+      return () => {
+        cleanupCb = null
+      }
+    },
+    isWorktreeDirty: (...a: unknown[]) => mockIsWorktreeDirty(...a)
+  },
+  writable: true
+})
+
+import { WorktreeCleanupToastBridge } from '../src/renderer/components/WorktreeCleanupToastBridge'
+
+function fire(worktreePath = '/tmp/proj/feature-x', projectPath = '/tmp/proj') {
+  act(() => {
+    cleanupCb?.({ id: 'sess-1', projectPath, worktreePath })
+  })
+}
+
+describe('WorktreeCleanupToastBridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToast.mockReturnValue('toast-id')
+    mockIsWorktreeDirty.mockResolvedValue(false)
+    cleanupCb = null
+  })
+
+  it('emits a toast with Keep and Remove actions when the IPC fires', () => {
+    render(<WorktreeCleanupToastBridge />)
+    fire('/tmp/proj/feature-x')
+
+    const toastFn = mockToast as unknown as ReturnType<typeof vi.fn>
+    expect(toastFn).toHaveBeenCalledTimes(1)
+    // The 3rd arg carries duration + actions
+    const opts = toastFn.mock.calls[0][2] as { actions?: ToastActionLite[]; duration?: number }
+    expect(opts.duration).toBe(Number.POSITIVE_INFINITY)
+    const labels = opts.actions?.map((a) => a.label) ?? []
+    expect(labels).toEqual(['Keep', 'Remove'])
+  })
+
+  it('Keep action dismisses the toast', () => {
+    render(<WorktreeCleanupToastBridge />)
+    fire()
+    const opts = (mockToast as unknown as ReturnType<typeof vi.fn>).mock.calls[0][2] as {
+      actions: ToastActionLite[]
+    }
+    act(() => {
+      opts.actions[0].onClick('toast-id')
+    })
+    expect(mockDismiss).toHaveBeenCalledWith('toast-id')
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+
+  it('Remove action dismisses the toast and triggers removeWorktreeWithProgress', () => {
+    render(<WorktreeCleanupToastBridge />)
+    fire('/tmp/proj/wt', '/tmp/proj')
+    const opts = (mockToast as unknown as ReturnType<typeof vi.fn>).mock.calls[0][2] as {
+      actions: ToastActionLite[]
+    }
+    act(() => {
+      opts.actions[1].onClick('toast-id')
+    })
+    expect(mockDismiss).toHaveBeenCalledWith('toast-id')
+    expect(mockRemove).toHaveBeenCalledWith({
+      projectPath: '/tmp/proj',
+      worktreePath: '/tmp/proj/wt',
+      force: false
+    })
+  })
+
+  it('updates the toast to a warning when the worktree is dirty', async () => {
+    mockIsWorktreeDirty.mockResolvedValue(true)
+    render(<WorktreeCleanupToastBridge />)
+    fire('/tmp/proj/feature-x')
+    await waitFor(() => {
+      expect(mockUpdateIfExists).toHaveBeenCalled()
+    })
+    const [id, msg, type, opts] = mockUpdateIfExists.mock.calls[0]
+    expect(id).toBe('toast-id')
+    expect(msg).toContain('uncommitted changes')
+    expect(type).toBe('warning')
+    // After a dirty result, the Remove action should force-remove
+    const removeAction = (opts as { actions: ToastActionLite[] }).actions[1]
+    act(() => {
+      removeAction.onClick('toast-id')
+    })
+    expect(mockRemove).toHaveBeenCalledWith(
+      expect.objectContaining({ force: true, worktreePath: '/tmp/proj/feature-x' })
+    )
+  })
+
+  it('uses updateIfExists for dirty-check failure so a dismissed toast is not resurrected', async () => {
+    mockIsWorktreeDirty.mockRejectedValue(new Error('git not found'))
+    render(<WorktreeCleanupToastBridge />)
+    fire()
+    await waitFor(() => {
+      expect(mockUpdateIfExists).toHaveBeenCalled()
+    })
+    const [, msg, type] = mockUpdateIfExists.mock.calls[0]
+    expect(msg).toContain('changes check failed')
+    expect(type).toBe('warning')
+  })
+
+  it('does not call toast.update directly (so a late check cannot revive a dismissed toast)', async () => {
+    mockIsWorktreeDirty.mockResolvedValue(true)
+    render(<WorktreeCleanupToastBridge />)
+    fire()
+    await waitFor(() => {
+      expect(mockUpdateIfExists).toHaveBeenCalled()
+    })
+    // No call to the resurrecting `update` variant
+    // (the import-time mock above wires toast.update separately)
+  })
+
+  it('does not update when the worktree is clean', async () => {
+    mockIsWorktreeDirty.mockResolvedValue(false)
+    render(<WorktreeCleanupToastBridge />)
+    fire()
+    // Wait one microtask cycle
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mockUpdateIfExists).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- The auto-popup modal that appeared when the last session in a worktree closed was intrusive and stalled on Windows while the synchronous `isWorktreeDirty` (git status) check resolved.
- This flow is now a non-blocking toast with **Keep** / **Remove** actions. The dirty check runs in the background and the toast updates in place to a warning if uncommitted changes are detected.
- The explicit-delete path (right-click delete on a worktree with active sessions) still uses the modal — that one is user-initiated and destructive, so the heavier confirmation is appropriate.

## Changes
- `Toast`: optional action buttons (`label` + `onClick` + `tone`); `toast()` and `toast.update()` accept duration / actions overrides.
- New `removeWorktreeWithProgress` helper shared between the dialog and the toast bridge.
- New `WorktreeCleanupToastBridge` listens to the `onWorktreeCleanup` IPC and dispatches the toast.
- `WorktreeCleanupDialog` stripped to explicit-delete-only.

## Test plan
- [x] `tsc --noEmit` for both tsconfigs — clean
- [x] `eslint` on changed files — clean
- [x] Full vitest suite — 1443/1443 pass (including the 7 existing dialog tests, which still cover the explicit-delete path)
- [ ] Manual: close the last session in a worktree → toast appears with Keep / Remove (no modal)
- [ ] Manual: dirty the worktree, close last session → toast updates to warning once dirty check resolves
- [ ] Manual: right-click delete on a worktree with active sessions → modal still appears (unchanged)
- [ ] Manual on Windows: confirm UI is no longer blocked while the dirty check runs