### PR TITLE
chore(deps): ignore TypeScript major (7.x) bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,57 @@
 version: 2
 updates:
+  # TypeScript 7 is the native (Go port) rewrite: its main entry no longer
+  # exposes the classic compiler API (breaks typescript-eslint) and Yarn's
+  # bundled compat/typescript patch fails to install it. Hold the major bump
+  # in every npm package until the toolchain supports the native port.
+  # TS 6.x minor/patch updates still flow.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'npm'
     directory: '/packages/web'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'npm'
     directory: '/packages/desktop'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'npm'
     directory: '/packages/server'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'npm'
     directory: '/packages/shared'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'npm'
     directory: '/packages/mcp'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## What
Adds a Dependabot `ignore` rule for **major** `typescript` updates across all six npm packages. Minor/patch TS 6.x updates continue to flow.

## Why
TypeScript 7 is the native (Go port) rewrite and is **not a drop-in replacement** for the `typescript` package:

1. **Install fails** — Yarn 4's bundled `compat/typescript` patch expects `lib/_tsc.js`, which the native port doesn't ship (`ENOENT`). It's applied by the bundled plugin before `resolutions`, so it can't be cleanly disabled.
2. **Lint breaks** — TS7's main entry now returns only `{ version, versionMajorMinor }`; the classic compiler API (`createSourceFile`, `createProgram`) moved to `typescript/unstable/*`. `typescript-eslint` relies on the classic API, so `yarn lint` cannot run.

The native port is meant to run **alongside** classic TypeScript (as `@typescript/native-preview`/`tsgo`), not replace the `typescript` package. This hold can be lifted once Yarn's compat plugin and typescript-eslint support the native port.

## Follow-up
Closes Dependabot PRs #351, #352, #353, #355 (they will stop being re-created).