### PR TITLE
feat(connectors): MCP connector poll/trigger capability (#379)

### DIFF
--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -19,6 +19,8 @@ import type {
   ConnectorActionDef,
   ConnectorConfigField,
   ActionResult,
+  PollResult,
+  TriggerEvent,
   SourceConnection
 } from '@vornrun/shared/types'
 import { schemaProperties, schemaTypeHint, schemaRequired } from '@vornrun/shared/json-schema-utils'
@@ -27,6 +29,11 @@ import { getOrStartClient } from './mcp-clients'
 /** Stable id for the generic MCP connector. Used everywhere the server
  *  needs to distinguish MCP from static connectors. */
 export const MCP_CONNECTOR_ID = 'mcp'
+
+/** The single trigger type the MCP connector exposes. Its behavior is driven
+ *  entirely by the connection's poll config (pollTool/itemsPath/…), so one
+ *  static event covers every MCP server rather than a per-server manifest. */
+export const MCP_POLL_EVENT = 'mcpPoll'
 
 export interface McpDiscoveredTool {
   name: string
@@ -198,6 +205,145 @@ export async function invokeMcpTool(
   }
 }
 
+// --- Poll / trigger support -------------------------------------------------
+
+/** Per-connection poll config, read from `conn.filters`. All optional; without
+ *  a `pollTool` the connection simply isn't a trigger source. */
+interface McpPollConfig {
+  pollTool?: string
+  pollArgs?: string
+  itemsPath?: string
+  idField?: string
+  timestampField?: string
+  titleField?: string
+  urlField?: string
+}
+
+function readPollConfig(conn: SourceConnection): McpPollConfig {
+  const f = conn.filters
+  const str = (v: unknown): string | undefined => {
+    const s = typeof v === 'string' ? v.trim() : ''
+    return s || undefined
+  }
+  return {
+    pollTool: str(f.pollTool),
+    pollArgs: str(f.pollArgs),
+    itemsPath: str(f.itemsPath),
+    idField: str(f.idField),
+    timestampField: str(f.timestampField),
+    titleField: str(f.titleField),
+    urlField: str(f.urlField)
+  }
+}
+
+/** Walk a dotted path (e.g. `data.pullRequests`) into a value. An empty path
+ *  returns the root so a tool that returns the array at top level still works. */
+function walkPath(root: unknown, path: string | undefined): unknown {
+  if (!path) return root
+  let current: unknown = root
+  for (const segment of path.split('.')) {
+    if (current == null || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function fieldString(item: Record<string, unknown>, field: string | undefined): string | undefined {
+  if (!field) return undefined
+  const v = item[field]
+  return v == null ? undefined : String(v)
+}
+
+/**
+ * Poll an MCP connection: invoke its configured `pollTool`, pull the array at
+ * `itemsPath` out of the result, and emit one `TriggerEvent` per new item.
+ *
+ * Kept as a standalone function (not `mcpConnector.poll`) because — like
+ * `invokeMcpTool` — it needs the full `SourceConnection` to spawn/address the
+ * per-connection stdio client, which the generic `poll(config)` signature (a
+ * flattened filters object) can't provide. The scheduler special-cases MCP to
+ * call this directly.
+ *
+ * Cursor semantics mirror the GitHub connector: when a `timestampField` is
+ * configured, only items with `timestampField > cursor` are emitted and the
+ * cursor advances to the newest timestamp seen. Without a `timestampField`
+ * every item is emitted each poll; that stays at-most-once because
+ * `createTaskFromItem` upserts by `externalId` (from `idField`).
+ */
+export async function pollMcpConnection(
+  conn: SourceConnection,
+  cursor?: string
+): Promise<PollResult> {
+  const cfg = readPollConfig(conn)
+  if (!cfg.pollTool) return { events: [] }
+
+  let pollArgs: Record<string, unknown> = {}
+  if (cfg.pollArgs) {
+    try {
+      const parsed = JSON.parse(cfg.pollArgs)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        pollArgs = parsed as Record<string, unknown>
+      } else {
+        throw new Error('pollArgs must be a JSON object')
+      }
+    } catch (err) {
+      throw new Error(
+        `Invalid pollArgs JSON: ${err instanceof Error ? err.message : String(err)}`,
+        {
+          cause: err
+        }
+      )
+    }
+  }
+
+  const result = await invokeMcpTool(conn, cfg.pollTool, pollArgs)
+  if (!result.success) {
+    throw new Error(result.error || `MCP poll tool ${cfg.pollTool} failed`)
+  }
+
+  const rawItems = walkPath(result.output, cfg.itemsPath)
+  if (!Array.isArray(rawItems)) {
+    const where = cfg.itemsPath ? `itemsPath "${cfg.itemsPath}"` : 'the tool result'
+    throw new Error(`MCP poll: ${where} did not resolve to an array`)
+  }
+
+  const items = rawItems.filter(
+    (it): it is Record<string, unknown> => !!it && typeof it === 'object' && !Array.isArray(it)
+  )
+
+  const events: TriggerEvent[] = []
+  let newest = cursor
+  for (const item of items) {
+    const ts = fieldString(item, cfg.timestampField)
+    // Skip items at or before the cursor when we can order by timestamp.
+    if (cfg.timestampField && cursor && ts !== undefined && ts <= cursor) continue
+    if (ts !== undefined && (newest === undefined || ts > newest)) newest = ts
+
+    const idVal = fieldString(item, cfg.idField)
+    const id = idVal ?? JSON.stringify(item)
+    const url = fieldString(item, cfg.urlField)
+    const title = fieldString(item, cfg.titleField)
+
+    events.push({
+      id,
+      type: MCP_POLL_EVENT,
+      timestamp: ts ?? new Date().toISOString(),
+      // Spread the raw item so nothing is lost, then normalize the fields the
+      // scheduler reads to build the connectorItem (externalId/url/title).
+      data: {
+        ...item,
+        externalId: id,
+        ...(url !== undefined && { url }),
+        ...(title !== undefined && { title })
+      }
+    })
+  }
+
+  // Advance the cursor only when we can order by timestamp; otherwise leave it
+  // unset and rely on upsert dedup.
+  return cfg.timestampField ? { events, nextCursor: newest ?? cursor } : { events }
+}
+
 function extractTextError(content: unknown): string | undefined {
   if (!Array.isArray(content)) return undefined
   for (const block of content) {
@@ -213,7 +359,9 @@ export const mcpConnector: VornConnector = {
   id: 'mcp',
   name: 'MCP',
   icon: 'mcp',
-  capabilities: ['actions'],
+  // 'triggers' is always declared; whether a given connection actually fires
+  // depends on it having a `pollTool` configured (see pollMcpConnection).
+  capabilities: ['actions', 'triggers'],
 
   describe(): ConnectorManifest {
     return {
@@ -247,6 +395,76 @@ export const mcpConnector: VornConnector = {
           type: 'password',
           placeholder: '{"AZURE_DEVOPS_EXT_PAT": "<token>"}',
           description: 'Secret env vars encrypted via OS keychain. JSON object of string values.'
+        },
+        // --- Poll trigger (optional) ---
+        // Setting `pollTool` turns this connection into a trigger source: a
+        // `connectorPoll` trigger with event `mcpPoll` runs the tool on a cron
+        // and fires one workflow per new item. Leave blank for action-only use.
+        {
+          key: 'pollTool',
+          label: 'Poll tool (optional)',
+          type: 'text',
+          placeholder: 'list_pull_requests',
+          description:
+            'MCP tool to run on the poll interval. Setting this makes the connection a ' +
+            'trigger source (event: MCP Poll).'
+        },
+        {
+          key: 'pollArgs',
+          label: 'Poll args (JSON object)',
+          type: 'textarea',
+          placeholder: '{"status": "active"}',
+          description: 'Static arguments passed to the poll tool. JSON object.'
+        },
+        {
+          key: 'itemsPath',
+          label: 'Items path',
+          type: 'text',
+          placeholder: 'pullRequests',
+          description:
+            'Dotted path into the tool result that holds the array of items (e.g. `value` ' +
+            'or `data.pullRequests`). Blank = the result is itself the array.'
+        },
+        {
+          key: 'idField',
+          label: 'ID field',
+          type: 'text',
+          placeholder: 'pullRequestId',
+          description: 'Field on each item used as the dedup key (recommended for at-most-once).'
+        },
+        {
+          key: 'timestampField',
+          label: 'Timestamp field',
+          type: 'text',
+          placeholder: 'creationDate',
+          description:
+            'Field used to advance the cursor and only fire for items newer than the last ' +
+            'poll. Blank = every item fires each poll (deduped by ID field).'
+        },
+        {
+          key: 'titleField',
+          label: 'Title field',
+          type: 'text',
+          placeholder: 'title',
+          description: 'Field mapped into the created task title.'
+        },
+        {
+          key: 'urlField',
+          label: 'URL field',
+          type: 'text',
+          placeholder: 'url',
+          description: 'Field mapped into the created task URL.'
+        }
+      ],
+      triggers: [
+        {
+          type: MCP_POLL_EVENT,
+          label: 'MCP Poll',
+          description:
+            "Runs this connection's configured poll tool on a schedule and fires once per new item.",
+          // Config lives on the connection (poll tool/mapping), not the trigger.
+          configFields: [],
+          defaultIntervalMs: 300_000
         }
       ],
       // Actions are per-connection (discovered via tools/list). The static

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -315,8 +315,14 @@ export async function pollMcpConnection(
   let newest = cursor
   for (const item of items) {
     const ts = fieldString(item, cfg.timestampField)
-    // Skip items at or before the cursor when we can order by timestamp.
-    if (cfg.timestampField && cursor && ts !== undefined && ts <= cursor) continue
+    if (cfg.timestampField) {
+      // With ordering configured, an item that lacks the timestamp field can't
+      // be placed relative to the cursor — emit it and it would re-fire every
+      // poll. Skip it rather than churn.
+      if (ts === undefined) continue
+      // Skip items at or before the cursor.
+      if (cursor && ts <= cursor) continue
+    }
     if (ts !== undefined && (newest === undefined || ts > newest)) newest = ts
 
     const idVal = fieldString(item, cfg.idField)

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -13,7 +13,7 @@ import {
 import { configManager } from './config-manager'
 import { dbGetSourceConnection, dbUpdateSourceConnection } from './database'
 import { connectorRegistry, applyDecryptedCreds } from './connectors'
-import { MCP_CONNECTOR_ID, pollMcpConnection } from './connectors/mcp'
+import { MCP_CONNECTOR_ID, MCP_POLL_EVENT, pollMcpConnection } from './connectors/mcp'
 import log from './logger'
 
 const LOCK_DIR = path.join(os.homedir(), '.vorn')
@@ -211,10 +211,20 @@ class Scheduler extends EventEmitter {
     // MCP is polymorphic: its poll needs the full SourceConnection to spawn the
     // per-connection stdio client, so it's routed through pollMcpConnection
     // rather than the generic connector.poll (which only gets flattened
-    // filters) — mirroring how MCP execute is special-cased.
+    // filters) — mirroring how MCP execute is special-cased. Decrypted secrets
+    // don't need overlaying here: getOrStartClient pulls secretEnv from the
+    // decrypted-creds store keyed by conn.id.
     const isMcp = conn.connectorId === MCP_CONNECTOR_ID
     if (!isMcp && !connector?.poll) {
       log.warn(`[scheduler] connectorPoll: connector ${conn.connectorId} has no poll() — skipping`)
+      return
+    }
+    // MCP defines exactly one event; reject a misconfigured trigger rather than
+    // fan out on an event the connector never emits.
+    if (isMcp && trigger.event !== MCP_POLL_EVENT) {
+      log.warn(
+        `[scheduler] connectorPoll: MCP connection ${conn.id} got unexpected event "${trigger.event}" — skipping`
+      )
       return
     }
 

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -13,6 +13,7 @@ import {
 import { configManager } from './config-manager'
 import { dbGetSourceConnection, dbUpdateSourceConnection } from './database'
 import { connectorRegistry, applyDecryptedCreds } from './connectors'
+import { MCP_CONNECTOR_ID, pollMcpConnection } from './connectors/mcp'
 import log from './logger'
 
 const LOCK_DIR = path.join(os.homedir(), '.vorn')
@@ -207,7 +208,12 @@ class Scheduler extends EventEmitter {
       return
     }
     const connector = connectorRegistry.get(conn.connectorId)
-    if (!connector?.poll) {
+    // MCP is polymorphic: its poll needs the full SourceConnection to spawn the
+    // per-connection stdio client, so it's routed through pollMcpConnection
+    // rather than the generic connector.poll (which only gets flattened
+    // filters) — mirroring how MCP execute is special-cased.
+    const isMcp = conn.connectorId === MCP_CONNECTOR_ID
+    if (!isMcp && !connector?.poll) {
       log.warn(`[scheduler] connectorPoll: connector ${conn.connectorId} has no poll() — skipping`)
       return
     }
@@ -216,7 +222,9 @@ class Scheduler extends EventEmitter {
     const now = new Date().toISOString()
     let result
     try {
-      result = await connector.poll(trigger.event, applyDecryptedCreds(conn), cursor)
+      result = isMcp
+        ? await pollMcpConnection(conn, cursor)
+        : await connector!.poll!(trigger.event, applyDecryptedCreds(conn), cursor)
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err)
       log.error(

--- a/tests/mcp-connector.test.ts
+++ b/tests/mcp-connector.test.ts
@@ -281,13 +281,37 @@ describe('mcpConnector.describe', () => {
     const { mcpConnector } = await importMcp()
     const manifest = mcpConnector.describe()
     const keys = manifest.auth.map((f) => f.key)
-    expect(keys).toEqual(['command', 'args', 'env', 'secretEnv'])
+    // The connection form leads with the server/credential fields (optional
+    // poll-config fields follow — asserted separately).
+    expect(keys.slice(0, 4)).toEqual(['command', 'args', 'env', 'secretEnv'])
     expect(manifest.auth.find((f) => f.key === 'secretEnv')?.type).toBe('password')
   })
 
-  it('is an actions-only connector with an empty static action list', async () => {
+  it('exposes actions and triggers, with an empty static action list', async () => {
     const { mcpConnector } = await importMcp()
-    expect(mcpConnector.capabilities).toEqual(['actions'])
+    expect(mcpConnector.capabilities).toEqual(['actions', 'triggers'])
+    // Actions are per-connection (discovered via tools/list), so the static
+    // list stays empty.
     expect(mcpConnector.describe().actions).toEqual([])
+  })
+
+  it('exposes a single mcpPoll trigger driven by the connection poll config', async () => {
+    const { mcpConnector, MCP_POLL_EVENT } = await importMcp()
+    const triggers = mcpConnector.describe().triggers ?? []
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0].type).toBe(MCP_POLL_EVENT)
+    // The poll mapping lives on the connection (auth/config form), not the
+    // trigger, so the trigger itself declares no config fields.
+    expect(triggers[0].configFields).toEqual([])
+  })
+
+  it('advertises the optional poll-config fields on the connection form', async () => {
+    const { mcpConnector } = await importMcp()
+    const keys = mcpConnector.describe().auth.map((f) => f.key)
+    for (const k of ['pollTool', 'itemsPath', 'idField', 'timestampField']) {
+      expect(keys).toContain(k)
+    }
+    // Poll fields are optional so action-only connections aren't forced to set them.
+    expect(mcpConnector.describe().auth.find((f) => f.key === 'pollTool')?.required).toBeFalsy()
   })
 })

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -82,6 +82,23 @@ describe('pollMcpConnection', () => {
     expect(result.nextCursor).toBe('2026-07-03')
   })
 
+  it('skips items missing the timestampField when ordering is configured', async () => {
+    toolReturns({
+      items: [
+        { id: 'a', ts: '2026-07-03' },
+        { id: 'b' }, // no ts — can't be ordered, must not fire every poll
+        { id: 'c', ts: '2026-07-01' }
+      ]
+    })
+    const result = await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'items', idField: 'id', timestampField: 'ts' }),
+      '2026-07-02'
+    )
+    // Only 'a' (ts > cursor) fires; 'b' (no ts) and 'c' (<= cursor) are skipped.
+    expect(result.events.map((e) => e.id)).toEqual(['a'])
+    expect(result.nextCursor).toBe('2026-07-03')
+  })
+
   it('emits every item and sets no cursor when no timestampField is configured', async () => {
     toolReturns({ items: [{ id: 'a' }, { id: 'b' }] })
     const result = await pollMcpConnection(

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Control the MCP client so pollMcpConnection → invokeMcpTool → getOrStartClient
+// returns our canned tool result instead of spawning a real server.
+const callTool = vi.fn()
+vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  getOrStartClient: vi.fn(async () => ({ callTool }))
+}))
+
+import { pollMcpConnection, MCP_POLL_EVENT } from '../packages/server/src/connectors/mcp'
+import type { SourceConnection } from '../src/shared/types'
+
+function makeConn(pollFilters: Record<string, unknown>): SourceConnection {
+  return {
+    id: 'conn-1',
+    connectorId: 'mcp',
+    name: 'ADO',
+    filters: { command: 'npx', args: '[]', ...pollFilters },
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-01-01T00:00:00Z'
+  }
+}
+
+/** Canned tool result in the shape invokeMcpTool surfaces (structuredContent). */
+function toolReturns(structuredContent: Record<string, unknown>) {
+  callTool.mockResolvedValueOnce({ structuredContent, isError: false })
+}
+
+beforeEach(() => {
+  callTool.mockReset()
+})
+
+describe('pollMcpConnection', () => {
+  it('returns no events (and calls nothing) when no pollTool is configured', async () => {
+    const result = await pollMcpConnection(makeConn({}))
+    expect(result.events).toEqual([])
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('maps items at itemsPath into events with id/title/url/timestamp', async () => {
+    toolReturns({
+      pullRequests: [
+        { pullRequestId: 7, title: 'Fix bug', url: 'https://x/7', creationDate: '2026-07-01' },
+        { pullRequestId: 8, title: 'Add feature', url: 'https://x/8', creationDate: '2026-07-02' }
+      ]
+    })
+    const result = await pollMcpConnection(
+      makeConn({
+        pollTool: 'list_pull_requests',
+        itemsPath: 'pullRequests',
+        idField: 'pullRequestId',
+        titleField: 'title',
+        urlField: 'url',
+        timestampField: 'creationDate'
+      })
+    )
+    expect(callTool).toHaveBeenCalledWith({ name: 'list_pull_requests', arguments: {} })
+    expect(result.events).toHaveLength(2)
+    expect(result.events[0]).toMatchObject({
+      id: '7',
+      type: MCP_POLL_EVENT,
+      timestamp: '2026-07-01',
+      data: { externalId: '7', title: 'Fix bug', url: 'https://x/7', pullRequestId: 7 }
+    })
+    // Cursor advances to the newest timestamp seen.
+    expect(result.nextCursor).toBe('2026-07-02')
+  })
+
+  it('filters out items at or before the cursor when a timestampField is set', async () => {
+    toolReturns({
+      items: [
+        { id: 'a', ts: '2026-07-01' },
+        { id: 'b', ts: '2026-07-03' }
+      ]
+    })
+    const result = await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'items', idField: 'id', timestampField: 'ts' }),
+      '2026-07-02'
+    )
+    expect(result.events.map((e) => e.id)).toEqual(['b'])
+    expect(result.nextCursor).toBe('2026-07-03')
+  })
+
+  it('emits every item and sets no cursor when no timestampField is configured', async () => {
+    toolReturns({ items: [{ id: 'a' }, { id: 'b' }] })
+    const result = await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'items', idField: 'id' }),
+      'ignored-cursor'
+    )
+    expect(result.events.map((e) => e.id)).toEqual(['a', 'b'])
+    expect(result.nextCursor).toBeUndefined()
+  })
+
+  it('walks a nested itemsPath', async () => {
+    toolReturns({ data: { value: [{ id: '1' }] } })
+    const result = await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'data.value', idField: 'id' })
+    )
+    expect(result.events.map((e) => e.id)).toEqual(['1'])
+  })
+
+  it('falls back to a stable id when idField is missing', async () => {
+    toolReturns({ items: [{ foo: 'bar' }] })
+    const result = await pollMcpConnection(makeConn({ pollTool: 'list', itemsPath: 'items' }))
+    expect(result.events[0].id).toBe(JSON.stringify({ foo: 'bar' }))
+    expect(result.events[0].data.externalId).toBe(JSON.stringify({ foo: 'bar' }))
+  })
+
+  it('passes static pollArgs through to the tool', async () => {
+    toolReturns({ items: [] })
+    await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'items', pollArgs: '{"status":"active"}' })
+    )
+    expect(callTool).toHaveBeenCalledWith({
+      name: 'list',
+      arguments: { status: 'active' }
+    })
+  })
+
+  it('throws when itemsPath does not resolve to an array', async () => {
+    toolReturns({ notAnArray: true })
+    await expect(
+      pollMcpConnection(makeConn({ pollTool: 'list', itemsPath: 'missing' }))
+    ).rejects.toThrow(/did not resolve to an array/)
+  })
+
+  it('throws when the tool reports an error', async () => {
+    callTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: 'text', text: 'boom' }]
+    })
+    await expect(
+      pollMcpConnection(makeConn({ pollTool: 'list', itemsPath: 'items' }))
+    ).rejects.toThrow(/boom/)
+  })
+
+  it('throws on invalid pollArgs JSON', async () => {
+    await expect(
+      pollMcpConnection(makeConn({ pollTool: 'list', pollArgs: '{ not json' }))
+    ).rejects.toThrow(/Invalid pollArgs JSON/)
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('throws when pollArgs is valid JSON but not an object', async () => {
+    await expect(
+      pollMcpConnection(makeConn({ pollTool: 'list', pollArgs: '[1, 2, 3]' }))
+    ).rejects.toThrow(/must be a JSON object/)
+    expect(callTool).not.toHaveBeenCalled()
+  })
+})

--- a/tests/scheduler-connector-poll.test.ts
+++ b/tests/scheduler-connector-poll.test.ts
@@ -13,12 +13,14 @@ const {
   loadConfigMock,
   dbGetSourceConnectionMock,
   dbUpdateSourceConnectionMock,
-  connectorGetMock
+  connectorGetMock,
+  pollMcpConnectionMock
 } = vi.hoisted(() => ({
   loadConfigMock: vi.fn(),
   dbGetSourceConnectionMock: vi.fn(),
   dbUpdateSourceConnectionMock: vi.fn(),
-  connectorGetMock: vi.fn()
+  connectorGetMock: vi.fn(),
+  pollMcpConnectionMock: vi.fn()
 }))
 
 vi.mock('../packages/server/src/logger', () => ({
@@ -48,6 +50,11 @@ vi.mock('../packages/server/src/connectors', async (importOriginal) => {
     connectorRegistry: { get: connectorGetMock },
     applyDecryptedCreds: (conn: { filters: Record<string, unknown> }) => ({ ...conn.filters })
   }
+})
+// Keep the real MCP_CONNECTOR_ID / MCP_POLL_EVENT constants; stub only the poll.
+vi.mock('../packages/server/src/connectors/mcp', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, pollMcpConnection: pollMcpConnectionMock }
 })
 
 // Import after mocks are set up.
@@ -103,6 +110,7 @@ beforeEach(() => {
   dbGetSourceConnectionMock.mockReset()
   dbUpdateSourceConnectionMock.mockReset()
   connectorGetMock.mockReset()
+  pollMcpConnectionMock.mockReset()
   // Clean up any stale lock files from previous tests to avoid the minute-key
   // dedup blocking subsequent triggerWorkflow() calls in the same minute.
   try {
@@ -234,6 +242,71 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     scheduler.triggerWorkflow('wf-nopoll')
     await new Promise((r) => setImmediate(r))
 
+    expect(dbUpdateSourceConnectionMock).not.toHaveBeenCalled()
+  })
+
+  // --- MCP connections are routed through pollMcpConnection, not connector.poll ---
+
+  function makeMcpPollWorkflow(id: string, event: string): WorkflowDefinition {
+    const trigger: ConnectorPollTriggerConfig = {
+      triggerType: 'connectorPoll',
+      connectionId: 'conn-1',
+      event,
+      cron: '*/5 * * * *'
+    }
+    return {
+      id,
+      name: 'MCP Poll',
+      icon: 'Plug',
+      iconColor: '#64748b',
+      enabled: true,
+      nodes: [
+        { id: 'trigger-1', type: 'trigger', label: 't', config: trigger, position: { x: 0, y: 0 } }
+      ],
+      edges: []
+    }
+  }
+
+  it('routes an mcpPoll event through pollMcpConnection and advances the cursor', async () => {
+    const wf = makeMcpPollWorkflow('wf-mcp', 'mcpPoll')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(
+      makeConn({ connectorId: 'mcp', filters: { pollTool: 'list' }, syncCursor: 'c0' })
+    )
+    connectorGetMock.mockReturnValue({}) // MCP has no generic poll()
+    pollMcpConnectionMock.mockResolvedValue({
+      events: [
+        { id: '1', type: 'mcpPoll', data: { externalId: '1', title: 'X' }, timestamp: 't1' }
+      ],
+      nextCursor: 't1'
+    })
+
+    scheduler.triggerWorkflow('wf-mcp')
+    await new Promise((r) => setImmediate(r))
+
+    // pollMcpConnection called with the full connection + cursor.
+    expect(pollMcpConnectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conn-1', connectorId: 'mcp' }),
+      'c0'
+    )
+    expect(dbUpdateSourceConnectionMock).toHaveBeenCalledWith(
+      'conn-1',
+      expect.objectContaining({ syncCursor: 't1' })
+    )
+  })
+
+  it('skips an MCP connection whose event is not mcpPoll', async () => {
+    const wf = makeMcpPollWorkflow('wf-mcp-bad', 'issueCreated')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(
+      makeConn({ connectorId: 'mcp', filters: { pollTool: 'list' } })
+    )
+    connectorGetMock.mockReturnValue({})
+
+    scheduler.triggerWorkflow('wf-mcp-bad')
+    await new Promise((r) => setImmediate(r))
+
+    expect(pollMcpConnectionMock).not.toHaveBeenCalled()
     expect(dbUpdateSourceConnectionMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Closes #379. Turns **any MCP server into a workflow trigger source through config alone** — no native connector code, no forking. Setting a connection's `pollTool` makes it fire a `connectorPoll` trigger (event **MCP Poll**) that runs the tool on a cron and emits one workflow execution per new item.

Motivating case from the issue: *"a new Azure DevOps PR appears → a Vorn workflow reviews it."* The ADO MCP server already exposes `list_pull_requests`; now the MCP connection can poll it into a trigger.

## How it works

A connection gains optional poll-config fields (in the existing MCP connection form):

| Field | Purpose |
|-------|---------|
| `pollTool` | MCP tool to run each interval (e.g. `list_pull_requests`). Presence = trigger source. |
| `pollArgs` | Static JSON args for the tool. |
| `itemsPath` | Dotted path to the item array in the result (e.g. `value`, `data.pullRequests`). |
| `idField` | Per-item dedup key → `TriggerEvent.id` / `externalId`. |
| `timestampField` | Advances the cursor; only newer items fire. |
| `titleField` / `urlField` | Mapped into the created task's title / URL. |

`pollMcpConnection(conn, cursor)` invokes the tool, walks `itemsPath`, maps each item into a `TriggerEvent` shaped for `createTaskFromItem`. **Cursor semantics mirror `github.ts`:** with a `timestampField`, only items with `timestamp > cursor` fire and the cursor advances to the newest seen; without one, every item fires each poll and stays **at-most-once** via `createTaskFromItem`'s upsert-by-`externalId`.

## Design notes

- **No renderer changes.** The connection form renders `manifest.auth` fields generically (→ saved to `filters`), and the trigger picker's Event dropdown reads `manifest.triggers` — so adding the fields + a single static `mcpPoll` trigger to `describe()` wires the whole UI automatically.
- **Scheduler special-cases MCP** (like `execute`): MCP's poll needs the full `SourceConnection` to spawn its per-connection stdio client, which the generic `poll(flattenedFilters)` signature can't provide.
- One static `mcpPoll` trigger covers *every* MCP server; the per-server behavior is entirely connection config.

## Deferred (called out, not silently dropped)
- **`defaultWorkflows` seeding** — an MCP connection has no `pollTool` at create time, so seeding a poll workflow then would be premature. User adds the trigger after configuring the tool.
- **`pollArgs` template resolution** — there's no execution context at poll time; args are static for now.

## Tests & checks
- New `tests/mcp-poll.test.ts` (11 cases): mapping, nested `itemsPath`, cursor filtering + advancement, no-timestamp emit-all, id fallback, static args, and the error paths (non-array result, tool error, invalid/non-object `pollArgs`).
- Updated `mcp-connector.test.ts` for the new capabilities/trigger/poll-fields.
- Full suite **1612 pass**; typecheck + lint clean; patch coverage **98%** (verified with the same `diff-cover` gate CI runs).