### PR TITLE
fix(build): use function-form manualChunks for Vite 8 rolldown

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -27,15 +27,13 @@ export default defineConfig({
           widget: resolve(__dirname, 'src/renderer/widget.html')
         },
         output: {
-          manualChunks: {
-            'vendor-react': ['react', 'react-dom'],
-            'vendor-xterm': [
-              '@xterm/xterm',
-              '@xterm/addon-fit',
-              '@xterm/addon-webgl',
-              '@xterm/addon-canvas'
-            ],
-            'vendor-motion': ['framer-motion']
+          manualChunks(id) {
+            if (!id.includes('node_modules')) return
+            if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+              return 'vendor-react'
+            }
+            if (id.includes('@xterm/')) return 'vendor-xterm'
+            if (id.includes('framer-motion')) return 'vendor-motion'
           }
         }
       }


### PR DESCRIPTION
## Problem
The v0.3.1 release build failed on Linux and Windows:
```
TypeError: manualChunks is not a function
```
Vite 8 (merged in #358) switched to the **rolldown** bundler, which only supports the **function** form of `output.manualChunks`. Our `electron.vite.config.ts` used the object form. CI didn't catch this because CI runs typecheck/lint/test + server build — not the full production renderer build (`electron-vite build`).

## Fix
Convert `manualChunks` to the function form (accepted by both rolldown and Rollup), preserving the `vendor-react` / `vendor-xterm` / `vendor-motion` chunks.

## Verification
`yarn build` now completes; the three vendor chunks are emitted. typecheck/lint/format all pass.