### PR TITLE
ci: verify production build to catch renderer build regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,11 @@ jobs:
             }
             setTimeout(() => process.exit(0), 2000);
           "
+
+      - name: Verify production build
+        # Catches renderer/main/preload build regressions (e.g. Vite 8 rolldown
+        # rejecting object-form manualChunks) that the unit tests don't exercise.
+        # The server bundle is already built in the step above.
+        run: |
+          yarn build:web
+          yarn electron-vite build


### PR DESCRIPTION
## Problem
CI ran typecheck, lint, test, and the **server** bundle build — but never the full **renderer/main/preload** production build. That gap let the Vite 8 rolldown `manualChunks` regression (fixed in #367) pass CI and only surface at release time, breaking the v0.3.1 Linux/Windows builds.

## Fix
Add a **Verify production build** step to CI that runs `yarn build:web` and `yarn electron-vite build`, exercising the same production build path as the release workflow.

## Verification
Both commands run clean locally on this branch.