### PR TITLE
ci(release): pin windows build to windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
   build-windows:
     needs: create-release
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- windows-latest is mid-transition to windows-2025-vs2026 (per the runner-image deprecation notice) and is currently missing a Visual Studio install
- The v0.2.1-beta.1 release build failed at electron-builder installAppDeps when node-gyp tried to rebuild node-pty: \`Could not find any Visual Studio installation to use\`
- Pin the windows job to windows-2022 (stable VS2022) until the new image stabilises

## Test plan
- [ ] Re-tag v0.2.1-beta.1 after merge and confirm windows .exe artifacts upload