### PR TITLE
feat(grid): dim non-selected card chrome instead of selection border

### DIFF
--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -67,6 +67,10 @@ export const AgentCard = memo(
 
     const isFocused = focusedId === terminalId
     const isSelected = selectedId === terminalId
+    // Selection is signalled by dimming the chrome (header + status bar) on
+    // every *other* card so the active one stands out by relative brightness,
+    // without painting a border that fights with the terminal contents.
+    const isChromeDimmed = selectedId !== null && !isSelected && !isFocused
 
     const handleExpand = (): void => {
       setFocused(terminalId)
@@ -80,11 +84,9 @@ export const AgentCard = memo(
                    ${
                      isFocused
                        ? 'border-blue-500/60 ring-1 ring-blue-500/30'
-                       : isSelected
-                         ? 'border-white/40 ring-1 ring-white/10'
-                         : isDragTarget
-                           ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
-                           : 'border-white/[0.06] hover:border-white/[0.12]'
+                       : isDragTarget
+                         ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
+                         : 'border-white/[0.06] hover:border-white/[0.12]'
                    }
                    ${
                      flexible
@@ -106,6 +108,7 @@ export const AgentCard = memo(
           onDragStart={onDragStart}
           onDoubleClick={handleExpand}
           revealActions={isTouchDevice}
+          dimmed={isChromeDimmed}
         />
 
         {/* Terminal */}
@@ -165,7 +168,7 @@ export const AgentCard = memo(
           )}
         </div>
 
-        <CardStatusBar terminalId={terminalId} />
+        <CardStatusBar terminalId={terminalId} dimmed={isChromeDimmed} />
 
         {!flexible && <RowResizeHandle />}
       </div>

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -18,6 +18,8 @@ interface Props {
   onDoubleClick?: () => void
   /** Force the action cluster to be visible (e.g. on touch devices where hover is unreliable). */
   revealActions?: boolean
+  /** Visually de-emphasise this header when another card is the active selection. */
+  dimmed?: boolean
 }
 
 export function CardHeader({
@@ -27,7 +29,8 @@ export function CardHeader({
   draggable,
   onDragStart,
   onDoubleClick,
-  revealActions
+  revealActions,
+  dimmed
 }: Props) {
   const { terminal, isRenaming, setRenamingTerminalId, renameTerminal } = useAppStore(
     useShallow((s) => ({
@@ -51,7 +54,9 @@ export function CardHeader({
 
   return (
     <div
-      className="flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0"
+      className={`flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0
+                  transition-opacity duration-200 ease-out
+                  ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
       style={{ background: '#141416' }}
     >
       <div

--- a/src/renderer/components/card/CardStatusBar.tsx
+++ b/src/renderer/components/card/CardStatusBar.tsx
@@ -7,9 +7,11 @@ import { ListTodo } from 'lucide-react'
 
 interface Props {
   terminalId: string
+  /** Visually de-emphasise this status bar when another card is the active selection. */
+  dimmed?: boolean
 }
 
-export function CardStatusBar({ terminalId }: Props) {
+export function CardStatusBar({ terminalId, dimmed }: Props) {
   const { terminal, assignedTask, setEditingTask, setTaskDialogOpen } = useAppStore(
     useShallow((s) => ({
       terminal: s.terminals.get(terminalId),
@@ -27,7 +29,9 @@ export function CardStatusBar({ terminalId }: Props) {
 
   return (
     <div
-      className="shrink-0 flex items-center gap-2 px-2 h-[22px] border-t border-white/[0.04] text-[11px]"
+      className={`shrink-0 flex items-center gap-2 px-2 h-[22px] border-t border-white/[0.04] text-[11px]
+                  transition-opacity duration-200 ease-out
+                  ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
       style={{ background: '#141416' }}
     >
       {hasBranch && <BranchChip terminalId={terminalId} />}


### PR DESCRIPTION
## Summary
- Replace the white border + ring on the keyboard-selected card with a soft 60%-opacity dim on the header and status bar of every *other* card.
- Hover on a dimmed card restores full opacity (200ms ease).
- The active selection now stands out by relative brightness instead of painting a hard outline over the console.
- The blue ring on `isFocused` (expanded mode) is unchanged — it's a distinct render path.

## Test plan
- [x] Grid view: keyboard-navigate between cards — non-selected cards' top bar and status bar dim; hover restores them
- [x] Selection still legible against the terminal contents
- [x] Expanded/focused card still shows the blue ring
- [x] `yarn typecheck` / `yarn lint` pass