### PR TITLE
feat(atelier): top-toolbar placement for minimized cards + per-tab project marker

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -798,6 +798,9 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     ...(map.layoutMode !== undefined && {
       layoutMode: map.layoutMode as AppConfig['defaults']['layoutMode']
     }),
+    ...(map.minimizedPlacement !== undefined && {
+      minimizedPlacement: map.minimizedPlacement as AppConfig['defaults']['minimizedPlacement']
+    }),
     ...(map.updateChannel !== undefined && {
       updateChannel: map.updateChannel as AppConfig['defaults']['updateChannel']
     }),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -159,6 +159,9 @@ export type TaskStatus = 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancel
 
 export type TaskViewMode = 'list' | 'kanban'
 
+export const MINIMIZED_PLACEMENTS = ['canvas', 'toolbar', 'both'] as const
+export type MinimizedPlacement = (typeof MINIMIZED_PLACEMENTS)[number]
+
 export type MainViewMode = 'sessions' | 'tasks' | 'workflows'
 
 export interface TaskConfig {
@@ -692,6 +695,7 @@ export interface AppConfig {
     widgetEnabled?: boolean
     taskViewMode?: TaskViewMode
     layoutMode?: 'grid' | 'tabs'
+    minimizedPlacement?: MinimizedPlacement
     mainViewMode?: MainViewMode
     activeWorkspace?: string
     updateChannel?: 'stable' | 'beta'

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -30,6 +30,7 @@ import { ToolbarBreadcrumb } from './components/ToolbarBreadcrumb'
 import { SettingsPage } from './components/SettingsPage'
 import { SidebarToggleButton } from './components/SidebarToggleButton'
 import { MainViewPills } from './components/MainViewPills'
+import { ToolbarMinimizedStrip } from './components/ToolbarMinimizedStrip'
 import { RecentSessionsButton } from './components/RecentSessionsButton'
 import { Tooltip } from './components/Tooltip'
 import { Plus, Menu } from 'lucide-react'
@@ -75,6 +76,7 @@ export function App() {
     editingWorkflowId,
     layoutMode,
     mainViewMode,
+    minimizedPlacement,
     selectedTaskId,
     diffSidebarTerminalId
   } = useAppStore(
@@ -90,6 +92,7 @@ export function App() {
       editingWorkflowId: s.editingWorkflowId,
       layoutMode: s.config?.defaults?.layoutMode ?? 'grid',
       mainViewMode: s.config?.defaults?.mainViewMode ?? 'sessions',
+      minimizedPlacement: s.config?.defaults?.minimizedPlacement ?? 'toolbar',
       selectedTaskId: s.selectedTaskId,
       diffSidebarTerminalId: s.diffSidebarTerminalId
     }))
@@ -434,6 +437,10 @@ export function App() {
                   <MainViewPills />
                 </>
               )}
+              {!isMobile &&
+                layoutMode === 'grid' &&
+                mainViewMode === 'sessions' &&
+                minimizedPlacement !== 'canvas' && <ToolbarMinimizedStrip />}
             </div>
             {!isMobile && (
               <div className="flex-1 flex justify-center min-w-0 titlebar-no-drag">

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -87,6 +87,7 @@ export const GridView = memo(function GridView() {
   )
   const filteredHeadless = useFilteredHeadless()
   const waitingApprovals = useWaitingApprovals()
+  const minimizedPlacement = useAppStore((s) => s.config?.defaults?.minimizedPlacement ?? 'toolbar')
 
   const [dragState, setDragState] = useState<DragState | null>(null)
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null)
@@ -248,6 +249,14 @@ export const GridView = memo(function GridView() {
     setGridContextMenu({ x: e.clientX, y: e.clientY })
   }, [])
 
+  const trayMinimizedIds =
+    minimizedPlacement === 'canvas' || minimizedPlacement === 'both' ? minimizedIds : []
+  const showBackgroundTray = backgroundTrayHasItems(
+    filteredHeadless,
+    trayMinimizedIds,
+    waitingApprovals
+  )
+
   return (
     <div
       className={`h-full flex flex-col ${isSmartAuto ? 'overflow-hidden' : 'overflow-auto'}`}
@@ -258,12 +267,12 @@ export const GridView = memo(function GridView() {
       onDoubleClick={handleGridDoubleClick}
       onContextMenu={handleGridContextMenu}
     >
-      {/* Background tray: headless + minimized */}
-      {backgroundTrayHasItems(filteredHeadless, minimizedIds, waitingApprovals) && (
+      {/* Minimized chips move out of the tray when placement === 'toolbar'. */}
+      {showBackgroundTray && (
         <div className="px-4 pt-4 shrink-0">
           <BackgroundTray
             headlessSessions={filteredHeadless}
-            minimizedIds={minimizedIds}
+            minimizedIds={trayMinimizedIds}
             waitingApprovals={waitingApprovals}
             variant="grid"
             hasItemsBelow={orderedIds.length > 0}

--- a/src/renderer/components/MinimizedPill.tsx
+++ b/src/renderer/components/MinimizedPill.tsx
@@ -30,7 +30,11 @@ export function MinimizedPill({ terminalId }: { terminalId: string }) {
       }}
       title="Click to restore"
     >
-      <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${STATUS_DOT[status]}`} />
+      <span
+        className={`w-1.5 h-1.5 rounded-full shrink-0 ${STATUS_DOT[status]} ${
+          status === 'running' ? 'animate-pulse' : ''
+        }`}
+      />
 
       <AgentIcon agentType={session.agentType} size={14} />
 

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -19,6 +19,8 @@ import { ConfirmPopover } from './ConfirmPopover'
 import { Tooltip } from './Tooltip'
 import { toast } from './Toast'
 import { ChevronDown, FolderOpen, GripVertical, Pencil, Plus, X } from 'lucide-react'
+import { ProjectIcon } from './project-sidebar/ProjectIcon'
+import type { ProjectConfig } from '../../shared/types'
 import { GridContextMenu } from './GridContextMenu'
 import { GridToolbar } from './GridToolbar'
 import { WindowControls } from './WindowControls'
@@ -26,7 +28,7 @@ import { SidebarToggleButton } from './SidebarToggleButton'
 import { MainViewPills } from './MainViewPills'
 import { RecentSessionsButton } from './RecentSessionsButton'
 import { resolveActiveProject, createSessionFromProject } from '../lib/session-utils'
-import { MOD, isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from '../lib/platform'
+import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from '../lib/platform'
 
 const DRAG_THRESHOLD = 5
 
@@ -133,6 +135,7 @@ export function TabView() {
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
   const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
   const tasks = useAppStore((s) => s.config?.tasks)
+  const projects = useAppStore((s) => s.config?.projects)
   const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
   const filteredHeadless = useFilteredHeadless()
   const waitingApprovals = useWaitingApprovals()
@@ -150,6 +153,12 @@ export function TabView() {
   const isFiltered = statusFilter !== 'all'
   const isManualSort = sortMode === 'manual'
   const needsTrafficLightPad = isMac && !isSidebarOpen && !isWeb
+
+  const projectByName = useMemo(() => {
+    const map = new Map<string, ProjectConfig>()
+    for (const p of projects ?? []) map.set(p.name, p)
+    return map
+  }, [projects])
 
   const assignedTaskBySessionId = useMemo(() => {
     type Task = NonNullable<typeof tasks>[number]
@@ -313,6 +322,7 @@ export function TabView() {
             const tooltipTaskTitle =
               displayName === assignedTask?.title ? undefined : assignedTask?.title
             const isShell = terminal.session.agentType === 'shell'
+            const project = projectByName.get(terminal.session.projectName)
             const tooltip = buildTooltip(
               displayName,
               terminal.status,
@@ -320,7 +330,8 @@ export function TabView() {
               isShell ? undefined : terminal.session.isWorktree,
               isShell ? undefined : tooltipTaskTitle,
               isShell ? terminal.session.shellCwd : undefined,
-              isShell ? terminal.session.shellExitCode : undefined
+              isShell ? terminal.session.shellExitCode : undefined,
+              terminal.session.projectName
             )
 
             return (
@@ -338,8 +349,8 @@ export function TabView() {
                   e.stopPropagation()
                   setContextMenu({ terminalId: id, x: e.clientX, y: e.clientY })
                 }}
-                className={`titlebar-no-drag group relative flex items-center gap-2 pl-3 pr-10 h-[36px] text-[13px] cursor-pointer
-                           transition-colors flex-1 min-w-[120px] max-w-[260px] select-none border-b
+                className={`titlebar-no-drag group relative flex items-center gap-1.5 pl-2.5 pr-2 h-[36px] text-[13px] cursor-pointer
+                           transition-colors flex-1 min-w-[96px] max-w-[260px] select-none border-b
                            ${isDragTarget ? 'ring-1 ring-blue-500/50' : ''}
                            ${isDragging ? 'opacity-50' : ''}
                            ${
@@ -381,24 +392,34 @@ export function TabView() {
                     className="text-xs w-[100px]"
                   />
                 ) : (
-                  <span className="truncate flex-1 min-w-0" title={tooltip}>
-                    {displayName}
-                  </span>
+                  <>
+                    <span className="truncate flex-1 min-w-0" title={tooltip}>
+                      {displayName}
+                    </span>
+                    {/* Project marker — always visible so two tabs that share a displayName
+                        (e.g. both running on `main`) stay distinguishable. */}
+                    <span
+                      className="shrink-0 flex items-center"
+                      title={tooltip}
+                      aria-label={
+                        terminal.session.projectName
+                          ? `Project: ${terminal.session.projectName}`
+                          : undefined
+                      }
+                    >
+                      <ProjectIcon icon={project?.icon} color={project?.iconColor} size={11} />
+                    </span>
+                  </>
                 )}
 
-                <span className="absolute right-2 top-0 bottom-0 flex items-center gap-1 group-hover:bg-[#1a1a1e] group-hover:rounded-l-sm">
-                  {index < 9 && !isRenaming && (
-                    <span
-                      className="absolute right-0 top-1/2 -translate-y-1/2
-                                   opacity-100 group-hover:opacity-0 transition-opacity
-                                   px-1 py-0.5 text-[9px] font-mono text-gray-500
-                                   bg-white/[0.06] border border-white/[0.1] rounded leading-none
-                                   pointer-events-none"
-                    >
-                      {MOD}
-                      {index + 1}
-                    </span>
-                  )}
+                {/* Hover-only action toolbar — overlays the marker so the marker has the
+                    right edge to itself in the resting state. */}
+                <span
+                  className="absolute right-1.5 top-0 bottom-0 flex items-center gap-0.5
+                             opacity-0 group-hover:opacity-100 transition-opacity
+                             pointer-events-none group-hover:pointer-events-auto
+                             bg-[#1a1a1e] pl-1.5 pr-0.5 rounded-l-sm"
+                >
                   {!isRenaming && (
                     <>
                       <TabIconButton

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -397,17 +397,14 @@ export function TabView() {
                       {displayName}
                     </span>
                     {/* Project marker — always visible so two tabs that share a displayName
-                        (e.g. both running on `main`) stay distinguishable. */}
-                    <span
-                      className="shrink-0 flex items-center"
-                      title={tooltip}
-                      aria-label={
-                        terminal.session.projectName
-                          ? `Project: ${terminal.session.projectName}`
-                          : undefined
-                      }
-                    >
+                        (e.g. both running on `main`) stay distinguishable. The icon is
+                        decorative; the sr-only span is what actually reaches screen
+                        readers via the tab role's accessible name. */}
+                    <span className="shrink-0 flex items-center" title={tooltip}>
                       <ProjectIcon icon={project?.icon} color={project?.iconColor} size={11} />
+                      {terminal.session.projectName && (
+                        <span className="sr-only"> (project: {terminal.session.projectName})</span>
+                      )}
                     </span>
                   </>
                 )}

--- a/src/renderer/components/ToolbarMinimizedStrip.tsx
+++ b/src/renderer/components/ToolbarMinimizedStrip.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronsLeft, ChevronsRight, Layers } from 'lucide-react'
+import { useAppStore } from '../stores'
+import { useVisibleTerminals } from '../hooks/useVisibleTerminals'
+import { MinimizedPill } from './MinimizedPill'
+
+const MAX_INLINE = 6
+
+export function ToolbarMinimizedStrip() {
+  const placement = useAppStore((s) => s.config?.defaults?.minimizedPlacement ?? 'toolbar')
+  const collapsed = useAppStore((s) => s.toolbarMinimizedCollapsed)
+  const toggleCollapsed = useAppStore((s) => s.toggleToolbarMinimizedCollapsed)
+  const { minimizedIds } = useVisibleTerminals()
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!popoverOpen) return
+    const onDown = (e: MouseEvent): void => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setPopoverOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [popoverOpen])
+
+  if (placement === 'canvas' || minimizedIds.length === 0) return null
+
+  const count = minimizedIds.length
+
+  if (collapsed) {
+    return (
+      <div ref={popoverRef} className="relative flex items-center titlebar-no-drag">
+        <button
+          type="button"
+          onClick={() => setPopoverOpen((v) => !v)}
+          className="inline-flex items-center gap-1.5 h-[26px] px-2
+                     rounded-md border border-white/[0.06] bg-[#1a1a1e]
+                     text-[11px] font-medium text-gray-300
+                     hover:text-white hover:border-white/[0.12] transition-colors"
+          title={`${count} minimized`}
+          aria-haspopup="menu"
+          aria-expanded={popoverOpen}
+          aria-label={`${count} minimized sessions`}
+        >
+          <Layers size={11} strokeWidth={1.5} />
+          <span className="font-mono leading-none">{count}</span>
+        </button>
+
+        {popoverOpen && (
+          <div
+            role="menu"
+            className="absolute top-full left-0 mt-1.5 z-50 p-1.5
+                       flex flex-col gap-1 max-h-[60vh] overflow-y-auto min-w-[200px]
+                       bg-[#1a1a1e] border border-white/[0.08] rounded-md shadow-lg"
+          >
+            <div className="flex items-center justify-between px-1.5 pb-1.5 mb-1 border-b border-white/[0.06]">
+              <span className="text-[10px] font-medium text-gray-500 uppercase tracking-wider">
+                {count} minimized
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  setPopoverOpen(false)
+                  toggleCollapsed()
+                }}
+                className="inline-flex items-center gap-1 text-[10px] text-gray-400 hover:text-white transition-colors"
+                title="Expand strip"
+              >
+                <ChevronsRight size={11} strokeWidth={1.75} />
+                Expand
+              </button>
+            </div>
+            <div onClick={() => setPopoverOpen(false)} className="flex flex-col gap-1">
+              {minimizedIds.map((id) => (
+                <MinimizedPill key={id} terminalId={id} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const inline = minimizedIds.slice(0, MAX_INLINE)
+  const overflow = minimizedIds.slice(MAX_INLINE)
+
+  return (
+    <div className="flex items-center gap-1.5 min-w-0 titlebar-no-drag">
+      <div className="flex items-center gap-1.5 overflow-hidden">
+        {inline.map((id) => (
+          <MinimizedPill key={id} terminalId={id} />
+        ))}
+      </div>
+
+      {overflow.length > 0 && (
+        <div ref={popoverRef} className="relative flex items-center">
+          <button
+            type="button"
+            onClick={() => setPopoverOpen((v) => !v)}
+            className="inline-flex items-center justify-center h-[26px] min-w-[28px] px-1.5
+                       rounded-md border border-white/[0.06] bg-[#1a1a1e]
+                       text-[11px] font-medium text-gray-400
+                       hover:text-white hover:border-white/[0.12] transition-colors"
+            title={`${overflow.length} more minimized`}
+            aria-haspopup="menu"
+            aria-expanded={popoverOpen}
+          >
+            +{overflow.length}
+          </button>
+
+          {popoverOpen && (
+            <div
+              role="menu"
+              className="absolute top-full right-0 mt-1.5 z-50 p-1.5
+                         flex flex-col gap-1 max-h-[60vh] overflow-y-auto
+                         bg-[#1a1a1e] border border-white/[0.08] rounded-md shadow-lg"
+              onClick={() => setPopoverOpen(false)}
+            >
+              {overflow.map((id) => (
+                <MinimizedPill key={id} terminalId={id} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="inline-flex items-center justify-center h-[22px] w-[22px]
+                   rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+        title="Collapse to badge"
+        aria-label="Collapse minimized strip"
+      >
+        <ChevronsLeft size={12} strokeWidth={1.75} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/ToolbarMinimizedStrip.tsx
+++ b/src/renderer/components/ToolbarMinimizedStrip.tsx
@@ -17,7 +17,10 @@ export function ToolbarMinimizedStrip() {
   useEffect(() => {
     if (!popoverOpen) return
     const onDown = (e: MouseEvent): void => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      // Treat a missing anchor as "outside" so the popover still closes if the
+      // overflow button (or collapsed badge) unmounts while open — e.g. the
+      // user restored every minimized session.
+      if (!popoverRef.current || !popoverRef.current.contains(e.target as Node)) {
         setPopoverOpen(false)
       }
     }
@@ -40,7 +43,7 @@ export function ToolbarMinimizedStrip() {
                      text-[11px] font-medium text-gray-300
                      hover:text-white hover:border-white/[0.12] transition-colors"
           title={`${count} minimized`}
-          aria-haspopup="menu"
+          aria-haspopup="dialog"
           aria-expanded={popoverOpen}
           aria-label={`${count} minimized sessions`}
         >
@@ -50,7 +53,8 @@ export function ToolbarMinimizedStrip() {
 
         {popoverOpen && (
           <div
-            role="menu"
+            role="dialog"
+            aria-label="Minimized sessions"
             className="absolute top-full left-0 mt-1.5 z-50 p-1.5
                        flex flex-col gap-1 max-h-[60vh] overflow-y-auto min-w-[200px]
                        bg-[#1a1a1e] border border-white/[0.08] rounded-md shadow-lg"
@@ -104,7 +108,7 @@ export function ToolbarMinimizedStrip() {
                        text-[11px] font-medium text-gray-400
                        hover:text-white hover:border-white/[0.12] transition-colors"
             title={`${overflow.length} more minimized`}
-            aria-haspopup="menu"
+            aria-haspopup="dialog"
             aria-expanded={popoverOpen}
           >
             +{overflow.length}
@@ -112,7 +116,8 @@ export function ToolbarMinimizedStrip() {
 
           {popoverOpen && (
             <div
-              role="menu"
+              role="dialog"
+              aria-label="Additional minimized sessions"
               className="absolute top-full right-0 mt-1.5 z-50 p-1.5
                          flex flex-col gap-1 max-h-[60vh] overflow-y-auto
                          bg-[#1a1a1e] border border-white/[0.08] rounded-md shadow-lg"

--- a/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/src/renderer/components/settings/AppearanceSettings.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from '../../stores'
 import { setAllTerminalsFontSize } from '../../lib/terminal-registry'
-import { TaskViewMode } from '../../../shared/types'
+import { TaskViewMode, type MinimizedPlacement } from '../../../shared/types'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
 import { SegmentedControl } from './SegmentedControl'
@@ -126,6 +126,24 @@ export function AppearanceSettings() {
             ]}
             value={config.defaults.layoutMode || 'grid'}
             onChange={(value) => updateDefaults({ layoutMode: value as 'grid' | 'tabs' })}
+          />
+        </SettingRow>
+
+        {/* Minimized cards placement */}
+        <SettingRow
+          label="Minimized cards"
+          description="Where minimized agent cards live in the atelier"
+        >
+          <SegmentedControl
+            options={[
+              { value: 'canvas', label: 'Canvas strip' },
+              { value: 'toolbar', label: 'Top toolbar' },
+              { value: 'both', label: 'Both' }
+            ]}
+            value={config.defaults.minimizedPlacement || 'toolbar'}
+            onChange={(value) =>
+              updateDefaults({ minimizedPlacement: value as MinimizedPlacement })
+            }
           />
         </SettingRow>
 

--- a/src/renderer/lib/tab-tooltip.ts
+++ b/src/renderer/lib/tab-tooltip.ts
@@ -14,9 +14,11 @@ export function buildTooltip(
   isWorktree?: boolean,
   taskTitle?: string,
   shellCwd?: string,
-  shellExitCode?: number
+  shellExitCode?: number,
+  projectName?: string
 ): string {
-  const lines = [`${displayName} — ${STATUS_LABEL[status]}`]
+  const heading = projectName ? `${projectName} / ${displayName}` : displayName
+  const lines = [`${heading} — ${STATUS_LABEL[status]}`]
   if (branch) {
     lines.push(`Branch: ${branch}${isWorktree ? ' (worktree)' : ''}`)
   }

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -143,6 +143,7 @@ export interface UISlice {
   focusableTerminalIds: string[]
   minimizedTerminals: Set<string>
   backgroundTrayCollapsed: boolean
+  toolbarMinimizedCollapsed: boolean
   isOnboardingOpen: boolean
   diffSidebarTerminalId: string | null
   gitDiffStats: Map<string, GitDiffStat>
@@ -188,6 +189,7 @@ export interface UISlice {
   reorderTerminals: (fromIndex: number, toIndex: number) => void
   toggleMinimized: (id: string) => void
   toggleBackgroundTray: () => void
+  toggleToolbarMinimizedCollapsed: () => void
   setOnboardingOpen: (open: boolean) => void
   setDiffSidebarTerminalId: (id: string | null, tab?: PanelTab) => void
   updateGitDiffStat: (terminalId: string, stat: GitDiffStat) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -94,6 +94,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   focusableTerminalIds: [],
   minimizedTerminals: new Set(),
   backgroundTrayCollapsed: false,
+  toolbarMinimizedCollapsed: false,
   isOnboardingOpen: false,
   diffSidebarTerminalId: null,
   gitDiffStats: new Map(),
@@ -213,6 +214,8 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   toggleBackgroundTray: () =>
     set((state) => ({ backgroundTrayCollapsed: !state.backgroundTrayCollapsed })),
+  toggleToolbarMinimizedCollapsed: () =>
+    set((state) => ({ toolbarMinimizedCollapsed: !state.toolbarMinimizedCollapsed })),
 
   setOnboardingOpen: (open) => set({ isOnboardingOpen: open }),
   setDiffSidebarTerminalId: (id, tab) =>

--- a/tests/appearance-minimized-placement.test.tsx
+++ b/tests/appearance-minimized-placement.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockSaveConfig = vi.fn()
+Object.defineProperty(window, 'api', {
+  value: { saveConfig: (...args: unknown[]) => mockSaveConfig(...args) },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { AppearanceSettings } from '../src/renderer/components/settings/AppearanceSettings'
+
+const initialState = useAppStore.getState()
+
+beforeEach(() => {
+  mockSaveConfig.mockReset()
+  act(() => {
+    useAppStore.setState({
+      config: {
+        version: 1,
+        projects: [],
+        workflows: [],
+        defaults: { shell: '/bin/zsh', fontSize: 13, theme: 'dark' },
+        agentCommands: {},
+        remoteHosts: [],
+        workspaces: []
+      }
+    })
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    useAppStore.setState(initialState)
+  })
+})
+
+describe('AppearanceSettings: Minimized cards row', () => {
+  it('renders all three placement options', () => {
+    render(<AppearanceSettings />)
+    expect(screen.getByRole('radio', { name: /canvas strip/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /top toolbar/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /both/i })).toBeInTheDocument()
+  })
+
+  it('selecting "Canvas strip" persists minimizedPlacement=canvas via saveConfig', () => {
+    render(<AppearanceSettings />)
+    fireEvent.click(screen.getByRole('radio', { name: /canvas strip/i }))
+    expect(mockSaveConfig).toHaveBeenCalled()
+    const payload = mockSaveConfig.mock.calls[0][0]
+    expect(payload.defaults.minimizedPlacement).toBe('canvas')
+  })
+
+  it('selecting "Both" persists minimizedPlacement=both via saveConfig', () => {
+    render(<AppearanceSettings />)
+    fireEvent.click(screen.getByRole('radio', { name: /both/i }))
+    const payload = mockSaveConfig.mock.calls[0][0]
+    expect(payload.defaults.minimizedPlacement).toBe('both')
+  })
+})

--- a/tests/minimized-pill-pulse.test.tsx
+++ b/tests/minimized-pill-pulse.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { TerminalState } from '../src/renderer/stores/types'
+import type { AgentStatus } from '../src/shared/types'
+
+vi.mock('../src/renderer/components/AgentIcon', () => ({
+  AgentIcon: () => <div data-testid="agent-icon" />
+}))
+
+const toggleMinimized = vi.fn()
+const setActiveTabId = vi.fn()
+let terminal: TerminalState | undefined
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      terminals: { get: () => terminal },
+      toggleMinimized,
+      setActiveTabId
+    }
+    return selector ? selector(state) : state
+  }
+}))
+
+import { MinimizedPill } from '../src/renderer/components/MinimizedPill'
+
+function term(status: AgentStatus): TerminalState {
+  return {
+    id: 't1',
+    session: {
+      id: 't1',
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      status,
+      createdAt: Date.now()
+    },
+    status,
+    lastOutputTimestamp: Date.now()
+  } as unknown as TerminalState
+}
+
+describe('MinimizedPill status dot', () => {
+  it('animates the dot only when the agent is running', () => {
+    terminal = term('running')
+    const { container } = render(<MinimizedPill terminalId="t1" />)
+    const dot = container.querySelector('span.rounded-full')
+    expect(dot).not.toBeNull()
+    expect(dot?.className).toContain('animate-pulse')
+  })
+
+  it('leaves the dot static for non-running statuses', () => {
+    for (const s of ['idle', 'waiting', 'error'] as const) {
+      terminal = term(s)
+      const { container, unmount } = render(<MinimizedPill terminalId="t1" />)
+      const dot = container.querySelector('span.rounded-full')
+      expect(dot?.className).not.toContain('animate-pulse')
+      unmount()
+    }
+  })
+})

--- a/tests/tab-view-tooltip.test.ts
+++ b/tests/tab-view-tooltip.test.ts
@@ -58,4 +58,27 @@ describe('buildTooltip (TabView tab hover)', () => {
     expect(text).not.toMatch(/Cwd:/)
     expect(text).not.toMatch(/Exit:/)
   })
+
+  it('prefixes the heading with the project when projectName is provided', () => {
+    const text = buildTooltip(
+      'main',
+      'running',
+      'main',
+      false,
+      undefined,
+      undefined,
+      undefined,
+      'vorn'
+    )
+    const firstLine = text.split('\n')[0]
+    expect(firstLine).toBe('vorn / main — Running')
+    expect(text).toMatch(/Branch: main/)
+  })
+
+  it('falls back to displayName-only heading when projectName is undefined', () => {
+    const text = buildTooltip('fix-auth', 'running')
+    const firstLine = text.split('\n')[0]
+    expect(firstLine).toBe('fix-auth — Running')
+    expect(firstLine).not.toMatch(/\//)
+  })
 })

--- a/tests/toolbar-minimized-strip.test.tsx
+++ b/tests/toolbar-minimized-strip.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// ── Mock the store: placement, collapsed flag, and the toggle ─────────────
+let minimizedPlacement: 'canvas' | 'toolbar' | 'both' = 'toolbar'
+let collapsed = false
+const toggleCollapsed = vi.fn()
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      config: { defaults: { minimizedPlacement } },
+      toolbarMinimizedCollapsed: collapsed,
+      toggleToolbarMinimizedCollapsed: toggleCollapsed
+    }
+    return selector ? selector(state) : state
+  }
+}))
+
+// ── Mock useVisibleTerminals: only the minimizedIds field is read ─────────
+let minimizedIds: string[] = []
+vi.mock('../src/renderer/hooks/useVisibleTerminals', () => ({
+  useVisibleTerminals: () => ({ orderedIds: [], minimizedIds })
+}))
+
+// ── Stub MinimizedPill so we can count rendered chips by terminalId ───────
+vi.mock('../src/renderer/components/MinimizedPill', () => ({
+  MinimizedPill: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="pill" data-id={terminalId}>
+      {terminalId}
+    </div>
+  )
+}))
+
+import { ToolbarMinimizedStrip } from '../src/renderer/components/ToolbarMinimizedStrip'
+
+beforeEach(() => {
+  minimizedPlacement = 'toolbar'
+  collapsed = false
+  minimizedIds = []
+  toggleCollapsed.mockReset()
+})
+
+describe('ToolbarMinimizedStrip', () => {
+  it('renders nothing when placement is canvas', () => {
+    minimizedPlacement = 'canvas'
+    minimizedIds = ['t1', 't2']
+    const { container } = render(<ToolbarMinimizedStrip />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when there are no minimized terminals', () => {
+    minimizedIds = []
+    const { container } = render(<ToolbarMinimizedStrip />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders all chips inline when count <= MAX_INLINE (6)', () => {
+    minimizedIds = ['a', 'b', 'c', 'd', 'e', 'f']
+    const { getAllByTestId, queryByText } = render(<ToolbarMinimizedStrip />)
+    expect(getAllByTestId('pill')).toHaveLength(6)
+    // No overflow badge when nothing spills past MAX_INLINE
+    expect(queryByText(/^\+\d+$/)).toBeNull()
+  })
+
+  it('shows +N overflow when count exceeds MAX_INLINE', () => {
+    minimizedIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+    const { getAllByTestId, getByText } = render(<ToolbarMinimizedStrip />)
+    // Inline shows the first 6
+    expect(getAllByTestId('pill')).toHaveLength(6)
+    // Plus a +3 badge for the rest
+    expect(getByText('+3')).toBeInTheDocument()
+  })
+
+  it('clicking +N opens the overflow popover with the remaining chips', () => {
+    minimizedIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+    const { getByText, getAllByTestId } = render(<ToolbarMinimizedStrip />)
+    fireEvent.click(getByText('+2'))
+    // Popover renders the 2 overflow pills in addition to the 6 inline
+    expect(getAllByTestId('pill')).toHaveLength(8)
+  })
+
+  it('clicking the trailing chevron toggles the collapsed flag', () => {
+    minimizedIds = ['a', 'b']
+    const { container } = render(<ToolbarMinimizedStrip />)
+    const collapseBtn = container.querySelector('button[aria-label="Collapse minimized strip"]')
+    expect(collapseBtn).not.toBeNull()
+    fireEvent.click(collapseBtn!)
+    expect(toggleCollapsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the count badge (Layers icon + count) when collapsed', () => {
+    collapsed = true
+    minimizedIds = ['a', 'b', 'c', 'd']
+    const { getByLabelText, queryAllByTestId } = render(<ToolbarMinimizedStrip />)
+    const badge = getByLabelText('4 minimized sessions')
+    expect(badge).toBeInTheDocument()
+    expect(badge.textContent).toContain('4')
+    // Pills are not rendered until the peek popover opens
+    expect(queryAllByTestId('pill')).toHaveLength(0)
+  })
+
+  it('clicking the badge opens a peek popover listing every minimized pill', () => {
+    collapsed = true
+    minimizedIds = ['a', 'b', 'c']
+    const { getByLabelText, getAllByTestId } = render(<ToolbarMinimizedStrip />)
+    fireEvent.click(getByLabelText('3 minimized sessions'))
+    expect(getAllByTestId('pill')).toHaveLength(3)
+  })
+
+  it('clicking Expand inside the peek popover toggles the strip back to inline', () => {
+    collapsed = true
+    minimizedIds = ['a', 'b']
+    const { getByLabelText, getByTitle } = render(<ToolbarMinimizedStrip />)
+    fireEvent.click(getByLabelText('2 minimized sessions'))
+    fireEvent.click(getByTitle('Expand strip'))
+    expect(toggleCollapsed).toHaveBeenCalledTimes(1)
+  })
+
+  it('placement=both still renders the toolbar strip (chip duplication is by design)', () => {
+    minimizedPlacement = 'both'
+    minimizedIds = ['x']
+    const { getAllByTestId } = render(<ToolbarMinimizedStrip />)
+    expect(getAllByTestId('pill')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Two related affordances for keeping context when the canvas is busy or the sidebar is collapsed:

- **Top-toolbar placement for minimized cards.** New \`Appearance → Minimized cards\` setting (Canvas strip / Top toolbar / Both, default Top toolbar). New \`ToolbarMinimizedStrip\` shows up to 6 chips inline + \`+N\` overflow popover; status dots pulse while running. The whole strip can collapse to a single Layers-icon \`[◇ N]\` badge — clicking the badge opens a peek popover with an Expand action to return to the inline strip.
- **Per-tab project marker.** Tabs now trail the session name with a compact \`ProjectIcon\` in the project's accent color, so two tabs that share a displayName (e.g. both \`main\`) stay distinguishable when the sidebar is hidden. Tooltip becomes \`Project / Session\` via \`buildTooltip\`. Tightens tab padding and drops the keyboard shortcut chip so the marker stays visible at the narrowest tab width.

Both changes follow the existing colour doctrine — chip/tab chrome stays neutral, colour belongs only to the project marker / status dot. The new placement option is a first-class visible setting, not a hidden flag.

## Test plan

- [ ] Toggle \`Minimized cards\` between Canvas / Toolbar / Both — chips appear/disappear in the right places, no double-render
- [ ] Minimize 7+ sessions; verify inline 6 + \`+N\` overflow + popover restore
- [ ] Click the \`«\` collapse chevron — strip collapses to \`[◇ N]\` badge
- [ ] Click the badge — peek popover lists every minimized session; pills restore on click; \`Expand\` returns to inline strip
- [ ] Switch to Tabs layout with two sessions both named \`main\` from different projects — markers render in the right colours, tooltip shows \`<Project> / main\`
- [ ] Resize window narrow enough to compact tabs — marker stays visible
- [ ] Hover over a tab — action toolbar (browse / rename / close) overlays the marker without flickering