### PR TITLE
fix: pin fresh sessions with --session-id instead of --resume

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -29,7 +29,7 @@ export function getSessionIdPinningFlag(agentType: AgentType): string {
     case 'claude':
       return '--session-id'
     case 'copilot':
-      return '--resume'
+      return '--session-id'
     default:
       throw new Error(`getSessionIdPinningFlag: ${agentType} does not support session ID pinning`)
   }

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -241,6 +241,7 @@ describe('buildHeadlessSpawnArgs', () => {
     const idx = result.args.indexOf('--session-id')
     expect(idx).toBeGreaterThanOrEqual(0)
     expect(result.args[idx + 1]).toBe('uuid-head')
+    expect(result.args).not.toContain('--resume')
   })
 
   it('resumes claude headless via --resume', () => {

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -99,14 +99,14 @@ describe('buildAgentLaunchLine', () => {
     expect(result).not.toContain('--session-id')
   })
 
-  it('pins fresh copilot session via --resume', () => {
+  it('pins fresh copilot session via --session-id', () => {
     const result = buildAgentLaunchLine(
       makePayload({ agentType: 'copilot', sessionId: 'uuid-123' }),
       cmds,
       env
     )
-    expect(result).toBe('copilot --resume uuid-123')
-    expect(result).not.toContain('--session-id')
+    expect(result).toBe('copilot --session-id uuid-123')
+    expect(result).not.toContain('--resume')
   })
 
   it('prefers resumeSessionId over pinned sessionId for copilot', () => {
@@ -232,13 +232,13 @@ describe('buildHeadlessSpawnArgs', () => {
     expect(result.args[idx + 1]).toBe('uuid-head')
   })
 
-  it('pins copilot headless session via --resume (pinning flag is --resume for copilot)', () => {
+  it('pins copilot headless session via --session-id', () => {
     const result = buildHeadlessSpawnArgs(
       makePayload({ agentType: 'copilot', sessionId: 'uuid-head', initialPrompt: 'go' }),
       cmds,
       env
     )
-    const idx = result.args.indexOf('--resume')
+    const idx = result.args.indexOf('--session-id')
     expect(idx).toBeGreaterThanOrEqual(0)
     expect(result.args[idx + 1]).toBe('uuid-head')
   })


### PR DESCRIPTION
## Summary

The Copilot CLI changed its session flags. `--resume` no longer starts a new session with a given UUID — the new `--session-id <id>` flag does that ("set the UUID for a new session"). `--resume` is now used only to resume an existing session.

This broke Vorn's logic for pinning a pre-generated UUID on fresh Copilot launches, since it was passing `--resume <uuid>` to start a new session.

## Changes

- `getSessionIdPinningFlag('copilot')` now returns `--session-id` (was `--resume`) in `packages/shared/src/types.ts`. The flag is centralized, so this fixes both interactive (`buildAgentLaunchLine`) and headless (`buildHeadlessSpawnArgs`) launch paths.
- Fresh Copilot sessions now launch as `copilot --session-id <uuid>`.
- Resuming existing sessions still uses `--resume`, which remains valid in the new CLI.
- Updated `tests/agent-launch.test.ts` to expect `--session-id` for Copilot pinning.

## Verification

- Full test suite passes (1563 tests).
- Typecheck clean.