### PR TITLE
feat(workflows): typed agent outputs for launchAgent nodes (#377)

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -35,7 +35,14 @@ const launchAgentConfigSchema = z.object({
   prompt: V.prompt.optional(),
   promptDelayMs: z.number().optional(),
   taskId: V.id.optional(),
-  taskFromQueue: z.boolean().optional()
+  taskFromQueue: z.boolean().optional(),
+  // Runs the agent in the background and waits for it to finish (required for
+  // typed output). Opens a terminal tab when false/omitted.
+  headless: z.boolean().optional(),
+  // JSON Schema the agent's final answer must satisfy (headless only). When set,
+  // the engine parses a matching object from the run and exposes its fields as
+  // `{{steps.<slug>.<field>}}` for downstream condition nodes.
+  outputSchema: z.record(z.string(), z.unknown()).optional()
 })
 
 const triggerConfigSchema = z.union([
@@ -60,8 +67,21 @@ const triggerConfigSchema = z.union([
 
 const nodeSchema = z.object({
   id: V.id,
-  type: z.enum(['trigger', 'launchAgent']),
+  // Full node palette — parity with the editor. `config` is a passthrough so
+  // each type carries its own shape (ConditionConfig, ApprovalConfig, etc.).
+  type: z.enum([
+    'trigger',
+    'launchAgent',
+    'script',
+    'condition',
+    'approval',
+    'createTaskFromItem',
+    'callConnectorAction'
+  ]),
   label: V.shortText,
+  // Referenced by typed step vars as `{{steps.<slug>.<field>}}`. Set one on any
+  // node whose output a later node consumes.
+  slug: V.shortText.optional(),
   config: z.record(z.string(), z.unknown()),
   position: z.object({ x: z.number(), y: z.number() })
 })
@@ -69,7 +89,10 @@ const nodeSchema = z.object({
 const edgeSchema = z.object({
   id: V.id,
   source: V.id,
-  target: V.id
+  target: V.id,
+  // Which branch of a `condition` node this edge represents. Omit for normal
+  // edges; required to wire both outcomes of a condition.
+  conditionBranch: z.enum(['true', 'false']).optional()
 })
 
 /**
@@ -144,7 +167,12 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'create_workflow',
-    'Create a new workflow. Accepts either full nodes/edges or a convenience flat format (trigger + actions array).',
+    'Create a new workflow. Accepts either full nodes/edges (advanced mode — every node ' +
+      'type is supported: trigger, launchAgent, script, condition, approval, ' +
+      'createTaskFromItem, callConnectorAction; wire condition outcomes with edge ' +
+      'conditionBranch "true"/"false") or a convenience flat format (trigger + actions ' +
+      'array). Give a node a slug to reference its output downstream as {{steps.<slug>.<field>}}. ' +
+      'A headless launchAgent with an outputSchema returns typed fields for condition nodes.',
     {
       name: V.title.describe('Workflow name'),
       trigger: triggerConfigSchema

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -21,29 +21,36 @@ import {
 } from '@vornrun/server/database'
 import { rpcCall } from '../ws-client'
 
-const launchAgentConfigSchema = z.object({
-  agentType: z.enum(['claude', 'copilot', 'codex', 'opencode', 'gemini']),
-  projectName: V.name,
-  projectPath: V.absolutePath,
-  args: z.array(V.shortText).optional(),
-  displayName: V.shortText.optional(),
-  branch: V.shortText.optional(),
-  // boolean | 'fromContext' — `'fromContext'` only valid when the workflow's
-  // manual trigger is contextual (validated at runtime, not here).
-  useWorktree: z.union([z.boolean(), z.literal('fromContext')]).optional(),
-  remoteHostId: V.id.optional(),
-  prompt: V.prompt.optional(),
-  promptDelayMs: z.number().optional(),
-  taskId: V.id.optional(),
-  taskFromQueue: z.boolean().optional(),
-  // Runs the agent in the background and waits for it to finish (required for
-  // typed output). Opens a terminal tab when false/omitted.
-  headless: z.boolean().optional(),
-  // JSON Schema the agent's final answer must satisfy (headless only). When set,
-  // the engine parses a matching object from the run and exposes its fields as
-  // `{{steps.<slug>.<field>}}` for downstream condition nodes.
-  outputSchema: z.record(z.string(), z.unknown()).optional()
-})
+const launchAgentConfigSchema = z
+  .object({
+    agentType: z.enum(['claude', 'copilot', 'codex', 'opencode', 'gemini']),
+    projectName: V.name,
+    projectPath: V.absolutePath,
+    args: z.array(V.shortText).optional(),
+    displayName: V.shortText.optional(),
+    branch: V.shortText.optional(),
+    // boolean | 'fromContext' — `'fromContext'` only valid when the workflow's
+    // manual trigger is contextual (validated at runtime, not here).
+    useWorktree: z.union([z.boolean(), z.literal('fromContext')]).optional(),
+    remoteHostId: V.id.optional(),
+    prompt: V.prompt.optional(),
+    promptDelayMs: z.number().optional(),
+    taskId: V.id.optional(),
+    taskFromQueue: z.boolean().optional(),
+    // Runs the agent in the background and waits for it to finish (required for
+    // typed output). Opens a terminal tab when false/omitted.
+    headless: z.boolean().optional(),
+    // JSON Schema the agent's final answer must satisfy (headless only). When set,
+    // the engine parses a matching object from the run and exposes its fields as
+    // `{{steps.<slug>.<field>}}` for downstream condition nodes.
+    outputSchema: z.record(z.string(), z.unknown()).optional()
+  })
+  .refine((c) => !c.outputSchema || c.headless === true, {
+    // The engine only parses typed output for headless runs; reject a config that
+    // declares a schema it would silently ignore instead of accepting a lie.
+    message: 'outputSchema requires headless: true',
+    path: ['outputSchema']
+  })
 
 const triggerConfigSchema = z.union([
   z.object({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,7 @@
     "./prompt-builder": "./src/prompt-builder.ts",
     "./protocol": "./src/protocol.ts",
     "./string-utils": "./src/string-utils.ts",
-    "./json-schema-utils": "./src/json-schema-utils.ts"
+    "./json-schema-utils": "./src/json-schema-utils.ts",
+    "./structured-output": "./src/structured-output.ts"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types'
 export * from './agent-defaults'
 export * from './prompt-builder'
+export * from './structured-output'
 export * from './protocol'
 export * from './string-utils'

--- a/packages/shared/src/prompt-builder.ts
+++ b/packages/shared/src/prompt-builder.ts
@@ -1,4 +1,5 @@
 import { TaskConfig, ProjectConfig, TaskStatus, WorkflowDefinition } from './types'
+import { buildStructuredOutputInstructions } from './structured-output'
 
 export interface TaskPromptContext {
   task: TaskConfig
@@ -13,6 +14,9 @@ export interface WorkflowPromptContext {
   workflow: WorkflowDefinition
   stepName: string
   userPrompt: string
+  /** When set, the agent is asked to end its run with a JSON object matching
+   *  this schema so the engine can capture typed step output. */
+  outputSchema?: Record<string, unknown>
 }
 
 /**
@@ -117,7 +121,7 @@ export function buildTaskPrompt(ctx: TaskPromptContext): string {
  * previous run logs.
  */
 export function buildWorkflowPrompt(ctx: WorkflowPromptContext): string {
-  const { workflow, stepName, userPrompt } = ctx
+  const { workflow, stepName, userPrompt, outputSchema } = ctx
   const lines: string[] = []
 
   lines.push(`# Workflow: ${workflow.name}`)
@@ -141,6 +145,10 @@ export function buildWorkflowPrompt(ctx: WorkflowPromptContext): string {
   lines.push('- `list_tasks` — List tasks in this project')
   lines.push('- `update_task` — Update task status when done')
   lines.push('')
+
+  if (outputSchema) {
+    lines.push(buildStructuredOutputInstructions(outputSchema))
+  }
 
   return lines.join('\n')
 }

--- a/packages/shared/src/structured-output.ts
+++ b/packages/shared/src/structured-output.ts
@@ -1,0 +1,174 @@
+/**
+ * Typed agent outputs for `launchAgent` workflow nodes.
+ *
+ * A headless agent emits only freeform text, so to let downstream `condition`
+ * nodes branch on what the agent *decided* we ask it to end its run with a JSON
+ * object matching a user-declared JSON Schema, wrapped in sentinel markers we
+ * can find in the logs. `extractStructuredOutput` pulls that object back out and
+ * validates it; the engine stores the result as the node's `structuredOutput`,
+ * which surfaces as `{{steps.<slug>.<field>}}` step vars via the same path the
+ * connector actions already use.
+ */
+import { schemaProperties, schemaTypeHint, schemaRequired } from './json-schema-utils'
+
+/** Markers the agent wraps its JSON answer in. Deliberately unlikely to appear
+ *  in normal prose so the extractor can find the block even amid other output. */
+export const STRUCTURED_OUTPUT_BEGIN = '<<<VORN_OUTPUT>>>'
+export const STRUCTURED_OUTPUT_END = '<<<END_VORN_OUTPUT>>>'
+
+export interface StructuredOutputResult {
+  /** The parsed, validated object — present only when `error` is absent. */
+  output?: Record<string, unknown>
+  /** Human-readable reason extraction/validation failed, if it did. */
+  error?: string
+}
+
+/**
+ * The instruction block appended to a workflow prompt when a node declares an
+ * `outputSchema`. Kept here so the marker contract lives in one place alongside
+ * the extractor that relies on it.
+ */
+export function buildStructuredOutputInstructions(schema: Record<string, unknown>): string {
+  const lines: string[] = []
+  lines.push('## Required Output')
+  lines.push('')
+  lines.push(
+    'When you have finished, output a single JSON object that conforms to the ' +
+      'JSON Schema below. Wrap it exactly between the two marker lines — nothing ' +
+      'else after the closing marker:'
+  )
+  lines.push('')
+  lines.push(STRUCTURED_OUTPUT_BEGIN)
+  lines.push('{ ...your JSON here... }')
+  lines.push(STRUCTURED_OUTPUT_END)
+  lines.push('')
+  lines.push('Schema:')
+  lines.push('')
+  lines.push('```json')
+  lines.push(JSON.stringify(schema, null, 2))
+  lines.push('```')
+  lines.push('')
+  return lines.join('\n')
+}
+
+/** Pull the JSON text the agent produced out of a run's full log output.
+ *  Precedence: the sentinel-delimited block (last occurrence, since an agent
+ *  may echo the schema/example earlier), then a fenced ```json block, then the
+ *  last balanced top-level `{...}`. Returns null when nothing usable is found. */
+function extractJsonText(text: string): string | null {
+  // 1. Sentinel-delimited block — the happy path.
+  const beginIdx = text.lastIndexOf(STRUCTURED_OUTPUT_BEGIN)
+  if (beginIdx !== -1) {
+    const afterBegin = beginIdx + STRUCTURED_OUTPUT_BEGIN.length
+    const endIdx = text.indexOf(STRUCTURED_OUTPUT_END, afterBegin)
+    const block = text.slice(afterBegin, endIdx === -1 ? undefined : endIdx)
+    const balanced = lastBalancedObject(block)
+    if (balanced) return balanced
+  }
+
+  // 2. Fenced ```json block (last one).
+  const fenceMatches = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)]
+  for (let i = fenceMatches.length - 1; i >= 0; i--) {
+    const balanced = lastBalancedObject(fenceMatches[i][1])
+    if (balanced) return balanced
+  }
+
+  // 3. Last balanced top-level object anywhere in the text.
+  return lastBalancedObject(text)
+}
+
+/** Find the last complete, brace-balanced top-level `{...}` in a string. Scans
+ *  once from the start tracking string-literal state, so braces inside string
+ *  values are ignored and nested objects don't split the match. Returns null if
+ *  no complete top-level object is present. */
+function lastBalancedObject(text: string): string | null {
+  let depth = 0
+  let inString = false
+  let escaped = false
+  let start = -1
+  let last: string | null = null
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === '\\') escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === '{') {
+      if (depth === 0) start = i
+      depth++
+    } else if (ch === '}' && depth > 0) {
+      depth--
+      if (depth === 0 && start !== -1) {
+        last = text.slice(start, i + 1)
+        start = -1
+      }
+    }
+  }
+  return last
+}
+
+/** Coerce stringified scalars to the type the schema declares. Models sometimes
+ *  emit `"true"` / `"42"` for boolean/number fields; be lenient at the top level
+ *  so a downstream numeric/boolean comparison sees the intended value. */
+function coerceToSchema(
+  obj: Record<string, unknown>,
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const props = schemaProperties(schema)
+  const out: Record<string, unknown> = { ...obj }
+  for (const [key, propSchema] of Object.entries(props)) {
+    if (typeof out[key] !== 'string') continue
+    const type = schemaTypeHint(propSchema)
+    const raw = out[key] as string
+    if (type === 'number' || type === 'integer') {
+      const n = Number(raw)
+      if (raw.trim() !== '' && !Number.isNaN(n)) out[key] = n
+    } else if (type === 'boolean') {
+      if (raw === 'true') out[key] = true
+      else if (raw === 'false') out[key] = false
+    }
+  }
+  return out
+}
+
+/**
+ * Extract and validate the structured object an agent produced for a node with
+ * the given `outputSchema`. Validation is intentionally lightweight: the value
+ * must be a plain JSON object and must contain every `required` key the schema
+ * declares. On any failure a descriptive `error` is returned so the engine can
+ * mark the node `error` rather than let a downstream branch act on garbage.
+ */
+export function extractStructuredOutput(
+  logs: string,
+  schema: Record<string, unknown>
+): StructuredOutputResult {
+  const jsonText = extractJsonText(logs || '')
+  if (!jsonText) {
+    return { error: 'No JSON output block found in the agent output.' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonText)
+  } catch {
+    return { error: 'The agent output was not valid JSON.' }
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { error: 'The agent output was not a JSON object.' }
+  }
+
+  const coerced = coerceToSchema(parsed as Record<string, unknown>, schema)
+
+  const missing = Object.keys(schemaProperties(schema)).filter(
+    (key) => schemaRequired(schema, key) && !(key in coerced)
+  )
+  if (missing.length > 0) {
+    return { error: `Agent output is missing required field(s): ${missing.join(', ')}.` }
+  }
+
+  return { output: coerced }
+}

--- a/packages/shared/src/structured-output.ts
+++ b/packages/shared/src/structured-output.ts
@@ -157,10 +157,9 @@ export function extractStructuredOutput(
     return { error: 'The agent output was not valid JSON.' }
   }
 
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { error: 'The agent output was not a JSON object.' }
-  }
-
+  // `extractJsonText` only ever returns a brace-balanced `{...}` substring, so a
+  // successful parse is always a plain object here — no array/non-object guard
+  // needed.
   const coerced = coerceToSchema(parsed as Record<string, unknown>, schema)
 
   // Validate against the schema's `required` list directly, not just the keys

--- a/packages/shared/src/structured-output.ts
+++ b/packages/shared/src/structured-output.ts
@@ -9,7 +9,7 @@
  * which surfaces as `{{steps.<slug>.<field>}}` step vars via the same path the
  * connector actions already use.
  */
-import { schemaProperties, schemaTypeHint, schemaRequired } from './json-schema-utils'
+import { schemaProperties, schemaTypeHint } from './json-schema-utils'
 
 /** Markers the agent wraps its JSON answer in. Deliberately unlikely to appear
  *  in normal prose so the extractor can find the block even amid other output. */
@@ -163,9 +163,13 @@ export function extractStructuredOutput(
 
   const coerced = coerceToSchema(parsed as Record<string, unknown>, schema)
 
-  const missing = Object.keys(schemaProperties(schema)).filter(
-    (key) => schemaRequired(schema, key) && !(key in coerced)
-  )
+  // Validate against the schema's `required` list directly, not just the keys
+  // that happen to appear under `properties` — a schema may require a field it
+  // doesn't otherwise describe, and that must still be enforced.
+  const required = (schema as { required?: unknown }).required
+  const missing = Array.isArray(required)
+    ? required.filter((key): key is string => typeof key === 'string' && !(key in coerced))
+    : []
   if (missing.length > 0) {
     return { error: `Agent output is missing required field(s): ${missing.join(', ')}.` }
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -504,6 +504,15 @@ export interface LaunchAgentConfig {
   taskId?: string
   taskFromQueue?: boolean
   headless?: boolean
+  /**
+   * JSON Schema the agent's final answer must satisfy. When set (headless only),
+   * the engine instructs the agent to emit a matching JSON object, parses it out
+   * of the run logs, and stores it as the node's `structuredOutput` — surfaced as
+   * typed step vars (`{{steps.<slug>.<field>}}`) that downstream `condition`
+   * nodes can gate on instead of substring-matching the model's prose. A run
+   * whose output can't be parsed/validated is marked `error`.
+   */
+  outputSchema?: Record<string, unknown>
 }
 
 export interface ScriptConfig {

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronRight, Settings2, GitBranch, EyeOff, Zap } from 'lucide-react'
 import {
@@ -531,12 +531,26 @@ function OutputSchemaField({
 }) {
   const [text, setText] = useState(() => (value ? JSON.stringify(value, null, 2) : ''))
   const [error, setError] = useState<string | null>(null)
+  // Track the last value we emitted (compact form) so we can tell our own edits
+  // apart from an external change — e.g. the config panel switching to a
+  // different node. Only the latter should reset the textarea.
+  const lastEmitted = useRef<string | undefined>(value ? JSON.stringify(value) : undefined)
+
+  useEffect(() => {
+    const incoming = value ? JSON.stringify(value) : undefined
+    if (incoming !== lastEmitted.current) {
+      setText(value ? JSON.stringify(value, null, 2) : '')
+      setError(null)
+      lastEmitted.current = incoming
+    }
+  }, [value])
 
   const handleChange = (raw: string) => {
     setText(raw)
     const trimmed = raw.trim()
     if (!trimmed) {
       setError(null)
+      lastEmitted.current = undefined
       onChange(undefined)
       return
     }
@@ -552,6 +566,7 @@ function OutputSchemaField({
       return
     }
     setError(null)
+    lastEmitted.current = JSON.stringify(parsed)
     onChange(parsed as Record<string, unknown>)
   }
 

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -455,6 +455,13 @@ export function LaunchAgentConfigForm({
             />
           </div>
         )}
+
+        {isHeadless && (
+          <OutputSchemaField
+            value={config.outputSchema}
+            onChange={(schema) => onChange({ ...config, outputSchema: schema })}
+          />
+        )}
       </div>
 
       <div>
@@ -504,6 +511,77 @@ export function LaunchAgentConfigForm({
           )}
         </AnimatePresence>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Editor for a node's typed-output JSON Schema. Keeps the raw text locally so a
+ * half-typed schema doesn't clobber config; commits the parsed object only when
+ * it's valid JSON (an object), clears it when emptied, and surfaces a parse
+ * error otherwise. When set, the agent is required to return a matching object
+ * and its fields become `{{steps.<slug>.<field>}}` for downstream nodes.
+ */
+function OutputSchemaField({
+  value,
+  onChange
+}: {
+  value?: Record<string, unknown>
+  onChange: (schema: Record<string, unknown> | undefined) => void
+}) {
+  const [text, setText] = useState(() => (value ? JSON.stringify(value, null, 2) : ''))
+  const [error, setError] = useState<string | null>(null)
+
+  const handleChange = (raw: string) => {
+    setText(raw)
+    const trimmed = raw.trim()
+    if (!trimmed) {
+      setError(null)
+      onChange(undefined)
+      return
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      setError('Not valid JSON')
+      return
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      setError('Schema must be a JSON object')
+      return
+    }
+    setError(null)
+    onChange(parsed as Record<string, unknown>)
+  }
+
+  return (
+    <div>
+      <label className="text-[13px] text-gray-400 font-medium block mb-2">Output Schema</label>
+      <textarea
+        value={text}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder={
+          '{\n  "type": "object",\n  "properties": { "verdict": { "type": "string" } },\n  "required": ["verdict"]\n}'
+        }
+        spellCheck={false}
+        rows={6}
+        className={`w-full px-3 py-2 text-[12px] bg-white/[0.06] border rounded-md text-white
+                    placeholder:text-gray-600 focus:outline-none font-mono resize-y ${
+                      error
+                        ? 'border-red-500/50 focus:border-red-500/70'
+                        : 'border-white/[0.1] focus:border-white/[0.2]'
+                    }`}
+      />
+      {error ? (
+        <p className="text-[11px] text-red-400 mt-1">{error}</p>
+      ) : (
+        <p className="text-[11px] text-gray-500 mt-1 leading-relaxed">
+          Agent must return a JSON object matching this schema. Its fields become{' '}
+          <span className="text-gray-400 font-mono">{'{{steps.<step>.<field>}}'}</span> for later
+          nodes. A run that doesn&apos;t match is marked failed.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -5,6 +5,7 @@ import {
   WorkflowNode,
   WorkflowEdge,
   CallConnectorActionConfig,
+  LaunchAgentConfig,
   ConnectorActionDef
 } from '../../shared/types'
 import { schemaProperties, schemaTypeHint } from '../../shared/json-schema-utils'
@@ -207,6 +208,15 @@ export function buildStepGroups(
             // reach for. The three defaults stay at the bottom as fallbacks.
             keys = [...schemaKeys, ...defaultKeys]
           }
+        }
+      } else if (n.type === 'launchAgent') {
+        // A launchAgent node with a declared outputSchema surfaces its typed
+        // fields the same way — `{{steps.<slug>.<field>}}` — populated at run
+        // time from the agent's parsed structuredOutput.
+        const cfg = n.config as LaunchAgentConfig
+        const schemaKeys = schemaTopLevelKeys(cfg.outputSchema)
+        if (schemaKeys.length > 0) {
+          keys = [...schemaKeys, ...defaultKeys]
         }
       }
       return {

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -210,11 +210,13 @@ export function buildStepGroups(
           }
         }
       } else if (n.type === 'launchAgent') {
-        // A launchAgent node with a declared outputSchema surfaces its typed
+        // A headless launchAgent with a declared outputSchema surfaces its typed
         // fields the same way — `{{steps.<slug>.<field>}}` — populated at run
-        // time from the agent's parsed structuredOutput.
+        // time from the agent's parsed structuredOutput. Gated on `headless`
+        // because the engine only parses typed output for headless runs, so
+        // advertising these vars for an interactive node would be misleading.
         const cfg = n.config as LaunchAgentConfig
-        const schemaKeys = schemaTopLevelKeys(cfg.outputSchema)
+        const schemaKeys = cfg.headless ? schemaTopLevelKeys(cfg.outputSchema) : []
         if (schemaKeys.length > 0) {
           keys = [...schemaKeys, ...defaultKeys]
         }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -18,6 +18,7 @@ import {
 import { resolveContextField, resolveTemplateVars, StepOutputs } from './template-vars'
 import { getWorktreeMode } from './workflow-helpers'
 import { buildTaskPrompt, buildWorkflowPrompt } from '../../shared/prompt-builder'
+import { extractStructuredOutput } from '../../shared/structured-output'
 import { useAppStore } from '../stores'
 import { sendWorkflowGateNotification } from './notifications'
 
@@ -614,11 +615,16 @@ async function executeNode(
     initialPrompt = resolveTemplateVars(initialPrompt, context, stepOutputs)
   }
 
+  // Typed output only makes sense headless: the engine parses the finished
+  // run's logs, which an interactive terminal session never produces on exit.
+  const outputSchema = config.headless ? config.outputSchema : undefined
+
   if (initialPrompt) {
     initialPrompt = buildWorkflowPrompt({
       workflow,
       stepName: config.displayName || node.label,
-      userPrompt: initialPrompt
+      userPrompt: initialPrompt,
+      outputSchema
     })
   }
 
@@ -717,17 +723,32 @@ async function executeNode(
         logs += `\nProcess exited with code ${exitCode}`
       }
 
+      // Typed output: a clean exit still fails the node if the agent didn't
+      // return a parseable object matching the declared schema, so downstream
+      // branches never gate on garbage. On success the parsed object becomes the
+      // node's structuredOutput → `{{steps.<slug>.<field>}}`.
+      let structured: Record<string, unknown> | undefined
+      let schemaError: string | undefined
+      if (exitCode === 0 && outputSchema) {
+        const result = extractStructuredOutput(logs, outputSchema)
+        if (result.output) structured = result.output
+        else schemaError = result.error || 'Agent output did not match the declared schema.'
+      }
+
+      const failed = exitCode !== 0 || !!schemaError
       updateNodeState(execution, node.id, {
-        status: exitCode === 0 ? 'success' : 'error',
+        status: failed ? 'error' : 'success',
         completedAt: new Date().toISOString(),
         output: logs,
         logs,
-        ...(exitCode !== 0 && { error: `Exit code ${exitCode}` })
+        ...(structured && { structuredOutput: structured }),
+        ...(exitCode !== 0 && { error: `Exit code ${exitCode}` }),
+        ...(schemaError && exitCode === 0 && { error: schemaError })
       })
       persistExecution(workflow.id, execution)
 
       // Reset task back to todo on failure so it can be retried
-      if (exitCode !== 0 && resolvedTaskId) {
+      if (failed && resolvedTaskId) {
         useAppStore.getState().reopenTask(resolvedTaskId)
       }
     } finally {

--- a/src/shared/structured-output.ts
+++ b/src/shared/structured-output.ts
@@ -1,0 +1,1 @@
+export * from '@vornrun/shared/structured-output'

--- a/tests/launch-agent-config-form.test.tsx
+++ b/tests/launch-agent-config-form.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mocks must be hoisted before imports that use them
@@ -327,6 +327,103 @@ describe('LaunchAgentConfigForm — UI sections', () => {
       <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={vi.fn()} />
     )
     expect(container.textContent).toContain('Headless')
+  })
+})
+
+describe('LaunchAgentConfigForm — Output Schema (typed outputs)', () => {
+  it('shows the Output Schema field only when headless', () => {
+    const interactive = render(
+      <LaunchAgentConfigForm config={baseConfig({ headless: false })} onChange={vi.fn()} />
+    )
+    expect(interactive.container.textContent).not.toContain('Output Schema')
+
+    const headless = render(
+      <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={vi.fn()} />
+    )
+    expect(headless.container.textContent).toContain('Output Schema')
+    expect(headless.container.querySelector('textarea')).toBeTruthy()
+  })
+
+  it('pre-fills the textarea from an existing schema', () => {
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({
+          headless: true,
+          outputSchema: { type: 'object', properties: { verdict: { type: 'string' } } }
+        })}
+        onChange={vi.fn()}
+      />
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(ta.value).toContain('"verdict"')
+  })
+
+  it('commits a parsed object when valid JSON is entered', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={onChange} />
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(ta, { target: { value: '{ "type": "object" }' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ outputSchema: { type: 'object' } })
+    )
+  })
+
+  it('shows an error and does not commit when JSON is invalid', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={onChange} />
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(ta, { target: { value: '{ not json' } })
+    expect(container.textContent).toContain('Not valid JSON')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-object schema (array)', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <LaunchAgentConfigForm config={baseConfig({ headless: true })} onChange={onChange} />
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(ta, { target: { value: '[1, 2, 3]' } })
+    expect(container.textContent).toContain('Schema must be a JSON object')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('clears the schema (onChange undefined) when the field is emptied', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({ headless: true, outputSchema: { type: 'object' } })}
+        onChange={onChange}
+      />
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(ta, { target: { value: '   ' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ outputSchema: undefined }))
+  })
+
+  it('resyncs the textarea when the incoming schema changes (node switch)', () => {
+    const { container, rerender } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig({ headless: true, outputSchema: { first: true } })}
+        onChange={vi.fn()}
+      />
+    )
+    let ta = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(ta.value).toContain('"first"')
+
+    rerender(
+      <LaunchAgentConfigForm
+        config={baseConfig({ headless: true, outputSchema: { second: true } })}
+        onChange={vi.fn()}
+      />
+    )
+    ta = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(ta.value).toContain('"second"')
+    expect(ta.value).not.toContain('"first"')
   })
 })
 

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -188,4 +188,30 @@ describe('buildWorkflowPrompt', () => {
     expect(result).toContain('wf-123')
     expect(result).toContain('get_my_context')
   })
+
+  it('appends the structured-output instructions when an outputSchema is given', () => {
+    const result = buildWorkflowPrompt({
+      workflow,
+      stepName: 'Review',
+      userPrompt: 'Review the PR',
+      outputSchema: {
+        type: 'object',
+        properties: { verdict: { type: 'string' } },
+        required: ['verdict']
+      }
+    })
+    expect(result).toContain('## Required Output')
+    expect(result).toContain('<<<VORN_OUTPUT>>>')
+    expect(result).toContain('"verdict"')
+  })
+
+  it('omits the structured-output section when no schema is given', () => {
+    const result = buildWorkflowPrompt({
+      workflow,
+      stepName: 'Review',
+      userPrompt: 'Review the PR'
+    })
+    expect(result).not.toContain('Required Output')
+    expect(result).not.toContain('<<<VORN_OUTPUT>>>')
+  })
 })

--- a/tests/structured-output.test.ts
+++ b/tests/structured-output.test.ts
@@ -58,6 +58,13 @@ describe('extractStructuredOutput', () => {
     expect(output).toEqual({ verdict: 'APPROVE', tests_passed: true, coverage: 82 })
   })
 
+  it('coerces stringified "false" and leaves non-numeric strings alone', () => {
+    const logs = wrap('{ "verdict": "APPROVE", "tests_passed": "false", "coverage": "n/a" }')
+    const { output } = extractStructuredOutput(logs, schema)
+    // "false" → false; "n/a" isn't a number so `coverage` stays a string.
+    expect(output).toEqual({ verdict: 'APPROVE', tests_passed: false, coverage: 'n/a' })
+  })
+
   it('errors when no JSON is present', () => {
     const { output, error } = extractStructuredOutput('the agent said nothing useful', schema)
     expect(output).toBeUndefined()

--- a/tests/structured-output.test.ts
+++ b/tests/structured-output.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractStructuredOutput,
+  buildStructuredOutputInstructions,
+  STRUCTURED_OUTPUT_BEGIN,
+  STRUCTURED_OUTPUT_END
+} from '@vornrun/shared/structured-output'
+
+const schema = {
+  type: 'object',
+  properties: {
+    verdict: { type: 'string' },
+    tests_passed: { type: 'boolean' },
+    coverage: { type: 'number' }
+  },
+  required: ['verdict']
+}
+
+function wrap(json: string): string {
+  return `Some reasoning here.\n${STRUCTURED_OUTPUT_BEGIN}\n${json}\n${STRUCTURED_OUTPUT_END}\nDone.`
+}
+
+describe('extractStructuredOutput', () => {
+  it('parses the object from the sentinel block', () => {
+    const logs = wrap('{ "verdict": "APPROVE", "tests_passed": true }')
+    const { output, error } = extractStructuredOutput(logs, schema)
+    expect(error).toBeUndefined()
+    expect(output).toEqual({ verdict: 'APPROVE', tests_passed: true })
+  })
+
+  it('takes the LAST sentinel block when the schema/example was echoed earlier', () => {
+    const logs = wrap('{ "verdict": "EXAMPLE" }') + '\n' + wrap('{ "verdict": "REQUEST_CHANGES" }')
+    const { output } = extractStructuredOutput(logs, schema)
+    expect(output).toEqual({ verdict: 'REQUEST_CHANGES' })
+  })
+
+  it('falls back to a fenced ```json block when markers are absent', () => {
+    const logs = 'Here is my answer:\n```json\n{ "verdict": "APPROVE" }\n```\n'
+    const { output } = extractStructuredOutput(logs, schema)
+    expect(output).toEqual({ verdict: 'APPROVE' })
+  })
+
+  it('falls back to the last balanced object in freeform text', () => {
+    const logs = 'blah {not json} blah\nfinal: { "verdict": "APPROVE" } trailing words'
+    const { output } = extractStructuredOutput(logs, schema)
+    expect(output).toEqual({ verdict: 'APPROVE' })
+  })
+
+  it('ignores braces inside string literals when balancing', () => {
+    const logs = wrap('{ "verdict": "use { and } carefully" }')
+    const { output } = extractStructuredOutput(logs, schema)
+    expect(output).toEqual({ verdict: 'use { and } carefully' })
+  })
+
+  it('coerces stringified scalars to the schema-declared type', () => {
+    const logs = wrap('{ "verdict": "APPROVE", "tests_passed": "true", "coverage": "82" }')
+    const { output } = extractStructuredOutput(logs, schema)
+    expect(output).toEqual({ verdict: 'APPROVE', tests_passed: true, coverage: 82 })
+  })
+
+  it('errors when no JSON is present', () => {
+    const { output, error } = extractStructuredOutput('the agent said nothing useful', schema)
+    expect(output).toBeUndefined()
+    expect(error).toMatch(/no json/i)
+  })
+
+  it('errors on invalid JSON', () => {
+    const logs = wrap('{ "verdict": "APPROVE", }} broken')
+    const { error } = extractStructuredOutput(logs, schema)
+    expect(error).toMatch(/not valid json|not a json object/i)
+  })
+
+  it('errors when the value is a JSON array, not an object', () => {
+    const logs = `${STRUCTURED_OUTPUT_BEGIN}\n[1, 2, 3]\n${STRUCTURED_OUTPUT_END}`
+    const { error } = extractStructuredOutput(logs, schema)
+    // An array has no top-level object, so extraction reports no object found.
+    expect(error).toBeTruthy()
+  })
+
+  it('errors when a required field is missing', () => {
+    const logs = wrap('{ "tests_passed": true }')
+    const { output, error } = extractStructuredOutput(logs, schema)
+    expect(output).toBeUndefined()
+    expect(error).toMatch(/missing required field/i)
+    expect(error).toMatch(/verdict/)
+  })
+
+  it('does not require optional fields', () => {
+    const logs = wrap('{ "verdict": "APPROVE" }')
+    const { output, error } = extractStructuredOutput(logs, schema)
+    expect(error).toBeUndefined()
+    expect(output).toEqual({ verdict: 'APPROVE' })
+  })
+})
+
+describe('buildStructuredOutputInstructions', () => {
+  it('includes both markers and the serialized schema', () => {
+    const text = buildStructuredOutputInstructions(schema)
+    expect(text).toContain(STRUCTURED_OUTPUT_BEGIN)
+    expect(text).toContain(STRUCTURED_OUTPUT_END)
+    expect(text).toContain('"verdict"')
+    expect(text).toContain('Required Output')
+  })
+})

--- a/tests/structured-output.test.ts
+++ b/tests/structured-output.test.ts
@@ -91,6 +91,16 @@ describe('extractStructuredOutput', () => {
     expect(error).toBeUndefined()
     expect(output).toEqual({ verdict: 'APPROVE' })
   })
+
+  it('enforces required keys even when absent from properties', () => {
+    // A schema can require a field it doesn't otherwise describe under
+    // properties; that must still be validated.
+    const sparse = { type: 'object', properties: {}, required: ['verdict'] }
+    const { output, error } = extractStructuredOutput(wrap('{ "other": 1 }'), sparse)
+    expect(output).toBeUndefined()
+    expect(error).toMatch(/missing required field/i)
+    expect(error).toMatch(/verdict/)
+  })
 })
 
 describe('buildStructuredOutputInstructions', () => {

--- a/tests/template-vars.test.ts
+++ b/tests/template-vars.test.ts
@@ -202,6 +202,21 @@ describe('buildStepGroups', () => {
     const groups = buildStepGroups([node])
     expect(groups[0].keys.map((k) => k.key)).toEqual(['output', 'status', 'error'])
   })
+
+  it('does not surface schema keys for a non-headless launchAgent', () => {
+    // The engine only parses typed output for headless runs, so a schema on an
+    // interactive node must not advertise vars that never get populated.
+    const node = makeNode('a', 'launchAgent', 'review')
+    node.config = {
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      headless: false,
+      outputSchema: { type: 'object', properties: { verdict: { type: 'string' } } }
+    } as WorkflowNode['config']
+    const groups = buildStepGroups([node])
+    expect(groups[0].keys.map((k) => k.key)).toEqual(['output', 'status', 'error'])
+  })
 })
 
 describe('resolveTemplateVars', () => {

--- a/tests/template-vars.test.ts
+++ b/tests/template-vars.test.ts
@@ -163,6 +163,45 @@ describe('buildStepGroups', () => {
     expect(keys.slice(0, 2)).toEqual(['html_url', 'number'])
     expect(keys.slice(-3)).toEqual(['output', 'status', 'error'])
   })
+
+  it('prepends outputSchema keys for launchAgent nodes', () => {
+    const node: WorkflowNode = {
+      id: 'n1',
+      type: 'launchAgent',
+      label: 'Review',
+      slug: 'review',
+      config: {
+        agentType: 'claude',
+        projectName: 'p',
+        projectPath: '/p',
+        headless: true,
+        outputSchema: {
+          type: 'object',
+          properties: {
+            verdict: { type: 'string', description: 'APPROVE or REQUEST_CHANGES' },
+            tests_passed: { type: 'boolean' }
+          },
+          required: ['verdict']
+        }
+      },
+      position: { x: 0, y: 0 }
+    }
+    const groups = buildStepGroups([node])
+    const keys = groups[0].keys.map((k) => k.key)
+    expect(keys.slice(0, 2)).toEqual(['verdict', 'tests_passed'])
+    expect(keys.slice(-3)).toEqual(['output', 'status', 'error'])
+  })
+
+  it('keeps only default keys for a launchAgent node without a schema', () => {
+    const node = makeNode('a', 'launchAgent', 'plain')
+    node.config = {
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p'
+    } as WorkflowNode['config']
+    const groups = buildStepGroups([node])
+    expect(groups[0].keys.map((k) => k.key)).toEqual(['output', 'status', 'error'])
+  })
 })
 
 describe('resolveTemplateVars', () => {


### PR DESCRIPTION
## Summary

Implements **item 1 (typed agent outputs)** of #377 and brings the **MCP workflow surface up to node parity** (item 7), which is what was blocking agents from authoring full workflows.

Today a `launchAgent` node emits only freeform text, so a downstream `condition` node can only substring-match the model's prose (`contains "VERDICT: APPROVE"`). That's brittle. This makes agent decisions **typed**.

## How it works

A **headless** `launchAgent` node can declare an `outputSchema` (JSON Schema). The engine:
1. Appends an instruction block asking the agent to end its run with a JSON object matching the schema, wrapped in `<<<VORN_OUTPUT>>>` … `<<<END_VORN_OUTPUT>>>` markers.
2. On exit, parses that object out of the run logs and validates it.
3. Stores it as the node's `structuredOutput` → surfaced as `{{steps.<slug>.<field>}}`.

Downstream `condition` nodes then gate on real fields (`{{steps.review.verdict}}`, `{{steps.review.tests_passed}}`). A run whose output can't be parsed/validated is marked **error**, so a branch never acts on garbage.

This reuses the exact `structuredOutput` + nested `{{steps.*}}` machinery `callConnectorAction` already uses; autocomplete surfaces a node's schema fields the same way.

## Changes

- **`packages/shared/src/structured-output.ts`** (new) — markers, prompt-instruction builder, and a string-literal-aware extractor (last sentinel block → fenced ```json → last balanced object) with lightweight validation (plain object + required keys + top-level scalar coercion).
- **`prompt-builder.ts`** — appends the instruction block when a schema is set.
- **`types.ts`** — `LaunchAgentConfig.outputSchema?`.
- **`workflow-execution.ts`** — parses on headless exit; stores `structuredOutput` or fails the node.
- **`template-vars.ts`** — `buildStepGroups` surfaces launchAgent schema keys.
- **`LaunchAgentConfigForm.tsx`** — first-class "Output Schema" field (headless only), live-validated.

### MCP parity (fixes "agents can't create workflows freely")

- `create`/`update_workflow` node schema now accepts **every** `WorkflowNodeType` (was `trigger`/`launchAgent` only) — `script`, `condition`, `approval`, `createTaskFromItem`, `callConnectorAction` — plus node **`slug`** and edge **`conditionBranch`**. Previously other node types and branch wiring round-tripped as dropped.
- launchAgent convenience schema gains `headless` and `outputSchema`.

## Scope / deferred

- **Mismatch handling:** node is marked `error` (chosen over auto-retry). Retry-on-mismatch (ties into #377 item 5) is deferred.
- **Headless only:** interactive terminal sessions produce no parseable completion; the field is gated on the headless toggle.
- **forEach** (#377 item 2) is a separate follow-up.

## Tests & checks

- New `tests/structured-output.test.ts` (12 cases: sentinel/fence/balanced extraction, last-occurrence, in-string braces, coercion, invalid JSON, missing-required).
- Extended `template-vars` (launchAgent schema keys) and `prompt-builder` (schema section present/absent).
- Full suite **1588 pass**; typecheck clean; MCP `tsup` build clean.