### PR TITLE
fix(terminal): let Ctrl+C reach a command started from the composer

### DIFF
--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { focusTerminal, pasteToTerminal, scrollToBottom } from '../lib/terminal-registry'
+import { getShellInputState } from '../lib/command-blocks'
 import {
   ghostSuggestion,
   recordCommand,
@@ -123,6 +124,22 @@ function longestCommonPrefix(inserts: string[]): string {
  * newline, Escape returns focus to the terminal. Tab fills the longest
  * common prefix, then inserts the highlighted (or first) completion.
  */
+/**
+ * Control chords forwarded to the pty while a command is running.
+ *
+ * The composer keeps focus after a command is submitted, so these would
+ * otherwise be swallowed by the textarea and there would be no way to
+ * interrupt anything without first clicking into the terminal. Ctrl, never
+ * Cmd: control characters are Ctrl-based on every platform, and on macOS
+ * Cmd+C is copy.
+ */
+const CONTROL_CHORDS: Record<string, string> = {
+  c: '\x03', // SIGINT
+  d: '\x04', // EOF
+  z: '\x1a', // SIGTSTP
+  '\\': '\x1c' // SIGQUIT
+}
+
 export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   const session = useAppStore((s) => s.terminals.get(terminalId)?.session)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -385,6 +402,22 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Interrupts belong to the running command, not to this input.
+      if (e.ctrlKey && !e.metaKey && !e.altKey) {
+        const chord = CONTROL_CHORDS[e.key.toLowerCase()]
+        const target = e.currentTarget
+        const hasSelection = target.selectionStart !== target.selectionEnd
+        // Copying out of the composer still wins, which is what the terminal
+        // itself does with a selection too.
+        if (chord && !(e.key.toLowerCase() === 'c' && hasSelection)) {
+          if (getShellInputState(terminalId) === 'running') {
+            e.preventDefault()
+            window.api.writeTerminal(terminalId, chord)
+            return
+          }
+        }
+      }
+
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'i') {
         e.preventDefault()
         toggleMode()

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -402,13 +402,15 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Interrupts belong to the running command, not to this input.
-      if (e.ctrlKey && !e.metaKey && !e.altKey) {
+      // Interrupts belong to the running command, not to this input. Shift is
+      // excluded because Ctrl+Shift+C is the terminal's copy chord, which it
+      // swallows even with nothing selected — forwarding it here would
+      // interrupt on a keystroke pressed to copy.
+      if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
         const chord = CONTROL_CHORDS[e.key.toLowerCase()]
         const target = e.currentTarget
         const hasSelection = target.selectionStart !== target.selectionEnd
-        // Copying out of the composer still wins, which is what the terminal
-        // itself does with a selection too.
+        // Copying out of the composer still wins, as it does in the terminal.
         if (chord && !(e.key.toLowerCase() === 'c' && hasSelection)) {
           if (getShellInputState(terminalId) === 'running') {
             e.preventDefault()

--- a/tests/intent-bar.test.tsx
+++ b/tests/intent-bar.test.tsx
@@ -517,6 +517,15 @@ describe('interrupting a running command from the composer', () => {
     expect(pty).not.toHaveBeenCalled()
   })
 
+  it('does not interrupt on the terminal copy chord', async () => {
+    // Ctrl+Shift+C copies in the terminal, which swallows it even with nothing
+    // selected. Forwarding it here would interrupt on a keystroke meant to copy.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key: 'c', ctrlKey: true, shiftKey: true })
+    expect(pty).not.toHaveBeenCalled()
+  })
+
   it('does not treat Cmd+C as an interrupt', async () => {
     // Control characters are Ctrl-based on every platform; on macOS Cmd+C is
     // copy and must stay that way.

--- a/tests/intent-bar.test.tsx
+++ b/tests/intent-bar.test.tsx
@@ -30,6 +30,13 @@ const registryMocks = vi.hoisted(() => ({
 
 vi.mock('../src/renderer/lib/terminal-registry', () => registryMocks)
 
+// What the shell is doing right now decides where a keystroke belongs.
+const shellState = vi.hoisted(() => ({ value: 'prompt' as 'prompt' | 'running' | 'unknown' }))
+vi.mock('../src/renderer/lib/command-blocks', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, getShellInputState: () => shellState.value }
+})
+
 Object.defineProperty(window, 'api', {
   value: {
     writeTerminal: vi.fn()
@@ -435,5 +442,96 @@ describe('IntentBar intent modes', () => {
       await new Promise((r) => setTimeout(r, 120))
     })
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})
+
+describe('interrupting a running command from the composer', () => {
+  /**
+   * Submitting leaves focus in the composer, so without this the textarea
+   * swallows Ctrl+C and a running command cannot be stopped without first
+   * clicking into the terminal.
+   */
+  /** The known-command set loads asynchronously; let it settle. */
+  async function ready() {
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+  }
+
+  // Earlier tests replace window.api wholesale, so the module-level handle to
+  // writeTerminal goes stale. Install a fresh one per test and assert on that.
+  let pty: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    resetCommandHistoryCache()
+    seedStore()
+    pty = vi.fn()
+    // Assigned, not redefined: the module-level definition is not configurable.
+    window.api = { writeTerminal: pty } as unknown as typeof window.api
+    shellState.value = 'running'
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    shellState.value = 'prompt'
+  })
+
+  it('sends SIGINT to the pty', async () => {
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key: 'c', ctrlKey: true })
+    expect(pty).toHaveBeenCalledWith('term-1', '\x03')
+  })
+
+  it.each([
+    ['d', '\x04'],
+    ['z', '\x1a'],
+    ['\\', '\x1c']
+  ])('forwards Ctrl+%s', async (key, byte) => {
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key, ctrlKey: true })
+    expect(pty).toHaveBeenCalledWith('term-1', byte)
+  })
+
+  it('leaves the typed text alone', async () => {
+    // The command being interrupted is not the one being composed.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    const input = getInput()
+    fireEvent.change(input, { target: { value: 'next command' } })
+    fireEvent.keyDown(input, { key: 'c', ctrlKey: true })
+    expect(input.value).toBe('next command')
+  })
+
+  it('copies instead of interrupting when text is selected', async () => {
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    const input = getInput()
+    fireEvent.change(input, { target: { value: 'git status' } })
+    input.setSelectionRange(0, 3)
+    fireEvent.keyDown(input, { key: 'c', ctrlKey: true })
+    expect(pty).not.toHaveBeenCalled()
+  })
+
+  it('does not treat Cmd+C as an interrupt', async () => {
+    // Control characters are Ctrl-based on every platform; on macOS Cmd+C is
+    // copy and must stay that way.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key: 'c', metaKey: true })
+    expect(pty).not.toHaveBeenCalled()
+  })
+
+  it('stays out of the way while the shell waits at its prompt', async () => {
+    // Nothing is running, so Ctrl+C belongs to the composer.
+    shellState.value = 'prompt'
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key: 'c', ctrlKey: true })
+    expect(pty).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Submitting a command from the composer leaves focus in the textarea, and the textarea swallowed every control chord. A running command could not be interrupted without first clicking into the terminal or pressing Escape.

```
type `sleep 100` in the composer → Enter → command runs → press Ctrl+C
→ browser treats it as copy-in-a-textarea with no selection → nothing reaches the pty
```

In block mode the composer is the primary input, so this was the common path rather than an edge case.

## What changed

The chords are forwarded to the pty while the shell reports a command running: SIGINT `\x03`, EOF `\x04`, SIGTSTP `\x1a`, SIGQUIT `\x1c`.

Ctrl, never Cmd — control characters are Ctrl-based on every platform, and on macOS Cmd+C is copy.

A selection in the composer still copies rather than interrupting, which is what the terminal path already does with a selection. At the prompt nothing is forwarded: there is no command to interrupt, and the keystroke belongs to what is being typed.

## What was already right

Input routing is a state machine rather than a blanket block, and the rest of it was correct:

- `attachCustomKeyEventHandler` only intercepts `metaKey` on macOS, so Ctrl+C passes through to xterm as `\x03`. On Windows and Linux it copies only with a selection or Shift held, and otherwise falls through to SIGINT.
- The redirect that sends plain typing into the composer returns early on `metaKey || ctrlKey`, so a chord aimed at the terminal was never captured, and it only fires when the shell reports a prompt — a running command keeps raw input.

The gap was only the composer-focused case, which is what this fixes.