### PR TITLE
Contextual workflows + log persistence + run reconciliation

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -28,7 +28,9 @@ const launchAgentConfigSchema = z.object({
   args: z.array(V.shortText).optional(),
   displayName: V.shortText.optional(),
   branch: V.shortText.optional(),
-  useWorktree: z.boolean().optional(),
+  // boolean | 'fromContext' — `'fromContext'` only valid when the workflow's
+  // manual trigger is contextual (validated at runtime, not here).
+  useWorktree: z.union([z.boolean(), z.literal('fromContext')]).optional(),
   remoteHostId: V.id.optional(),
   prompt: V.prompt.optional(),
   promptDelayMs: z.number().optional(),
@@ -37,7 +39,10 @@ const launchAgentConfigSchema = z.object({
 })
 
 const triggerConfigSchema = z.union([
-  z.object({ triggerType: z.literal('manual') }),
+  z.object({
+    triggerType: z.literal('manual'),
+    contextual: z.boolean().optional()
+  }),
   z.object({ triggerType: z.literal('once'), runAt: V.shortText }),
   z.object({
     triggerType: z.literal('recurring'),

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2208,68 +2208,20 @@ function fetchNodesByRunIds(
   return out
 }
 
-export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecution[] {
-  const d = getDb()
-
-  type RunRow = {
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-  }
-  const rows = d
-    .prepare('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?')
-    .all(workflowId, limit) as RunRow[]
-
-  const nodesByRun = fetchNodesByRunIds(
-    d,
-    rows.map((r) => r.id)
-  )
-
-  return rows.map((r) => ({
-    workflowId: r.workflow_id,
-    startedAt: r.started_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at }),
-    status: r.status as WorkflowExecution['status'],
-    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    nodeStates: nodesByRun.get(r.id) ?? []
-  }))
+type RunRow = {
+  id: string
+  workflow_id: string
+  started_at: string
+  completed_at: string | null
+  status: string
+  trigger_task_id: string | null
+  workflow_name?: string | null
 }
 
-export function listWorkflowRunsByTask(
-  taskId: string,
-  limit = 20
+function mapRunRows(
+  rows: RunRow[],
+  nodesByRun: Map<string, NodeExecutionState[]>
 ): (WorkflowExecution & { workflowName?: string })[] {
-  const d = getDb()
-
-  type RunRow = {
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-    workflow_name: string | null
-  }
-  const rows = d
-    .prepare(
-      `SELECT DISTINCT wr.*, w.name as workflow_name
-       FROM workflow_runs wr
-       LEFT JOIN workflows w ON w.id = wr.workflow_id
-       WHERE wr.trigger_task_id = ?
-          OR wr.id IN (SELECT run_id FROM workflow_run_nodes WHERE task_id = ?)
-       ORDER BY wr.started_at DESC
-       LIMIT ?`
-    )
-    .all(taskId, taskId, limit) as RunRow[]
-
-  const nodesByRun = fetchNodesByRunIds(
-    d,
-    rows.map((r) => r.id)
-  )
-
   return rows.map((r) => ({
     workflowId: r.workflow_id,
     startedAt: r.started_at,
@@ -2281,6 +2233,45 @@ export function listWorkflowRunsByTask(
   }))
 }
 
+export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecution[] {
+  const d = getDb()
+  const rows = d
+    .prepare('SELECT * FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at DESC LIMIT ?')
+    .all(workflowId, limit) as RunRow[]
+  return mapRunRows(
+    rows,
+    fetchNodesByRunIds(
+      d,
+      rows.map((r) => r.id)
+    )
+  )
+}
+
+export function listWorkflowRunsByTask(
+  taskId: string,
+  limit = 20
+): (WorkflowExecution & { workflowName?: string })[] {
+  const d = getDb()
+  const rows = d
+    .prepare(
+      `SELECT DISTINCT wr.*, w.name as workflow_name
+       FROM workflow_runs wr
+       LEFT JOIN workflows w ON w.id = wr.workflow_id
+       WHERE wr.trigger_task_id = ?
+          OR wr.id IN (SELECT run_id FROM workflow_run_nodes WHERE task_id = ?)
+       ORDER BY wr.started_at DESC
+       LIMIT ?`
+    )
+    .all(taskId, taskId, limit) as RunRow[]
+  return mapRunRows(
+    rows,
+    fetchNodesByRunIds(
+      d,
+      rows.map((r) => r.id)
+    )
+  )
+}
+
 /**
  * Runs in `running` state. Used at renderer startup to reconcile orphaned
  * runs: when the renderer reloads mid-execution, headless agents in the main
@@ -2289,15 +2280,6 @@ export function listWorkflowRunsByTask(
  */
 export function listRunningRuns(): WorkflowExecution[] {
   const d = getDb()
-
-  type RunRow = {
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-  }
   const rows = d
     .prepare(
       `SELECT * FROM workflow_runs
@@ -2305,20 +2287,13 @@ export function listRunningRuns(): WorkflowExecution[] {
        ORDER BY started_at DESC`
     )
     .all() as RunRow[]
-
-  const nodesByRun = fetchNodesByRunIds(
-    d,
-    rows.map((r) => r.id)
+  return mapRunRows(
+    rows,
+    fetchNodesByRunIds(
+      d,
+      rows.map((r) => r.id)
+    )
   )
-
-  return rows.map((r) => ({
-    workflowId: r.workflow_id,
-    startedAt: r.started_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at }),
-    status: r.status as WorkflowExecution['status'],
-    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    nodeStates: nodesByRun.get(r.id) ?? []
-  }))
 }
 
 // Surfaces every run that has at least one waiting node — small in practice
@@ -2327,15 +2302,6 @@ export function listRunningRuns(): WorkflowExecution[] {
 // chunk `fetchNodesByRunIds` to stay under SQLite's IN-clause variable cap.
 export function listRunsWithWaitingGates(): WorkflowExecution[] {
   const d = getDb()
-
-  type RunRow = {
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-  }
   const rows = d
     .prepare(
       `SELECT DISTINCT wr.*
@@ -2345,20 +2311,13 @@ export function listRunsWithWaitingGates(): WorkflowExecution[] {
        ORDER BY wr.started_at DESC`
     )
     .all() as RunRow[]
-
-  const nodesByRun = fetchNodesByRunIds(
-    d,
-    rows.map((r) => r.id)
+  return mapRunRows(
+    rows,
+    fetchNodesByRunIds(
+      d,
+      rows.map((r) => r.id)
+    )
   )
-
-  return rows.map((r) => ({
-    workflowId: r.workflow_id,
-    startedAt: r.started_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at }),
-    status: r.status as WorkflowExecution['status'],
-    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    nodeStates: nodesByRun.get(r.id) ?? []
-  }))
 }
 
 /**
@@ -2376,15 +2335,6 @@ export function listAllWorkflowRuns(
   // when fetching node rows for each run.
   const cappedLimit = Math.max(1, Math.min(limit, 500))
 
-  type RunRow = {
-    id: string
-    workflow_id: string
-    started_at: string
-    completed_at: string | null
-    status: string
-    trigger_task_id: string | null
-    workflow_name: string | null
-  }
   // When filtering by workspace, exclude orphaned runs (workflow deleted, the
   // LEFT JOIN nulls everything on `w`). Without `w.id IS NOT NULL`, the
   // COALESCE would silently bucket every orphan into 'personal'.
@@ -2399,21 +2349,13 @@ export function listAllWorkflowRuns(
                LIMIT ?`
   const params = workspaceId ? [workspaceId, cappedLimit] : [cappedLimit]
   const rows = d.prepare(sql).all(...params) as RunRow[]
-
-  const nodesByRun = fetchNodesByRunIds(
-    d,
-    rows.map((r) => r.id)
+  return mapRunRows(
+    rows,
+    fetchNodesByRunIds(
+      d,
+      rows.map((r) => r.id)
+    )
   )
-
-  return rows.map((r) => ({
-    workflowId: r.workflow_id,
-    startedAt: r.started_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at }),
-    status: r.status as WorkflowExecution['status'],
-    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    ...(r.workflow_name != null && { workflowName: r.workflow_name }),
-    nodeStates: nodesByRun.get(r.id) ?? []
-  }))
 }
 
 // ─── Session Logs ─────────────────────────────────────────────────

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2281,6 +2281,46 @@ export function listWorkflowRunsByTask(
   }))
 }
 
+/**
+ * Runs in `running` state. Used at renderer startup to reconcile orphaned
+ * runs: when the renderer reloads mid-execution, headless agents in the main
+ * process keep going but the in-memory exit-promise dies, leaving the run
+ * stuck. The reconciler closes these out against `session_events`.
+ */
+export function listRunningRuns(): WorkflowExecution[] {
+  const d = getDb()
+
+  type RunRow = {
+    id: string
+    workflow_id: string
+    started_at: string
+    completed_at: string | null
+    status: string
+    trigger_task_id: string | null
+  }
+  const rows = d
+    .prepare(
+      `SELECT * FROM workflow_runs
+       WHERE status = 'running'
+       ORDER BY started_at DESC`
+    )
+    .all() as RunRow[]
+
+  const nodesByRun = fetchNodesByRunIds(
+    d,
+    rows.map((r) => r.id)
+  )
+
+  return rows.map((r) => ({
+    workflowId: r.workflow_id,
+    startedAt: r.started_at,
+    ...(r.completed_at != null && { completedAt: r.completed_at }),
+    status: r.status as WorkflowExecution['status'],
+    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+    nodeStates: nodesByRun.get(r.id) ?? []
+  }))
+}
+
 // Surfaces every run that has at least one waiting node — small in practice
 // because gates pause execution. No LIMIT is intentional so the badge count
 // matches the real backlog. If this ever grows, cap with a LIMIT here and

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -42,6 +42,7 @@ import {
   listWorkflowRunsByTask,
   listAllWorkflowRuns,
   listRunsWithWaitingGates,
+  listRunningRuns,
   updateWorkflowRunStatus,
   dbSaveSSHKey,
   dbListSSHKeys,
@@ -540,6 +541,7 @@ export function registerAllMethods(): void {
     listWorkflowRunsByTask(taskId, limit)
   )
   registerMethod('workflowRun:listWaiting', () => listRunsWithWaitingGates())
+  registerMethod('workflowRun:listRunning', () => listRunningRuns())
   registerMethod('workflowRun:listAll', ({ workspaceId, limit }) =>
     listAllWorkflowRuns(workspaceId, limit)
   )

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -935,6 +935,7 @@ export const IPC = {
   WORKFLOW_RUN_LIST: 'workflowRun:list',
   WORKFLOW_RUN_LIST_BY_TASK: 'workflowRun:listByTask',
   WORKFLOW_RUN_LIST_WAITING: 'workflowRun:listWaiting',
+  WORKFLOW_RUN_LIST_RUNNING: 'workflowRun:listRunning',
   WORKFLOW_RUN_LIST_ALL: 'workflowRun:listAll',
   SESSION_LOG_LIST: 'sessionLog:list',
   SESSION_LOG_UPDATE: 'sessionLog:update',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -407,6 +407,11 @@ export interface ConnectorItemContext {
 // Execution context passed from triggers to the execution engine
 export interface WorkflowExecutionContext {
   task?: TaskConfig
+  /**
+   * Terminal session that launched a contextual workflow (right-click on a
+   * card or terminal). Drives the `{{context.*}}` namespace alongside `task`.
+   */
+  source?: TerminalSession
   trigger?: {
     type: TriggerConfig['triggerType']
     fromStatus?: TaskStatus
@@ -432,6 +437,13 @@ export interface WorkflowNodePosition {
 // Trigger configs (discriminated union)
 export interface ManualTriggerConfig {
   triggerType: 'manual'
+  /**
+   * Contextual workflows inherit folder/branch/worktree from the source that
+   * launched them (a card or terminal right-click). They appear only in the
+   * card and terminal context menus; from the sidebar/palette the user is
+   * prompted for the source via SourcePromptDialog.
+   */
+  contextual?: boolean
 }
 export interface OnceTriggerConfig {
   triggerType: 'once'
@@ -479,6 +491,13 @@ export type TriggerConfig =
  */
 export type LaunchAgentType = AiAgentType | 'fromTask'
 
+/**
+ * `'fromContext'` defers the boolean to runtime, reading worktree state from
+ * the source that launched a contextual workflow (a card or terminal).
+ * Editor only allows this sentinel when the trigger is contextual.
+ */
+export type UseWorktreeOption = boolean | 'fromContext'
+
 // Launch Agent action config
 export interface LaunchAgentConfig {
   agentType: LaunchAgentType
@@ -487,7 +506,7 @@ export interface LaunchAgentConfig {
   args?: string[]
   displayName?: string
   branch?: string
-  useWorktree?: boolean
+  useWorktree?: UseWorktreeOption
   worktreeMode?: 'none' | 'new' | 'fromStep' | 'existing'
   worktreeFromStepSlug?: string
   existingWorktreePath?: string
@@ -623,6 +642,13 @@ export interface NodeExecutionState {
   projectPath?: string
   worktreePath?: string
   worktreeName?: string
+  /**
+   * Whether the worktree at `worktreePath` was created by this node
+   * (`'created'`) or inherited from a contextual source like a card / terminal
+   * (`'inherited'`). Cleanup pass only removes `'created'` worktrees so a
+   * contextual workflow never deletes the parent card's worktree.
+   */
+  worktreeOrigin?: 'created' | 'inherited'
   /** Timestamp when an approval gate was approved. */
   approvedAt?: string
 }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -132,6 +132,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.WORKFLOW_RUN_LIST_ALL, (_, workspaceId, limit) =>
     requireBridge().request(IPC.WORKFLOW_RUN_LIST_ALL, { workspaceId, limit })
   )
+  safeHandle(IPC.WORKFLOW_RUN_LIST_RUNNING, () =>
+    requireBridge().request(IPC.WORKFLOW_RUN_LIST_RUNNING, {})
+  )
 
   // Session logs
   safeHandle(IPC.SESSION_LOG_LIST, (_, taskId) =>
@@ -139,6 +142,11 @@ export function registerIpcHandlers(): void {
   )
   safeHandle(IPC.SESSION_LOG_UPDATE, (_, entry) =>
     requireBridge().request(IPC.SESSION_LOG_UPDATE, entry)
+  )
+
+  // Session events
+  safeHandle(IPC.SESSION_EVENT_LIST_BY_SESSION, (_, sessionId, limit) =>
+    requireBridge().request(IPC.SESSION_EVENT_LIST_BY_SESSION, { sessionId, limit })
   )
 
   // Workflow execution complete

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -347,6 +347,13 @@ const api = {
     }
   },
 
+  // Session events (lifecycle log: created / exited / task_linked)
+  listSessionEventsBySession: (
+    sessionId: string,
+    limit?: number
+  ): Promise<import('../shared/types').SessionEvent[]> =>
+    ipcRenderer.invoke(IPC.SESSION_EVENT_LIST_BY_SESSION, sessionId, limit),
+
   // Workflow runs
   saveWorkflowRun: (execution: WorkflowExecution): Promise<void> =>
     ipcRenderer.invoke(IPC.WORKFLOW_RUN_SAVE, execution),
@@ -362,6 +369,9 @@ const api = {
 
   listRunsWithWaitingGates: (): Promise<WorkflowExecution[]> =>
     ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_WAITING),
+
+  listRunningWorkflowRuns: (): Promise<WorkflowExecution[]> =>
+    ipcRenderer.invoke(IPC.WORKFLOW_RUN_LIST_RUNNING),
 
   listAllWorkflowRuns: (
     workspaceId?: string,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,7 +20,8 @@ const WorkflowsLandingView = lazy(() =>
 )
 import {
   executeWorkflow as runWorkflow,
-  rescheduleWaitingGateTimers
+  rescheduleWaitingGateTimers,
+  reconcileRunningExecutions
 } from './lib/workflow-execution'
 import type { WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
@@ -358,6 +359,23 @@ export function App() {
         rescheduleWaitingGateTimers(hydrated, store.config?.workflows ?? [])
       })
       .catch((err) => console.error('[App] failed to hydrate waiting gates:', err))
+
+    // Resolve runs the previous renderer left in `running`. The main process
+    // keeps headless agents alive past a renderer reload, but the in-memory
+    // exit-promise dies — the run wedges. Reconcile against session_events
+    // and close out anything that already exited.
+    window.api
+      .listRunningWorkflowRuns()
+      .then((runs) => {
+        const store = useAppStore.getState()
+        for (const run of runs) {
+          if (!store.workflowExecutions.has(run.workflowId)) {
+            store.setWorkflowExecution(run.workflowId, run)
+          }
+        }
+        return reconcileRunningExecutions(runs)
+      })
+      .catch((err) => console.error('[App] failed to reconcile running runs:', err))
 
     // Auto-prune exited headless sessions
     const pruneInterval = setInterval(() => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -53,6 +53,7 @@ import { TaskBoardView } from './components/TaskBoardView'
 import { TaskDetailPanel } from './components/TaskDetailPanel'
 import { KeyboardShortcutsPanel } from './components/KeyboardShortcutsPanel'
 import { MissedScheduleDialog } from './components/MissedScheduleDialog'
+import { SourcePromptDialog } from './components/SourcePromptDialog'
 import { OnboardingModal } from './components/OnboardingModal'
 import { UpdateBanner } from './components/UpdateBanner'
 import { ToastContainer } from './components/Toast'
@@ -586,6 +587,7 @@ export function App() {
       <WorktreeCleanupDialog />
       <WorktreeCleanupToastBridge />
       <MissedScheduleDialog />
+      <SourcePromptDialog />
       <AnimatePresence>{isShortcutsPanelOpen && <KeyboardShortcutsPanel />}</AnimatePresence>
 
       <AnimatePresence>{isSettingsOpen && <SettingsPage />}</AnimatePresence>

--- a/src/renderer/components/CardContextMenu.tsx
+++ b/src/renderer/components/CardContextMenu.tsx
@@ -149,11 +149,14 @@ export function CardContextMenu({ terminalId, position, onClose }: Props) {
     })
   }
 
-  if (workspaceWorkflows.length > 0) {
+  const workflowMenuItems = buildWorkflowMenuItems(workspaceWorkflows, onClose, {
+    source: terminal.session
+  })
+  if (workflowMenuItems.length > 0) {
     items.push({
       iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
-      submenu: buildWorkflowMenuItems(workspaceWorkflows, onClose)
+      submenu: workflowMenuItems
     })
   }
 

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
   createSessionFromProject,
   createShellInProject
 } from '../lib/session-utils'
-import { executeWorkflow } from '../lib/workflow-execution'
+import { runWorkflowFromGlobalSurface } from '../lib/workflow-menu-items'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import {
   Search,
@@ -337,8 +337,8 @@ function useCommands(
         keywords: actionNodes
           .map((n) => (n.config as unknown as Record<string, unknown>)?.projectName as string)
           .filter(Boolean),
-        onExecute: async () => {
-          await executeWorkflow(wf)
+        onExecute: () => {
+          runWorkflowFromGlobalSurface(wf)
         }
       })
     }

--- a/src/renderer/components/GridContextMenu.tsx
+++ b/src/renderer/components/GridContextMenu.tsx
@@ -238,7 +238,12 @@ export function GridContextMenu({ position, onClose }: Props) {
     separator: workspaceProjects.length > 0
   })
 
-  if (workspaceWorkflows.length > 0) {
+  // Empty grid space has no card / session under cursor — show only
+  // non-contextual workflows (contextual ones are listed in card and
+  // terminal right-click menus). buildWorkflowMenuItems handles the filter
+  // when called without a context argument.
+  const gridWorkflowItems = buildWorkflowMenuItems(workspaceWorkflows, onClose)
+  if (gridWorkflowItems.length > 0) {
     items.push({
       iconElement: <Zap size={14} className="text-gray-500" />,
       label: 'Run workflow',
@@ -255,13 +260,14 @@ export function GridContextMenu({ position, onClose }: Props) {
   const hoveredItem = hoveredSubmenu !== null ? items[hoveredSubmenu] : null
   const activeSubmenu = hoveredItem?.submenuKey
     ? hoveredItem.submenuKey === 'run-workflow'
-      ? buildWorkflowMenuItems(workspaceWorkflows, onClose)
+      ? gridWorkflowItems
       : buildScopedSubmenu(hoveredItem.submenuKey === 'session-in' ? 'session' : 'terminal')
     : null
 
   let submenuLeft = left + MENU_WIDTH + 4
   let submenuTop = top
   if (hoveredSubmenu !== null) {
+    // eslint-disable-next-line react-hooks/refs
     const itemEl = itemRefs.current.get(hoveredSubmenu)
     if (itemEl) submenuTop = itemEl.getBoundingClientRect().top
     if (submenuLeft + SUBMENU_WIDTH > window.innerWidth - 8) {

--- a/src/renderer/components/ProjectPicker.tsx
+++ b/src/renderer/components/ProjectPicker.tsx
@@ -145,18 +145,25 @@ export function ProjectPicker({
             : 'flex items-center gap-1.5 hover:bg-white/[0.04] rounded px-1.5 py-0.5 -mx-1.5 transition-colors text-[12px] text-gray-300'
         }
       >
-        {isFromContext ? (
-          <Zap size={13} color="#60a5fa" strokeWidth={1.5} />
-        ) : (
-          <ProjectIcon icon={current?.icon} color={current?.iconColor} />
-        )}
-        <span
-          className={`flex-1 text-left ${
-            isFromContext ? 'text-gray-200' : currentProject ? '' : 'text-gray-600'
-          }`}
-        >
-          {isFromContext ? 'From Context' : currentProject || 'Select project...'}
-        </span>
+        {(() => {
+          if (isFromContext) {
+            return (
+              <>
+                <Zap size={13} color="#60a5fa" strokeWidth={1.5} />
+                <span className="flex-1 text-left text-gray-200">From Context</span>
+              </>
+            )
+          }
+          const labelClass = currentProject ? '' : 'text-gray-600'
+          return (
+            <>
+              <ProjectIcon icon={current?.icon} color={current?.iconColor} />
+              <span className={`flex-1 text-left ${labelClass}`}>
+                {currentProject || 'Select project...'}
+              </span>
+            </>
+          )
+        })()}
         <ChevronDown size={11} className="text-gray-500" />
       </button>
 

--- a/src/renderer/components/ProjectPicker.tsx
+++ b/src/renderer/components/ProjectPicker.tsx
@@ -71,13 +71,23 @@ export function ProjectPicker({
   projects,
   onChange,
   variant = 'compact',
-  allowNone = false
+  allowNone = false,
+  allowFromContext = false,
+  isFromContext = false,
+  onSelectFromContext
 }: {
   currentProject: string
   projects: ProjectConfig[]
   onChange: (projectName: string) => void
   variant?: 'compact' | 'form'
   allowNone?: boolean
+  /** When true, shows a "From Context" entry at the top of the dropdown. */
+  allowFromContext?: boolean
+  /** When true, the trigger renders the "From Context" chip instead of a project name. */
+  isFromContext?: boolean
+  /** Called when the user picks "From Context". The caller writes the
+   *  appropriate sentinel into its config. */
+  onSelectFromContext?: () => void
 }) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -135,9 +145,17 @@ export function ProjectPicker({
             : 'flex items-center gap-1.5 hover:bg-white/[0.04] rounded px-1.5 py-0.5 -mx-1.5 transition-colors text-[12px] text-gray-300'
         }
       >
-        <ProjectIcon icon={current?.icon} color={current?.iconColor} />
-        <span className={`flex-1 text-left ${currentProject ? '' : 'text-gray-600'}`}>
-          {currentProject || 'Select project...'}
+        {isFromContext ? (
+          <Zap size={13} color="#60a5fa" strokeWidth={1.5} />
+        ) : (
+          <ProjectIcon icon={current?.icon} color={current?.iconColor} />
+        )}
+        <span
+          className={`flex-1 text-left ${
+            isFromContext ? 'text-gray-200' : currentProject ? '' : 'text-gray-600'
+          }`}
+        >
+          {isFromContext ? 'From Context' : currentProject || 'Select project...'}
         </span>
         <ChevronDown size={11} className="text-gray-500" />
       </button>
@@ -159,6 +177,20 @@ export function ProjectPicker({
                 minWidth: Math.max(180, position.width)
               }}
             >
+              {allowFromContext && onSelectFromContext && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setOpen(false)
+                    onSelectFromContext()
+                  }}
+                  className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-gray-300 hover:bg-white/[0.06] transition-colors border-b border-white/[0.06]"
+                >
+                  <Zap size={13} color="#60a5fa" strokeWidth={1.5} />
+                  <span className="flex-1 text-left">From Context</span>
+                  {isFromContext && <Check size={13} className="text-gray-400" />}
+                </button>
+              )}
               {allowNone && (
                 <button
                   onClick={(e) => {
@@ -169,7 +201,9 @@ export function ProjectPicker({
                 >
                   <Folder size={13} className="text-gray-600" />
                   <span className="flex-1 text-left italic">None</span>
-                  {!currentProject && <Check size={13} className="text-gray-400" />}
+                  {!currentProject && !isFromContext && (
+                    <Check size={13} className="text-gray-400" />
+                  )}
                 </button>
               )}
               {projects.map((p) => (
@@ -183,7 +217,9 @@ export function ProjectPicker({
                 >
                   <ProjectIcon icon={p.icon} color={p.iconColor} />
                   <span className="flex-1 text-left">{p.name}</span>
-                  {p.name === currentProject && <Check size={13} className="text-gray-400" />}
+                  {!isFromContext && p.name === currentProject && (
+                    <Check size={13} className="text-gray-400" />
+                  )}
                 </button>
               ))}
             </motion.div>

--- a/src/renderer/components/SourcePromptDialog.tsx
+++ b/src/renderer/components/SourcePromptDialog.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { GitBranch, Zap } from 'lucide-react'
+import { useAppStore } from '../stores'
+import { ProjectPicker } from './ProjectPicker'
+import { executeWorkflow } from '../lib/workflow-execution'
+import { containsContextRef, isContextRef } from '../lib/template-vars'
+import type {
+  LaunchAgentConfig,
+  ScriptConfig,
+  TerminalSession,
+  WorkflowDefinition
+} from '../../shared/types'
+
+/**
+ * Walk the workflow's nodes and decide which fields the user actually needs
+ * to fill in. A contextual workflow that only references `{{context.cwd}}`
+ * shouldn't bother prompting for branch — and vice versa.
+ */
+function detectRequiredFields(workflow: WorkflowDefinition): {
+  needsProject: boolean
+  needsBranch: boolean
+  needsWorktree: boolean
+} {
+  const projectFields = ['cwd', 'projectPath', 'projectName']
+  let needsProject = false
+  let needsBranch = false
+  let needsWorktree = false
+
+  for (const node of workflow.nodes) {
+    if (node.type === 'launchAgent') {
+      const cfg = node.config as LaunchAgentConfig
+      if (
+        isContextRef(cfg.projectName) ||
+        isContextRef(cfg.projectPath) ||
+        projectFields.some((f) => containsContextRef(cfg.prompt, f))
+      ) {
+        needsProject = true
+      }
+      if (isContextRef(cfg.branch) || containsContextRef(cfg.prompt, 'branch')) {
+        needsBranch = true
+      }
+      if (cfg.useWorktree === 'fromContext') {
+        needsWorktree = true
+        // worktree implies branch + project so the cwd resolves correctly
+        needsProject = true
+        needsBranch = true
+      }
+    } else if (node.type === 'script') {
+      const cfg = node.config as ScriptConfig
+      if (
+        isContextRef(cfg.cwd) ||
+        isContextRef(cfg.projectName) ||
+        isContextRef(cfg.projectPath) ||
+        projectFields.some((f) => containsContextRef(cfg.scriptContent, f))
+      ) {
+        needsProject = true
+      }
+      if (containsContextRef(cfg.scriptContent, 'branch')) {
+        needsBranch = true
+      }
+    }
+  }
+
+  return { needsProject, needsBranch, needsWorktree }
+}
+
+export function SourcePromptDialog() {
+  const pendingId = useAppStore((s) => s.pendingContextualWorkflowId)
+  const setPendingId = useAppStore((s) => s.setPendingContextualWorkflowId)
+  const config = useAppStore((s) => s.config)
+  const workflow = useAppStore((s) =>
+    pendingId ? (s.config?.workflows ?? []).find((w) => w.id === pendingId) : undefined
+  )
+
+  const [projectName, setProjectName] = useState('')
+  const [projectPath, setProjectPath] = useState('')
+  const [branch, setBranch] = useState('')
+  const [useWorktree, setUseWorktree] = useState(false)
+
+  const required = useMemo(
+    () =>
+      workflow
+        ? detectRequiredFields(workflow)
+        : { needsProject: true, needsBranch: false, needsWorktree: false },
+    [workflow]
+  )
+
+  // Reset state and seed sensible defaults each time the dialog opens for a
+  // new workflow. Depending on `config` here would clobber user input
+  // mid-edit on any unrelated config change.
+  useEffect(() => {
+    if (!pendingId) return
+    const first = (useAppStore.getState().config?.projects ?? [])[0]
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setProjectName(first?.name ?? '')
+    setProjectPath(first?.path ?? '')
+    setBranch('')
+    setUseWorktree(false)
+  }, [pendingId])
+
+  if (!pendingId || !workflow) return null
+
+  const close = () => setPendingId(null)
+
+  const submit = () => {
+    if (required.needsProject && (!projectName || !projectPath)) return
+    // Synthesize a TerminalSession-shaped source for the resolver. Fields
+    // the dialog doesn't capture (id, status, etc.) are placeholders.
+    const source: TerminalSession = {
+      id: `prompt:${pendingId}:${Date.now()}`,
+      agentType: 'shell',
+      projectName,
+      projectPath,
+      status: 'idle',
+      createdAt: Date.now(),
+      pid: 0,
+      branch: branch || undefined,
+      isWorktree: useWorktree
+    }
+    void executeWorkflow(workflow, { source }, { source: 'manual' })
+    close()
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm"
+        onClick={close}
+      />
+      <motion.div
+        className="fixed top-1/2 left-1/2 z-50 w-[460px] border border-white/[0.08] rounded-xl shadow-2xl
+                   overflow-hidden"
+        style={{ background: '#1e1e22' }}
+        initial={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}
+        animate={{ opacity: 1, scale: 1, x: '-50%', y: '-50%' }}
+        exit={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      >
+        <div className="px-6 py-4 border-b border-white/[0.06]">
+          <div className="flex items-center gap-2 text-white text-[15px] font-medium">
+            <Zap size={14} className="text-blue-400" />
+            Run "{workflow.name}"
+          </div>
+          <p className="text-[12px] text-gray-500 mt-1">
+            This contextual workflow needs a source. Pick the folder it should run against.
+          </p>
+        </div>
+
+        <div className="p-6 space-y-4">
+          {required.needsProject && (
+            <div>
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wider mb-2 block">
+                Project
+              </label>
+              <ProjectPicker
+                currentProject={projectName}
+                projects={config?.projects ?? []}
+                onChange={(name) => {
+                  const proj = (config?.projects ?? []).find((p) => p.name === name)
+                  if (proj) {
+                    setProjectName(proj.name)
+                    setProjectPath(proj.path)
+                  }
+                }}
+                variant="form"
+              />
+            </div>
+          )}
+
+          {required.needsBranch && (
+            <div>
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wider mb-2 block">
+                Branch
+              </label>
+              <div className="flex items-center gap-1.5 px-3 py-2 bg-white/[0.06] border border-white/[0.1] rounded-md">
+                <GitBranch size={12} className="text-gray-500 shrink-0" />
+                <input
+                  type="text"
+                  value={branch}
+                  onChange={(e) => setBranch(e.target.value)}
+                  placeholder="leave blank to use the project's current branch"
+                  className="flex-1 min-w-0 bg-transparent text-[13px] text-white placeholder-gray-600
+                             focus:outline-none border-none px-0"
+                />
+              </div>
+            </div>
+          )}
+
+          {required.needsWorktree && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={useWorktree}
+                onChange={(e) => setUseWorktree(e.target.checked)}
+                className="accent-white/80"
+              />
+              <span className="text-[13px] text-gray-300">Run in a new worktree</span>
+            </label>
+          )}
+        </div>
+
+        <div className="px-6 py-3 border-t border-white/[0.06] flex justify-end gap-2">
+          <button
+            onClick={close}
+            className="px-3 py-1.5 text-[13px] text-gray-300 hover:text-white rounded-md
+                       hover:bg-white/[0.06] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={required.needsProject && !projectName}
+            className="px-4 py-1.5 text-[13px] text-white bg-white/[0.1] hover:bg-white/[0.15]
+                       rounded-md transition-colors disabled:opacity-40 disabled:pointer-events-none"
+          >
+            Run
+          </button>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   pasteToTerminal,
   focusTerminal
 } from '../lib/terminal-registry'
+import { useAppStore } from '../stores'
 import { useWorkspaceWorkflows } from '../hooks/useWorkspaceWorkflows'
 import { buildWorkflowMenuItems } from '../lib/workflow-menu-items'
 
@@ -23,6 +24,7 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const selection = getTerminalSelection(terminalId)
   const workspaceWorkflows = useWorkspaceWorkflows()
+  const sourceSession = useAppStore((s) => s.terminals.get(terminalId)?.session)
 
   const [showWorkflowSubmenu, setShowWorkflowSubmenu] = useState(false)
   const [workflowBtnTop, setWorkflowBtnTop] = useState(0)
@@ -77,14 +79,18 @@ export function TerminalContextMenu({ terminalId, position, onClose }: Props) {
     close()
   }
 
-  const hasWorkflows = workspaceWorkflows.length > 0
+  const workflowSubmenuItems = buildWorkflowMenuItems(
+    workspaceWorkflows,
+    close,
+    sourceSession ? { source: sourceSession } : undefined
+  )
+
+  const hasWorkflows = workflowSubmenuItems.length > 0
   const itemCount = 2 + (hasWorkflows ? 1 : 0)
   const menuWidth = 180
   const menuHeight = itemCount * 32 + (hasWorkflows ? 9 : 0) + 16
   const left = Math.max(8, Math.min(position.x, window.innerWidth - menuWidth - 8))
   const top = Math.max(8, Math.min(position.y, window.innerHeight - menuHeight - 8))
-
-  const workflowSubmenuItems = buildWorkflowMenuItems(workspaceWorkflows, close)
 
   const submenuWidth = 200
   let submenuLeft = left + menuWidth + 4

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -4,7 +4,7 @@ import { parseConnectorWorkflowId } from '../../../shared/types'
 import { ICON_MAP } from './icon-map'
 import { useAppStore } from '../../stores'
 import { isScheduledWorkflow } from '../../lib/workflow-helpers'
-import { executeWorkflow } from '../../lib/workflow-execution'
+import { runWorkflowFromGlobalSurface } from '../../lib/workflow-menu-items'
 import { useConnectorIdFor } from '../../lib/use-connections'
 import { Zap, Play, MoreHorizontal } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
@@ -117,7 +117,7 @@ export function WorkflowItem({
               aria-label={`Run workflow ${workflow.name}`}
               onClick={(e) => {
                 e.stopPropagation()
-                executeWorkflow(workflow)
+                runWorkflowFromGlobalSurface(workflow)
               }}
               className="opacity-0 group-hover/wf:opacity-100 focus:opacity-100 text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0"
             >

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -165,11 +165,12 @@ export function RunStepsList({
                   </span>
                 )}
               </div>
-              {(ns.logs || ns.error) && (
-                <span className="text-[10px] text-gray-600">
-                  {expandedNodeId === ns.nodeId ? 'hide' : 'logs'}
-                </span>
-              )}
+              <ChevronDown
+                size={12}
+                className={`text-gray-600 shrink-0 transition-transform ${
+                  expandedNodeId === ns.nodeId ? '' : '-rotate-90'
+                }`}
+              />
             </button>
 
             {isWaitingGate && (
@@ -254,6 +255,20 @@ export function RunStepsList({
                     </Tooltip>
                   </div>
                 )}
+              </div>
+            )}
+
+            {expandedNodeId === ns.nodeId && !ns.logs && !ns.error && (
+              <div className="px-4 pb-2">
+                <p className="text-[11px] text-gray-600 italic">
+                  {ns.status === 'running'
+                    ? 'No output captured yet…'
+                    : ns.status === 'pending'
+                      ? "Step hasn't started yet."
+                      : ns.status === 'skipped'
+                        ? 'Step was skipped.'
+                        : 'No output recorded.'}
+                </p>
               </div>
             )}
           </div>

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -36,7 +36,8 @@ import {
   insertBeforeFork,
   insertConditionBetween,
   addParallelBranch,
-  removeNode
+  removeNode,
+  getWorktreeMode
 } from '../../lib/workflow-helpers'
 import { executeWorkflow } from '../../lib/workflow-execution'
 import { toast } from '../Toast'
@@ -96,6 +97,28 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     const triggerNode = nodes.find((n) => n.type === 'trigger')
     if (!triggerNode) return undefined
     return (triggerNode.config as TriggerConfig).triggerType
+  }, [nodes])
+
+  const isContextualTrigger = useMemo(() => {
+    const triggerNode = nodes.find((n) => n.type === 'trigger')
+    if (!triggerNode) return false
+    const cfg = triggerNode.config as TriggerConfig
+    return cfg.triggerType === 'manual' && cfg.contextual === true
+  }, [nodes])
+
+  // Disabled state for the cleanup toggle: when every LaunchAgent inherits
+  // its worktree from context, there's nothing for autoCleanupWorktrees to
+  // act on, so toggling has no effect.
+  const allWorktreesInherited = useMemo(() => {
+    let anyCreates = false
+    let anyInherits = false
+    for (const node of nodes) {
+      if (node.type !== 'launchAgent') continue
+      const mode = getWorktreeMode(node.config as import('../../../shared/types').LaunchAgentConfig)
+      if (mode === 'fromContext') anyInherits = true
+      else if (mode === 'new') anyCreates = true
+    }
+    return anyInherits && !anyCreates
   }, [nodes])
 
   // Map of connectionId → action defs. Populated for every connection the
@@ -718,6 +741,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             onDelete={handleDeleteNode}
             onClose={() => setSelectedNodeId(null)}
             triggerType={triggerType}
+            isContextualTrigger={isContextualTrigger}
             stepGroups={stepGroups}
           />
         )}
@@ -730,6 +754,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             onStaggerChange={setStaggerDelayMs}
             autoCleanupWorktrees={autoCleanupWorktrees}
             onCleanupChange={setAutoCleanupWorktrees}
+            cleanupDisabled={allWorktreesInherited}
             triggerNode={nodes.find((n) => n.type === 'trigger') ?? null}
             onSelectTrigger={() => {
               const t = nodes.find((n) => n.type === 'trigger')

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -74,14 +74,26 @@ export function LaunchAgentConfigForm({
       setIsGitRepo(true)
       return
     }
+    let cancelled = false
     window.api
       .isGitRepo(config.projectPath)
-      .then(setIsGitRepo)
-      .catch(() => setIsGitRepo(false))
+      .then((v) => {
+        if (!cancelled) setIsGitRepo(v)
+      })
+      .catch(() => {
+        if (!cancelled) setIsGitRepo(false)
+      })
     window.api
       .listWorktrees(config.projectPath)
-      .then((wts) => setExistingWorktrees(wts.filter((w) => !w.isMain)))
-      .catch(() => setExistingWorktrees([]))
+      .then((wts) => {
+        if (!cancelled) setExistingWorktrees(wts.filter((w) => !w.isMain))
+      })
+      .catch(() => {
+        if (!cancelled) setExistingWorktrees([])
+      })
+    return () => {
+      cancelled = true
+    }
   }, [config.projectPath, isRemote])
 
   const priorWorktreeSteps = useMemo(

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ChevronRight, Settings2, GitBranch, EyeOff } from 'lucide-react'
+import { ChevronRight, Settings2, GitBranch, EyeOff, Zap } from 'lucide-react'
 import {
   LaunchAgentConfig,
   TriggerConfig,
@@ -8,18 +8,26 @@ import {
   getProjectRemoteHostId
 } from '../../../../shared/types'
 import { useAppStore } from '../../../stores'
-import { TEMPLATE_VARIABLES, StepVariableGroup } from '../../../lib/template-vars'
+import {
+  StepVariableGroup,
+  CONTEXT_REF,
+  getAvailableContextVars,
+  isContextRef
+} from '../../../lib/template-vars'
+import { getWorktreeMode } from '../../../lib/workflow-helpers'
 import { useAgentInstallStatus } from '../../../hooks/useAgentInstallStatus'
 import { VariableAutocomplete } from './VariableAutocomplete'
 import { ProjectPicker } from '../../ProjectPicker'
 import { AgentPicker } from '../../AgentPicker'
 import { SelectPicker } from '../../SelectPicker'
+import { Tooltip } from '../../Tooltip'
 import { RichMarkdownEditor } from '../../rich-editor/RichMarkdownEditor'
 
 interface Props {
   config: LaunchAgentConfig
   onChange: (config: LaunchAgentConfig) => void
   triggerType?: TriggerConfig['triggerType']
+  isContextualTrigger?: boolean
   stepGroups?: StepVariableGroup[]
   currentNodeId?: string
   allNodes?: WorkflowNode[]
@@ -38,6 +46,7 @@ export function LaunchAgentConfigForm({
   config,
   onChange,
   triggerType,
+  isContextualTrigger = false,
   stepGroups = [],
   currentNodeId,
   allNodes
@@ -60,6 +69,7 @@ export function LaunchAgentConfigForm({
 
   useEffect(() => {
     if (!config.projectPath || isRemote) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setExistingWorktrees([])
       setIsGitRepo(true)
       return
@@ -79,17 +89,19 @@ export function LaunchAgentConfigForm({
       (allNodes ?? []).filter((n) => {
         if (n.id === currentNodeId) return false
         if (n.type !== 'launchAgent') return false
-        const c = n.config as LaunchAgentConfig
-        const mode = c.worktreeMode ?? (c.useWorktree ? 'new' : 'none')
+        const mode = getWorktreeMode(n.config as LaunchAgentConfig)
         return mode === 'new' || mode === 'fromStep'
       }),
     [allNodes, currentNodeId]
   )
 
-  const worktreeMode = config.worktreeMode ?? (config.useWorktree ? 'new' : 'none')
+  const projectIsFromContext = isContextRef(config.projectName) || isContextRef(config.projectPath)
+  const branchIsFromContext = isContextRef(config.branch)
+  const worktreeIsFromContext = config.useWorktree === 'fromContext'
+  const worktreeMode = getWorktreeMode(config)
   const promptSource = config.taskId ? 'task' : config.taskFromQueue ? 'queue' : 'inline'
   const isTaskTrigger = triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
-  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger
+  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger || isContextualTrigger
   const hasBranch = !isRemote && !!(config.branch && config.branch.trim())
   const isHeadless = !!config.headless
   const canUseFromTask = isTaskTrigger || promptSource === 'task' || promptSource === 'queue'
@@ -102,12 +114,28 @@ export function LaunchAgentConfigForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canUseFromTask])
 
-  const contextVars = isTaskTrigger
-    ? TEMPLATE_VARIABLES.filter(
-        (v) =>
-          v.category === 'task' || (v.category === 'trigger' && triggerType === 'taskStatusChanged')
-      )
-    : []
+  // Reset any "From Context" fields if the trigger is no longer contextual.
+  // The runtime resolver returns empty strings for `{{context.*}}` without a
+  // source — silently leaving these in place after toggling off would mean
+  // the workflow runs with empty cwd / branch.
+  useEffect(() => {
+    if (isContextualTrigger) return
+    if (!projectIsFromContext && !branchIsFromContext && !worktreeIsFromContext) return
+    const updates: Partial<LaunchAgentConfig> = {}
+    if (projectIsFromContext) {
+      updates.projectName = ''
+      updates.projectPath = ''
+    }
+    if (branchIsFromContext) updates.branch = undefined
+    if (worktreeIsFromContext) {
+      updates.useWorktree = undefined
+      updates.worktreeMode = 'none'
+    }
+    onChange({ ...config, ...updates })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isContextualTrigger])
+
+  const contextVars = getAvailableContextVars({ triggerType, isContextualTrigger })
 
   return (
     <div className="space-y-5">
@@ -125,13 +153,22 @@ export function LaunchAgentConfigForm({
       <div>
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Project</label>
         <ProjectPicker
-          currentProject={config.projectName}
+          currentProject={projectIsFromContext ? '' : config.projectName}
           projects={projects}
           onChange={(name) => {
             const proj = projects.find((p) => p.name === name)
             if (proj) onChange({ ...config, projectName: proj.name, projectPath: proj.path })
           }}
           variant="form"
+          allowFromContext={isContextualTrigger}
+          isFromContext={projectIsFromContext}
+          onSelectFromContext={() =>
+            onChange({
+              ...config,
+              projectName: CONTEXT_REF.projectName,
+              projectPath: CONTEXT_REF.projectPath
+            })
+          }
         />
       </div>
 
@@ -210,20 +247,49 @@ export function LaunchAgentConfigForm({
 
           <div>
             <div className="flex items-center gap-1.5 px-3 py-2 bg-white/[0.06] border border-white/[0.1] rounded-md">
-              <GitBranch size={12} strokeWidth={2} className="text-gray-500 shrink-0" />
-              <input
-                type="text"
-                value={config.branch || ''}
-                onChange={(e) => {
-                  const branch = e.target.value || undefined
-                  const updates: Partial<LaunchAgentConfig> = { branch }
-                  if (!branch) updates.useWorktree = undefined
-                  onChange({ ...config, ...updates })
-                }}
-                placeholder="feature/my-branch"
-                className="flex-1 min-w-0 bg-transparent text-[13px] text-white placeholder-gray-600
-                           focus:outline-none border-none px-0"
-              />
+              {branchIsFromContext ? (
+                <Zap size={12} color="#60a5fa" className="shrink-0" />
+              ) : (
+                <GitBranch size={12} strokeWidth={2} className="text-gray-500 shrink-0" />
+              )}
+              {branchIsFromContext ? (
+                <span className="flex-1 text-[13px] text-gray-200">From Context</span>
+              ) : (
+                <input
+                  type="text"
+                  value={config.branch || ''}
+                  onChange={(e) => {
+                    const branch = e.target.value || undefined
+                    const updates: Partial<LaunchAgentConfig> = { branch }
+                    if (!branch) updates.useWorktree = undefined
+                    onChange({ ...config, ...updates })
+                  }}
+                  placeholder="feature/my-branch"
+                  className="flex-1 min-w-0 bg-transparent text-[13px] text-white placeholder-gray-600
+                             focus:outline-none border-none px-0"
+                />
+              )}
+              {isContextualTrigger && (
+                <Tooltip
+                  label={branchIsFromContext ? 'Use a specific branch' : 'Use From Context'}
+                  position="top"
+                >
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange({
+                        ...config,
+                        branch: branchIsFromContext ? undefined : CONTEXT_REF.branch
+                      })
+                    }
+                    className={`shrink-0 p-0.5 rounded hover:bg-white/[0.08] transition-colors ${
+                      branchIsFromContext ? 'text-blue-400' : 'text-gray-500 hover:text-gray-300'
+                    }`}
+                  >
+                    <Zap size={11} />
+                  </button>
+                </Tooltip>
+              )}
             </div>
             <p className="text-[11px] text-gray-500 mt-1">
               Checks out this branch before launching
@@ -246,12 +312,23 @@ export function LaunchAgentConfigForm({
                   label: 'From step',
                   hint: priorWorktreeSteps.length === 0 ? 'no steps' : undefined
                 },
-                { value: 'existing', label: 'Existing worktree' }
+                { value: 'existing', label: 'Existing worktree' },
+                ...(isContextualTrigger ? [{ value: 'fromContext', label: 'From Context' }] : [])
               ]}
               onChange={(v) => {
-                const key = v as 'none' | 'new' | 'fromStep' | 'existing'
+                const key = v as 'none' | 'new' | 'fromStep' | 'existing' | 'fromContext'
                 if (key === 'new' && !hasBranch) return
                 if (key === 'fromStep' && priorWorktreeSteps.length === 0) return
+                if (key === 'fromContext') {
+                  onChange({
+                    ...config,
+                    useWorktree: 'fromContext',
+                    worktreeMode: undefined,
+                    worktreeFromStepSlug: undefined,
+                    existingWorktreePath: undefined
+                  })
+                  return
+                }
                 const updates: Partial<LaunchAgentConfig> = {
                   worktreeMode: key,
                   useWorktree: key === 'new' ? true : undefined,
@@ -271,6 +348,8 @@ export function LaunchAgentConfigForm({
               {worktreeMode === 'new' && "Isolated directory — won't affect the main working tree"}
               {worktreeMode === 'fromStep' && 'Reuses the worktree created by a previous step'}
               {worktreeMode === 'existing' && 'Launches into an existing worktree on disk'}
+              {worktreeMode === 'fromContext' &&
+                "Inherits the launching card or terminal's worktree (won't be auto-cleaned)"}
             </p>
           </div>
 

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -68,6 +68,7 @@ interface Props {
   onDelete: (nodeId: string) => void
   onClose: () => void
   triggerType?: TriggerConfig['triggerType']
+  isContextualTrigger?: boolean
   stepGroups?: StepVariableGroup[]
 }
 
@@ -79,6 +80,7 @@ export function NodeConfigPanel({
   onDelete,
   onClose,
   triggerType,
+  isContextualTrigger,
   stepGroups
 }: Props) {
   const [showMenu, setShowMenu] = useState(false)
@@ -188,6 +190,7 @@ export function NodeConfigPanel({
             config={node.config as LaunchAgentConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
+            isContextualTrigger={isContextualTrigger}
             stepGroups={stepGroups}
             currentNodeId={node.id}
             allNodes={allNodes}
@@ -199,6 +202,7 @@ export function NodeConfigPanel({
             config={node.config as ScriptConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
+            isContextualTrigger={isContextualTrigger}
             stepGroups={stepGroups}
           />
         )}

--- a/src/renderer/components/workflow-editor/panels/ScriptConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ScriptConfigForm.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Terminal, FileCode, Braces, ChevronRight, Settings2 } from 'lucide-react'
 import { ScriptConfig, TriggerConfig } from '../../../../shared/types'
 import { useAppStore } from '../../../stores'
-import { TEMPLATE_VARIABLES, StepVariableGroup } from '../../../lib/template-vars'
+import {
+  StepVariableGroup,
+  CONTEXT_REF,
+  getAvailableContextVars,
+  isContextRef
+} from '../../../lib/template-vars'
 import { VariableAutocomplete } from './VariableAutocomplete'
 import { ProjectPicker } from '../../ProjectPicker'
 import { SelectPicker } from '../../SelectPicker'
@@ -12,6 +17,7 @@ interface Props {
   config: ScriptConfig
   onChange: (config: ScriptConfig) => void
   triggerType?: TriggerConfig['triggerType']
+  isContextualTrigger?: boolean
   stepGroups?: StepVariableGroup[]
 }
 
@@ -28,17 +34,29 @@ const SCRIPT_TYPES = [
   { value: 'node', label: 'Node', icon: <Braces size={12} className="text-gray-400" /> }
 ]
 
-export function ScriptConfigForm({ config, onChange, triggerType, stepGroups = [] }: Props) {
+export function ScriptConfigForm({
+  config,
+  onChange,
+  triggerType,
+  isContextualTrigger = false,
+  stepGroups = []
+}: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(!!config.args?.length)
   const projects = useAppStore((s) => s.config?.projects ?? EMPTY_PROJECTS)
   const isTaskTrigger = triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
-  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger
-  const contextVars = isTaskTrigger
-    ? TEMPLATE_VARIABLES.filter(
-        (v) =>
-          v.category === 'task' || (v.category === 'trigger' && triggerType === 'taskStatusChanged')
-      )
-    : []
+  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger || isContextualTrigger
+  const contextVars = getAvailableContextVars({ triggerType, isContextualTrigger })
+  const cwdIsFromContext =
+    isContextRef(config.cwd) || isContextRef(config.projectName) || isContextRef(config.projectPath)
+
+  // The runtime resolver returns empty strings for `{{context.*}}` when
+  // there's no source, so leaving sentinels in place after toggling off
+  // would silently launch with empty cwd.
+  useEffect(() => {
+    if (isContextualTrigger || !cwdIsFromContext) return
+    onChange({ ...config, cwd: undefined, projectName: undefined, projectPath: undefined })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isContextualTrigger])
 
   return (
     <div className="space-y-5">
@@ -57,7 +75,7 @@ export function ScriptConfigForm({ config, onChange, triggerType, stepGroups = [
           Working Directory
         </label>
         <ProjectPicker
-          currentProject={config.projectName || ''}
+          currentProject={cwdIsFromContext ? '' : config.projectName || ''}
           projects={projects}
           onChange={(name) => {
             if (!name) {
@@ -77,6 +95,16 @@ export function ScriptConfigForm({ config, onChange, triggerType, stepGroups = [
           }}
           variant="form"
           allowNone
+          allowFromContext={isContextualTrigger}
+          isFromContext={cwdIsFromContext}
+          onSelectFromContext={() =>
+            onChange({
+              ...config,
+              projectName: CONTEXT_REF.projectName,
+              projectPath: CONTEXT_REF.projectPath,
+              cwd: CONTEXT_REF.cwd
+            })
+          }
         />
       </div>
 

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -102,6 +102,54 @@ export function TriggerConfigForm({ config, onChange }: Props) {
         </p>
       </div>
 
+      {config.triggerType === 'manual' &&
+        (() => {
+          const isContextual = config.contextual === true
+          return (
+            <button
+              role="switch"
+              aria-checked={isContextual}
+              onClick={() =>
+                onChange({
+                  triggerType: 'manual',
+                  contextual: isContextual ? undefined : true
+                })
+              }
+              className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg border transition-all ${
+                isContextual
+                  ? 'border-white/[0.1] bg-white/[0.04]'
+                  : 'border-white/[0.04] bg-white/[0.02] hover:border-white/[0.1]'
+              }`}
+            >
+              <div
+                className={`w-7 h-[16px] rounded-full transition-colors relative shrink-0 ${
+                  isContextual ? 'bg-gray-400' : 'bg-white/[0.1]'
+                }`}
+              >
+                <div
+                  className={`absolute top-[2px] w-[12px] h-[12px] rounded-full bg-white transition-transform ${
+                    isContextual ? 'translate-x-[13px]' : 'translate-x-[2px]'
+                  }`}
+                />
+              </div>
+              <div className="text-left min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <Zap size={12} className={isContextual ? 'text-gray-300' : 'text-gray-500'} />
+                  <span
+                    className={`text-[12px] ${isContextual ? 'text-gray-200' : 'text-gray-400'}`}
+                  >
+                    Contextual
+                  </span>
+                </div>
+                <p className="text-[11px] text-gray-500 mt-0.5">
+                  Run this workflow directly from any card or terminal, against that session's
+                  folder and branch.
+                </p>
+              </div>
+            </button>
+          )
+        })()}
+
       {config.triggerType === 'once' && (
         <div>
           <label className="text-[13px] text-gray-400 font-medium block mb-2">Run At</label>

--- a/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
+++ b/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
@@ -88,6 +88,17 @@ export function VariableAutocomplete({
       })
     }
 
+    for (const v of contextVars.filter((v) => v.category === 'context')) {
+      items.push({
+        group: 'Context',
+        groupId: 'context',
+        key: v.key,
+        label: v.label,
+        description: 'Resolved from the launching card or terminal',
+        pattern: v.key
+      })
+    }
+
     return items
   }, [stepGroups, contextVars])
 

--- a/src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel.tsx
@@ -31,6 +31,9 @@ interface Props {
   onStaggerChange: (v: number | undefined) => void
   autoCleanupWorktrees: boolean
   onCleanupChange: (v: boolean) => void
+  /** True when every LaunchAgent inherits its worktree from context, so
+   *  there's no created worktree for cleanup to act on. */
+  cleanupDisabled?: boolean
   triggerNode: WorkflowNode | null
   onSelectTrigger: () => void
   lastRun: WorkflowExecution | null
@@ -44,6 +47,7 @@ export function WorkflowPropertiesPanel({
   onStaggerChange,
   autoCleanupWorktrees,
   onCleanupChange,
+  cleanupDisabled = false,
   triggerNode,
   onSelectTrigger,
   lastRun,
@@ -89,7 +93,19 @@ export function WorkflowPropertiesPanel({
         </PropertyRow>
 
         <PropertyRow label="Cleanup worktrees">
-          <ToggleSwitch checked={autoCleanupWorktrees} onChange={onCleanupChange} />
+          <span
+            title={
+              cleanupDisabled
+                ? 'Cleanup applies only to worktrees this workflow creates. All agents inherit their worktree from context, so there is nothing to clean up.'
+                : undefined
+            }
+            className={cleanupDisabled ? 'opacity-50' : undefined}
+          >
+            <ToggleSwitch
+              checked={cleanupDisabled ? false : autoCleanupWorktrees}
+              onChange={cleanupDisabled ? () => {} : onCleanupChange}
+            />
+          </span>
         </PropertyRow>
 
         <div className="pt-2" />

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -1,5 +1,6 @@
 import {
   TaskConfig,
+  TriggerConfig,
   WorkflowExecutionContext,
   WorkflowNode,
   WorkflowEdge,
@@ -58,7 +59,7 @@ export interface StepVariableGroup {
 export interface TemplateVariable {
   key: string
   label: string
-  category: 'task' | 'trigger' | 'connectorItem'
+  category: 'task' | 'trigger' | 'connectorItem' | 'context'
 }
 
 export const TEMPLATE_VARIABLES: TemplateVariable[] = [
@@ -74,8 +75,59 @@ export const TEMPLATE_VARIABLES: TemplateVariable[] = [
   { key: '{{connectorItem.title}}', label: 'Item Title', category: 'connectorItem' },
   { key: '{{connectorItem.externalUrl}}', label: 'Item URL', category: 'connectorItem' },
   { key: '{{connectorItem.body}}', label: 'Item Body', category: 'connectorItem' },
-  { key: '{{connectorItem.connectorId}}', label: 'Connector', category: 'connectorItem' }
+  { key: '{{connectorItem.connectorId}}', label: 'Connector', category: 'connectorItem' },
+  { key: '{{context.cwd}}', label: 'Working Directory', category: 'context' },
+  { key: '{{context.projectPath}}', label: 'Project Path', category: 'context' },
+  { key: '{{context.projectName}}', label: 'Project Name', category: 'context' },
+  { key: '{{context.branch}}', label: 'Branch', category: 'context' },
+  { key: '{{context.worktreePath}}', label: 'Worktree Path', category: 'context' }
 ]
+
+/**
+ * Sentinels written into LaunchAgent / Script string fields when the user
+ * picks "From Context" in the editor. The runtime template resolver expands
+ * these against `WorkflowExecutionContext.task` (card) or `.source` (terminal).
+ */
+export const CONTEXT_REF = {
+  cwd: '{{context.cwd}}',
+  projectPath: '{{context.projectPath}}',
+  projectName: '{{context.projectName}}',
+  branch: '{{context.branch}}',
+  worktreePath: '{{context.worktreePath}}'
+} as const
+
+export function isContextRef(value: string | undefined): boolean {
+  return typeof value === 'string' && /^\s*\{\{\s*context\.[\w]+\s*\}\}\s*$/.test(value)
+}
+
+/**
+ * Variables available in autocomplete given the current trigger flags. Used
+ * by both LaunchAgentConfigForm and ScriptConfigForm.
+ */
+export function getAvailableContextVars(opts: {
+  triggerType: TriggerConfig['triggerType'] | undefined
+  isContextualTrigger: boolean
+}): TemplateVariable[] {
+  const isTaskTrigger =
+    opts.triggerType === 'taskCreated' || opts.triggerType === 'taskStatusChanged'
+  return TEMPLATE_VARIABLES.filter((v) => {
+    if (isTaskTrigger && v.category === 'task') return true
+    if (isTaskTrigger && v.category === 'trigger' && opts.triggerType === 'taskStatusChanged') {
+      return true
+    }
+    if (opts.isContextualTrigger && v.category === 'context') return true
+    return false
+  })
+}
+
+/** Whether `value` contains a `{{context.<field>}}` reference anywhere. */
+export function containsContextRef(value: string | undefined, field?: string): boolean {
+  if (typeof value !== 'string') return false
+  const pattern = field
+    ? new RegExp(`\\{\\{\\s*context\\.${field}\\s*\\}\\}`)
+    : /\{\{\s*context\.[\w]+\s*\}\}/
+  return pattern.test(value)
+}
 
 // --- DAG Ancestor Computation ---
 
@@ -236,7 +288,47 @@ export function resolveTemplateVars(
     if (ns === 'connectorItem' && context?.connectorItem) {
       return stringifyResolved(walkPath(context.connectorItem, rest))
     }
+    if (ns === 'context' && rest.length === 1 && context) {
+      const resolved = resolveContextField(rest[0], context)
+      return resolved != null ? String(resolved) : ''
+    }
 
     return match
   })
+}
+
+/**
+ * Resolve a `{{context.*}}` field. The workflow runtime synthesizes a
+ * `context.source` (TerminalSession-shaped) for card launches by looking up
+ * the task's project, so all path-like fields read from `source`. `task`
+ * remains the primary source for branch / projectName / worktree.
+ *
+ * Returns `undefined` (rather than throwing) when neither `task` nor `source`
+ * is present so callers can detect missing context and route through
+ * SourcePromptDialog.
+ */
+export function resolveContextField(
+  field: string,
+  context: WorkflowExecutionContext
+): string | boolean | undefined {
+  const task = context.task
+  const source = context.source
+  switch (field) {
+    case 'cwd':
+      return task?.worktreePath ?? source?.worktreePath ?? source?.projectPath
+    case 'projectPath':
+      return source?.projectPath
+    case 'projectName':
+      return task?.projectName ?? source?.projectName
+    case 'branch':
+      return task?.branch ?? source?.branch
+    case 'worktreePath':
+      return task?.worktreePath ?? source?.worktreePath
+    case 'useWorktree':
+      if (task) return task.useWorktree ?? !!task.worktreePath
+      if (source) return source.isWorktree ?? !!source.worktreePath
+      return undefined
+    default:
+      return undefined
+  }
 }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -50,6 +50,92 @@ function scheduleGateTimeout(
 }
 
 /**
+ * Resolve workflow runs that were left `running` when the renderer last
+ * unloaded. The main process keeps headless sessions alive past a renderer
+ * reload, so a node that was `running` may already have an `exited` event in
+ * `session_events` even though the in-renderer exit-promise was lost.
+ *
+ * For each `running` node with a session id we look up its lifecycle log; if
+ * it exited we mark the node success/error and persist. We do NOT auto-resume
+ * the rest of the DAG — quietly continuing a stale run hours later is
+ * surprising. Instead, the run is closed as `error` with a clear message so
+ * the user can re-run.
+ */
+export async function reconcileRunningExecutions(
+  executions: Iterable<WorkflowExecution>
+): Promise<void> {
+  for (const execution of executions) {
+    if (execution.completedAt && execution.status !== 'running') continue
+
+    let dirty = false
+    let anyStillRunning = false
+    let anyResolvedHere = false
+
+    for (const ns of execution.nodeStates) {
+      if (ns.status !== 'running') continue
+      if (!ns.sessionId) {
+        ns.status = 'error'
+        ns.error = 'Run abandoned (no session id recorded)'
+        ns.completedAt = new Date().toISOString()
+        dirty = true
+        continue
+      }
+      try {
+        const events = await window.api.listSessionEventsBySession(ns.sessionId, 50)
+        const exitEvent = events.find((e) => e.eventType === 'exited')
+        if (exitEvent) {
+          const meta = (exitEvent.metadata as { exitCode?: number } | undefined) ?? {}
+          const exitCode = typeof meta.exitCode === 'number' ? meta.exitCode : 0
+          ns.status = exitCode === 0 ? 'success' : 'error'
+          ns.completedAt = exitEvent.timestamp
+          if (exitCode !== 0 && !ns.error) ns.error = `Exit code ${exitCode}`
+          dirty = true
+          anyResolvedHere = true
+        } else {
+          // Session row exists but no exit yet — assume still alive somewhere
+          // and leave the node untouched. The user can manually rerun if it's
+          // truly stuck.
+          anyStillRunning = true
+        }
+      } catch (err) {
+        console.warn(
+          `[workflow] reconcile: failed to query session_events for ${ns.sessionId}`,
+          err
+        )
+        anyStillRunning = true
+      }
+    }
+
+    // If we resolved at least one node, the rest of the DAG never advanced
+    // (the in-memory exit promise died with the previous renderer). Close the
+    // run rather than auto-resuming a stale execution.
+    if (anyResolvedHere && !anyStillRunning) {
+      const hasPending = execution.nodeStates.some((ns) => ns.status === 'pending')
+      if (hasPending) {
+        for (const ns of execution.nodeStates) {
+          if (ns.status === 'pending') {
+            ns.status = 'skipped'
+            ns.error = 'Renderer reload abandoned this run; re-run to continue'
+          }
+        }
+        execution.status = 'error'
+      } else {
+        execution.status = execution.nodeStates.some((ns) => ns.status === 'error')
+          ? 'error'
+          : 'success'
+      }
+      execution.completedAt = new Date().toISOString()
+      dirty = true
+    }
+
+    if (dirty) {
+      useAppStore.getState().setWorkflowExecution(execution.workflowId, { ...execution })
+      await window.api.saveWorkflowRun(execution)
+    }
+  }
+}
+
+/**
  * Re-arm timeout timers for any approval gates that were `waiting` before the
  * app restarted. Called once after startup hydration; timers elsewhere are set
  * as gates enter `waiting` for the first time.
@@ -516,6 +602,25 @@ async function executeNode(
     let sessionId: string | null = null
     let logs = ''
 
+    // Logs only live in renderer memory until the node finishes — if the
+    // window reloads (HMR, devtools refresh, crash) mid-run they vanish even
+    // though the headless agent in the main process keeps going. Throttle a
+    // background save to disk so accumulated output survives a reload.
+    const PERSIST_INTERVAL_MS = 3000
+    let persistTimer: ReturnType<typeof setTimeout> | null = null
+    let lastPersistedBytes = 0
+    const schedulePersistLogs = () => {
+      if (persistTimer) return
+      persistTimer = setTimeout(() => {
+        persistTimer = null
+        if (logs.length === lastPersistedBytes) return
+        lastPersistedBytes = logs.length
+        // Only persist; the in-memory store was already updated by the
+        // listener so the editor UI is up to date already.
+        void window.api.saveWorkflowRun(execution)
+      }, PERSIST_INTERVAL_MS)
+    }
+
     const removeDataListener = window.api.onHeadlessData(
       ({ id, data }: { id: string; data: string }) => {
         if (sessionId && id === sessionId) {
@@ -525,6 +630,7 @@ async function executeNode(
           }
           updateNodeState(execution, node.id, { logs })
           useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
+          schedulePersistLogs()
         }
       }
     )
@@ -610,6 +716,10 @@ async function executeNode(
     } finally {
       removeDataListener()
       removeExitListener()
+      if (persistTimer) {
+        clearTimeout(persistTimer)
+        persistTimer = null
+      }
     }
   } else {
     const cfg = useAppStore.getState().config

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -23,6 +23,28 @@ import { sendWorkflowGateNotification } from './notifications'
 
 const runningWorkflows = new Set<string>()
 
+const LOG_BUFFER_MAX = 100_000
+const LOG_BUFFER_KEEP = 80_000
+
+/** Cap renderer-resident log buffers so a chatty agent can't exhaust memory. */
+function appendBoundedLog(buffer: string, chunk: string): string {
+  const next = buffer + chunk
+  return next.length > LOG_BUFFER_MAX ? next.slice(-LOG_BUFFER_KEEP) : next
+}
+
+/** Tag worktree provenance for cleanup. `undefined` when no worktree is in
+ *  play; `'inherited'` when the contextual source supplied one (don't delete);
+ *  `'created'` when this node spun one up itself. */
+function resolveWorktreeOrigin(
+  worktreePath: string | undefined,
+  inherited: boolean
+): 'created' | 'inherited' | undefined {
+  if (!worktreePath) return undefined
+  return inherited ? 'inherited' : 'created'
+}
+
+const PERSIST_INTERVAL_MS = 3000
+
 /** Cleared on approve/reject so a late timer can't reject an already-resolved gate. */
 const gateTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
@@ -71,37 +93,43 @@ export async function reconcileRunningExecutions(
     let anyStillRunning = false
     let anyResolvedHere = false
 
-    for (const ns of execution.nodeStates) {
-      if (ns.status !== 'running') continue
-      if (!ns.sessionId) {
+    const runningNodes = execution.nodeStates.filter((ns) => ns.status === 'running')
+    const probes = await Promise.all(
+      runningNodes.map(async (ns) => {
+        if (!ns.sessionId) return { ns, kind: 'no-session' as const }
+        try {
+          const events = await window.api.listSessionEventsBySession(ns.sessionId, 50)
+          const exitEvent = events.find((e) => e.eventType === 'exited')
+          return exitEvent
+            ? { ns, kind: 'exited' as const, exitEvent }
+            : { ns, kind: 'still-running' as const }
+        } catch (err) {
+          console.warn(
+            `[workflow] reconcile: failed to query session_events for ${ns.sessionId}`,
+            err
+          )
+          return { ns, kind: 'error' as const }
+        }
+      })
+    )
+
+    for (const probe of probes) {
+      const { ns } = probe
+      if (probe.kind === 'no-session') {
         ns.status = 'error'
         ns.error = 'Run abandoned (no session id recorded)'
         ns.completedAt = new Date().toISOString()
         dirty = true
-        continue
-      }
-      try {
-        const events = await window.api.listSessionEventsBySession(ns.sessionId, 50)
-        const exitEvent = events.find((e) => e.eventType === 'exited')
-        if (exitEvent) {
-          const meta = (exitEvent.metadata as { exitCode?: number } | undefined) ?? {}
-          const exitCode = typeof meta.exitCode === 'number' ? meta.exitCode : 0
-          ns.status = exitCode === 0 ? 'success' : 'error'
-          ns.completedAt = exitEvent.timestamp
-          if (exitCode !== 0 && !ns.error) ns.error = `Exit code ${exitCode}`
-          dirty = true
-          anyResolvedHere = true
-        } else {
-          // Session row exists but no exit yet — assume still alive somewhere
-          // and leave the node untouched. The user can manually rerun if it's
-          // truly stuck.
-          anyStillRunning = true
-        }
-      } catch (err) {
-        console.warn(
-          `[workflow] reconcile: failed to query session_events for ${ns.sessionId}`,
-          err
-        )
+      } else if (probe.kind === 'exited') {
+        const meta = (probe.exitEvent.metadata as { exitCode?: number } | undefined) ?? {}
+        const exitCode = typeof meta.exitCode === 'number' ? meta.exitCode : 0
+        ns.status = exitCode === 0 ? 'success' : 'error'
+        ns.completedAt = probe.exitEvent.timestamp
+        if (exitCode !== 0 && !ns.error) ns.error = `Exit code ${exitCode}`
+        dirty = true
+        anyResolvedHere = true
+      } else {
+        // 'still-running' or 'error' — leave the node untouched.
         anyStillRunning = true
       }
     }
@@ -346,10 +374,7 @@ async function executeNode(
     const removeScriptDataListener = window.api.onScriptData(
       ({ runId: id, data }: { runId: string; data: string }) => {
         if (id !== runId) return
-        streamedLogs += data
-        if (streamedLogs.length > 100000) {
-          streamedLogs = streamedLogs.slice(-80000)
-        }
+        streamedLogs = appendBoundedLog(streamedLogs, data)
         updateNodeState(execution, node.id, { logs: streamedLogs })
         useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
       }
@@ -509,9 +534,6 @@ async function executeNode(
     useWorktree = undefined
   }
 
-  // Track the task we resolved so we can pass it to resolveEffectiveAgent later
-  // — covers the taskId / taskFromQueue paths. The trigger-driven path uses
-  // context.task instead.
   let resolvedTask: TaskConfig | undefined
 
   // Fall back to the trigger's task id when the node doesn't bind to one
@@ -585,7 +607,6 @@ async function executeNode(
     initialPrompt = resolveTemplateVars(initialPrompt, context, stepOutputs)
   }
 
-  // Wrap with workflow context so the agent knows which workflow/step it belongs to
   if (initialPrompt) {
     initialPrompt = buildWorkflowPrompt({
       workflow,
@@ -606,7 +627,6 @@ async function executeNode(
     // window reloads (HMR, devtools refresh, crash) mid-run they vanish even
     // though the headless agent in the main process keeps going. Throttle a
     // background save to disk so accumulated output survives a reload.
-    const PERSIST_INTERVAL_MS = 3000
     let persistTimer: ReturnType<typeof setTimeout> | null = null
     let lastPersistedBytes = 0
     const schedulePersistLogs = () => {
@@ -624,10 +644,7 @@ async function executeNode(
     const removeDataListener = window.api.onHeadlessData(
       ({ id, data }: { id: string; data: string }) => {
         if (sessionId && id === sessionId) {
-          logs += data
-          if (logs.length > 100000) {
-            logs = logs.slice(-80000)
-          }
+          logs = appendBoundedLog(logs, data)
           updateNodeState(execution, node.id, { logs })
           useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
           schedulePersistLogs()
@@ -667,8 +684,6 @@ async function executeNode(
       })
 
       sessionId = headlessSession.id
-
-      // Make headless session visible in the UI immediately
       useAppStore.getState().addHeadlessSession(headlessSession)
 
       updateNodeState(execution, node.id, {
@@ -676,11 +691,7 @@ async function executeNode(
         taskId: resolvedTaskId,
         worktreePath: headlessSession.worktreePath,
         worktreeName: headlessSession.worktreeName,
-        worktreeOrigin: headlessSession.worktreePath
-          ? inheritedWorktree
-            ? 'inherited'
-            : 'created'
-          : undefined,
+        worktreeOrigin: resolveWorktreeOrigin(headlessSession.worktreePath, inheritedWorktree),
         agentType: effectiveAgent,
         projectName: effectiveProjectName,
         projectPath: effectiveProjectPath,
@@ -753,11 +764,7 @@ async function executeNode(
       taskId: resolvedTaskId,
       worktreePath: session.worktreePath,
       worktreeName: session.worktreeName,
-      worktreeOrigin: session.worktreePath
-        ? inheritedWorktree
-          ? 'inherited'
-          : 'created'
-        : undefined,
+      worktreeOrigin: resolveWorktreeOrigin(session.worktreePath, inheritedWorktree),
       agentType: effectiveAgent,
       projectName: effectiveProjectName,
       projectPath: effectiveProjectPath

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -15,7 +15,8 @@ import {
   TaskConfig,
   getProjectRemoteHostId
 } from '../../shared/types'
-import { resolveTemplateVars, StepOutputs } from './template-vars'
+import { resolveContextField, resolveTemplateVars, StepOutputs } from './template-vars'
+import { getWorktreeMode } from './workflow-helpers'
 import { buildTaskPrompt, buildWorkflowPrompt } from '../../shared/prompt-builder'
 import { useAppStore } from '../stores'
 import { sendWorkflowGateNotification } from './notifications'
@@ -384,13 +385,21 @@ async function executeNode(
 
   let initialPrompt = config.prompt
   let resolvedTaskId: string | undefined
-  let branch = config.branch
-  let useWorktree = config.useWorktree
+  let branch = config.branch ? resolveTemplateVars(config.branch, context) || undefined : undefined
+  // When 'fromContext' but no context is available (SourcePromptDialog
+  // cancelled mid-flight), fall through with undefined so session creation
+  // uses its own default.
+  let useWorktree: boolean | undefined =
+    config.useWorktree === 'fromContext'
+      ? context
+        ? ((resolveContextField('useWorktree', context) as boolean | undefined) ?? undefined)
+        : undefined
+      : config.useWorktree
+  const inheritedWorktree = config.useWorktree === 'fromContext'
   let existingWorktreePath: string | undefined
   const currentState = useAppStore.getState()
 
-  // Resolve worktreeMode for cross-step worktree passing
-  const worktreeMode = config.worktreeMode ?? (useWorktree ? 'new' : 'none')
+  const worktreeMode = getWorktreeMode(config)
   if (worktreeMode === 'fromStep') {
     if (!config.worktreeFromStepSlug) {
       throw new Error('Worktree mode "fromStep" requires a source step slug')
@@ -466,8 +475,8 @@ async function executeNode(
   // project at run time. Without this fallback, createHeadlessSession /
   // createTerminal would receive `cwd: ''` and silently spawn in an
   // undefined directory.
-  let effectiveProjectName = config.projectName
-  let effectiveProjectPath = config.projectPath
+  let effectiveProjectName = resolveTemplateVars(config.projectName ?? '', context) || ''
+  let effectiveProjectPath = resolveTemplateVars(config.projectPath ?? '', context) || ''
   if (!effectiveProjectName || !effectiveProjectPath) {
     const taskForProject = context?.task ?? resolvedTask
     if (taskForProject) {
@@ -477,6 +486,13 @@ async function executeNode(
         effectiveProjectPath = effectiveProjectPath || proj.path
       }
     }
+  }
+  // If we resolved projectName from context but couldn't pull a path
+  // (template-only case), still walk the projects store one more time so
+  // contextual workflows launched without a `source` object still work.
+  if (effectiveProjectName && !effectiveProjectPath) {
+    const proj = currentState.config?.projects.find((p) => p.name === effectiveProjectName)
+    if (proj) effectiveProjectPath = proj.path
   }
 
   if (initialPrompt) {
@@ -554,6 +570,11 @@ async function executeNode(
         taskId: resolvedTaskId,
         worktreePath: headlessSession.worktreePath,
         worktreeName: headlessSession.worktreeName,
+        worktreeOrigin: headlessSession.worktreePath
+          ? inheritedWorktree
+            ? 'inherited'
+            : 'created'
+          : undefined,
         agentType: effectiveAgent,
         projectName: effectiveProjectName,
         projectPath: effectiveProjectPath,
@@ -622,6 +643,11 @@ async function executeNode(
       taskId: resolvedTaskId,
       worktreePath: session.worktreePath,
       worktreeName: session.worktreeName,
+      worktreeOrigin: session.worktreePath
+        ? inheritedWorktree
+          ? 'inherited'
+          : 'created'
+        : undefined,
       agentType: effectiveAgent,
       projectName: effectiveProjectName,
       projectPath: effectiveProjectPath
@@ -911,16 +937,18 @@ async function runExecution(
   persistExecution(workflow.id, execution)
 
   if (workflow.autoCleanupWorktrees) {
-    // Only clean up worktrees created during this run (mode 'new'), not pre-existing ones
+    // Skip 'inherited' worktrees: a contextual workflow reused the parent
+    // card/terminal's worktree, so deleting it would nuke work the user is
+    // actively in.
     const worktreeMap = new Map<string, string>()
     for (const ns of execution.nodeStates) {
       if (!ns.worktreePath || worktreeMap.has(ns.worktreePath)) continue
+      if (ns.worktreeOrigin === 'inherited') continue
       const node = workflow.nodes.find((n) => n.id === ns.nodeId)
       if (!node || node.type !== 'launchAgent') continue
       const cfg = node.config as LaunchAgentConfig
-      const mode = cfg.worktreeMode ?? (cfg.useWorktree ? 'new' : 'none')
-      if (mode === 'new') {
-        worktreeMap.set(ns.worktreePath, cfg.projectPath)
+      if (getWorktreeMode(cfg) === 'new') {
+        worktreeMap.set(ns.worktreePath, ns.projectPath || cfg.projectPath)
       }
     }
 

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -127,6 +127,18 @@ export function isScheduledWorkflow(wf: WorkflowDefinition): boolean {
   return trigger != null && trigger.triggerType !== 'manual'
 }
 
+export function isContextualWorkflow(wf: WorkflowDefinition): boolean {
+  const trigger = getTriggerConfig(wf)
+  return trigger?.triggerType === 'manual' && trigger.contextual === true
+}
+
+export type WorktreeMode = 'none' | 'new' | 'fromStep' | 'existing' | 'fromContext'
+
+export function getWorktreeMode(cfg: LaunchAgentConfig): WorktreeMode {
+  if (cfg.useWorktree === 'fromContext') return 'fromContext'
+  return cfg.worktreeMode ?? (cfg.useWorktree === true ? 'new' : 'none')
+}
+
 export function getTriggerLabel(wf: WorkflowDefinition): string | undefined {
   const trigger = getTriggerConfig(wf)
   if (!trigger) return undefined

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -2,7 +2,9 @@ import { type ReactNode } from 'react'
 import { Zap } from 'lucide-react'
 import { ICON_MAP } from '../components/project-sidebar/icon-map'
 import { executeWorkflow } from './workflow-execution'
-import type { WorkflowDefinition } from '../../shared/types'
+import { isContextualWorkflow } from './workflow-helpers'
+import { useAppStore } from '../stores'
+import type { TaskConfig, TerminalSession, WorkflowDefinition } from '../../shared/types'
 
 export interface WorkflowMenuItem {
   id: string
@@ -14,11 +16,42 @@ export interface WorkflowMenuItem {
   isHeader?: boolean
 }
 
+/**
+ * Caller-supplied context for a workflow menu. When `task` or `source` is
+ * present, the menu lists only contextual workflows (those whose manual
+ * trigger has `contextual: true`); when both are absent (e.g. empty grid
+ * right-click) it lists only non-contextual workflows so users don't see
+ * actions that would dead-end on a missing source.
+ */
+export interface WorkflowMenuContext {
+  task?: TaskConfig
+  source?: TerminalSession
+}
+
+/**
+ * Routes a workflow run from a non-contextual surface (sidebar, palette).
+ * Contextual workflows open SourcePromptDialog so the user picks the source;
+ * everything else launches immediately. Centralized here so each call site
+ * doesn't need to repeat the gating logic.
+ */
+export function runWorkflowFromGlobalSurface(workflow: WorkflowDefinition): void {
+  if (isContextualWorkflow(workflow)) {
+    useAppStore.getState().setPendingContextualWorkflowId(workflow.id)
+    return
+  }
+  void executeWorkflow(workflow, undefined, { source: 'manual' })
+}
+
 export function buildWorkflowMenuItems(
   workflows: WorkflowDefinition[],
-  onSelect: () => void
+  onSelect: () => void,
+  context?: WorkflowMenuContext
 ): WorkflowMenuItem[] {
-  return workflows.map((wf) => {
+  const hasContext = !!(context?.task || context?.source)
+  const filtered = workflows.filter((wf) =>
+    hasContext ? isContextualWorkflow(wf) : !isContextualWorkflow(wf)
+  )
+  return filtered.map((wf) => {
     const WfIcon = ICON_MAP[wf.icon] || Zap
     return {
       id: wf.id,
@@ -26,7 +59,11 @@ export function buildWorkflowMenuItems(
       label: wf.name,
       onClick: () => {
         onSelect()
-        executeWorkflow(wf, undefined, { source: 'manual' })
+        executeWorkflow(
+          wf,
+          hasContext ? { task: context?.task, source: context?.source } : undefined,
+          { source: 'manual' }
+        )
       }
     }
   })

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -126,6 +126,13 @@ export interface UISlice {
   isAddProjectDialogOpen: boolean
   isWorkflowEditorOpen: boolean
   editingWorkflowId: string | null
+  /**
+   * A contextual workflow whose run was triggered from a non-contextual
+   * surface (sidebar, command palette). The SourcePromptDialog renders when
+   * this is set and asks the user to pick a folder/branch before launching.
+   * Cleared when the user submits or cancels.
+   */
+  pendingContextualWorkflowId: string | null
   editingProject: ProjectConfig | null
   isCommandPaletteOpen: boolean
   isShortcutsPanelOpen: boolean
@@ -173,6 +180,7 @@ export interface UISlice {
   setNewAgentDialogOpen: (open: boolean) => void
   setAddProjectDialogOpen: (open: boolean) => void
   setWorkflowEditorOpen: (open: boolean) => void
+  setPendingContextualWorkflowId: (id: string | null) => void
   setEditingWorkflowId: (id: string | null) => void
   setEditingProject: (project: ProjectConfig | null) => void
   setCommandPaletteOpen: (open: boolean) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -76,6 +76,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   isAddProjectDialogOpen: false,
   isWorkflowEditorOpen: false,
   editingWorkflowId: null,
+  pendingContextualWorkflowId: null,
   editingProject: null,
   isCommandPaletteOpen: false,
   isShortcutsPanelOpen: false,
@@ -149,6 +150,8 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   setAddProjectDialogOpen: (open) => set({ isAddProjectDialogOpen: open }),
 
   setWorkflowEditorOpen: (open) => set({ isWorkflowEditorOpen: open }),
+
+  setPendingContextualWorkflowId: (id) => set({ pendingContextualWorkflowId: id }),
 
   setEditingWorkflowId: (id) => set({ editingWorkflowId: id }),
 

--- a/tests/card-context-menu.test.tsx
+++ b/tests/card-context-menu.test.tsx
@@ -260,7 +260,15 @@ describe('CardContextMenu', () => {
           name: 'Deploy Staging',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger-1',
+              type: 'trigger',
+              config: { triggerType: 'manual', contextual: true },
+              position: { x: 0, y: 0 },
+              label: 'Manual'
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -270,7 +278,15 @@ describe('CardContextMenu', () => {
           name: 'Run Tests',
           icon: 'Play',
           iconColor: '#00ff00',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger-2',
+              type: 'trigger',
+              config: { triggerType: 'manual', contextual: true },
+              position: { x: 0, y: 0 },
+              label: 'Manual'
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -298,7 +314,15 @@ describe('CardContextMenu', () => {
           name: 'Deploy Staging',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger-1',
+              type: 'trigger',
+              config: { triggerType: 'manual', contextual: true },
+              position: { x: 0, y: 0 },
+              label: 'Manual'
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -320,12 +344,23 @@ describe('CardContextMenu', () => {
     expect(onClose).toHaveBeenCalled()
     expect(mockExecuteWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'wf-1', name: 'Deploy Staging' }),
-      undefined,
+      expect.objectContaining({
+        source: expect.objectContaining({ projectName: expect.any(String) })
+      }),
       { source: 'manual' }
     )
   })
 
   it('only shows workflows from the active workspace', () => {
+    const contextualTrigger = [
+      {
+        id: 'trigger-x',
+        type: 'trigger',
+        config: { triggerType: 'manual', contextual: true },
+        position: { x: 0, y: 0 },
+        label: 'Manual'
+      }
+    ]
     const configWithWorkflows = {
       ...mockConfig,
       workflows: [
@@ -334,7 +369,7 @@ describe('CardContextMenu', () => {
           name: 'Personal WF',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: contextualTrigger,
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -344,7 +379,7 @@ describe('CardContextMenu', () => {
           name: 'Work WF',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: contextualTrigger,
           edges: [],
           enabled: true,
           workspaceId: 'work'
@@ -372,7 +407,15 @@ describe('CardContextMenu', () => {
           name: 'Manual Deploy',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger-manual',
+              type: 'trigger',
+              config: { triggerType: 'manual', contextual: true },
+              position: { x: 0, y: 0 },
+              label: 'Manual'
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'

--- a/tests/launch-agent-config-form.test.tsx
+++ b/tests/launch-agent-config-form.test.tsx
@@ -29,9 +29,14 @@ vi.mock('../src/renderer/components/AgentPicker', () => ({
   }
 }))
 
-// Stub the heavier unrelated children so we don't need to mount them.
+// Capture props each render so tests can read allowFromContext / isFromContext
+// without mounting the real picker.
+const projectPickerProps: Array<Record<string, unknown>> = []
 vi.mock('../src/renderer/components/ProjectPicker', () => ({
-  ProjectPicker: () => <div data-testid="project-picker" />
+  ProjectPicker: (props: Record<string, unknown>) => {
+    projectPickerProps.push(props)
+    return <div data-testid="project-picker" />
+  }
 }))
 vi.mock('../src/renderer/components/rich-editor/RichMarkdownEditor', () => ({
   RichMarkdownEditor: () => <div data-testid="rich-md" />
@@ -72,6 +77,7 @@ vi.mock('../src/renderer/stores', () => ({
 // in an effect that's harmless if we stub them as resolved empty arrays.
 beforeEach(() => {
   agentPickerProps.length = 0
+  projectPickerProps.length = 0
   ;(globalThis as unknown as { window: { api: Record<string, unknown> } }).window = {
     api: {
       isGitRepo: vi.fn().mockResolvedValue(true),
@@ -321,5 +327,119 @@ describe('LaunchAgentConfigForm — UI sections', () => {
       <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={vi.fn()} />
     )
     expect(container.textContent).toContain('Headless')
+  })
+})
+
+describe('LaunchAgentConfigForm — contextual workflow surface', () => {
+  it('passes allowFromContext=true to ProjectPicker when trigger is contextual', () => {
+    render(
+      <LaunchAgentConfigForm
+        config={baseConfig()}
+        onChange={vi.fn()}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+    expect(projectPickerProps.at(-1)!.allowFromContext).toBe(true)
+  })
+
+  it('passes allowFromContext=false when the trigger is not contextual', () => {
+    render(<LaunchAgentConfigForm config={baseConfig()} onChange={vi.fn()} triggerType="manual" />)
+    expect(projectPickerProps.at(-1)!.allowFromContext).toBe(false)
+  })
+
+  it('flags isFromContext on the ProjectPicker when projectName holds the sentinel', () => {
+    render(
+      <LaunchAgentConfigForm
+        config={baseConfig({
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}'
+        })}
+        onChange={vi.fn()}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+    expect(projectPickerProps.at(-1)!.isFromContext).toBe(true)
+  })
+
+  it('renders the From Context branch chip when branch holds the sentinel', () => {
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({ branch: '{{context.branch}}' })}
+        onChange={vi.fn()}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+    expect(container.textContent).toContain('From Context')
+  })
+
+  it("describes 'From Context' worktree mode in the helper text", () => {
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({ branch: 'feature/x', useWorktree: 'fromContext' })}
+        onChange={vi.fn()}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+    expect(container.textContent).toContain("won't be auto-cleaned")
+  })
+
+  it('clears From Context fields when the trigger flips off contextual', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}',
+          branch: '{{context.branch}}',
+          useWorktree: 'fromContext'
+        })}
+        onChange={onChange}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+
+    rerender(
+      <LaunchAgentConfigForm
+        config={baseConfig({
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}',
+          branch: '{{context.branch}}',
+          useWorktree: 'fromContext'
+        })}
+        onChange={onChange}
+        triggerType="manual"
+        isContextualTrigger={false}
+      />
+    )
+
+    const reset = onChange.mock.calls.find(([c]: [LaunchAgentConfig]) => {
+      return (
+        c.projectName === '' &&
+        c.projectPath === '' &&
+        c.branch === undefined &&
+        c.useWorktree === undefined
+      )
+    })
+    expect(reset).toBeDefined()
+  })
+
+  it('exposes context vars to the prompt autocomplete when contextual', () => {
+    // hasTemplateVars becomes true via isContextualTrigger which switches the
+    // prompt slot to VariableAutocomplete (mocked) — the absence of a crash is
+    // enough; the prior path renders RichMarkdownEditor.
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig()}
+        onChange={vi.fn()}
+        triggerType="manual"
+        isContextualTrigger
+      />
+    )
+    expect(container.querySelector('[data-testid="variable-autocomplete"]')).toBeTruthy()
   })
 })

--- a/tests/project-picker.test.tsx
+++ b/tests/project-picker.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+import { ProjectPicker } from '../src/renderer/components/ProjectPicker'
+import type { ProjectConfig } from '../src/shared/types'
+
+const projects: ProjectConfig[] = [
+  { name: 'Vorn', path: '/r/vorn', preferredAgents: [], icon: 'Rocket', iconColor: '#fff' },
+  { name: 'Other', path: '/r/other', preferredAgents: [], icon: 'Folder', iconColor: '#fff' }
+]
+
+describe('ProjectPicker — From Context entry', () => {
+  it('renders the trigger label as the current project name by default', () => {
+    render(
+      <ProjectPicker currentProject="Vorn" projects={projects} onChange={vi.fn()} variant="form" />
+    )
+    expect(screen.getByText('Vorn')).toBeInTheDocument()
+  })
+
+  it("renders the trigger label as 'From Context' when isFromContext is true", () => {
+    render(
+      <ProjectPicker
+        currentProject=""
+        projects={projects}
+        onChange={vi.fn()}
+        variant="form"
+        isFromContext
+      />
+    )
+    // Two "From Context" labels can appear (trigger + dropdown), expect at least one
+    expect(screen.getAllByText('From Context').length).toBeGreaterThan(0)
+  })
+
+  it('renders the placeholder when currentProject is empty and not from-context', () => {
+    render(
+      <ProjectPicker currentProject="" projects={projects} onChange={vi.fn()} variant="form" />
+    )
+    expect(screen.getByText('Select project...')).toBeInTheDocument()
+  })
+
+  it("shows a 'From Context' option in the dropdown when allowFromContext is true", () => {
+    render(
+      <ProjectPicker
+        currentProject="Vorn"
+        projects={projects}
+        onChange={vi.fn()}
+        variant="form"
+        allowFromContext
+        onSelectFromContext={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Vorn/ }))
+    // After opening, the dropdown also surfaces 'From Context' as an entry
+    expect(screen.getByText('From Context')).toBeInTheDocument()
+  })
+
+  it('invokes onSelectFromContext when the dropdown entry is clicked', () => {
+    const onSelectFromContext = vi.fn()
+    render(
+      <ProjectPicker
+        currentProject="Vorn"
+        projects={projects}
+        onChange={vi.fn()}
+        variant="form"
+        allowFromContext
+        onSelectFromContext={onSelectFromContext}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Vorn/ }))
+    fireEvent.click(screen.getByText('From Context'))
+    expect(onSelectFromContext).toHaveBeenCalled()
+  })
+
+  it("includes a 'None' entry when allowNone is set", () => {
+    render(
+      <ProjectPicker
+        currentProject=""
+        projects={projects}
+        onChange={vi.fn()}
+        variant="form"
+        allowNone
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Select project/ }))
+    expect(screen.getByText('None')).toBeInTheDocument()
+  })
+
+  it('selects a project from the dropdown', () => {
+    const onChange = vi.fn()
+    render(
+      <ProjectPicker currentProject="Vorn" projects={projects} onChange={onChange} variant="form" />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Vorn/ }))
+    fireEvent.click(screen.getByText('Other'))
+    expect(onChange).toHaveBeenCalledWith('Other')
+  })
+})

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -198,4 +198,46 @@ describe('RunEntry', () => {
     fireEvent.click(getByLabelText('Resume session'))
     expect(onResume).toHaveBeenCalled()
   })
+
+  it('shows the running empty state when an expanded step has no output yet', () => {
+    const exec = makeExec({
+      status: 'running',
+      completedAt: undefined,
+      nodeStates: [makeState({ status: 'running', logs: undefined })]
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    expect(getByText(/No output captured yet/)).toBeInTheDocument()
+  })
+
+  it("shows the pending empty state for a step that hasn't started", () => {
+    const exec = makeExec({
+      status: 'running',
+      completedAt: undefined,
+      nodeStates: [
+        makeState({
+          status: 'pending',
+          logs: undefined,
+          startedAt: undefined,
+          completedAt: undefined
+        })
+      ]
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    expect(getByText(/Step hasn't started yet/)).toBeInTheDocument()
+  })
+
+  it('shows the skipped empty state for a skipped step', () => {
+    const exec = makeExec({
+      status: 'error',
+      nodeStates: [makeState({ status: 'skipped', logs: undefined })]
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+    expect(getByText(/Step was skipped/)).toBeInTheDocument()
+  })
 })

--- a/tests/script-config-form.test.tsx
+++ b/tests/script-config-form.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (n: React.ReactNode) => n }
+})
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...p }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...p}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const projectPickerProps: Array<Record<string, unknown>> = []
+vi.mock('../src/renderer/components/ProjectPicker', () => ({
+  ProjectPicker: (props: Record<string, unknown>) => {
+    projectPickerProps.push(props)
+    return <div data-testid="project-picker" />
+  }
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/VariableAutocomplete', () => ({
+  VariableAutocomplete: () => <div data-testid="variable-autocomplete" />
+}))
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (s: unknown) => unknown) =>
+    selector ? selector({ config: { projects: [] } }) : { config: { projects: [] } }
+}))
+
+import { ScriptConfigForm } from '../src/renderer/components/workflow-editor/panels/ScriptConfigForm'
+import type { ScriptConfig } from '../src/shared/types'
+
+function base(o: Partial<ScriptConfig> = {}): ScriptConfig {
+  return { scriptType: 'bash', scriptContent: '', ...o }
+}
+
+describe('ScriptConfigForm — contextual surface', () => {
+  beforeEach(() => {
+    projectPickerProps.length = 0
+  })
+
+  it('passes allowFromContext=true when contextual', () => {
+    render(<ScriptConfigForm config={base()} onChange={vi.fn()} isContextualTrigger />)
+    expect(projectPickerProps.at(-1)!.allowFromContext).toBe(true)
+  })
+
+  it('flags isFromContext when cwd holds the sentinel', () => {
+    render(
+      <ScriptConfigForm
+        config={base({ cwd: '{{context.cwd}}' })}
+        onChange={vi.fn()}
+        isContextualTrigger
+      />
+    )
+    expect(projectPickerProps.at(-1)!.isFromContext).toBe(true)
+  })
+
+  it('writes context sentinels when onSelectFromContext is invoked', () => {
+    const onChange = vi.fn()
+    render(<ScriptConfigForm config={base()} onChange={onChange} isContextualTrigger />)
+    const onSelect = projectPickerProps.at(-1)!.onSelectFromContext as () => void
+    onSelect()
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: '{{context.projectName}}',
+        projectPath: '{{context.projectPath}}',
+        cwd: '{{context.cwd}}'
+      })
+    )
+  })
+
+  it('clears From Context fields when the trigger flips off contextual', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ScriptConfigForm
+        config={base({
+          cwd: '{{context.cwd}}',
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}'
+        })}
+        onChange={onChange}
+        isContextualTrigger
+      />
+    )
+    rerender(
+      <ScriptConfigForm
+        config={base({
+          cwd: '{{context.cwd}}',
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}'
+        })}
+        onChange={onChange}
+        isContextualTrigger={false}
+      />
+    )
+    const reset = onChange.mock.calls.find(
+      ([c]: [ScriptConfig]) =>
+        c.cwd === undefined && c.projectName === undefined && c.projectPath === undefined
+    )
+    expect(reset).toBeDefined()
+  })
+})

--- a/tests/source-prompt-dialog.test.tsx
+++ b/tests/source-prompt-dialog.test.tsx
@@ -220,4 +220,67 @@ describe('SourcePromptDialog', () => {
     )
     expect(useAppStore.getState().pendingContextualWorkflowId).toBeNull()
   })
+
+  it('detects context references in script nodes (cwd / projectName / projectPath)', () => {
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          config: { triggerType: 'manual', contextual: true },
+          position: { x: 0, y: 0 },
+          label: 'Manual'
+        },
+        {
+          id: 's',
+          type: 'script',
+          config: {
+            scriptType: 'bash',
+            scriptContent: 'cd {{context.cwd}} && pwd',
+            cwd: '{{context.cwd}}',
+            projectName: '{{context.projectName}}',
+            projectPath: '{{context.projectPath}}'
+          },
+          position: { x: 0, y: 0 },
+          label: 'Run'
+        }
+      ]
+    })
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.getByText('Project')).toBeInTheDocument()
+  })
+
+  it('detects branch references inside a script body', () => {
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          config: { triggerType: 'manual', contextual: true },
+          position: { x: 0, y: 0 },
+          label: 'Manual'
+        },
+        {
+          id: 's',
+          type: 'script',
+          config: {
+            scriptType: 'bash',
+            scriptContent: 'git checkout {{context.branch}}'
+          },
+          position: { x: 0, y: 0 },
+          label: 'Run'
+        }
+      ]
+    })
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.getByText('Branch')).toBeInTheDocument()
+  })
 })

--- a/tests/source-prompt-dialog.test.tsx
+++ b/tests/source-prompt-dialog.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const projectPickerProps: Array<Record<string, unknown>> = []
+vi.mock('../src/renderer/components/ProjectPicker', () => ({
+  ProjectPicker: (props: Record<string, unknown>) => {
+    projectPickerProps.push(props)
+    return (
+      <button
+        data-testid="project-picker"
+        onClick={() => (props.onChange as (n: string) => void)('Vorn')}
+      >
+        {String(props.currentProject) || 'pick'}
+      </button>
+    )
+  }
+}))
+
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { SourcePromptDialog } from '../src/renderer/components/SourcePromptDialog'
+import type { WorkflowDefinition } from '../src/shared/types'
+
+function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: 'wf-context',
+    name: 'Contextual Workflow',
+    icon: 'Zap',
+    iconColor: '#fff',
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        config: { triggerType: 'manual', contextual: true },
+        position: { x: 0, y: 0 },
+        label: 'Manual'
+      },
+      {
+        id: 'launch-1',
+        type: 'launchAgent',
+        config: {
+          agentType: 'claude',
+          projectName: '{{context.projectName}}',
+          projectPath: '{{context.projectPath}}'
+        },
+        position: { x: 0, y: 0 },
+        label: 'Run agent'
+      }
+    ],
+    edges: [],
+    enabled: true,
+    workspaceId: 'personal',
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  projectPickerProps.length = 0
+  useAppStore.setState({
+    pendingContextualWorkflowId: null,
+    config: {
+      projects: [
+        { name: 'Vorn', path: '/repo/vorn', preferredAgents: [], icon: '', iconColor: '' }
+      ],
+      workflows: [],
+      defaults: { defaultAgent: 'claude' as const, rowHeight: 208 },
+      remoteHosts: [],
+      workspaces: [],
+      tasks: []
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+  })
+})
+
+describe('SourcePromptDialog', () => {
+  it('renders nothing when no contextual workflow is pending', () => {
+    const { container } = render(<SourcePromptDialog />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders the workflow name in its title when pending', () => {
+    const wf = makeWorkflow()
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: {
+        ...useAppStore.getState().config!,
+        workflows: [wf]
+      }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.getByText(/Run "Contextual Workflow"/)).toBeInTheDocument()
+  })
+
+  it('asks for a branch only when the workflow references {{context.branch}}', () => {
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          config: { triggerType: 'manual', contextual: true },
+          position: { x: 0, y: 0 },
+          label: 'Manual'
+        },
+        {
+          id: 'a',
+          type: 'launchAgent',
+          config: {
+            agentType: 'claude',
+            projectName: '{{context.projectName}}',
+            projectPath: '{{context.projectPath}}',
+            branch: '{{context.branch}}'
+          },
+          position: { x: 0, y: 0 },
+          label: 'Run'
+        }
+      ]
+    })
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.getByText('Branch')).toBeInTheDocument()
+  })
+
+  it('hides the branch input when nothing references {{context.branch}}', () => {
+    const wf = makeWorkflow()
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.queryByText('Branch')).not.toBeInTheDocument()
+  })
+
+  it('shows a worktree checkbox when an agent uses useWorktree: fromContext', () => {
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          config: { triggerType: 'manual', contextual: true },
+          position: { x: 0, y: 0 },
+          label: 'Manual'
+        },
+        {
+          id: 'a',
+          type: 'launchAgent',
+          config: {
+            agentType: 'claude',
+            projectName: '{{context.projectName}}',
+            projectPath: '{{context.projectPath}}',
+            useWorktree: 'fromContext'
+          },
+          position: { x: 0, y: 0 },
+          label: 'Run'
+        }
+      ]
+    })
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    expect(screen.getByText('Run in a new worktree')).toBeInTheDocument()
+  })
+
+  it('clears the pending id and does not run on Cancel', () => {
+    const wf = makeWorkflow()
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(useAppStore.getState().pendingContextualWorkflowId).toBeNull()
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('runs executeWorkflow with a synthesized source on submit', () => {
+    const wf = makeWorkflow()
+    useAppStore.setState({
+      pendingContextualWorkflowId: wf.id,
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+    render(<SourcePromptDialog />)
+    // The default-seeded effect picks the first project automatically; click
+    // Run directly.
+    fireEvent.click(screen.getByText('Run'))
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-context' }),
+      expect.objectContaining({
+        source: expect.objectContaining({
+          projectName: 'Vorn',
+          projectPath: '/repo/vorn'
+        })
+      }),
+      { source: 'manual' }
+    )
+    expect(useAppStore.getState().pendingContextualWorkflowId).toBeNull()
+  })
+})

--- a/tests/template-vars.test.ts
+++ b/tests/template-vars.test.ts
@@ -4,9 +4,19 @@ import {
   ensureUniqueSlug,
   getAncestorNodes,
   buildStepGroups,
-  resolveTemplateVars
+  resolveTemplateVars,
+  resolveContextField,
+  isContextRef,
+  containsContextRef,
+  getAvailableContextVars,
+  CONTEXT_REF
 } from '../src/renderer/lib/template-vars'
-import type { WorkflowNode, WorkflowEdge, WorkflowExecutionContext } from '../src/shared/types'
+import type {
+  TerminalSession,
+  WorkflowNode,
+  WorkflowEdge,
+  WorkflowExecutionContext
+} from '../src/shared/types'
 import type { StepOutputs } from '../src/renderer/lib/template-vars'
 
 function makeNode(id: string, type: string, slug?: string): WorkflowNode {
@@ -230,5 +240,150 @@ describe('resolveTemplateVars', () => {
   it('returns empty when a nested path segment is missing', () => {
     const outputs: StepOutputs = { x: { a: { b: 1 } } }
     expect(resolveTemplateVars('{{steps.x.a.missing}}', context, outputs)).toBe('')
+  })
+})
+
+describe('isContextRef', () => {
+  it('matches every CONTEXT_REF sentinel', () => {
+    for (const ref of Object.values(CONTEXT_REF)) {
+      expect(isContextRef(ref)).toBe(true)
+    }
+  })
+  it('tolerates surrounding whitespace and inner spaces', () => {
+    expect(isContextRef('  {{ context.cwd }}  ')).toBe(true)
+  })
+  it('rejects non-context templates and plain strings', () => {
+    expect(isContextRef('{{task.title}}')).toBe(false)
+    expect(isContextRef('plain folder')).toBe(false)
+    expect(isContextRef(undefined)).toBe(false)
+    expect(isContextRef('')).toBe(false)
+  })
+  it('rejects strings that contain but are not equal to a context ref', () => {
+    expect(isContextRef('Run in {{context.cwd}}')).toBe(false)
+  })
+})
+
+describe('containsContextRef', () => {
+  it('matches an embedded context ref anywhere in the value', () => {
+    expect(containsContextRef('Run in {{context.cwd}} now')).toBe(true)
+  })
+  it('honors the field filter', () => {
+    expect(containsContextRef('cd {{context.cwd}}', 'cwd')).toBe(true)
+    expect(containsContextRef('cd {{context.cwd}}', 'branch')).toBe(false)
+  })
+  it('returns false for non-string and empty input', () => {
+    expect(containsContextRef(undefined)).toBe(false)
+    expect(containsContextRef('')).toBe(false)
+  })
+})
+
+describe('resolveContextField', () => {
+  const task = {
+    id: 't1',
+    projectName: 'Vorn',
+    title: 'card',
+    description: '',
+    status: 'in_progress' as const,
+    order: 0,
+    branch: 'feature/x',
+    useWorktree: true,
+    worktreePath: '/wt/feature-x',
+    createdAt: '',
+    updatedAt: ''
+  }
+  const source: TerminalSession = {
+    id: 's1',
+    agentType: 'shell',
+    projectName: 'Other',
+    projectPath: '/repo/other',
+    status: 'idle',
+    createdAt: 0,
+    pid: 0,
+    branch: 'main',
+    isWorktree: false
+  }
+
+  it('reads cwd from task worktree first', () => {
+    expect(resolveContextField('cwd', { task })).toBe('/wt/feature-x')
+  })
+  it('reads cwd from source projectPath when task has no worktree', () => {
+    const ctx: WorkflowExecutionContext = { source }
+    expect(resolveContextField('cwd', ctx)).toBe('/repo/other')
+  })
+  it('prefers source.worktreePath over source.projectPath for cwd', () => {
+    const wtSource = { ...source, worktreePath: '/wt/other-feat', isWorktree: true }
+    expect(resolveContextField('cwd', { source: wtSource })).toBe('/wt/other-feat')
+  })
+  it('reads projectName from task before source', () => {
+    expect(resolveContextField('projectName', { task, source })).toBe('Vorn')
+  })
+  it('reads projectName from source when task has none', () => {
+    expect(resolveContextField('projectName', { source })).toBe('Other')
+  })
+  it('reads branch with task taking precedence', () => {
+    expect(resolveContextField('branch', { task, source })).toBe('feature/x')
+    expect(resolveContextField('branch', { source })).toBe('main')
+  })
+  it('reads useWorktree as boolean from either side', () => {
+    expect(resolveContextField('useWorktree', { task })).toBe(true)
+    const sourceWt = { ...source, isWorktree: true }
+    expect(resolveContextField('useWorktree', { source: sourceWt })).toBe(true)
+    expect(resolveContextField('useWorktree', { source })).toBe(false)
+  })
+  it('returns undefined for unknown fields', () => {
+    expect(resolveContextField('bogus', { task })).toBeUndefined()
+  })
+  it('returns undefined when context has neither task nor source', () => {
+    expect(resolveContextField('cwd', {})).toBeUndefined()
+  })
+})
+
+describe('resolveTemplateVars — context namespace', () => {
+  const task = {
+    id: 't1',
+    projectName: 'Vorn',
+    title: '',
+    description: '',
+    status: 'in_progress' as const,
+    order: 0,
+    branch: 'feat/a',
+    worktreePath: '/wt/a',
+    createdAt: '',
+    updatedAt: ''
+  }
+  it('expands {{context.cwd}} from task', () => {
+    expect(resolveTemplateVars('cd {{context.cwd}}', { task })).toBe('cd /wt/a')
+  })
+  it('expands {{context.branch}}', () => {
+    expect(resolveTemplateVars('on {{context.branch}}', { task })).toBe('on feat/a')
+  })
+  it('returns empty for {{context.*}} when no source available', () => {
+    expect(resolveTemplateVars('cd {{context.cwd}}', {})).toBe('cd ')
+  })
+})
+
+describe('getAvailableContextVars', () => {
+  it('returns context vars only when trigger is contextual', () => {
+    const vars = getAvailableContextVars({ triggerType: 'manual', isContextualTrigger: true })
+    expect(vars.every((v) => v.category === 'context')).toBe(true)
+    expect(vars.length).toBeGreaterThan(0)
+  })
+  it('returns task vars for taskCreated trigger', () => {
+    const vars = getAvailableContextVars({ triggerType: 'taskCreated', isContextualTrigger: false })
+    expect(vars.some((v) => v.category === 'task')).toBe(true)
+  })
+  it('returns task + trigger + context vars for a contextual taskStatusChanged', () => {
+    const vars = getAvailableContextVars({
+      triggerType: 'taskStatusChanged',
+      isContextualTrigger: true
+    })
+    const cats = new Set(vars.map((v) => v.category))
+    expect(cats.has('task')).toBe(true)
+    expect(cats.has('trigger')).toBe(true)
+    expect(cats.has('context')).toBe(true)
+  })
+  it('returns empty list for plain manual non-contextual trigger', () => {
+    const vars = getAvailableContextVars({ triggerType: 'manual', isContextualTrigger: false })
+    expect(vars).toEqual([])
   })
 })

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -84,3 +84,44 @@ describe('TriggerConfigForm', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ triggerType: 'recurring' }))
   })
 })
+
+describe('TriggerConfigForm — contextual toggle', () => {
+  it('renders the Contextual switch only for manual triggers', () => {
+    const { container, rerender } = render(
+      <TriggerConfigForm config={{ triggerType: 'manual' }} onChange={vi.fn()} />
+    )
+    expect(container.textContent).toContain('Contextual')
+
+    rerender(
+      <TriggerConfigForm
+        config={{ triggerType: 'recurring', cron: '0 9 * * *' }}
+        onChange={vi.fn()}
+      />
+    )
+    expect(container.textContent).not.toContain('Contextual')
+  })
+
+  it('reflects the current contextual flag on the switch', () => {
+    render(
+      <TriggerConfigForm config={{ triggerType: 'manual', contextual: true }} onChange={vi.fn()} />
+    )
+    const sw = screen.getAllByRole('switch')[0]
+    expect(sw.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('sets contextual: true when toggled from off', () => {
+    const onChange = vi.fn()
+    render(<TriggerConfigForm config={{ triggerType: 'manual' }} onChange={onChange} />)
+    fireEvent.click(screen.getAllByRole('switch')[0])
+    expect(onChange).toHaveBeenCalledWith({ triggerType: 'manual', contextual: true })
+  })
+
+  it('drops the contextual flag when toggled from on', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm config={{ triggerType: 'manual', contextual: true }} onChange={onChange} />
+    )
+    fireEvent.click(screen.getAllByRole('switch')[0])
+    expect(onChange).toHaveBeenCalledWith({ triggerType: 'manual', contextual: undefined })
+  })
+})

--- a/tests/variable-autocomplete.test.tsx
+++ b/tests/variable-autocomplete.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import { VariableAutocomplete } from '../src/renderer/components/workflow-editor/panels/VariableAutocomplete'
+import type { TemplateVariable } from '../src/renderer/lib/template-vars'
+
+describe('VariableAutocomplete', () => {
+  it('lists context variables under a Context group when typing {{', () => {
+    const contextVars: TemplateVariable[] = [
+      { key: '{{context.cwd}}', label: 'cwd', category: 'context' },
+      { key: '{{context.branch}}', label: 'branch', category: 'context' }
+    ]
+    const { container, getByText } = render(
+      <VariableAutocomplete value="" onChange={vi.fn()} stepGroups={[]} contextVars={contextVars} />
+    )
+    const textarea = container.querySelector('textarea')!
+    fireEvent.change(textarea, { target: { value: '{{' } })
+    expect(getByText('Context')).toBeInTheDocument()
+  })
+})

--- a/tests/workflow-helpers.test.ts
+++ b/tests/workflow-helpers.test.ts
@@ -24,6 +24,8 @@ import {
   getOrderedActionNodes,
   getActionCount,
   isScheduledWorkflow,
+  isContextualWorkflow,
+  getWorktreeMode,
   getTriggerLabel,
   createTriggerNode,
   createLaunchAgentNode,
@@ -150,6 +152,63 @@ describe('isScheduledWorkflow', () => {
   it('returns false for manual', () => {
     const wf = makeWorkflow([makeTriggerNode({ triggerType: 'manual' })], [])
     expect(isScheduledWorkflow(wf)).toBe(false)
+  })
+})
+
+describe('isContextualWorkflow', () => {
+  it('returns true when manual trigger has contextual: true', () => {
+    const wf = makeWorkflow([makeTriggerNode({ triggerType: 'manual', contextual: true })], [])
+    expect(isContextualWorkflow(wf)).toBe(true)
+  })
+  it('returns false for plain manual trigger', () => {
+    const wf = makeWorkflow([makeTriggerNode({ triggerType: 'manual' })], [])
+    expect(isContextualWorkflow(wf)).toBe(false)
+  })
+  it('returns false for scheduled trigger even with contextual flag', () => {
+    const wf = makeWorkflow([makeTriggerNode({ triggerType: 'recurring', cron: '0 0 * * *' })], [])
+    expect(isContextualWorkflow(wf)).toBe(false)
+  })
+  it('returns false when there is no trigger', () => {
+    const wf = makeWorkflow([makeActionNode('a')], [])
+    expect(isContextualWorkflow(wf)).toBe(false)
+  })
+})
+
+describe('getWorktreeMode', () => {
+  it("returns 'fromContext' when useWorktree === 'fromContext'", () => {
+    expect(
+      getWorktreeMode({
+        agentType: 'claude',
+        projectName: '',
+        projectPath: '',
+        useWorktree: 'fromContext'
+      })
+    ).toBe('fromContext')
+  })
+  it("returns 'new' when useWorktree === true and worktreeMode is unset", () => {
+    expect(
+      getWorktreeMode({
+        agentType: 'claude',
+        projectName: '',
+        projectPath: '',
+        useWorktree: true
+      })
+    ).toBe('new')
+  })
+  it("returns 'none' when useWorktree is false / undefined", () => {
+    expect(getWorktreeMode({ agentType: 'claude', projectName: '', projectPath: '' })).toBe('none')
+  })
+  it('honors an explicit worktreeMode over the boolean shortcut', () => {
+    expect(
+      getWorktreeMode({
+        agentType: 'claude',
+        projectName: '',
+        projectPath: '',
+        useWorktree: true,
+        worktreeMode: 'fromStep',
+        worktreeFromStepSlug: 'prep'
+      })
+    ).toBe('fromStep')
   })
 })
 

--- a/tests/workflow-menu-items.test.tsx
+++ b/tests/workflow-menu-items.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
+const mockSetPending = vi.fn()
+vi.mock('../src/renderer/stores', () => {
+  const state = {
+    setPendingContextualWorkflowId: (id: string | null) => mockSetPending(id)
+  }
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: unknown) => unknown) => (selector ? selector(state) : state),
+      { getState: () => state }
+    )
+  }
+})
+
+import {
+  buildWorkflowMenuItems,
+  runWorkflowFromGlobalSurface
+} from '../src/renderer/lib/workflow-menu-items'
+import type { TaskConfig, TerminalSession, WorkflowDefinition } from '../src/shared/types'
+
+function makeWorkflow(id: string, contextual: boolean): WorkflowDefinition {
+  return {
+    id,
+    name: `wf ${id}`,
+    icon: 'Zap',
+    iconColor: '#fff',
+    nodes: [
+      {
+        id: 'trigger',
+        type: 'trigger',
+        config: { triggerType: 'manual', contextual: contextual || undefined },
+        position: { x: 0, y: 0 },
+        label: 'Manual'
+      }
+    ],
+    edges: [],
+    enabled: true
+  }
+}
+
+const someTask: TaskConfig = {
+  id: 't',
+  projectName: 'p',
+  title: 'x',
+  description: '',
+  status: 'in_progress',
+  order: 0,
+  createdAt: '',
+  updatedAt: ''
+}
+const someSession: TerminalSession = {
+  id: 's',
+  agentType: 'shell',
+  projectName: 'p',
+  projectPath: '/p',
+  status: 'idle',
+  createdAt: 0,
+  pid: 0
+}
+
+beforeEach(() => {
+  mockExecuteWorkflow.mockClear()
+  mockSetPending.mockClear()
+})
+
+describe('buildWorkflowMenuItems', () => {
+  it('returns only contextual workflows when called with a task context', () => {
+    const items = buildWorkflowMenuItems(
+      [makeWorkflow('a', true), makeWorkflow('b', false)],
+      vi.fn(),
+      { task: someTask }
+    )
+    expect(items.map((i) => i.id)).toEqual(['a'])
+  })
+
+  it('returns only contextual workflows when called with a source context', () => {
+    const items = buildWorkflowMenuItems(
+      [makeWorkflow('a', true), makeWorkflow('b', false)],
+      vi.fn(),
+      { source: someSession }
+    )
+    expect(items.map((i) => i.id)).toEqual(['a'])
+  })
+
+  it('returns only non-contextual workflows when called with no context', () => {
+    const items = buildWorkflowMenuItems(
+      [makeWorkflow('a', true), makeWorkflow('b', false)],
+      vi.fn()
+    )
+    expect(items.map((i) => i.id)).toEqual(['b'])
+  })
+
+  it('threads context into executeWorkflow on click', () => {
+    const onSelect = vi.fn()
+    const items = buildWorkflowMenuItems([makeWorkflow('a', true)], onSelect, {
+      source: someSession
+    })
+    items[0].onClick()
+    expect(onSelect).toHaveBeenCalled()
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'a' }),
+      { task: undefined, source: someSession },
+      { source: 'manual' }
+    )
+  })
+
+  it('passes undefined context for non-contextual call sites', () => {
+    const items = buildWorkflowMenuItems([makeWorkflow('b', false)], vi.fn())
+    items[0].onClick()
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b' }),
+      undefined,
+      { source: 'manual' }
+    )
+  })
+})
+
+describe('runWorkflowFromGlobalSurface', () => {
+  it('opens SourcePromptDialog for contextual workflows', () => {
+    runWorkflowFromGlobalSurface(makeWorkflow('a', true))
+    expect(mockSetPending).toHaveBeenCalledWith('a')
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('runs non-contextual workflows directly', () => {
+    runWorkflowFromGlobalSurface(makeWorkflow('b', false))
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'b' }),
+      undefined,
+      { source: 'manual' }
+    )
+    expect(mockSetPending).not.toHaveBeenCalled()
+  })
+})

--- a/tests/workflow-properties-panel.test.tsx
+++ b/tests/workflow-properties-panel.test.tsx
@@ -171,4 +171,41 @@ describe('WorkflowPropertiesPanel', () => {
     if (switchButton) fireEvent.click(switchButton)
     expect(onEnabledChange).toHaveBeenCalled()
   })
+
+  it('renders the cleanup toggle as off and ignores clicks when cleanupDisabled is true', () => {
+    const onCleanupChange = vi.fn()
+    const { container } = render(
+      <WorkflowPropertiesPanel
+        {...baseProps}
+        autoCleanupWorktrees={true}
+        cleanupDisabled
+        onCleanupChange={onCleanupChange}
+      />
+    )
+    // The cleanup row sits after Status / Stagger — find its switch by its parent row label.
+    const cleanupRow = Array.from(container.querySelectorAll('div')).find((d) =>
+      d.textContent?.startsWith('Cleanup worktrees')
+    )!
+    const cleanupSwitch = cleanupRow.querySelector('button[role="switch"]') as HTMLButtonElement
+    expect(cleanupSwitch.getAttribute('aria-checked')).toBe('false')
+    fireEvent.click(cleanupSwitch)
+    expect(onCleanupChange).not.toHaveBeenCalled()
+  })
+
+  it('calls onCleanupChange when the cleanup toggle is enabled and clicked', () => {
+    const onCleanupChange = vi.fn()
+    const { container } = render(
+      <WorkflowPropertiesPanel
+        {...baseProps}
+        autoCleanupWorktrees={false}
+        onCleanupChange={onCleanupChange}
+      />
+    )
+    const cleanupRow = Array.from(container.querySelectorAll('div')).find((d) =>
+      d.textContent?.startsWith('Cleanup worktrees')
+    )!
+    const cleanupSwitch = cleanupRow.querySelector('button[role="switch"]') as HTMLButtonElement
+    fireEvent.click(cleanupSwitch)
+    expect(onCleanupChange).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

- New **contextual workflow** trigger: a `contextual` flag on the manual trigger plus a per-field "From Context" option that resolves folder, branch, and worktree from the launching card or terminal. Surfaced in card and terminal right-click menus; the sidebar / palette opens a small dialog asking for the source.
- **Persist headless logs incrementally** so renderer reloads no longer lose mid-run output.
- **Reconcile orphaned runs** on startup against `session_events`: a run left `running` after a renderer crash / HMR reload now gets closed out (success/error from the exit event) instead of staying wedged forever.
- A polish pass that flattens nested ternaries, extracts a `resolveWorktreeOrigin` helper, parallelizes the reconciler's session-event lookups, dedupes workflow-run row mapping, and makes every run-step row expandable with a chevron + sensible empty state.

Closes [#284](https://github.com/jcanizalez/vorn/issues/284) is **not** addressed here — that issue (live streaming + ticking duration) is filed separately and will land in a follow-up PR.

## Test plan

- [ ] Author a workflow, toggle "Contextual workflow" on, switch project / branch / worktree to "From Context", save.
- [ ] Right-click a card → "Run workflow ▸" lists only contextual workflows; running it spawns a session in the card's cwd / branch / worktree (verify with `pwd` and `git branch`).
- [ ] Right-click a terminal session → same behavior, source = that session.
- [ ] Right-click empty grid space → "Run workflow ▸" lists only non-contextual workflows.
- [ ] Run the contextual workflow from the sidebar / command palette → SourcePromptDialog opens, asks for project (and branch / worktree if referenced).
- [ ] Toggle "Contextual workflow" off → "From Context" fields auto-reset.
- [ ] Run a contextual workflow whose LaunchAgent inherits a worktree → confirm the parent card's worktree is NOT removed even when `autoCleanupWorktrees` is set.
- [ ] Trigger an HMR reload mid-run → the run's logs persist (not lost) and on next load the run is closed out cleanly instead of staying `running`.
- [ ] Pre-existing workflows using `agentType: 'fromTask'` still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)