### PR TITLE
fix(tests): stabilize run-entry relative-time matchers

### DIFF
--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -70,6 +70,14 @@ function makeState(overrides: Partial<NodeExecutionState> = {}): NodeExecutionSt
 }
 
 describe('RunEntry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-20T10:00:10Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('expands and shows the Resume button when agentSessionId is present', () => {
     const onResume = vi.fn()
     const exec = makeExec({ nodeStates: [makeState({ agentSessionId: 'agent-abc' })] })


### PR DESCRIPTION
The 'X ago / just now' regex in `tests/run-entry.test.tsx` no longer matched once fixture dates (2026-04-20) crossed the 30-day threshold in `formatRelativeTime`, which falls back to a locale date (e.g. 'Apr 20'). Anchor the test clock with `vi.setSystemTime` so the relative-time output stays stable regardless of when CI runs.

This unblocks the queued dependabot PRs (#316–#320) that were failing CI on this same test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>