### PR TITLE
fix(test): wait for new-worktree button by aria-label, not class

### DIFF
--- a/src/renderer/components/project-sidebar/ProjectItem.tsx
+++ b/src/renderer/components/project-sidebar/ProjectItem.tsx
@@ -284,6 +284,7 @@ export function ProjectItem({
                   <Tooltip label="New worktree" position="right">
                     <button
                       type="button"
+                      aria-label="New worktree"
                       disabled={creatingWorktree}
                       onClick={(e) => {
                         e.stopPropagation()

--- a/tests/project-item.test.tsx
+++ b/tests/project-item.test.tsx
@@ -149,12 +149,11 @@ describe('ProjectItem progress-toast handlers', () => {
 
   it('new worktree button fires a loading toast and calls window.api.createWorktree', async () => {
     const { container } = renderProjectItem()
-    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
-    // The new-worktree button is the 2nd visible action button (after new session)
-    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
-    // Find it via its SVG child: FolderGit2 is distinctive because it has class text-amber-400/70
-    const wtButton = buttons.find((b) => b.querySelector('.text-amber-400\\/70')) as HTMLElement
-    expect(wtButton).toBeDefined()
+    const wtButton = (await waitFor(() => {
+      const btn = container.querySelector('button[aria-label="New worktree"]')
+      if (!btn) throw new Error('worktree button not yet rendered')
+      return btn
+    })) as HTMLElement
     act(() => {
       fireEvent.click(wtButton)
     })


### PR DESCRIPTION
## Summary

- Main CI started failing on \`tests/project-item.test.tsx\` after PR #271 landed even though that PR didn't touch \`ProjectItem.tsx\` or the test. The amber Tailwind class on the worktree button is still in place — the failure is a race the new test files exposed by shifting parallel scheduling.
- The test waited only for \`mockIsGitRepo\` to be called, then queried by \`.text-amber-400/70\`. The follow-up \`setIsGitRepo(true)\` state update hadn't always flushed by then, so the conditional \`<FolderGit2>\` hadn't rendered and \`Array.find\` returned undefined.
- Add \`aria-label=\"New worktree\"\` to the button (matches the sibling \"New session\" button — small a11y win) and have the test poll for that label inside \`waitFor\` so it only proceeds once the button is actually in the DOM.

## Test plan

- [x] \`yarn test tests/project-item.test.tsx\` — 7/7 pass
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [ ] CI on this branch goes green