### PR TITLE
fix(headless): deliver workflow prompt without shell word-splitting on Windows

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -160,15 +160,36 @@ export function buildHeadlessLaunchLine(
   }
 }
 
+export interface HeadlessSpawnArgs {
+  command: string
+  args: string[]
+  /**
+   * When set, the prompt should be written to the child's stdin rather than
+   * passed as a command-line argument. Used for agents that read their prompt
+   * from stdin (claude) so a multi-line prompt survives intact on Windows,
+   * where `spawn(..., { shell: true })` word-splits and line-breaks unquoted
+   * argv on the cmd.exe command line. See buildHeadlessSpawnArgs.
+   */
+  stdin?: string
+}
+
 /**
  * Returns { command, args } for direct spawn (no shell wrapper).
  * Avoids TTY/stdin issues that occur when spawning through sh -c in Node.js.
+ *
+ * On Windows the headless spawn uses `shell: true` (required to run the
+ * `.cmd`/`.ps1` shims that npm-installed agents ship as). Under `shell: true`,
+ * Node concatenates argv into a single cmd.exe command line with no quoting,
+ * so a workflow prompt — which is multi-word and multi-line — gets word-split
+ * (claude's `-p` then sees only the first token, e.g. `#`) and truncated at the
+ * first newline. To avoid this entirely, agents that can read their prompt from
+ * stdin return it via `stdin` instead of on the command line.
  */
 export function buildHeadlessSpawnArgs(
   payload: CreateTerminalPayload,
   agentCommands: Record<AiAgentType, AgentCommandConfig>,
   env: Record<string, string>
-): { command: string; args: string[] } {
+): HeadlessSpawnArgs {
   if (payload.agentType === 'shell') {
     throw new Error('buildHeadlessSpawnArgs called for shell session')
   }
@@ -189,7 +210,11 @@ export function buildHeadlessSpawnArgs(
 
   switch (payload.agentType) {
     case 'claude':
-      return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
+      // `claude -p` (print mode) reads the prompt from stdin when no positional
+      // prompt is given. Deliver it there so the shell never sees it.
+      return prompt
+        ? { command: cmd.command, args: [...extraArgs, '-p'], stdin: prompt }
+        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
     case 'copilot':
       return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
     case 'codex':

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -18,7 +18,7 @@ import {
   extractWorktreeName,
   isGitRepo
 } from './git-utils'
-import { getSafeEnv } from './process-utils'
+import { getSafeEnv, shellEscape } from './process-utils'
 import { buildHeadlessSpawnArgs } from './agent-launch'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import log from './logger'
@@ -99,20 +99,37 @@ class HeadlessManager extends EventEmitter {
 
     const env = getSafeEnv()
     const spawnArgs = buildHeadlessSpawnArgs(payload, this.agentCommands, env)
+
+    // Windows needs `shell: true` to run the `.cmd`/`.ps1` shims that
+    // npm-installed agents ship as. Under `shell: true`, Node concatenates argv
+    // into a single cmd.exe command line WITHOUT quoting, so a multi-word prompt
+    // passed as an argument (copilot/codex/gemini/opencode) gets word-split —
+    // the agent's `-p` then sees only the first token. Quote each arg so it
+    // survives as one argument. On POSIX we spawn without a shell, so args reach
+    // execve verbatim and must NOT be quoted. (claude sidesteps this entirely by
+    // taking its prompt on stdin — see buildHeadlessSpawnArgs.)
+    const useShell = process.platform === 'win32'
+    const spawnArgList = useShell ? spawnArgs.args.map((a) => shellEscape(a)) : spawnArgs.args
     log.info(
-      `[headless] launching: ${spawnArgs.command} ${spawnArgs.args.join(' ').slice(0, 100)}...`
+      `[headless] launching: ${spawnArgs.command} ${spawnArgList.join(' ').slice(0, 100)}...`
     )
 
-    const child = spawn(spawnArgs.command, spawnArgs.args, {
+    const child = spawn(spawnArgs.command, spawnArgList, {
       cwd: effectivePath,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
-      shell: process.platform === 'win32'
+      shell: useShell
     })
 
-    // Close stdin immediately so the process doesn't hang waiting for input
+    // Some agents (claude) receive their prompt on stdin rather than as an argv
+    // element, so a multi-line workflow prompt isn't mangled by the Windows
+    // `shell: true` command line. Write it, then close stdin. When there's no
+    // stdin payload, close immediately so the process doesn't hang on input.
     child.stdin?.on('error', () => {}) // prevent EPIPE if process exits early
+    if (spawnArgs.stdin != null) {
+      child.stdin?.write(spawnArgs.stdin)
+    }
     child.stdin?.end()
 
     this.processes.set(id, child)

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -108,8 +108,14 @@ class HeadlessManager extends EventEmitter {
     // survives as one argument. On POSIX we spawn without a shell, so args reach
     // execve verbatim and must NOT be quoted. (claude sidesteps this entirely by
     // taking its prompt on stdin — see buildHeadlessSpawnArgs.)
+    // `shell: true` on Windows always runs `comspec || cmd.exe`, so quote with
+    // the 'cmd' flavor rather than the user's default shell — otherwise a
+    // PowerShell default (or unset COMSPEC) would single-quote args that cmd.exe
+    // doesn't treat as quoting, re-introducing the word-split.
     const useShell = process.platform === 'win32'
-    const spawnArgList = useShell ? spawnArgs.args.map((a) => shellEscape(a)) : spawnArgs.args
+    const spawnArgList = useShell
+      ? spawnArgs.args.map((a) => shellEscape(a, 'cmd'))
+      : spawnArgs.args
     log.info(
       `[headless] launching: ${spawnArgs.command} ${spawnArgList.join(' ').slice(0, 100)}...`
     )

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -34,14 +34,26 @@ export function getDefaultShell(): string {
   return process.env.SHELL || '/bin/zsh'
 }
 
-export function shellEscape(s: string, flavor: 'auto' | 'posix' = 'auto'): string {
-  const isWin = flavor === 'auto' && process.platform === 'win32'
+/**
+ * Quote an argument for a shell.
+ *  - `'auto'`  — pick by platform, and on Windows by `getDefaultShell()`
+ *    (PowerShell vs cmd.exe). Use for a PTY running the user's shell.
+ *  - `'cmd'`   — force cmd.exe quoting. Use when the command runs through
+ *    Node's `spawn(..., { shell: true })` on Windows, which always invokes
+ *    `comspec || cmd.exe` regardless of the user's default shell — so quoting
+ *    by `getDefaultShell()` (which falls back to PowerShell when COMSPEC is
+ *    unset) would mismatch and leave args un-quoted / mangled.
+ *  - `'posix'` — force POSIX single-quote quoting.
+ */
+export function shellEscape(s: string, flavor: 'auto' | 'posix' | 'cmd' = 'auto'): string {
+  const isWin = flavor === 'cmd' || (flavor === 'auto' && process.platform === 'win32')
   // Skip quoting for simple safe strings (flags, paths without spaces, etc.)
   // On Windows, exclude % from safe chars to prevent env var expansion in cmd.exe.
   const safePattern = isWin ? /^[a-zA-Z0-9_./:=@+,-]+$/ : /^[a-zA-Z0-9_./:=@%+,-]+$/
   if (safePattern.test(s)) return s
   if (isWin) {
-    const shell = getDefaultShell().toLowerCase()
+    // 'cmd' pins cmd.exe; 'auto' honors the user's PowerShell default.
+    const shell = flavor === 'cmd' ? 'cmd.exe' : getDefaultShell().toLowerCase()
     if (shell.includes('powershell') || shell.includes('pwsh')) {
       return "'" + s.replace(/'/g, "''") + "'"
     }

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -189,12 +189,23 @@ describe('buildHeadlessLaunchLine', () => {
 })
 
 describe('buildHeadlessSpawnArgs', () => {
-  it('returns { command, args } for claude', () => {
+  it('returns { command, args } for claude with the prompt on stdin', () => {
     const result = buildHeadlessSpawnArgs(makePayload({ initialPrompt: 'hello' }), cmds, env)
     expect(result.command).toBe('claude')
     expect(result.args).toContain('-p')
-    expect(result.args).toContain('hello')
     expect(result.args).toContain('--dangerously-skip-permissions')
+    // Prompt goes to stdin, not argv, so the Windows shell command line can't
+    // word-split or line-break it.
+    expect(result.stdin).toBe('hello')
+    expect(result.args).not.toContain('hello')
+  })
+
+  it('keeps a multi-line claude prompt intact on stdin', () => {
+    const prompt = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing.'
+    const result = buildHeadlessSpawnArgs(makePayload({ initialPrompt: prompt }), cmds, env)
+    expect(result.stdin).toBe(prompt)
+    // `-p` is a bare flag here; the last argv element must not be the prompt.
+    expect(result.args[result.args.length - 1]).toBe('-p')
   })
 
   it('returns exec for codex', () => {
@@ -219,6 +230,7 @@ describe('buildHeadlessSpawnArgs', () => {
   it('uses empty string for missing prompt', () => {
     const result = buildHeadlessSpawnArgs(makePayload(), cmds, env)
     expect(result.args).toContain('')
+    expect(result.stdin).toBeUndefined()
   })
 
   it('pins claude headless session via --session-id', () => {
@@ -276,6 +288,52 @@ describe('buildHeadlessSpawnArgs', () => {
       expect(result.args).not.toContain('--session-id')
       expect(result.args).not.toContain('--resume')
     }
+  })
+})
+
+// A workflow prompt (buildWorkflowPrompt) is multi-word and multi-line. On
+// Windows the headless spawn runs through `shell: true`, which word-splits
+// unquoted argv — the trigger for issue #374 (claude got only `#`) and the
+// equivalent copilot "extra words were treated as separate arguments" failure.
+// Every supported agent must therefore deliver the ENTIRE prompt as one unit:
+// claude on stdin (bare `-p`), everyone else as a single argv element that the
+// spawn site can quote. These tests lock that contract in per agent.
+describe('buildHeadlessSpawnArgs — every agent delivers the whole prompt as one unit', () => {
+  const PROMPT = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing with spaces.'
+
+  it('claude delivers the prompt on stdin, never on argv', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ agentType: 'claude', initialPrompt: PROMPT }),
+      cmds,
+      env
+    )
+    expect(result.command).toBe('claude')
+    expect(result.stdin).toBe(PROMPT)
+    expect(result.args).not.toContain(PROMPT)
+    // `-p` present with no positional prompt following it.
+    expect(result.args).toContain('-p')
+    expect(result.args[result.args.length - 1]).toBe('-p')
+  })
+
+  // For the arg-based agents the prompt must be exactly one array element so
+  // it can be quoted as a single token — never spread across several.
+  it.each([
+    { agentType: 'copilot' as const, command: 'copilot', flag: '--allow-all' },
+    { agentType: 'codex' as const, command: 'codex', flag: 'exec' },
+    { agentType: 'opencode' as const, command: 'opencode', flag: 'run' },
+    { agentType: 'gemini' as const, command: 'gemini', flag: '-y' }
+  ])('$agentType delivers the prompt as a single argv element', ({ agentType, command, flag }) => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ agentType, initialPrompt: PROMPT }),
+      cmds,
+      env
+    )
+    expect(result.command).toBe(command)
+    expect(result.stdin).toBeUndefined()
+    expect(result.args).toContain(flag)
+    // The full multi-word/multi-line prompt is a single element, not split.
+    expect(result.args).toContain(PROMPT)
+    expect(result.args.filter((a) => a === PROMPT)).toHaveLength(1)
   })
 })
 

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('node:child_process', async () => {
   const { EventEmitter } = await import('node:events')
   class FakeChild extends EventEmitter {
     pid = 4242
-    stdin = { on: vi.fn(), end: vi.fn() }
+    stdin = { on: vi.fn(), end: vi.fn(), write: vi.fn() }
     stdout = new EventEmitter()
     stderr = new EventEmitter()
     kill = vi.fn()
+    unref = vi.fn()
   }
   return {
     spawn: vi.fn(() => new FakeChild()),
@@ -72,6 +73,29 @@ describe('headlessManager.createHeadless', () => {
     headlessManager.killHeadless(session.id)
   })
 
+  it('writes a multi-line claude prompt to stdin instead of argv', () => {
+    const prompt = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing.'
+    const session = headlessManager.createHeadless({
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: prompt,
+      headless: true
+    })
+
+    const child = spawnMock.mock.results[0].value as {
+      stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    }
+    expect(child.stdin.write).toHaveBeenCalledWith(prompt)
+    expect(child.stdin.end).toHaveBeenCalled()
+
+    // The prompt must not leak onto argv, where the Windows shell would split it.
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).not.toContain(prompt)
+
+    headlessManager.killHeadless(session.id)
+  })
+
   it('does not populate agentSessionId for non-pinning agents', () => {
     const session = headlessManager.createHeadless({
       agentType: 'codex',
@@ -101,5 +125,55 @@ describe('headlessManager.createHeadless', () => {
     expect(session.workflowName).toBe('wf')
 
     headlessManager.killHeadless(session.id)
+  })
+
+  describe('Windows shell spawn', () => {
+    const realPlatform = process.platform
+    const setPlatform = (value: string) =>
+      Object.defineProperty(process, 'platform', { value, configurable: true })
+
+    afterEach(() => setPlatform(realPlatform))
+
+    it('spawns through the shell with the prompt quoted so it is not word-split', () => {
+      setPlatform('win32')
+      const prompt = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing with spaces.'
+      const session = headlessManager.createHeadless({
+        agentType: 'codex', // arg-based agent — the prompt rides on argv
+        projectName: 'p',
+        projectPath: '/p',
+        initialPrompt: prompt,
+        headless: true
+      })
+
+      const [, args, options] = spawnMock.mock.calls[0] as [string, string[], { shell?: boolean }]
+      expect(options.shell).toBe(true)
+      // The raw prompt must NOT appear as a bare element (that word-splits under
+      // cmd.exe); it must be a single quoted token that still contains the text.
+      expect(args).not.toContain(prompt)
+      const promptArgs = args.filter((a) => a.includes('Do the thing with spaces.'))
+      expect(promptArgs).toHaveLength(1)
+      expect(promptArgs[0]).not.toBe(prompt) // i.e. it was quoted/escaped
+
+      headlessManager.killHeadless(session.id)
+    })
+
+    it('does not quote args on POSIX (no shell wrapper)', () => {
+      setPlatform('linux')
+      const prompt = 'do a thing with spaces'
+      const session = headlessManager.createHeadless({
+        agentType: 'codex',
+        projectName: 'p',
+        projectPath: '/p',
+        initialPrompt: prompt,
+        headless: true
+      })
+
+      const [, args, options] = spawnMock.mock.calls[0] as [string, string[], { shell?: boolean }]
+      expect(options.shell).toBe(false)
+      // Passed to execve verbatim — one unquoted element.
+      expect(args).toContain(prompt)
+
+      headlessManager.killHeadless(session.id)
+    })
   })
 })

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -152,7 +152,11 @@ describe('headlessManager.createHeadless', () => {
       expect(args).not.toContain(prompt)
       const promptArgs = args.filter((a) => a.includes('Do the thing with spaces.'))
       expect(promptArgs).toHaveLength(1)
-      expect(promptArgs[0]).not.toBe(prompt) // i.e. it was quoted/escaped
+      // cmd.exe quoting (double quotes) is used regardless of the machine's
+      // default shell, since Node's shell:true always runs cmd.exe — not
+      // PowerShell single-quotes, which cmd.exe wouldn't treat as quoting.
+      expect(promptArgs[0].startsWith('"')).toBe(true)
+      expect(promptArgs[0].endsWith('"')).toBe(true)
 
       headlessManager.killHeadless(session.id)
     })

--- a/tests/process-utils.test.ts
+++ b/tests/process-utils.test.ts
@@ -68,6 +68,19 @@ describe('process-utils (server package)', () => {
     expect(shellEscape('')).toBe("''")
   })
 
+  it('shellEscape cmd flavor uses cmd.exe quoting on any platform', async () => {
+    const { shellEscape } = await import('../packages/server/src/process-utils')
+    // Multi-word → cmd.exe double quotes (not POSIX/PowerShell single quotes),
+    // matching Node's shell:true which always runs cmd.exe on Windows.
+    expect(shellEscape('# Workflow: Demo', 'cmd')).toBe('"# Workflow: Demo"')
+    // Safe tokens still skip quoting.
+    expect(shellEscape('-p', 'cmd')).toBe('-p')
+    // cmd metacharacters are caret-escaped inside the quotes.
+    expect(shellEscape('a "b" %PATH%', 'cmd')).toBe('"a ^"b^" ^%PATH^%"')
+    // Empty → empty quoted arg.
+    expect(shellEscape('', 'cmd')).toBe('""')
+  })
+
   it('getSafeEnv filters sensitive vars', async () => {
     const { getSafeEnv } = await import('../packages/server/src/process-utils')
     const env = getSafeEnv()


### PR DESCRIPTION
## Summary

Fixes #374 and the equivalent Copilot failure. When a workflow launches a **headless** agent on **Windows**, the injected prompt was mangled:

- **Claude** received only `#` ("message came through empty")
- **Copilot** errored: *"your prompt was not quoted, so the extra words were treated as separate arguments"*

### Root cause

Not Claude's `#` memory shortcut (that's an interactive-TUI feature, inactive in `-p` print mode). The real cause is the headless spawn:

```ts
shell: process.platform === 'win32'
```

Windows needs `shell: true` to run the `.cmd`/`.ps1` shims that npm-installed agents ship as. But under `shell: true`, Node concatenates argv into a single `cmd.exe` command line **without quoting**, so a multi-word/multi-line workflow prompt passed as an argument gets **word-split** — the agent's `-p` then sees only the first token. Same bug for every agent whose prompt rides on argv; it just degrades most visibly for Claude.

## Fix (all 5 supported agents)

| Agent | Delivery | Why |
|-------|----------|-----|
| `claude` | prompt on **stdin** (bare `-p`) | `claude -p` reads stdin — sidesteps the shell entirely; survives spaces, newlines, and a leading `#` |
| `copilot` / `codex` / `gemini` / `opencode` | prompt as a **single quoted argv element** | None read a bare-flag stdin, so they keep the prompt as one argument; the spawn site now quotes args via `shellEscape` when `shell:true` so cmd.exe no longer splits them |

POSIX is unchanged — no shell, so args reach `execve` verbatim (and must not be quoted).

## Changes

- `packages/server/src/agent-launch.ts` — `buildHeadlessSpawnArgs` returns an optional `stdin`; Claude uses bare `-p` + stdin.
- `packages/server/src/headless-manager.ts` — writes the stdin payload; quotes argv for the Windows shell.
- `tests/*` — +7 tests: per-agent prompt-delivery contract (each agent delivers the whole multi-line prompt as one unit) and win32-quoting vs POSIX-no-quoting at the spawn site.

## Verification

- Ran the real Claude invocation end-to-end (multi-line, `#`-leading prompt piped in → full prompt received).
- Full suite: **1572 pass**; typecheck, lint, prettier clean.

## Known caveat

For the four arg-based agents, quoting fixes the word-split (the reported failures). A theoretical residual on cmd.exe is embedded newlines inside a quoted arg, which I couldn't verify without a Windows box. Claude avoids it entirely via stdin. If a truncated multi-line prompt shows up on Windows for copilot/codex/gemini specifically, the follow-up is a per-agent temp prompt-file.

Closes #374