### PR TITLE
fix(build): pin preload output to CJS and externalize electron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,23 @@ jobs:
         run: |
           yarn build:web
           yarn electron-vite build
+
+      - name: Verify preload artifacts
+        # The main process hard-codes out/preload/index.js and widget-preload.js.
+        # Vite 8 rolldown once emitted .mjs instead and bundled the npm electron
+        # shim into the preload, leaving window.api undefined in the packaged app.
+        run: |
+          for f in out/main/index.js out/preload/index.js out/preload/widget-preload.js; do
+            if [ ! -f "$f" ]; then
+              echo "ERROR: $f missing — main process loads this exact path"
+              exit 1
+            fi
+          done
+          if grep -rq 'Electron failed to install correctly' out/main out/preload; then
+            echo "ERROR: npm electron shim bundled into build output — 'electron' was not externalized"
+            exit 1
+          fi
+          if ! grep -q 'require("electron")' out/preload/index.js; then
+            echo "ERROR: out/preload/index.js does not require('electron') externally"
+            exit 1
+          fi

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/preload/index.ts'),
           'widget-preload': resolve(__dirname, 'src/preload/widget-preload.ts')
+        },
+        external: ['electron'],
+        output: {
+          format: 'cjs',
+          entryFileNames: '[name].js',
+          chunkFileNames: 'chunks/[name]-[hash].js'
         }
       }
     }


### PR DESCRIPTION
## Problem

v0.3.1 crashes at startup with `TypeError: Cannot read properties of undefined (reading 'onTerminalData')` — `window.api` is undefined because the preload script never runs in packaged builds.

The vite 7 → 8 (rolldown) bump changed the preload build output in two independent, fatal ways:

1. **Wrong filename**: the multi-entry preload build is emitted as `index.mjs`/`widget-preload.mjs`, but the main process loads `out/preload/index.js` by exact path (`src/main/index.ts`). The preload silently fails to load.
2. **Bundled electron shim**: rolldown inlined `node_modules/electron/index.js` (the npm installer shim that resolves the binary path) into the preload chunk instead of keeping `electron` external. Even with the correct filename, the preload would throw "Electron failed to install correctly" instead of getting `contextBridge`.

CI's production-build check (#368) ran the build but never inspected the preload artifacts, so this shipped.

## Fix

- Pin the preload rollup output to `format: 'cjs'` with `.js` entry/chunk names, matching the paths main hard-codes.
- Declare `electron` as an explicit external in the preload build.

## Verification

Extracted `out/preload` from a freshly packaged `.app` and loaded it in a minimal Electron window with the app's webPreferences:

- fixed package: `window.api` is an object, `onTerminalData` is a function
- shipped 0.3.1 asar (control): preload fails both ways described above

## Regression guard

New CI step after the production build fails if `out/preload/index.js` / `widget-preload.js` / `out/main/index.js` are missing, if the npm electron shim appears in build output, or if the preload stops requiring `electron` externally.