### PR TITLE
feat(files): chevron-only tree, stacked split, filter, inline edit

### DIFF
--- a/packages/server/src/file-utils.ts
+++ b/packages/server/src/file-utils.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { FileEntry, RemoteHost } from '@vornrun/shared/types'
-import { sshExecSync, shellEscape, getSafeEnv } from './process-utils'
+import { sshExecSync, shellEscape, getSafeEnv, buildSshArgs } from './process-utils'
 import { resolveExecutable } from './resolve-executable'
 
 const execFileAsync = promisify(execFile)
@@ -201,5 +201,41 @@ function readFileContentRemote(
     return text
   } catch {
     return null
+  }
+}
+
+export function writeFileContent(
+  filePath: string,
+  content: string,
+  remote?: RemoteHost
+): { success: boolean; error?: string } {
+  if (remote) return writeFileContentRemote(filePath, content, remote)
+  try {
+    fs.writeFileSync(filePath, content, 'utf-8')
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function writeFileContentRemote(
+  filePath: string,
+  content: string,
+  remote: RemoteHost
+): { success: boolean; error?: string } {
+  try {
+    // Pipe content via stdin to avoid argv length limits and quoting pitfalls.
+    const sshArgs = buildSshArgs(remote)
+    sshArgs.push(`cat > ${shellEscape(filePath, 'posix')}`)
+    execFileSync('ssh', sshArgs, {
+      input: content,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+      env: getSafeEnv(),
+      maxBuffer: 16 * 1024 * 1024
+    })
+    return { success: true }
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) }
   }
 }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -28,7 +28,7 @@ import {
 } from '@vornrun/shared/types'
 import type { SourceConnection, TaskStatus } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
-import { listDir, readFileContent } from './file-utils'
+import { listDir, readFileContent, writeFileContent } from './file-utils'
 import {
   saveTaskImage,
   saveTaskImageFromBase64,
@@ -592,6 +592,10 @@ export function registerAllMethods(): void {
   registerMethod('file:readContent', ({ filePath, maxBytes, remoteHostId }) => {
     const remote = remoteHostId ? resolveRemoteHostById(remoteHostId) : undefined
     return readFileContent(filePath, maxBytes, remote)
+  })
+  registerMethod('file:writeContent', ({ filePath, content, remoteHostId }) => {
+    const remote = remoteHostId ? resolveRemoteHostById(remoteHostId) : undefined
+    return writeFileContent(filePath, content, remote)
   })
 
   // SSH

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -194,6 +194,10 @@ export interface RequestMethods {
     params: { filePath: string; maxBytes?: number; remoteHostId?: string }
     result: string | null
   }
+  'file:writeContent': {
+    params: { filePath: string; content: string; remoteHostId?: string }
+    result: { success: boolean; error?: string }
+  }
 
   // Connectors
   'connector:list': {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -923,6 +923,7 @@ export const IPC = {
   OPEN_EXTERNAL: 'shell:openExternal',
   FILE_LIST_DIR: 'file:listDir',
   FILE_READ_CONTENT: 'file:readContent',
+  FILE_WRITE_CONTENT: 'file:writeContent',
   CONNECTOR_LIST: 'connector:list',
   CONNECTOR_GET: 'connector:get',
   CONNECTION_LIST: 'connection:list',

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -159,6 +159,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.FILE_READ_CONTENT, (_, params) =>
     requireBridge().request(IPC.FILE_READ_CONTENT, params)
   )
+  safeHandle(IPC.FILE_WRITE_CONTENT, (_, params) =>
+    requireBridge().request(IPC.FILE_WRITE_CONTENT, params)
+  )
 
   // Tailscale
   safeHandle(IPC.TAILSCALE_STATUS, () => requireBridge().request(IPC.TAILSCALE_STATUS))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -185,6 +185,12 @@ const api = {
     remoteHostId?: string
   ): Promise<string | null> =>
     ipcRenderer.invoke(IPC.FILE_READ_CONTENT, { filePath, maxBytes, remoteHostId }),
+  writeFileContent: (
+    filePath: string,
+    content: string,
+    remoteHostId?: string
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IPC.FILE_WRITE_CONTENT, { filePath, content, remoteHostId }),
 
   // Task images
   openImageDialog: (): Promise<string[] | null> => ipcRenderer.invoke(IPC.DIALOG_OPEN_IMAGE),

--- a/src/renderer/components/FileTreeExplorer.tsx
+++ b/src/renderer/components/FileTreeExplorer.tsx
@@ -1,20 +1,69 @@
 import { useState, useEffect, useCallback, useMemo, useRef, type JSX } from 'react'
 import type { FileEntry } from '../../shared/types'
-import { ChevronRight, Loader2, X, Folder, FolderOpen } from 'lucide-react'
+import { ChevronRight, Loader2, X, Search, Pencil, Save } from 'lucide-react'
 import { FileTypeIcon } from './file-icons'
 
 const MAX_PREVIEW_LINES = 2000
 const ROW_HEIGHT = 22 // px — matches VS Code's tree item height
 const INDENT_WIDTH = 16 // px per depth level
 const BASE_LEFT = 8 // px left gutter
+const SPLIT_RATIO_KEY = 'vorn:files-split-ratio'
+const MIN_RATIO = 0.15
+const MAX_RATIO = 0.85
+const DEFAULT_RATIO = 0.5
 
+// ---------------------------------------------------------------------------
+// Filter helpers
+// ---------------------------------------------------------------------------
+function computeFilterSets(
+  rootEntries: FileEntry[],
+  dirCache: Map<string, FileEntry[]>,
+  filter: string
+): { matched: Set<string>; expand: Set<string> } {
+  const matched = new Set<string>()
+  const expand = new Set<string>()
+  if (!filter) return { matched, expand }
+  const lc = filter.toLowerCase()
+
+  function visit(entry: FileEntry): boolean {
+    const selfMatch = entry.name.toLowerCase().includes(lc)
+    if (entry.isDirectory) {
+      let descendantMatch = false
+      const children = dirCache.get(entry.path)
+      if (children) {
+        for (const child of children) {
+          if (visit(child)) descendantMatch = true
+        }
+      }
+      if (descendantMatch) expand.add(entry.path)
+      if (selfMatch || descendantMatch) {
+        matched.add(entry.path)
+        return true
+      }
+      return false
+    } else {
+      if (selfMatch) matched.add(entry.path)
+      return selfMatch
+    }
+  }
+
+  for (const e of rootEntries) visit(e)
+  return { matched, expand }
+}
+
+// ---------------------------------------------------------------------------
+// Tree node
+// ---------------------------------------------------------------------------
 function TreeNode({
   entry,
   depth,
   dirCache,
   loadDir,
   selectedFile,
-  onSelectFile
+  onSelectFile,
+  filter,
+  matched,
+  forceExpand
 }: {
   entry: FileEntry
   depth: number
@@ -22,11 +71,17 @@ function TreeNode({
   loadDir: (path: string) => Promise<void>
   selectedFile: string | null
   onSelectFile: (path: string) => void
+  filter: string
+  matched: Set<string>
+  forceExpand: Set<string>
 }) {
   const [expanded, setExpanded] = useState(false)
   const [loading, setLoading] = useState(false)
 
-  const handleToggle = async () => {
+  const filterActive = filter.length > 0
+  if (filterActive && !matched.has(entry.path)) return null
+
+  const handleToggle = async (): Promise<void> => {
     if (!entry.isDirectory) return
     if (!expanded && !dirCache.has(entry.path)) {
       setLoading(true)
@@ -36,11 +91,12 @@ function TreeNode({
     setExpanded(!expanded)
   }
 
+  const effectivelyExpanded = expanded || (filterActive && forceExpand.has(entry.path))
   const children = dirCache.get(entry.path)
   const isSelected = !entry.isDirectory && selectedFile === entry.path
 
   // Indent guides: one vertical line per depth level
-  const guides = []
+  const guides: JSX.Element[] = []
   for (let i = 0; i < depth; i++) {
     guides.push(
       <span
@@ -71,18 +127,13 @@ function TreeNode({
             <ChevronRight
               size={14}
               strokeWidth={2}
-              className={`text-gray-500 shrink-0 transition-transform duration-100 ${expanded ? 'rotate-90' : ''}`}
+              className={`text-gray-500 shrink-0 transition-transform duration-100 ${effectivelyExpanded ? 'rotate-90' : ''}`}
               style={{ width: 14, height: 14 }}
             />
           )}
-          {expanded ? (
-            <FolderOpen size={14} strokeWidth={1.2} className="text-gray-500 shrink-0" />
-          ) : (
-            <Folder size={14} strokeWidth={1.2} className="text-gray-500 shrink-0" />
-          )}
           <span className="truncate text-gray-300 leading-none">{entry.name}</span>
         </button>
-        {expanded && children && (
+        {effectivelyExpanded && children && (
           <div>
             {children.map((child) => (
               <TreeNode
@@ -93,6 +144,9 @@ function TreeNode({
                 loadDir={loadDir}
                 selectedFile={selectedFile}
                 onSelectFile={onSelectFile}
+                filter={filter}
+                matched={matched}
+                forceExpand={forceExpand}
               />
             ))}
             {children.length === 0 && (
@@ -103,7 +157,6 @@ function TreeNode({
                   paddingLeft: `${BASE_LEFT + (depth + 1) * INDENT_WIDTH + 16}px`
                 }}
               >
-                {/* Indent guides for empty message */}
                 {[
                   ...guides,
                   <span
@@ -281,14 +334,46 @@ function useHighlightedLines(text: string, fileName: string): TokenLine[] | null
     }
   }, [text, lang, key])
 
-  // Only return tokens if they match the current file
   if (!lang || !result || result.key !== key) return null
   return result.tokens
 }
 
-function LineRow({ lineNum, children }: { lineNum: number; children: React.ReactNode }) {
+// ---------------------------------------------------------------------------
+// Find-in-file
+// ---------------------------------------------------------------------------
+type FindMatch = { line: number; start: number; end: number }
+
+function computeMatches(lines: string[], query: string): FindMatch[] {
+  if (!query) return []
+  const lc = query.toLowerCase()
+  const out: FindMatch[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const lower = lines[i].toLowerCase()
+    let from = 0
+    while (from <= lower.length - lc.length) {
+      const idx = lower.indexOf(lc, from)
+      if (idx < 0) break
+      out.push({ line: i, start: idx, end: idx + lc.length })
+      from = idx + lc.length
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Line row
+// ---------------------------------------------------------------------------
+function LineRow({
+  lineNum,
+  children,
+  rowRef
+}: {
+  lineNum: number
+  children: React.ReactNode
+  rowRef?: (el: HTMLDivElement | null) => void
+}) {
   return (
-    <div className="flex select-text hover:bg-white/[0.02]">
+    <div ref={rowRef} className="flex select-text hover:bg-white/[0.02]">
       <span className="w-[40px] shrink-0 text-right pr-3 text-[11px] text-gray-600 select-none">
         {lineNum}
       </span>
@@ -297,25 +382,115 @@ function LineRow({ lineNum, children }: { lineNum: number; children: React.React
   )
 }
 
-function FilePreview({
+// Render a line of plain text with `<mark>` overlays at the given match ranges.
+function renderLineWithMarks(
+  line: string,
+  marks: { start: number; end: number; active: boolean }[]
+): JSX.Element[] {
+  if (marks.length === 0) return [<span key="t">{line || ' '}</span>]
+  const out: JSX.Element[] = []
+  let cursor = 0
+  marks.forEach((m, i) => {
+    if (m.start > cursor) out.push(<span key={`p${i}`}>{line.slice(cursor, m.start)}</span>)
+    out.push(
+      <span
+        key={`m${i}`}
+        className={
+          m.active
+            ? 'bg-amber-300/70 text-black rounded-[1px]'
+            : 'bg-amber-300/25 text-gray-100 rounded-[1px]'
+        }
+      >
+        {line.slice(m.start, m.end)}
+      </span>
+    )
+    cursor = m.end
+  })
+  if (cursor < line.length) out.push(<span key="tail">{line.slice(cursor)}</span>)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Read view
+// ---------------------------------------------------------------------------
+function ReadView({
   filePath,
   content,
-  onClose
+  findQuery,
+  activeMatchIdx,
+  onMatchesComputed
 }: {
   filePath: string
   content: string
-  onClose: () => void
+  findQuery: string
+  activeMatchIdx: number
+  onMatchesComputed: (count: number) => void
 }) {
   const allLines = useMemo(() => content.split('\n'), [content])
   const fileName = filePath.split(/[/\\]/).pop() || filePath
   const capped = allLines.length > MAX_PREVIEW_LINES
-  const visibleText = useMemo(
-    () => (capped ? allLines.slice(0, MAX_PREVIEW_LINES).join('\n') : content),
-    [allLines, capped, content]
+  const visibleLines = useMemo(
+    () => (capped ? allLines.slice(0, MAX_PREVIEW_LINES) : allLines),
+    [allLines, capped]
   )
+  const visibleText = useMemo(() => visibleLines.join('\n'), [visibleLines])
   const highlighted = useHighlightedLines(visibleText, fileName)
 
+  const matches = useMemo(() => computeMatches(visibleLines, findQuery), [visibleLines, findQuery])
+  const matchesByLine = useMemo(() => {
+    const m = new Map<number, FindMatch[]>()
+    matches.forEach((mm) => {
+      const arr = m.get(mm.line) ?? []
+      arr.push(mm)
+      m.set(mm.line, arr)
+    })
+    return m
+  }, [matches])
+
+  useEffect(() => {
+    onMatchesComputed(matches.length)
+  }, [matches.length, onMatchesComputed])
+
+  const rowRefs = useRef(new Map<number, HTMLDivElement | null>())
+
+  useEffect(() => {
+    if (matches.length === 0) return
+    const m = matches[activeMatchIdx % matches.length]
+    if (!m) return
+    const el = rowRefs.current.get(m.line)
+    el?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  }, [activeMatchIdx, matches])
+
+  const findActive = findQuery.length > 0
+  const activeMatch =
+    findActive && matches.length > 0 ? matches[activeMatchIdx % matches.length] : null
+
   const renderedLines = useMemo<JSX.Element[]>(() => {
+    if (findActive) {
+      return visibleLines.map((line, i) => {
+        const lm = matchesByLine.get(i) ?? []
+        const marks = lm.map((m) => ({
+          start: m.start,
+          end: m.end,
+          active: !!activeMatch && activeMatch.line === i && activeMatch.start === m.start
+        }))
+        return (
+          <LineRow
+            key={i}
+            lineNum={i + 1}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set(i, el)
+              else rowRefs.current.delete(i)
+            }}
+          >
+            <span className="text-gray-300 px-1 flex-1 whitespace-pre">
+              {renderLineWithMarks(line, marks)}
+            </span>
+          </LineRow>
+        )
+      })
+    }
+
     if (highlighted) {
       return highlighted.map((tokens, i) => (
         <LineRow key={i} lineNum={i + 1}>
@@ -331,46 +506,491 @@ function FilePreview({
       ))
     }
 
-    const plain = capped ? allLines.slice(0, MAX_PREVIEW_LINES) : allLines
-    return plain.map((line, i) => (
+    return visibleLines.map((line, i) => (
       <LineRow key={i} lineNum={i + 1}>
         <span className="text-gray-400 px-1 flex-1 whitespace-pre">{line || ' '}</span>
       </LineRow>
     ))
-  }, [allLines, capped, highlighted])
+  }, [findActive, visibleLines, highlighted, matchesByLine, activeMatch])
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 border-t border-white/[0.06]">
+    <div className="flex-1 overflow-y-auto">
+      <pre className="text-[12px] leading-[1.6] font-mono">
+        {renderedLines}
+        {capped && (
+          <div className="px-3 py-2 text-[11px] text-gray-600 italic">
+            Showing first {MAX_PREVIEW_LINES} of {allLines.length} lines
+          </div>
+        )}
+      </pre>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Edit view
+// ---------------------------------------------------------------------------
+function EditView({
+  draft,
+  onChange,
+  onSaveShortcut
+}: {
+  draft: string
+  onChange: (next: string) => void
+  onSaveShortcut: () => void
+}) {
+  const lineCount = useMemo(() => draft.split('\n').length, [draft])
+  const gutter = useMemo(
+    () => Array.from({ length: lineCount }, (_, i) => i + 1).join('\n'),
+    [lineCount]
+  )
+
+  return (
+    <div className="flex-1 overflow-auto flex">
+      <pre
+        className="select-none text-right pr-3 pl-2 py-1 text-[11px] leading-[1.6] font-mono text-gray-600 shrink-0"
+        aria-hidden="true"
+      >
+        {gutter}
+      </pre>
+      <textarea
+        value={draft}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+            e.preventDefault()
+            onSaveShortcut()
+          }
+        }}
+        spellCheck={false}
+        className="flex-1 bg-transparent text-gray-200 text-[12px] leading-[1.6] font-mono outline-none resize-none whitespace-pre py-1 pr-3"
+        style={{ minHeight: '100%' }}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// File panel
+// ---------------------------------------------------------------------------
+function FilePanel({
+  cwd,
+  filePath,
+  content,
+  loading,
+  isBinary,
+  onClose,
+  onContentSaved,
+  remoteHostId,
+  dirtyRef
+}: {
+  cwd: string
+  filePath: string
+  content: string | null
+  loading: boolean
+  isBinary: boolean
+  onClose: () => void
+  onContentSaved: (next: string) => void
+  remoteHostId?: string
+  dirtyRef: React.MutableRefObject<boolean>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const [findOpen, setFindOpen] = useState(false)
+  const [findQuery, setFindQuery] = useState('')
+  const [findCount, setFindCount] = useState(0)
+  const [findIdx, setFindIdx] = useState(0)
+  const findInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Reset transient state when file changes
+  useEffect(() => {
+    setEditing(false)
+    setDraft('')
+    setSaveError(null)
+    setFindOpen(false)
+    setFindQuery('')
+    setFindIdx(0)
+  }, [filePath])
+
+  useEffect(() => {
+    if (findOpen) findInputRef.current?.focus()
+  }, [findOpen])
+
+  const fileName = filePath.split(/[/\\]/).pop() || filePath
+  const relPath = useMemo(() => {
+    if (cwd && filePath.startsWith(cwd)) {
+      const rel = filePath.slice(cwd.length).replace(/^[\\/]+/, '')
+      return rel || fileName
+    }
+    return filePath
+  }, [filePath, cwd, fileName])
+
+  const dirty = editing && content !== null && draft !== content
+  const canEdit = !isBinary && content !== null && !loading
+  const canFind = canEdit && !editing
+
+  useEffect(() => {
+    dirtyRef.current = dirty
+    return () => {
+      dirtyRef.current = false
+    }
+  }, [dirty, dirtyRef])
+
+  const handleStartEdit = (): void => {
+    if (!canEdit || content === null) return
+    setDraft(content)
+    setEditing(true)
+    setSaveError(null)
+  }
+
+  const handleCancelEdit = (): void => {
+    if (dirty && !window.confirm('Discard unsaved changes?')) return
+    setEditing(false)
+    setDraft('')
+    setSaveError(null)
+  }
+
+  const handleSave = useCallback(async (): Promise<void> => {
+    if (!editing) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await window.api.writeFileContent(filePath, draft, remoteHostId)
+      if (!res.success) {
+        setSaveError(res.error || 'Failed to save')
+        return
+      }
+      onContentSaved(draft)
+      setEditing(false)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [filePath, editing, draft, remoteHostId, onContentSaved])
+
+  const handleToggleFind = (): void => {
+    if (!canFind) return
+    setFindOpen((v) => !v)
+  }
+
+  const cycleMatch = (delta: number): void => {
+    if (findCount === 0) return
+    setFindIdx((i) => (i + delta + findCount) % findCount)
+  }
+
+  const onMatchesComputed = useCallback((count: number) => {
+    setFindCount(count)
+    setFindIdx((i) => (count === 0 ? 0 : Math.min(i, count - 1)))
+  }, [])
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <PanelHeader title="File" onClose={onClose} />
+
+      {/* Path strip + toolbar */}
       <div
-        className="sticky top-0 z-10 flex items-center gap-2 px-3 py-1.5 text-[12px] font-mono
-                    border-b border-white/[0.06] shrink-0"
+        className="flex items-center gap-2 px-3 py-1 text-[11px] font-mono border-b border-white/[0.06] shrink-0"
         style={{ background: '#1e1e22' }}
       >
-        <FileTypeIcon name={fileName} size={14} />
-        <span className="text-gray-300 flex-1 min-w-0 truncate">{fileName}</span>
-        <span className="text-gray-600 text-[11px] shrink-0">{allLines.length} lines</span>
+        <FileTypeIcon name={fileName} size={12} />
+        <span className="text-gray-400 flex-1 min-w-0 truncate" title={filePath} dir="rtl">
+          {relPath}
+        </span>
+        {dirty && (
+          <span
+            className="w-[6px] h-[6px] rounded-full bg-amber-400 shrink-0"
+            title="Unsaved changes"
+          />
+        )}
+        <ToolbarBtn
+          icon={Search}
+          label="Find in file"
+          active={findOpen}
+          disabled={!canFind}
+          onClick={handleToggleFind}
+        />
+        {editing ? (
+          <>
+            <ToolbarBtn
+              icon={Save}
+              label={saving ? 'Saving…' : 'Save (⌘S)'}
+              disabled={!dirty || saving}
+              onClick={handleSave}
+            />
+            <ToolbarBtn icon={X} label="Cancel edit" onClick={handleCancelEdit} />
+          </>
+        ) : (
+          <ToolbarBtn icon={Pencil} label="Edit" disabled={!canEdit} onClick={handleStartEdit} />
+        )}
+      </div>
+
+      {/* Find bar */}
+      {findOpen && canFind && (
+        <div
+          className="flex items-center gap-2 px-3 py-1 text-[11px] border-b border-white/[0.06] shrink-0"
+          style={{ background: '#1a1a1d' }}
+        >
+          <Search size={12} className="text-gray-500 shrink-0" />
+          <input
+            ref={findInputRef}
+            value={findQuery}
+            onChange={(e) => {
+              setFindQuery(e.target.value)
+              setFindIdx(0)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                cycleMatch(e.shiftKey ? -1 : 1)
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                setFindOpen(false)
+                setFindQuery('')
+              }
+            }}
+            placeholder="Find in file"
+            className="flex-1 bg-transparent text-gray-200 outline-none text-[12px] font-mono"
+          />
+          <span className="text-gray-500 shrink-0 tabular-nums">
+            {findCount === 0 ? '0/0' : `${findIdx + 1}/${findCount}`}
+          </span>
+          <button
+            onClick={() => cycleMatch(-1)}
+            disabled={findCount === 0}
+            className="text-gray-500 hover:text-white px-1 disabled:opacity-40"
+            title="Previous (Shift+Enter)"
+          >
+            ↑
+          </button>
+          <button
+            onClick={() => cycleMatch(1)}
+            disabled={findCount === 0}
+            className="text-gray-500 hover:text-white px-1 disabled:opacity-40"
+            title="Next (Enter)"
+          >
+            ↓
+          </button>
+          <button
+            onClick={() => {
+              setFindOpen(false)
+              setFindQuery('')
+            }}
+            className="text-gray-500 hover:text-white p-0.5"
+            title="Close (Esc)"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      )}
+
+      {/* Body */}
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <Loader2 size={16} className="text-gray-500 animate-spin" />
+        </div>
+      ) : isBinary ? (
+        <div className="flex-1 flex items-center justify-center text-gray-600 text-[12px]">
+          Binary file — preview unavailable
+        </div>
+      ) : editing ? (
+        <EditView draft={draft} onChange={setDraft} onSaveShortcut={handleSave} />
+      ) : content !== null ? (
+        <ReadView
+          filePath={filePath}
+          content={content}
+          findQuery={findOpen ? findQuery : ''}
+          activeMatchIdx={findIdx}
+          onMatchesComputed={onMatchesComputed}
+        />
+      ) : null}
+
+      {saveError && (
+        <div
+          className="px-3 py-1 text-[11px] text-red-400 border-t border-white/[0.06] shrink-0"
+          style={{ background: '#2a1a1a' }}
+        >
+          {saveError}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ToolbarBtn({
+  icon: Icon,
+  label,
+  active,
+  disabled,
+  onClick
+}: {
+  icon: typeof Search
+  label: string
+  active?: boolean
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={label}
+      aria-label={label}
+      className={`p-1 rounded transition-colors shrink-0 ${
+        disabled
+          ? 'text-gray-700 cursor-not-allowed'
+          : active
+            ? 'text-gray-100 bg-white/[0.08]'
+            : 'text-gray-500 hover:text-gray-200 hover:bg-white/[0.05]'
+      }`}
+    >
+      <Icon size={12} strokeWidth={2} />
+    </button>
+  )
+}
+
+function PanelHeader({ title, onClose }: { title: string; onClose?: () => void }) {
+  return (
+    <div
+      className="flex items-center px-3 py-1.5 border-b border-white/[0.06] shrink-0 text-[12px]"
+      style={{ background: '#17171a' }}
+    >
+      <span className="flex-1 text-gray-300 font-medium">{title}</span>
+      {onClose && (
         <button
           onClick={onClose}
-          className="text-gray-600 hover:text-white p-0.5 rounded transition-colors shrink-0"
+          className="text-gray-600 hover:text-white p-0.5 rounded transition-colors"
+          aria-label={`Close ${title}`}
         >
           <X size={12} strokeWidth={2} />
         </button>
-      </div>
+      )}
+    </div>
+  )
+}
 
-      <div className="flex-1 overflow-y-auto">
-        <pre className="text-[12px] leading-[1.6] font-mono">
-          {renderedLines}
-          {capped && (
-            <div className="px-3 py-2 text-[11px] text-gray-600 italic">
-              Showing first {MAX_PREVIEW_LINES} of {allLines.length} lines
-            </div>
+// ---------------------------------------------------------------------------
+// Files panel (header + filter + tree)
+// ---------------------------------------------------------------------------
+function FilesPanel({
+  rootEntries,
+  dirCache,
+  loadDir,
+  selectedFile,
+  onSelectFile
+}: {
+  rootEntries: FileEntry[]
+  dirCache: Map<string, FileEntry[]>
+  loadDir: (path: string) => Promise<void>
+  selectedFile: string | null
+  onSelectFile: (path: string) => void
+}) {
+  const [filter, setFilter] = useState('')
+  const { matched, expand } = useMemo(
+    () => computeFilterSets(rootEntries, dirCache, filter),
+    [rootEntries, dirCache, filter]
+  )
+
+  return (
+    <div className="flex flex-col min-h-0 h-full">
+      <PanelHeader title="Files" />
+      <div className="px-2 py-1.5 border-b border-white/[0.06] shrink-0">
+        <div className="flex items-center gap-1.5 px-2 py-1 rounded bg-white/[0.04] focus-within:bg-white/[0.06]">
+          <Search size={12} className="text-gray-600 shrink-0" />
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setFilter('')
+            }}
+            placeholder="Filter files…"
+            className="flex-1 bg-transparent text-gray-200 outline-none text-[12px] placeholder:text-gray-600"
+          />
+          {filter && (
+            <button
+              onClick={() => setFilter('')}
+              className="text-gray-600 hover:text-white p-0.5"
+              aria-label="Clear filter"
+            >
+              <X size={11} />
+            </button>
           )}
-        </pre>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto py-0.5">
+        {rootEntries.map((entry) => (
+          <TreeNode
+            key={entry.path}
+            entry={entry}
+            depth={0}
+            dirCache={dirCache}
+            loadDir={loadDir}
+            selectedFile={selectedFile}
+            onSelectFile={onSelectFile}
+            filter={filter}
+            matched={matched}
+            forceExpand={expand}
+          />
+        ))}
+        {filter && matched.size === 0 && (
+          <div className="px-3 py-2 text-[11px] text-gray-600 italic">No matching files loaded</div>
+        )}
       </div>
     </div>
   )
 }
 
+// ---------------------------------------------------------------------------
+// Stacked split divider
+// ---------------------------------------------------------------------------
+function SplitDivider({
+  containerRef,
+  onRatioChange,
+  onRatioCommit
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>
+  onRatioChange: (ratio: number) => void
+  onRatioCommit: (ratio: number) => void
+}) {
+  const handlePointerDown = (e: React.PointerEvent): void => {
+    e.preventDefault()
+    const container = containerRef.current
+    if (!container) return
+    const rect = container.getBoundingClientRect()
+    let lastRatio: number | null = null
+
+    const onMove = (ev: PointerEvent): void => {
+      const y = ev.clientY - rect.top
+      const ratio = Math.max(MIN_RATIO, Math.min(MAX_RATIO, y / rect.height))
+      lastRatio = ratio
+      onRatioChange(ratio)
+    }
+    const onUp = (): void => {
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onUp)
+      if (lastRatio !== null) onRatioCommit(lastRatio)
+    }
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onUp)
+  }
+
+  return (
+    <div
+      onPointerDown={handlePointerDown}
+      className="h-1 cursor-row-resize hover:bg-blue-500/30 transition-colors shrink-0"
+      style={{ background: 'rgba(255,255,255,0.06)' }}
+      aria-label="Resize files / file panels"
+      role="separator"
+    />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestrator
+// ---------------------------------------------------------------------------
 export function FileTreeExplorer({ cwd, remoteHostId }: { cwd: string; remoteHostId?: string }) {
   const [rootEntries, setRootEntries] = useState<FileEntry[] | null>(null)
   const [loading, setLoading] = useState(true)
@@ -378,7 +998,26 @@ export function FileTreeExplorer({ cwd, remoteHostId }: { cwd: string; remoteHos
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [fileLoading, setFileLoading] = useState(false)
+  const [isBinary, setIsBinary] = useState(false)
   const activeRequestRef = useRef<string | null>(null)
+  const dirtyRef = useRef(false)
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [splitRatio, setSplitRatio] = useState<number>(() => {
+    if (typeof localStorage === 'undefined') return DEFAULT_RATIO
+    const stored = localStorage.getItem(SPLIT_RATIO_KEY)
+    const n = stored ? Number(stored) : NaN
+    if (!Number.isFinite(n)) return DEFAULT_RATIO
+    return Math.max(MIN_RATIO, Math.min(MAX_RATIO, n))
+  })
+
+  const persistRatio = useCallback((next: number): void => {
+    try {
+      localStorage.setItem(SPLIT_RATIO_KEY, String(next))
+    } catch {
+      /* ignore quota errors */
+    }
+  }, [])
 
   useEffect(() => {
     let stale = false
@@ -416,21 +1055,36 @@ export function FileTreeExplorer({ cwd, remoteHostId }: { cwd: string; remoteHos
   const handleSelectFile = useCallback(
     async (filePath: string) => {
       if (filePath === activeRequestRef.current) return
+      if (dirtyRef.current && !window.confirm('Discard unsaved changes?')) return
       activeRequestRef.current = filePath
       setSelectedFile(filePath)
+      setFileContent(null)
+      setIsBinary(false)
       setFileLoading(true)
       const content = await window.api.readFileContent(filePath, undefined, remoteHostId)
       if (activeRequestRef.current !== filePath) return
-      setFileContent(content)
+      if (content === null) {
+        setIsBinary(true)
+        setFileContent(null)
+      } else {
+        setIsBinary(false)
+        setFileContent(content)
+      }
       setFileLoading(false)
     },
     [remoteHostId]
   )
 
   const handleClosePreview = useCallback(() => {
+    if (dirtyRef.current && !window.confirm('Discard unsaved changes?')) return
     activeRequestRef.current = null
     setSelectedFile(null)
     setFileContent(null)
+    setIsBinary(false)
+  }, [])
+
+  const handleContentSaved = useCallback((next: string) => {
+    setFileContent(next)
   }, [])
 
   if (loading) {
@@ -449,40 +1103,52 @@ export function FileTreeExplorer({ cwd, remoteHostId }: { cwd: string; remoteHos
     )
   }
 
-  const showPreview = selectedFile && (fileContent !== null || fileLoading)
+  const showFilePanel = selectedFile !== null
 
   return (
-    <div className="flex-1 flex flex-col min-h-0">
-      <div className={`overflow-y-auto py-0.5 ${showPreview ? 'max-h-[50%]' : 'flex-1'}`}>
-        {rootEntries.map((entry) => (
-          <TreeNode
-            key={entry.path}
-            entry={entry}
-            depth={0}
-            dirCache={dirCache}
-            loadDir={loadDir}
-            selectedFile={selectedFile}
-            onSelectFile={handleSelectFile}
-          />
-        ))}
+    <div ref={containerRef} className="flex-1 flex flex-col min-h-0">
+      <div
+        className="flex flex-col min-h-0"
+        style={
+          showFilePanel
+            ? { flex: `${splitRatio} 1 0`, minHeight: 0 }
+            : { flex: '1 1 0', minHeight: 0 }
+        }
+      >
+        <FilesPanel
+          rootEntries={rootEntries}
+          dirCache={dirCache}
+          loadDir={loadDir}
+          selectedFile={selectedFile}
+          onSelectFile={handleSelectFile}
+        />
       </div>
 
-      {showPreview &&
-        (fileLoading ? (
-          <div className="flex-1 flex items-center justify-center border-t border-white/[0.06]">
-            <Loader2 size={16} className="text-gray-500 animate-spin" />
-          </div>
-        ) : fileContent !== null ? (
-          <FilePreview
-            filePath={selectedFile!}
-            content={fileContent}
-            onClose={handleClosePreview}
+      {showFilePanel && (
+        <>
+          <SplitDivider
+            containerRef={containerRef}
+            onRatioChange={setSplitRatio}
+            onRatioCommit={persistRatio}
           />
-        ) : (
-          <div className="flex-1 flex items-center justify-center border-t border-white/[0.06] text-gray-600 text-[12px]">
-            Binary file — preview unavailable
+          <div
+            className="flex flex-col min-h-0"
+            style={{ flex: `${1 - splitRatio} 1 0`, minHeight: 0 }}
+          >
+            <FilePanel
+              cwd={cwd}
+              filePath={selectedFile}
+              content={fileContent}
+              loading={fileLoading}
+              isBinary={isBinary}
+              onClose={handleClosePreview}
+              onContentSaved={handleContentSaved}
+              remoteHostId={remoteHostId}
+              dirtyRef={dirtyRef}
+            />
           </div>
-        ))}
+        </>
+      )}
     </div>
   )
 }

--- a/tests/file-tree-explorer.test.tsx
+++ b/tests/file-tree-explorer.test.tsx
@@ -1,0 +1,300 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { FileEntry } from '../src/shared/types'
+
+// Replace Node's experimental localStorage (which needs a file path)
+// with an in-memory shim so the component's getItem/setItem work in tests.
+{
+  const store = new Map<string, string>()
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size
+      }
+    }
+  })
+}
+
+// Stub shiki so highlightCode resolves without WASM in jsdom.
+vi.mock('shiki', () => ({
+  createHighlighter: async () => ({
+    loadLanguage: async () => undefined,
+    codeToTokens: () => ({ tokens: [] })
+  }),
+  createJavaScriptRegexEngine: () => ({})
+}))
+
+// jsdom doesn't implement scrollIntoView; the find-cycle effect calls it.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {}
+}
+
+const mockListDir = vi.fn<(path: string) => Promise<FileEntry[]>>()
+const mockReadFileContent = vi.fn<(path: string) => Promise<string | null>>()
+const mockWriteFileContent =
+  vi.fn<(path: string, content: string) => Promise<{ success: boolean; error?: string }>>()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    listDir: (...args: unknown[]) => mockListDir(...(args as [string])),
+    readFileContent: (...args: unknown[]) => mockReadFileContent(...(args as [string])),
+    writeFileContent: (...args: unknown[]) => mockWriteFileContent(...(args as [string, string]))
+  },
+  writable: true,
+  configurable: true
+})
+
+import { FileTreeExplorer } from '../src/renderer/components/FileTreeExplorer'
+
+const ROOT_ENTRIES: FileEntry[] = [
+  { name: 'src', path: '/repo/src', isDirectory: true },
+  { name: 'tests', path: '/repo/tests', isDirectory: true },
+  { name: 'README.md', path: '/repo/README.md', isDirectory: false }
+]
+
+const SRC_CHILDREN: FileEntry[] = [
+  { name: 'index.ts', path: '/repo/src/index.ts', isDirectory: false },
+  { name: 'utils.ts', path: '/repo/src/utils.ts', isDirectory: false }
+]
+
+beforeEach(() => {
+  mockListDir.mockReset()
+  mockReadFileContent.mockReset()
+  mockWriteFileContent.mockReset()
+  localStorage.clear()
+
+  mockListDir.mockImplementation(async (path: string) => {
+    if (path === '/repo') return ROOT_ENTRIES
+    if (path === '/repo/src') return SRC_CHILDREN
+    if (path === '/repo/tests') return []
+    return []
+  })
+  mockReadFileContent.mockResolvedValue('hello\nworld\nworld again')
+  mockWriteFileContent.mockResolvedValue({ success: true })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function renderTree(): Promise<void> {
+  await act(async () => {
+    render(<FileTreeExplorer cwd="/repo" />)
+  })
+  await screen.findByText('Files')
+}
+
+describe('FileTreeExplorer', () => {
+  it('renders root entries with chevron-only directories', async () => {
+    await renderTree()
+    expect(screen.getByText('src')).toBeInTheDocument()
+    expect(screen.getByText('tests')).toBeInTheDocument()
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+  })
+
+  it('filters tree by name and shows empty hint when no matches', async () => {
+    await renderTree()
+    const filter = screen.getByPlaceholderText('Filter files…')
+
+    await act(async () => {
+      fireEvent.change(filter, { target: { value: 'README' } })
+    })
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+    expect(screen.queryByText('src')).not.toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.change(filter, { target: { value: 'zzznomatch' } })
+    })
+    expect(screen.getByText(/No matching files loaded/)).toBeInTheDocument()
+  })
+
+  it('expands a directory on chevron click and lists children', async () => {
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('src'))
+    })
+    await screen.findByText('index.ts')
+    expect(screen.getByText('utils.ts')).toBeInTheDocument()
+    expect(mockListDir).toHaveBeenCalledWith('/repo/src', undefined)
+  })
+
+  it('shows the File panel only after selecting a file', async () => {
+    await renderTree()
+    expect(screen.queryByText('File')).not.toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    await screen.findByText('File')
+    // Path strip in File panel header reflects the relative path.
+    expect(screen.getByTitle('/repo/README.md')).toBeInTheDocument()
+    expect(mockReadFileContent).toHaveBeenCalledWith('/repo/README.md', undefined, undefined)
+  })
+
+  it('opens find bar, counts matches, and cycles with Enter', async () => {
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    await screen.findByText('File')
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Find in file'))
+    })
+
+    const input = await screen.findByPlaceholderText('Find in file')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'world' } })
+    })
+
+    expect(screen.getByText('1/2')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+    expect(screen.getByText('2/2')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Escape' })
+    })
+    expect(screen.queryByPlaceholderText('Find in file')).not.toBeInTheDocument()
+  })
+
+  it('edits file and saves through writeFileContent', async () => {
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    await waitFor(() =>
+      expect((screen.getByLabelText('Edit') as HTMLButtonElement).disabled).toBe(false)
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Edit'))
+    })
+
+    const textarea = (await waitFor(() => {
+      const t = document.querySelector('textarea')
+      if (!t) throw new Error('textarea not yet rendered')
+      return t
+    })) as HTMLTextAreaElement
+    expect(textarea.value).toBe('hello\nworld\nworld again')
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'hello\nchanged' } })
+    })
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 's', metaKey: true })
+    })
+
+    await waitFor(() =>
+      expect(mockWriteFileContent).toHaveBeenCalledWith(
+        '/repo/README.md',
+        'hello\nchanged',
+        undefined
+      )
+    )
+    await screen.findByLabelText('Edit')
+  })
+
+  it('confirms before discarding unsaved edits when switching files', async () => {
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    await waitFor(() =>
+      expect((screen.getByLabelText('Edit') as HTMLButtonElement).disabled).toBe(false)
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Edit'))
+    })
+    const textarea = (await waitFor(() => {
+      const t = document.querySelector('textarea')
+      if (!t) throw new Error('textarea not yet rendered')
+      return t
+    })) as HTMLTextAreaElement
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'dirty content' } })
+    })
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    mockReadFileContent.mockClear()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('src'))
+    })
+    await screen.findByText('index.ts')
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('index.ts'))
+    })
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockReadFileContent).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('shows binary fallback when readFileContent returns null', async () => {
+    mockReadFileContent.mockResolvedValueOnce(null)
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    expect(await screen.findByText('Binary file — preview unavailable')).toBeInTheDocument()
+  })
+
+  it('returns Empty directory when root has no entries', async () => {
+    mockListDir.mockResolvedValueOnce([])
+    await act(async () => {
+      render(<FileTreeExplorer cwd="/empty" />)
+    })
+    expect(await screen.findByText('Empty directory')).toBeInTheDocument()
+  })
+
+  it('persists split ratio to localStorage on pointerup', async () => {
+    await renderTree()
+    await act(async () => {
+      fireEvent.click(screen.getByText('README.md'))
+    })
+    await screen.findByText('File')
+
+    const divider = screen.getByRole('separator')
+    const container = divider.parentElement as HTMLElement
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      left: 0,
+      right: 400,
+      bottom: 1000,
+      width: 400,
+      height: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    })
+
+    await act(async () => {
+      fireEvent.pointerDown(divider, { clientY: 500 })
+    })
+    await act(async () => {
+      fireEvent(document, new PointerEvent('pointermove', { clientY: 700 }))
+    })
+    expect(localStorage.getItem('vorn:files-split-ratio')).toBeNull()
+
+    await act(async () => {
+      fireEvent(document, new PointerEvent('pointerup'))
+    })
+    const stored = localStorage.getItem('vorn:files-split-ratio')
+    expect(stored).not.toBeNull()
+    expect(Number(stored)).toBeCloseTo(0.7, 1)
+  })
+})

--- a/tests/file-utils.test.ts
+++ b/tests/file-utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockExecFile = vi.fn()
+const mockExecFileSync = vi.fn()
 vi.mock('node:child_process', () => ({
-  execFile: (...args: unknown[]) => mockExecFile(...args)
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args)
 }))
 vi.mock('node:util', () => ({
   promisify: (fn: unknown) => fn
@@ -14,12 +16,14 @@ vi.mock('node:fs', () => ({
     statSync: vi.fn(),
     openSync: vi.fn(),
     readSync: vi.fn(),
-    closeSync: vi.fn()
+    closeSync: vi.fn(),
+    writeFileSync: vi.fn()
   }
 }))
 
 import fs from 'node:fs'
-import { listDir, readFileContent } from '../packages/server/src/file-utils'
+import { listDir, readFileContent, writeFileContent } from '../packages/server/src/file-utils'
+import type { RemoteHost } from '@vornrun/shared/types'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -185,5 +189,63 @@ describe('readFileContent', () => {
     const result = readFileContent('/test/bad.txt')
     expect(result).toBeNull()
     expect(fs.closeSync).toHaveBeenCalledWith(99)
+  })
+})
+
+describe('writeFileContent', () => {
+  it('writes content locally and returns success', () => {
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined)
+
+    const result = writeFileContent('/test/out.txt', 'hello\nworld')
+    expect(result).toEqual({ success: true })
+    expect(fs.writeFileSync).toHaveBeenCalledWith('/test/out.txt', 'hello\nworld', 'utf-8')
+  })
+
+  it('returns error on local write failure', () => {
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
+    const result = writeFileContent('/locked/file.txt', 'data')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('EACCES')
+  })
+
+  it('writes via SSH stdin for a remote host (no argv-length pitfall)', () => {
+    mockExecFileSync.mockReturnValue('')
+
+    const remote: RemoteHost = {
+      id: 'h1',
+      label: 'example',
+      hostname: 'example.com',
+      user: 'alice',
+      port: 22
+    }
+    const big = 'x'.repeat(300_000)
+    const result = writeFileContent('/remote/file.txt', big, remote)
+
+    expect(result).toEqual({ success: true })
+    const [cmd, args, opts] = mockExecFileSync.mock.calls[0]
+    expect(cmd).toBe('ssh')
+    expect(args[args.length - 1]).toMatch(/^cat > .*\/remote\/file\.txt'?$/)
+    expect((opts as { input: string }).input).toBe(big)
+  })
+
+  it('returns error when SSH exec throws', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('ssh: connect failed')
+    })
+
+    const remote: RemoteHost = {
+      id: 'h1',
+      label: 'example',
+      hostname: 'example.com',
+      user: 'alice',
+      port: 22
+    }
+    const result = writeFileContent('/remote/file.txt', 'data', remote)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('ssh: connect failed')
   })
 })


### PR DESCRIPTION
## Summary

- Refactor the right panel's All Files tab into two distinct panels — `Files` (tree) and `File` (viewer/editor) — stacked vertically with a draggable, persisted divider. The File panel only renders when a file is selected, so the tree gets the full height when nothing is open.
- Drop folder icons from the tree in favor of a chevron-only style (rotates `>` → `v`), and add a filename filter input that auto-expands ancestors of matches.
- Turn the read-only preview into a save-capable editor with a find-in-file toolbar (find ↑/↓/Esc, edit ✏️ + ⌘S save, dirty indicator). Switching files or closing the panel mid-edit prompts before discarding.
- Add a new `file:writeContent` IPC mirroring `file:readContent` at every layer (protocol, server, main, preload). Remote writes pipe content through `ssh` stdin to avoid argv length limits on large files.

## Test plan

- [ ] Open right panel → All Files. Tree shows chevron-only rows; expand/collapse rotates the chevron.
- [ ] Type a filename fragment into the filter; tree prunes and ancestors auto-expand. Esc clears.
- [ ] Click a file: File panel appears with a path strip and toolbar. Drag the divider — both panels resize. Reload — divider position persists.
- [ ] Magnifier toggles the find bar. Enter / Shift+Enter cycle matches; counter updates; Esc closes.
- [ ] Pencil swaps the preview for an editable textarea. Type a change → dirty dot + Save button. ⌘S writes; reopen file confirms the change is on disk.
- [ ] With unsaved edits, click another file or the panel's × → confirm dialog appears; Cancel keeps edits.
- [ ] Open a binary file → "Binary file — preview unavailable"; edit / find buttons disabled.
- [ ] Same flow against a remote terminal (`remoteHostId`) — read + save round-trip via SSH.