### PR TITLE
fix(workflow): reuse source worktree for contextual launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/jcanizalez/vorn/releases"><img src="https://img.shields.io/github/v/release/jcanizalez/vorn?style=flat-square" alt="Release"></a>
-  <a href="https://github.com/jcanizalez/vorn/blob/main/LICENSE"><img src="https://img.shields.io/github/license/jcanizalez/vorn?style=flat-square" alt="License"></a>
-  <a href="https://github.com/jcanizalez/vorn/stargazers"><img src="https://img.shields.io/github/stars/jcanizalez/vorn?style=flat-square" alt="Stars"></a>
+  <a href="https://github.com/vorn-run/vorn/releases"><img src="https://img.shields.io/github/v/release/vorn-run/vorn?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/vorn-run/vorn/blob/main/LICENSE"><img src="https://img.shields.io/github/license/vorn-run/vorn?style=flat-square" alt="License"></a>
+  <a href="https://github.com/vorn-run/vorn/stargazers"><img src="https://img.shields.io/github/stars/vorn-run/vorn?style=flat-square" alt="Stars"></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square" alt="Platform">
   <img src="https://img.shields.io/badge/status-alpha-orange?style=flat-square" alt="Alpha">
 </p>
@@ -50,22 +50,22 @@ Vorn is the agent command center. How you work is up to you.
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jcanizalez/vorn/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/vorn-run/vorn/main/install.sh | sh
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/jcanizalez/vorn/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/vorn-run/vorn/main/install.ps1 | iex
 ```
 
 **Homebrew (macOS):**
 
 ```bash
-brew tap jcanizalez/tap && brew install --cask vorn
+brew tap vorn-run/tap && brew install --cask vorn
 ```
 
-Or download directly from [GitHub Releases](https://github.com/jcanizalez/vorn/releases).
+Or download directly from [GitHub Releases](https://github.com/vorn-run/vorn/releases).
 
 ## Features
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 publish:
   provider: github
-  owner: jcanizalez
+  owner: vorn-run
   repo: vorn
   releaseType: release
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-$Repo = "jcanizalez/vorn"
+$Repo = "vorn-run/vorn"
 $AppName = "Vorn"
 
 function Get-LatestVersion {

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-REPO="jcanizalez/vorn"
+REPO="vorn-run/vorn"
 APP_NAME="Vorn"
 
 # Detect OS and architecture

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -7,7 +7,7 @@
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jcanizalez/vorn.git",
+    "url": "git+https://github.com/vorn-run/vorn.git",
     "directory": "packages/mcp"
   },
   "keywords": [

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -532,6 +532,13 @@ async function executeNode(
     }
     existingWorktreePath = config.existingWorktreePath
     useWorktree = undefined
+  } else if (worktreeMode === 'fromContext' && context) {
+    // Without this, createTerminal spawns a fresh worktree off project root instead of reusing the source's.
+    const ctxWorktree = resolveContextField('worktreePath', context) as string | undefined
+    if (ctxWorktree) {
+      existingWorktreePath = ctxWorktree
+      useWorktree = undefined
+    }
   }
 
   let resolvedTask: TaskConfig | undefined

--- a/website/index.html
+++ b/website/index.html
@@ -1542,7 +1542,7 @@
           <a href="#agents">Agents</a>
           <a href="#install">Install</a>
           <a
-            href="https://github.com/jcanizalez/vorn"
+            href="https://github.com/vorn-run/vorn"
             target="_blank"
             rel="noopener"
             class="nav-gh"
@@ -1572,7 +1572,7 @@
       <a href="#features">Features</a>
       <a href="#agents">Agents</a>
       <a href="#install">Install</a>
-      <a href="https://github.com/jcanizalez/vorn" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/vorn-run/vorn" target="_blank" rel="noopener">GitHub</a>
       <a href="#install" class="nav-cta">Download</a>
     </div>
 
@@ -1640,7 +1640,7 @@
               Download
             </a>
             <a
-              href="https://github.com/jcanizalez/vorn"
+              href="https://github.com/vorn-run/vorn"
               target="_blank"
               rel="noopener"
               class="btn-ghost"
@@ -2232,7 +2232,7 @@
                 <div class="terminal-line active" data-panel="mac">
                   <span class="terminal-prompt">$</span>
                   <code
-                    >curl -fsSL https://raw.githubusercontent.com/jcanizalez/vorn/main/install.sh |
+                    >curl -fsSL https://raw.githubusercontent.com/vorn-run/vorn/main/install.sh |
                     sh</code
                   >
                   <span class="terminal-cursor"></span>
@@ -2240,14 +2240,14 @@
                 <div class="terminal-line" data-panel="win">
                   <span class="terminal-prompt">&gt;</span>
                   <code
-                    >irm https://raw.githubusercontent.com/jcanizalez/vorn/main/install.ps1 |
+                    >irm https://raw.githubusercontent.com/vorn-run/vorn/main/install.ps1 |
                     iex</code
                   >
                   <span class="terminal-cursor"></span>
                 </div>
                 <div class="terminal-line" data-panel="brew">
                   <span class="terminal-prompt">$</span>
-                  <code>brew tap jcanizalez/tap && brew install --cask vorn</code>
+                  <code>brew tap vorn-run/tap && brew install --cask vorn</code>
                   <span class="terminal-cursor"></span>
                 </div>
                 <button class="copy-btn" aria-label="Copy command">Copy</button>
@@ -2259,7 +2259,7 @@
                 <a
                   class="os-btn"
                   data-os="mac"
-                  href="https://github.com/jcanizalez/vorn/releases"
+                  href="https://github.com/vorn-run/vorn/releases"
                   target="_blank"
                   rel="noopener"
                 >
@@ -2279,7 +2279,7 @@
                 <a
                   class="os-btn"
                   data-os="win"
-                  href="https://github.com/jcanizalez/vorn/releases"
+                  href="https://github.com/vorn-run/vorn/releases"
                   target="_blank"
                   rel="noopener"
                 >
@@ -2299,7 +2299,7 @@
                 <a
                   class="os-btn"
                   data-os="linux"
-                  href="https://github.com/jcanizalez/vorn/releases"
+                  href="https://github.com/vorn-run/vorn/releases"
                   target="_blank"
                   rel="noopener"
                 >
@@ -2319,7 +2319,7 @@
               </div>
               <p class="install-alt">
                 or see
-                <a href="https://github.com/jcanizalez/vorn/releases" target="_blank" rel="noopener"
+                <a href="https://github.com/vorn-run/vorn/releases" target="_blank" rel="noopener"
                   >all releases</a
                 >
               </p>
@@ -2388,7 +2388,7 @@
             <a href="#features">Features</a>
             <a href="#agents">Agents</a>
             <a href="#install">Install</a>
-            <a href="https://github.com/jcanizalez/vorn" target="_blank" rel="noopener">GitHub</a>
+            <a href="https://github.com/vorn-run/vorn" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>
       </div>
@@ -2508,7 +2508,7 @@
       // ═══════════════════════════════════════
       // DOWNLOAD BUTTONS
       // ═══════════════════════════════════════
-      const REPO = 'jcanizalez/vorn'
+      const REPO = 'vorn-run/vorn'
       const ASSET_MATCH = {
         mac: (name) => name.endsWith('.dmg') && !name.endsWith('.blockmap'),
         win: (name) => /-Setup-.*\.exe$/.test(name) && !name.endsWith('.blockmap'),


### PR DESCRIPTION
## Summary
- Contextual workflows launched from a worktree-backed card resolved `useWorktree=true` via `'fromContext'` but never set `existingWorktreePath`, so `createTerminal`/`createHeadlessSession` spawned a fresh worktree off the project root and the agent ran in the wrong cwd.
- Adds a `fromContext` branch in `executeNode` that resolves the source/task `worktreePath` and passes it as `existingWorktreePath`. The existing `inheritedWorktree` flag keeps cleanup from deleting the reused worktree.
- Also rolls in the GitHub org rename from `jcanizalez/vorn` to `vorn-run/vorn` across README, install scripts, electron-builder config, MCP package metadata, and the website.

## Test plan
- [ ] Right-click a worktree-backed card and trigger a contextual workflow whose launch step uses `useWorktree: 'fromContext'`; confirm the new agent lands in the same worktree path as the source.
- [ ] Run a contextual workflow from a non-worktree card; confirm it still launches at the project root.
- [ ] After the run completes, verify the inherited worktree is not deleted by the cleanup pass.