### PR TITLE
fix(workflows): headless runs hang forever on Windows, blocking every later run

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -165,10 +165,11 @@ export interface HeadlessSpawnArgs {
   args: string[]
   /**
    * When set, the prompt should be written to the child's stdin rather than
-   * passed as a command-line argument. Used for agents that read their prompt
-   * from stdin (claude) so a multi-line prompt survives intact on Windows,
-   * where `spawn(..., { shell: true })` word-splits and line-breaks unquoted
-   * argv on the cmd.exe command line. See buildHeadlessSpawnArgs.
+   * passed as a command-line argument. Every supported agent reads its prompt
+   * this way, so a multi-line prompt survives intact on Windows — there,
+   * `spawn(..., { shell: true })` word-splits unquoted argv on the cmd.exe
+   * command line, and a literal newline cannot be carried by it at all,
+   * quoted or not. See buildHeadlessSpawnArgs.
    */
   stdin?: string
 }
@@ -216,13 +217,44 @@ export function buildHeadlessSpawnArgs(
         ? { command: cmd.command, args: [...extraArgs, '-p'], stdin: prompt }
         : { command: cmd.command, args: [...extraArgs, '-p', ''] }
     case 'copilot':
-      return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
+      // `copilot` reads the prompt from stdin when `-p` is absent ("Run in an
+      // interactive terminal or provide a prompt with -p or via standard in").
+      // Deliver it there so the workflow prompt — always multi-line — never
+      // reaches the cmd.exe command line, which cannot carry a literal newline.
+      //
+      // Passing it as `-p` on Windows left copilot with a truncated value or
+      // none at all, and with no prompt it blocks on stdin producing no output
+      // whatsoever: the step never finished and its run never closed.
+      return prompt
+        ? { command: cmd.command, args: [...extraArgs], stdin: prompt }
+        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
     case 'codex':
-      return { command: cmd.command, args: [...extraArgs, 'exec', prompt] }
+      // `codex exec` reads its instructions from stdin when no PROMPT argument
+      // is given. Passing the prompt positionally instead would also work on
+      // POSIX, but on Windows it goes through the cmd.exe command line, which
+      // truncates it at the first newline. Note the prompt must NOT also be
+      // passed as an argument — codex then treats stdin as a separate
+      // `<stdin>` block rather than as the instructions.
+      return prompt
+        ? { command: cmd.command, args: [...extraArgs, 'exec'], stdin: prompt }
+        : { command: cmd.command, args: [...extraArgs, 'exec', ''] }
     case 'opencode':
-      return { command: cmd.command, args: [...extraArgs, 'run', prompt] }
+      // `opencode run` with no positional message reads the message from stdin.
+      return prompt
+        ? { command: cmd.command, args: [...extraArgs, 'run'], stdin: prompt }
+        : { command: cmd.command, args: [...extraArgs, 'run', ''] }
     case 'gemini':
-      return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
+      // gemini reads stdin whenever stdin isn't a TTY and uses it as the input
+      // when no `-p` is given (`input = input ? stdin + input : stdin`). Piped
+      // stdio also puts it in headless mode on its own, so `-p` isn't needed to
+      // stop it going interactive.
+      //
+      // Caveat: under gemini's own sandbox (GEMINI_SANDBOX), it reads stdin and
+      // re-injects it as `--prompt` on the relaunch command line — which would
+      // reintroduce the newline truncation. Vorn doesn't enable that sandbox.
+      return prompt
+        ? { command: cmd.command, args: [...extraArgs], stdin: prompt }
+        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
     default:
       return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
   }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -9,6 +9,7 @@ import {
   ProjectConfig,
   WorkflowDefinition,
   WorkflowExecution,
+  workflowRunId,
   NodeExecutionState,
   AgentCommandConfig,
   RemoteHost,
@@ -2108,20 +2109,20 @@ const MAX_WORKFLOW_RUNS = 50
 export function saveWorkflowRun(execution: WorkflowExecution): void {
   const d = getDb()
 
+  const runId = workflowRunId(execution)
+
   const run = d.transaction(() => {
     d.prepare(
       `INSERT OR REPLACE INTO workflow_runs (id, workflow_id, started_at, completed_at, status, trigger_task_id)
        VALUES (?, ?, ?, ?, ?, ?)`
     ).run(
-      execution.workflowId + ':' + execution.startedAt,
+      runId,
       execution.workflowId,
       execution.startedAt,
       execution.completedAt ?? null,
       execution.status,
       execution.triggerTaskId ?? null
     )
-
-    const runId = execution.workflowId + ':' + execution.startedAt
 
     // Delete existing nodes for this run (for upsert behavior)
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
@@ -2236,6 +2237,7 @@ function mapRunRows(
   nodesByRun: Map<string, NodeExecutionState[]>
 ): (WorkflowExecution & { workflowName?: string })[] {
   return rows.map((r) => ({
+    runId: r.id,
     workflowId: r.workflow_id,
     startedAt: r.started_at,
     ...(r.completed_at != null && { completedAt: r.completed_at }),

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -5,6 +5,7 @@ import { headlessManager } from './headless-manager'
 import { configManager } from './config-manager'
 import { sessionManager } from './session-persistence'
 import { scheduler } from './scheduler'
+import { claimWorkflowRun, releaseWorkflowRun, type RunClaimRequest } from './workflow-run-claims'
 import { scheduleLogManager } from './schedule-log'
 import { getRecentSessions } from './agent-history'
 import { detectIDEs, openInIDE } from './ide-detector'
@@ -556,12 +557,16 @@ export function registerAllMethods(): void {
       workflowId: string
       workflowName: string
       completedAt: string
-      status: 'success' | 'error'
+      status: 'success' | 'error' | 'cancelled'
       sessionsLaunched: number
       source?: 'scheduler' | 'manual'
     }) => {
-      if (data.status !== 'success' && data.status !== 'error') return
-      if (data.source === 'scheduler') {
+      if (data.status !== 'success' && data.status !== 'error' && data.status !== 'cancelled') {
+        return
+      }
+      // A run the user stopped isn't a schedule outcome — it still updates the
+      // workflow's last-run badge, but it would misreport the schedule's health.
+      if (data.source === 'scheduler' && data.status !== 'cancelled') {
         scheduleLogManager.addEntry({
           workflowId: data.workflowId,
           workflowName: data.workflowName,
@@ -679,6 +684,18 @@ export function registerAllMethods(): void {
   registerMethod('workflow:runManual', ({ workflowId }) => {
     scheduler.triggerWorkflow(workflowId)
   })
+
+  // Runs execute in the renderer, but a scheduler tick reaches every connected
+  // instance. Claiming here — in the one process they all share — is what stops
+  // two open windows from launching the same agents twice.
+  registerMethod('workflowRun:claim', (req: RunClaimRequest) => claimWorkflowRun(req))
+
+  registerMethod(
+    'workflowRun:release',
+    ({ workflowId, params, runId }: { workflowId: string; params?: string; runId: string }) => {
+      releaseWorkflowRun(workflowId, params, runId)
+    }
+  )
 
   registerMethod('credentials:setDecrypted', ({ connectionId, fields }) => {
     setDecryptedCreds(connectionId, fields)

--- a/packages/server/src/workflow-run-claims.ts
+++ b/packages/server/src/workflow-run-claims.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto'
+import log from './logger'
+
+/**
+ * Which app instance may run a given workflow trigger.
+ *
+ * Workflow steps execute in the renderer, but every instance connects to this
+ * one core, and core broadcasts a scheduler tick to *all* of them. Two open
+ * windows therefore each see the same tick and would each launch the same
+ * agents. The renderer asks here first: exactly one claim is granted per
+ * (workflow, trigger parameters) inside the dedupe window, and the losers stand
+ * down.
+ *
+ * Identity deliberately includes the trigger parameters. A connector poll fans
+ * out one run per new item — same workflow, different item — and those are
+ * genuinely different work that should proceed in parallel. Only a true
+ * double-fire, the same workflow with the same parameters at the same moment,
+ * collapses into one run.
+ *
+ * Claims lapse on their own, so an instance that disappears mid-run never wedges
+ * the workflow the way a lock held until release would.
+ */
+
+/** Long enough to swallow one tick seen by several instances, short enough that
+ *  a deliberate re-run moments later still goes through. */
+export const DEFAULT_DEDUPE_WINDOW_MS = 10_000
+
+export interface RunClaimRequest {
+  workflowId: string
+  /** Trigger parameters fingerprint — connector item id, task id, or 'manual'. */
+  params?: string
+  windowMs?: number
+}
+
+export interface RunClaimResult {
+  /** False when another instance already owns this exact trigger. */
+  granted: boolean
+  /** The winning run's id — this instance's when granted, the holder's when not. */
+  runId: string
+}
+
+interface HeldClaim {
+  runId: string
+  claimedAt: number
+  windowMs: number
+}
+
+const claims = new Map<string, HeldClaim>()
+
+function claimKey(workflowId: string, params: string): string {
+  // Encoded rather than concatenated: a fingerprint carries arbitrary upstream
+  // text, and any separator character it happened to contain would let two
+  // distinct pairs collide on one key.
+  return JSON.stringify([workflowId, params])
+}
+
+/** Drop lapsed entries so a long-lived core doesn't accumulate dead claims. */
+function evictLapsed(now: number): void {
+  for (const [key, held] of claims) {
+    if (now - held.claimedAt >= held.windowMs) claims.delete(key)
+  }
+}
+
+export function claimWorkflowRun(req: RunClaimRequest): RunClaimResult {
+  const params = req.params || 'manual'
+  const windowMs = req.windowMs ?? DEFAULT_DEDUPE_WINDOW_MS
+  const now = Date.now()
+  const key = claimKey(req.workflowId, params)
+
+  evictLapsed(now)
+
+  const held = claims.get(key)
+  if (held) {
+    log.info(
+      `[workflow-claims] duplicate trigger for ${req.workflowId} (params=${params}) — deferring to run ${held.runId}`
+    )
+    return { granted: false, runId: held.runId }
+  }
+
+  const runId = crypto.randomUUID()
+  claims.set(key, { runId, claimedAt: now, windowMs })
+  return { granted: true, runId }
+}
+
+/**
+ * Give up a claim early, so re-running the same trigger doesn't have to wait out
+ * the window. Only the holder may release it — a late release from a superseded
+ * run must not clear the claim its successor now owns.
+ */
+export function releaseWorkflowRun(
+  workflowId: string,
+  params: string | undefined,
+  runId: string
+): void {
+  const key = claimKey(workflowId, params || 'manual')
+  if (claims.get(key)?.runId === runId) claims.delete(key)
+}
+
+/** Test seam — the registry is process-global otherwise. */
+export function resetWorkflowRunClaims(): void {
+  claims.clear()
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -522,6 +522,13 @@ export interface LaunchAgentConfig {
    * whose output can't be parsed/validated is marked `error`.
    */
   outputSchema?: Record<string, unknown>
+  /**
+   * How long a headless step may run before the engine gives up on it, in
+   * milliseconds. On expiry the agent is killed, the node is marked `error`,
+   * and the run finishes — so one agent that never exits can't hold its run
+   * open forever. Unset falls back to `defaults.headlessStepTimeoutMinutes`.
+   */
+  timeoutMs?: number
 }
 
 export interface ScriptConfig {
@@ -675,12 +682,37 @@ export interface WorkflowDefinition {
 }
 
 export interface WorkflowExecution {
+  /**
+   * Identity of this run, unique across every run of every workflow. A workflow
+   * can have several runs in flight at once (connector fan-out gives one run per
+   * item), so `workflowId` alone does not identify a run.
+   *
+   * Runs written before this field existed are keyed `<workflowId>:<startedAt>`;
+   * that remains the fallback when reading them back, so old history still loads.
+   */
+  runId: string
   workflowId: string
   startedAt: string
   completedAt?: string
-  status: 'running' | 'success' | 'error'
+  status: 'running' | 'success' | 'error' | 'cancelled'
   nodeStates: NodeExecutionState[]
   triggerTaskId?: string
+  /**
+   * What this run was triggered *with* — a connector item id, a task id, or
+   * `'manual'`. Two runs of one workflow are duplicates only when this matches
+   * as well, which is what lets fan-out run in parallel while a double-fire
+   * (two app instances, one scheduler tick) collapses to a single run.
+   */
+  dedupeParams?: string
+}
+
+/** Stable identity for a run row, tolerating history written before `runId`. */
+export function workflowRunId(execution: {
+  runId?: string
+  workflowId: string
+  startedAt: string
+}): string {
+  return execution.runId || `${execution.workflowId}:${execution.startedAt}`
 }
 
 // ─── Tailscale Network Access ────────────────────────────────────
@@ -736,6 +768,12 @@ export interface AppConfig {
     networkAccessEnabled?: boolean
     showHeadlessAgents?: boolean
     headlessRetentionMinutes?: number
+    /**
+     * Ceiling on a headless workflow step, in minutes, for steps that don't set
+     * their own timeout. Guards against an agent that starts but never exits —
+     * without it the step waits forever and its run never closes. 0 disables it.
+     */
+    headlessStepTimeoutMinutes?: number
     enableHoverPreview?: boolean
     /**
      * Shell sessions only. Replaces the shell's own prompt with a single
@@ -973,6 +1011,8 @@ export const IPC = {
   WORKFLOW_RUN_LIST_WAITING: 'workflowRun:listWaiting',
   WORKFLOW_RUN_LIST_RUNNING: 'workflowRun:listRunning',
   WORKFLOW_RUN_LIST_ALL: 'workflowRun:listAll',
+  WORKFLOW_RUN_CLAIM: 'workflowRun:claim',
+  WORKFLOW_RUN_RELEASE: 'workflowRun:release',
   SESSION_EVENT_LIST: 'sessionEvent:list',
   SESSION_EVENT_LIST_BY_SESSION: 'sessionEvent:listBySession',
   AGENT_DETECT_INSTALLED: 'agent:detectInstalled',

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -135,6 +135,12 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.WORKFLOW_RUN_LIST_RUNNING, () =>
     requireBridge().request(IPC.WORKFLOW_RUN_LIST_RUNNING, {})
   )
+  safeHandle(IPC.WORKFLOW_RUN_CLAIM, (_, req) =>
+    requireBridge().request(IPC.WORKFLOW_RUN_CLAIM, req)
+  )
+  safeHandle(IPC.WORKFLOW_RUN_RELEASE, (_, req) =>
+    requireBridge().request(IPC.WORKFLOW_RUN_RELEASE, req)
+  )
 
   // Session events
   safeHandle(IPC.SESSION_EVENT_LIST_BY_SESSION, (_, sessionId, limit) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -386,10 +386,28 @@ const api = {
     workflowId: string
     workflowName: string
     completedAt: string
-    status: 'success' | 'error'
+    status: 'success' | 'error' | 'cancelled'
     sessionsLaunched: number
     source?: 'scheduler' | 'manual'
   }): Promise<void> => ipcRenderer.invoke(IPC.WORKFLOW_EXECUTION_COMPLETE, data),
+
+  /**
+   * Ask the core for the right to run this trigger. Every instance shares one
+   * core, so this is where a tick broadcast to several windows collapses into
+   * a single run. Returns the run id to use when granted.
+   */
+  claimWorkflowRun: (req: {
+    workflowId: string
+    params?: string
+    windowMs?: number
+  }): Promise<{ granted: boolean; runId: string }> =>
+    ipcRenderer.invoke(IPC.WORKFLOW_RUN_CLAIM, req),
+
+  releaseWorkflowRun: (req: {
+    workflowId: string
+    params?: string
+    runId: string
+  }): Promise<void> => ipcRenderer.invoke(IPC.WORKFLOW_RUN_RELEASE, req),
 
   // Credential vault
   storeSSHKey: (params: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -377,8 +377,8 @@ export function App() {
         const store = useAppStore.getState()
         const hydrated: WorkflowExecution[] = []
         for (const run of runs) {
-          if (store.workflowExecutions.has(run.workflowId)) continue
-          store.setWorkflowExecution(run.workflowId, run)
+          if (store.workflowExecutions.has(run.runId)) continue
+          store.setWorkflowExecution(run.runId, run)
           hydrated.push(run)
         }
         rescheduleWaitingGateTimers(hydrated, store.config?.workflows ?? [])
@@ -394,8 +394,8 @@ export function App() {
       .then((runs) => {
         const store = useAppStore.getState()
         for (const run of runs) {
-          if (!store.workflowExecutions.has(run.workflowId)) {
-            store.setWorkflowExecution(run.workflowId, run)
+          if (!store.workflowExecutions.has(run.runId)) {
+            store.setWorkflowExecution(run.runId, run)
           }
         }
         return reconcileRunningExecutions(runs)

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -56,9 +56,14 @@ export function WorkflowItem({
   const WfIcon = ICON_MAP[workflow.icon] || Workflow
   const isScheduled = isScheduledWorkflow(workflow)
   const isDisabled = isScheduled && !workflow.enabled
+  // Any run of this workflow, not just the newest — parallel runs mean the
+  // gate that needs attention may not be the most recent one.
   const hasWaitingGate = useAppStore((s) => {
-    const exec = s.workflowExecutions.get(workflow.id)
-    return exec ? exec.nodeStates.some((ns) => ns.status === 'waiting') : false
+    for (const exec of s.workflowExecutions.values()) {
+      if (exec.workflowId !== workflow.id) continue
+      if (exec.nodeStates.some((ns) => ns.status === 'waiting')) return true
+    }
+    return false
   })
   const dot = statusDotColor(workflow, isScheduled, hasWaitingGate)
 

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -8,6 +8,7 @@ import { isElectron } from '../../lib/platform'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
 import { ToggleSwitch } from './ToggleSwitch'
+import { DEFAULT_STEP_TIMEOUT_MINUTES } from '../../lib/workflow-execution'
 
 export function GeneralSettings() {
   const config = useAppStore((s) => s.config)
@@ -164,6 +165,26 @@ export function GeneralSettings() {
             </select>
           </SettingRow>
         )}
+
+        {/* Workflow Step Timeout */}
+        <SettingRow
+          label="Workflow Step Timeout"
+          description="How long a headless workflow step may run before its agent is killed and the step fails. Individual steps can override this."
+        >
+          <select
+            value={config.defaults.headlessStepTimeoutMinutes ?? DEFAULT_STEP_TIMEOUT_MINUTES}
+            onChange={(e) => updateDefaults({ headlessStepTimeoutMinutes: +e.target.value })}
+            className="w-32 px-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-md text-sm
+                       text-gray-200 focus:border-white/[0.15] focus:outline-none"
+          >
+            <option value={15}>15 minutes</option>
+            <option value={30}>30 minutes</option>
+            <option value={60}>1 hour</option>
+            <option value={120}>2 hours</option>
+            <option value={360}>6 hours</option>
+            <option value={0}>No limit</option>
+          </select>
+        </SettingRow>
 
         {/* Update Channel — Electron only */}
         {isElectron && (

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -14,6 +14,7 @@ import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import { STATUS_DOT_CLASSES as SHARED_STATUS_DOTS } from './statusDot'
 import { Tooltip } from '../Tooltip'
 import { approveWorkflowGate, rejectWorkflowGate } from '../../lib/workflow-execution'
+import { StopRunButton } from '../workflow-runs/StopRunButton'
 
 const STATUS_LABELS: Record<WorkflowExecution['status'] | NodeExecutionState['status'], string> = {
   success: 'Success',
@@ -21,7 +22,8 @@ const STATUS_LABELS: Record<WorkflowExecution['status'] | NodeExecutionState['st
   running: 'Running',
   pending: 'Pending',
   skipped: 'Skipped',
-  waiting: 'Waiting for approval'
+  waiting: 'Waiting for approval',
+  cancelled: 'Stopped'
 }
 
 export function StatusDot({
@@ -319,37 +321,43 @@ export function RunEntry({
 
   return (
     <div className="border border-white/[0.08] rounded-md overflow-hidden">
-      {/* Run header */}
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-white/[0.04] transition-colors"
-      >
-        {expanded ? (
-          <ChevronDown size={12} className="text-gray-500" />
-        ) : (
-          <ChevronRight size={12} className="text-gray-500" />
-        )}
-        <StatusDot status={execution.status} />
-        <span className="text-[12px] text-gray-300 flex-1 min-w-0 truncate">
-          {workflowName && <span className="text-gray-500 mr-1.5">{workflowName}</span>}
-          {formatRelativeTime(execution.startedAt)}
-        </span>
-        {triggerTask && (
-          <span
-            className="text-[10px] px-1.5 py-0.5 bg-violet-500/10 border border-violet-500/20 rounded text-violet-400 truncate max-w-[100px] shrink-0 cursor-pointer hover:bg-violet-500/20 transition-colors"
-            onClick={(e) => {
-              e.stopPropagation()
-              onClickTask?.(triggerTask.id)
-            }}
-            title={triggerTask.title}
-          >
-            {triggerTask.title}
+      {/* Run header — the toggle and the stop control are siblings so the
+          stop button isn't nested inside the row's button. */}
+      <div className="flex items-center hover:bg-white/[0.04] transition-colors">
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2.5 text-left"
+        >
+          {expanded ? (
+            <ChevronDown size={12} className="text-gray-500" />
+          ) : (
+            <ChevronRight size={12} className="text-gray-500" />
+          )}
+          <StatusDot status={execution.status} />
+          <span className="text-[12px] text-gray-300 flex-1 min-w-0 truncate">
+            {workflowName && <span className="text-gray-500 mr-1.5">{workflowName}</span>}
+            {formatRelativeTime(execution.startedAt)}
           </span>
-        )}
-        <span className="text-[11px] text-gray-500 shrink-0">
-          {formatRunDuration(execution.startedAt, execution.completedAt)}
+          {triggerTask && (
+            <span
+              className="text-[10px] px-1.5 py-0.5 bg-violet-500/10 border border-violet-500/20 rounded text-violet-400 truncate max-w-[100px] shrink-0 cursor-pointer hover:bg-violet-500/20 transition-colors"
+              onClick={(e) => {
+                e.stopPropagation()
+                onClickTask?.(triggerTask.id)
+              }}
+              title={triggerTask.title}
+            >
+              {triggerTask.title}
+            </span>
+          )}
+          <span className="text-[11px] text-gray-500 shrink-0">
+            {formatRunDuration(execution.startedAt, execution.completedAt)}
+          </span>
+        </button>
+        <span className="pr-2 shrink-0">
+          <StopRunButton execution={execution} stopPropagation={false} />
         </span>
-      </button>
+      </div>
 
       {expanded && (
         <RunStepsList

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -208,13 +208,19 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   // scalars avoids refetching on every streaming log chunk.
   const liveExecSignature = useAppStore((s) => {
     if (!editingId) return ''
-    const exec = s.workflowExecutions.get(editingId)
-    if (!exec) return ''
-    const waiting = (exec.nodeStates ?? [])
-      .filter((n) => n.status === 'waiting')
-      .map((n) => n.nodeId)
-      .join(',')
-    return `${exec.status ?? ''}|${exec.completedAt ?? ''}|${waiting}`
+    // Folds in every live run of this workflow: with runs in parallel, any of
+    // them changing status or parking on a gate should re-query.
+    const parts: string[] = []
+    for (const exec of s.workflowExecutions.values()) {
+      if (exec.workflowId !== editingId) continue
+      const waiting = (exec.nodeStates ?? [])
+        .filter((n) => n.status === 'waiting')
+        .map((n) => n.nodeId)
+        .join(',')
+      parts.push(`${exec.runId}|${exec.status ?? ''}|${exec.completedAt ?? ''}|${waiting}`)
+    }
+    parts.sort()
+    return parts.join(';')
   })
   useEffect(() => {
     if (!editingId || !isActive || !liveExecSignature) return

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -15,6 +15,7 @@ import {
   isContextRef
 } from '../../../lib/template-vars'
 import { getWorktreeMode } from '../../../lib/workflow-helpers'
+import { DEFAULT_STEP_TIMEOUT_MINUTES } from '../../../lib/workflow-execution'
 import { useAgentInstallStatus } from '../../../hooks/useAgentInstallStatus'
 import { VariableAutocomplete } from './VariableAutocomplete'
 import { ProjectPicker } from '../../ProjectPicker'
@@ -118,6 +119,9 @@ export function LaunchAgentConfigForm({
   const isHeadless = !!config.headless
   const canUseFromTask = isTaskTrigger || promptSource === 'task' || promptSource === 'queue'
   const defaultAgentFallback = useAppStore((s) => s.config?.defaults.defaultAgent) ?? 'claude'
+  const defaultTimeoutMinutes =
+    useAppStore((s) => s.config?.defaults.headlessStepTimeoutMinutes) ??
+    DEFAULT_STEP_TIMEOUT_MINUTES
 
   useEffect(() => {
     if (!canUseFromTask && config.agentType === 'fromTask') {
@@ -461,6 +465,43 @@ export function LaunchAgentConfigForm({
             value={config.outputSchema}
             onChange={(schema) => onChange({ ...config, outputSchema: schema })}
           />
+        )}
+
+        {isHeadless && (
+          <div>
+            <label className="text-[13px] text-gray-400 font-medium block mb-2">Timeout</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={
+                  typeof config.timeoutMs === 'number'
+                    ? String(Math.round(config.timeoutMs / 60_000))
+                    : ''
+                }
+                onChange={(e) => {
+                  const raw = e.target.value.trim()
+                  if (raw === '') {
+                    onChange({ ...config, timeoutMs: undefined })
+                    return
+                  }
+                  const minutes = Number(raw)
+                  if (!Number.isFinite(minutes) || minutes < 0) return
+                  onChange({ ...config, timeoutMs: Math.round(minutes) * 60_000 })
+                }}
+                placeholder={String(defaultTimeoutMinutes)}
+                className="w-24 px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md
+                           text-white placeholder:text-gray-600 focus:outline-none focus:border-white/[0.2]"
+              />
+              <span className="text-[12px] text-gray-500">minutes</span>
+            </div>
+            <p className="text-[11px] text-gray-500 mt-1.5">
+              {config.timeoutMs === 0
+                ? 'No limit. A step whose agent never exits keeps its run open indefinitely.'
+                : `Kills the agent and fails the step if it hasn't exited by then, so one stuck agent can't hold the run open. Blank uses the ${defaultTimeoutMinutes}-minute default; 0 means no limit.`}
+            </p>
+          </div>
         )}
       </div>
 

--- a/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 import { X } from 'lucide-react'
-import { WorkflowExecution, WorkflowNode, TaskConfig, AiAgentType } from '../../../../shared/types'
+import {
+  workflowRunId,
+  WorkflowExecution,
+  WorkflowNode,
+  TaskConfig,
+  AiAgentType
+} from '../../../../shared/types'
 import { RunEntry } from '../RunEntry'
 import { LogReplayModal } from '../../LogReplayModal'
 
@@ -47,9 +53,9 @@ export function RunHistoryPanel({
           {executions.length === 0 ? (
             <p className="text-[12px] text-gray-600 text-center py-8">No runs yet</p>
           ) : (
-            executions.map((exec, i) => (
+            executions.map((exec) => (
               <RunEntry
-                key={`${exec.workflowId}-${exec.startedAt}-${i}`}
+                key={workflowRunId(exec)}
                 execution={exec}
                 nodes={nodes}
                 tasks={tasks}

--- a/src/renderer/components/workflow-editor/statusDot.ts
+++ b/src/renderer/components/workflow-editor/statusDot.ts
@@ -1,15 +1,21 @@
 import type { NodeExecutionStatus } from '../../../shared/types'
 
-export const STATUS_DOT_STATIC: Record<NodeExecutionStatus | 'running', string> = {
+/** Run statuses share the node palette; `cancelled` is run-only. */
+export type StatusDotKey = NodeExecutionStatus | 'running' | 'cancelled'
+
+export const STATUS_DOT_STATIC: Record<StatusDotKey, string> = {
   success: 'bg-green-400',
   error: 'bg-red-500',
   running: 'bg-yellow-400',
   pending: 'bg-gray-600',
   skipped: 'bg-gray-600',
-  waiting: 'bg-amber-400'
+  waiting: 'bg-amber-400',
+  // Stopping a run is a decision, not a failure — grey keeps red for things
+  // that actually broke.
+  cancelled: 'bg-gray-500'
 }
 
-export const STATUS_DOT_CLASSES: Record<NodeExecutionStatus | 'running', string> = {
+export const STATUS_DOT_CLASSES: Record<StatusDotKey, string> = {
   ...STATUS_DOT_STATIC,
   running: `${STATUS_DOT_STATIC.running} animate-pulse`,
   waiting: `${STATUS_DOT_STATIC.waiting} animate-pulse`

--- a/src/renderer/components/workflow-runs/AllRunsTable.tsx
+++ b/src/renderer/components/workflow-runs/AllRunsTable.tsx
@@ -4,7 +4,13 @@ import { useAppStore } from '../../stores'
 import { formatRelativeTime, formatCompactDuration } from '../../lib/format-time'
 import { StatusDot, NodeLabel, RunStepsList } from '../workflow-editor/RunEntry'
 import { LogReplayModal } from '../LogReplayModal'
-import type { NodeExecutionState, WorkflowExecution, WorkflowNode } from '../../../shared/types'
+import { StopRunButton } from './StopRunButton'
+import {
+  workflowRunId,
+  type NodeExecutionState,
+  type WorkflowExecution,
+  type WorkflowNode
+} from '../../../shared/types'
 import type { RunListEntry } from '../../hooks/useAllWorkflowRuns'
 import type { RunBucket } from '../../stores/types'
 
@@ -89,7 +95,7 @@ export function AllRunsTable({ runs, workflowsById, filter }: Props) {
           <div className="text-center py-10 text-gray-600 text-[12px]">No runs to show</div>
         ) : (
           visible.map(({ run, bucket, last }) => {
-            const id = `${run.workflowId}-${run.startedAt}`
+            const id = workflowRunId(run)
             const expanded = expandedId === id
             const wf = workflowsById.get(run.workflowId)
             const wfNodes = wf?.nodes ?? []
@@ -168,7 +174,8 @@ export function AllRunsTable({ runs, workflowsById, filter }: Props) {
                 {expanded && (
                   <div className="bg-[#141416] border-b border-white/[0.04]">
                     <RunStepsList execution={run} nodes={wfNodes} onViewFullOutput={setLogModal} />
-                    <div className="px-4 py-2 flex items-center justify-end">
+                    <div className="px-4 py-2 flex items-center justify-end gap-2">
+                      <StopRunButton execution={run} />
                       <button
                         type="button"
                         disabled={isDeleted}

--- a/src/renderer/components/workflow-runs/StopRunButton.tsx
+++ b/src/renderer/components/workflow-runs/StopRunButton.tsx
@@ -28,6 +28,14 @@ export function StopRunButton({ execution, stopPropagation = true }: Props) {
     setStopping(true)
     try {
       await stopWorkflowRun(execution.runId)
+    } catch (err) {
+      // An async click handler that throws becomes an unhandled rejection and
+      // the run silently appears not to stop. Say so instead.
+      console.error(`[workflow] failed to stop run ${execution.runId}`, err)
+      // Imported here rather than at the top so a leaf button does not pull the
+      // toast system into the module graph of every run row that renders it.
+      const { toast } = await import('../Toast')
+      toast.error('Could not stop the run')
     } finally {
       setStopping(false)
     }

--- a/src/renderer/components/workflow-runs/StopRunButton.tsx
+++ b/src/renderer/components/workflow-runs/StopRunButton.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Square } from 'lucide-react'
+import { Tooltip } from '../Tooltip'
+import { isRunStoppable, stopWorkflowRun } from '../../lib/workflow-execution'
+import type { WorkflowExecution } from '../../../shared/types'
+
+interface Props {
+  execution: WorkflowExecution
+  /** Sits inside a clickable row; stops the click reaching it. */
+  stopPropagation?: boolean
+}
+
+/**
+ * Ends a run that is still going: kills the agents it launched and closes it as
+ * stopped. Worktrees stay on disk, so whatever the agents managed to do is
+ * still there to look at.
+ *
+ * Renders nothing once the run is finished — there is nothing left to stop.
+ */
+export function StopRunButton({ execution, stopPropagation = true }: Props) {
+  const [stopping, setStopping] = useState(false)
+
+  if (!isRunStoppable(execution)) return null
+
+  const handleClick = async (e: React.MouseEvent): Promise<void> => {
+    if (stopPropagation) e.stopPropagation()
+    if (stopping) return
+    setStopping(true)
+    try {
+      await stopWorkflowRun(execution.runId)
+    } finally {
+      setStopping(false)
+    }
+  }
+
+  return (
+    <Tooltip label={stopping ? 'Stopping run' : 'Stop run'}>
+      <button
+        type="button"
+        aria-label="Stop run"
+        disabled={stopping}
+        onClick={handleClick}
+        className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06]
+                   transition-colors disabled:opacity-40 disabled:cursor-not-allowed
+                   disabled:hover:bg-transparent disabled:hover:text-gray-500"
+      >
+        <Square size={11} strokeWidth={2.5} />
+      </button>
+    </Tooltip>
+  )
+}

--- a/src/renderer/hooks/useAllWorkflowRuns.ts
+++ b/src/renderer/hooks/useAllWorkflowRuns.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { useAppStore } from '../stores'
-import type { WorkflowExecution } from '../../shared/types'
+import { workflowRunId, type WorkflowExecution } from '../../shared/types'
 
 export type RunListEntry = WorkflowExecution & { workflowName?: string }
 
@@ -43,6 +43,7 @@ export function useAllWorkflowRuns(limit = 50): {
   }, [activeWorkspace, limit, beginLoad, endLoad])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: fetches the run snapshot on mount and whenever the workspace or reload token changes
     void reload()
   }, [reload, reloadToken])
 
@@ -67,20 +68,23 @@ export function useAllWorkflowRuns(limit = 50): {
 
   const runs = useMemo<RunListEntry[]>(() => {
     const out: RunListEntry[] = []
-    const live = new Map<string, WorkflowExecution>()
-    for (const [wfId, exec] of workflowExecutions) live.set(wfId, exec)
+    // Keyed by run: several runs of one workflow can be in flight at once, so
+    // matching a snapshot row to "the" live run by workflow id would collapse
+    // them onto each other.
+    const live = new Map<string, WorkflowExecution>(workflowExecutions)
 
     for (const r of persisted) {
-      const liveExec = live.get(r.workflowId)
-      if (liveExec && liveExec.startedAt === r.startedAt) {
+      const key = workflowRunId(r)
+      const liveExec = live.get(key)
+      if (liveExec) {
         out.push({ ...liveExec, workflowName: r.workflowName })
-        live.delete(r.workflowId)
+        live.delete(key)
       } else {
         out.push(r)
       }
     }
-    for (const [wfId, exec] of live) {
-      const wf = workflows?.find((w) => w.id === wfId)
+    for (const exec of live.values()) {
+      const wf = workflows?.find((w) => w.id === exec.workflowId)
       if (wf && (wf.workspaceId ?? 'personal') !== activeWorkspace) continue
       out.push({ ...exec, workflowName: wf?.name })
     }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -22,7 +22,36 @@ import { extractStructuredOutput } from '../../shared/structured-output'
 import { useAppStore } from '../stores'
 import { sendWorkflowGateNotification } from './notifications'
 
-const runningWorkflows = new Set<string>()
+/**
+ * Runs currently executing in this window, keyed by run id.
+ *
+ * Keyed by *run*, not by workflow: one workflow can have several runs in flight
+ * (a connector poll fans out a run per item), and they must not shoulder each
+ * other out. Duplicate suppression is a separate concern handled by the core's
+ * claim registry, which sees every instance rather than just this window.
+ *
+ * The handle carries what stopping a run needs — the sessions it launched, and
+ * a signal the steps watch so a stop lands promptly rather than at the next
+ * node boundary.
+ */
+interface ActiveRun {
+  runId: string
+  workflowId: string
+  dedupeParams: string
+  abort: AbortController
+  /** Headless sessions this run launched, so Stop can kill them. */
+  sessionIds: Set<string>
+  /**
+   * The very object the engine is driving. The store holds shallow copies, so
+   * stopping via a copy would leave the running execution's own status stale.
+   */
+  execution: WorkflowExecution
+}
+
+const activeRuns = new Map<string, ActiveRun>()
+
+/** Default ceiling for a headless step that never reports an exit. */
+export const DEFAULT_STEP_TIMEOUT_MINUTES = 60
 
 const LOG_BUFFER_MAX = 100_000
 const LOG_BUFFER_KEEP = 80_000
@@ -49,19 +78,20 @@ const PERSIST_INTERVAL_MS = 3000
 /** Cleared on approve/reject so a late timer can't reject an already-resolved gate. */
 const gateTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
-function gateKey(workflowId: string, nodeId: string): string {
-  return `${workflowId}:${nodeId}`
+/** Scoped to the run, not the workflow — parallel runs each have their own gate. */
+function gateKey(runId: string, nodeId: string): string {
+  return `${runId}:${nodeId}`
 }
 
 function scheduleGateTimeout(
-  workflowId: string,
+  runId: string,
   nodeId: string,
   timeoutMs: number | undefined,
   execution: WorkflowExecution,
   elapsedMs = 0
 ): void {
   if (!timeoutMs || timeoutMs <= 0) return
-  const key = gateKey(workflowId, nodeId)
+  const key = gateKey(runId, nodeId)
   const prev = gateTimers.get(key)
   if (prev) clearTimeout(prev)
   const remaining = Math.max(0, timeoutMs - elapsedMs)
@@ -158,7 +188,7 @@ export async function reconcileRunningExecutions(
     }
 
     if (dirty) {
-      useAppStore.getState().setWorkflowExecution(execution.workflowId, { ...execution })
+      useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
       await window.api.saveWorkflowRun(execution)
     }
   }
@@ -184,7 +214,7 @@ export function rescheduleWaitingGateTimers(
       const timeoutMs = (node.config as ApprovalConfig).timeoutMs
       if (!timeoutMs || timeoutMs <= 0) continue
       const startedAt = ns.startedAt ? new Date(ns.startedAt).getTime() : now
-      scheduleGateTimeout(workflow.id, ns.nodeId, timeoutMs, execution, now - startedAt)
+      scheduleGateTimeout(execution.runId, ns.nodeId, timeoutMs, execution, now - startedAt)
     }
   }
 }
@@ -239,9 +269,31 @@ function resolveTaskContext(task: TaskConfig, fallbackBranch?: string, fallbackW
   }
 }
 
-function persistExecution(workflowId: string, execution: WorkflowExecution): void {
-  useAppStore.getState().setWorkflowExecution(workflowId, { ...execution })
+function persistExecution(execution: WorkflowExecution): void {
+  useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
   window.api.saveWorkflowRun(execution)
+}
+
+/**
+ * What this run was triggered *with*. Two runs of one workflow count as the
+ * same trigger only when this matches, which is what lets a connector fan-out
+ * run its items in parallel while a genuine double-fire collapses to one run.
+ */
+function dedupeFingerprint(context?: WorkflowExecutionContext): string {
+  const item = context?.connectorItem
+  if (item) return `item:${item.connectionId}:${item.externalId}`
+  if (context?.task) return `task:${context.task.id}`
+  if (context?.source) return `session:${context.source.id}`
+  return 'manual'
+}
+
+/** Resolved step ceiling: the node's own value, else the configured default. 0 disables. */
+function resolveStepTimeoutMs(config: LaunchAgentConfig): number {
+  if (typeof config.timeoutMs === 'number') return config.timeoutMs
+  const minutes =
+    useAppStore.getState().config?.defaults?.headlessStepTimeoutMinutes ??
+    DEFAULT_STEP_TIMEOUT_MINUTES
+  return minutes > 0 ? minutes * 60_000 : 0
 }
 
 function updateNodeState(
@@ -303,7 +355,8 @@ async function executeNode(
   workflow: WorkflowDefinition,
   execution: WorkflowExecution,
   context?: WorkflowExecutionContext,
-  stepOutputs?: StepOutputs
+  stepOutputs?: StepOutputs,
+  active?: ActiveRun
 ): Promise<void> {
   if (node.type === 'approval') {
     const existing = execution.nodeStates.find((s) => s.nodeId === node.id)
@@ -317,7 +370,7 @@ async function executeNode(
       status: 'waiting',
       startedAt: new Date().toISOString()
     })
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
 
     sendWorkflowGateNotification(
       workflow,
@@ -331,7 +384,7 @@ async function executeNode(
       }
     )
 
-    scheduleGateTimeout(workflow.id, node.id, config.timeoutMs, execution)
+    scheduleGateTimeout(execution.runId, node.id, config.timeoutMs, execution)
     return
   }
 
@@ -339,7 +392,7 @@ async function executeNode(
     status: 'running',
     startedAt: new Date().toISOString()
   })
-  persistExecution(workflow.id, execution)
+  persistExecution(execution)
 
   if (node.type === 'condition') {
     const config = node.config as ConditionConfig
@@ -356,7 +409,7 @@ async function executeNode(
       completedAt: new Date().toISOString(),
       output: String(result)
     })
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
     return
   }
 
@@ -405,7 +458,7 @@ async function executeNode(
     } finally {
       removeScriptDataListener()
     }
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
     return
   }
 
@@ -442,7 +495,7 @@ async function executeNode(
         error: err instanceof Error ? err.message : String(err)
       })
     }
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
     return
   }
 
@@ -455,7 +508,7 @@ async function executeNode(
         completedAt: new Date().toISOString(),
         error: 'No connector item in context — this node only runs from a connectorPoll trigger.'
       })
-      persistExecution(workflow.id, execution)
+      persistExecution(execution)
       return
     }
 
@@ -486,7 +539,7 @@ async function executeNode(
         error: err instanceof Error ? err.message : String(err)
       })
     }
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
     return
   }
 
@@ -659,24 +712,54 @@ async function executeNode(
         if (sessionId && id === sessionId) {
           logs = appendBoundedLog(logs, data)
           updateNodeState(execution, node.id, { logs })
-          useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
+          useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
           schedulePersistLogs()
         }
       }
     )
 
-    let resolveExit: (code: number) => void
-    const exitPromise = new Promise<number>((resolve) => {
-      resolveExit = resolve
+    /**
+     * How the step ends: the agent's exit code, or why we stopped waiting for
+     * one. Waiting on the exit event alone is what wedged runs — an agent that
+     * never exits, or an exit that arrived before we knew our own session id,
+     * left the step pending forever and its run open with it.
+     */
+    type StepOutcome =
+      | { kind: 'exit'; code: number }
+      | { kind: 'timeout'; afterMs: number }
+      | { kind: 'stopped' }
+
+    // Definitely assigned: the Promise executor runs synchronously.
+    let settle!: (outcome: StepOutcome) => void
+    const outcomePromise = new Promise<StepOutcome>((resolve) => {
+      settle = resolve
     })
+
+    /**
+     * Exits seen before `createHeadlessSession` returned. The agent can be dead
+     * before we learn its id — a Windows shim that fails immediately exits in
+     * milliseconds — and an exit dropped there used to be unrecoverable.
+     */
+    const exitsBeforeIdKnown = new Map<string, number>()
 
     const removeExitListener = window.api.onHeadlessExit(
       ({ id, exitCode: code }: { id: string; exitCode: number }) => {
-        if (sessionId && id === sessionId) {
-          resolveExit(code)
+        if (!sessionId) {
+          exitsBeforeIdKnown.set(id, code)
+          return
         }
+        if (id === sessionId) settle({ kind: 'exit', code })
       }
     )
+
+    const timeoutMs = resolveStepTimeoutMs(config)
+    const timeoutTimer =
+      timeoutMs > 0
+        ? setTimeout(() => settle({ kind: 'timeout', afterMs: timeoutMs }), timeoutMs)
+        : null
+
+    const onAbort = (): void => settle({ kind: 'stopped' })
+    active?.abort.signal.addEventListener('abort', onAbort, { once: true })
 
     try {
       const headlessSession = await window.api.createHeadlessSession({
@@ -696,7 +779,13 @@ async function executeNode(
       })
 
       sessionId = headlessSession.id
+      active?.sessionIds.add(headlessSession.id)
       useAppStore.getState().addHeadlessSession(headlessSession)
+
+      // Claim any exit that landed while we were still learning our id.
+      const raced = exitsBeforeIdKnown.get(headlessSession.id)
+      if (raced !== undefined) settle({ kind: 'exit', code: raced })
+      exitsBeforeIdKnown.clear()
 
       updateNodeState(execution, node.id, {
         sessionId: headlessSession.id,
@@ -711,13 +800,43 @@ async function executeNode(
           ? { agentSessionId: headlessSession.agentSessionId }
           : {})
       })
-      persistExecution(workflow.id, execution)
+      persistExecution(execution)
 
       if (resolvedTaskId) {
         useAppStore.getState().startTask(resolvedTaskId, headlessSession.id, effectiveAgent)
       }
 
-      const exitCode = await exitPromise
+      const outcome = await outcomePromise
+
+      // Stopped: stopWorkflowRun owns the node's terminal state and has already
+      // killed the agent. Writing a status here would just fight it.
+      if (outcome.kind === 'stopped') return
+
+      if (outcome.kind === 'timeout') {
+        const minutes = Math.round(outcome.afterMs / 60_000)
+        const reason = `Step timed out after ${minutes} minute${minutes === 1 ? '' : 's'} without the agent exiting`
+        console.warn(
+          `[workflow] "${node.label}": ${reason} — killing session ${headlessSession.id}`
+        )
+        logs += `\n${reason}`
+        try {
+          await window.api.killHeadlessSession(headlessSession.id)
+        } catch (err) {
+          console.warn(`[workflow] failed to kill timed-out session ${headlessSession.id}`, err)
+        }
+        updateNodeState(execution, node.id, {
+          status: 'error',
+          completedAt: new Date().toISOString(),
+          output: logs,
+          logs,
+          error: reason
+        })
+        persistExecution(execution)
+        if (resolvedTaskId) useAppStore.getState().reopenTask(resolvedTaskId)
+        return
+      }
+
+      const exitCode = outcome.code
 
       if (exitCode !== 0) {
         logs += `\nProcess exited with code ${exitCode}`
@@ -745,7 +864,7 @@ async function executeNode(
         ...(exitCode !== 0 && { error: `Exit code ${exitCode}` }),
         ...(schemaError && exitCode === 0 && { error: schemaError })
       })
-      persistExecution(workflow.id, execution)
+      persistExecution(execution)
 
       // Reset task back to todo on failure so it can be retried
       if (failed && resolvedTaskId) {
@@ -754,6 +873,8 @@ async function executeNode(
     } finally {
       removeDataListener()
       removeExitListener()
+      active?.abort.signal.removeEventListener('abort', onAbort)
+      if (timeoutTimer) clearTimeout(timeoutTimer)
       if (persistTimer) {
         clearTimeout(persistTimer)
         persistTimer = null
@@ -795,7 +916,7 @@ async function executeNode(
       projectName: effectiveProjectName,
       projectPath: effectiveProjectPath
     })
-    persistExecution(workflow.id, execution)
+    persistExecution(execution)
   }
 }
 
@@ -852,11 +973,12 @@ export async function executeWorkflow(
     options?.source !== 'scheduler'
   ) {
     await window.api.runWorkflowManual(workflow.id)
-    const existing = useAppStore.getState().workflowExecutions.get(workflow.id)
+    const existing = latestRunForWorkflow(workflow.id)
     if (existing) return existing
     // Return a minimal synthetic execution so callers don't break. The real
     // executions will land via onSchedulerExecute as the scheduler fans out.
     return {
+      runId: `pending:${workflow.id}`,
       workflowId: workflow.id,
       startedAt: new Date().toISOString(),
       status: 'running',
@@ -867,22 +989,33 @@ export async function executeWorkflow(
     }
   }
 
-  if (runningWorkflows.has(workflow.id)) {
-    console.warn(`[workflow] skipping execution of "${workflow.name}" — already running`)
-    const existing = useAppStore.getState().workflowExecutions.get(workflow.id)
-    if (existing) return existing
-    throw new Error(`Workflow "${workflow.name}" is already executing`)
-  }
-
-  const pending = useAppStore.getState().workflowExecutions.get(workflow.id)
-  if (pending && pending.nodeStates.some((ns) => ns.status === 'waiting')) {
+  // A run parked on an approval gate still owns the workflow's queue position —
+  // starting another now would race two runs through the same gate.
+  const waiting = runsForWorkflow(workflow.id).find((e) =>
+    e.nodeStates.some((ns) => ns.status === 'waiting')
+  )
+  if (waiting) {
     console.warn(
       `[workflow] skipping execution of "${workflow.name}" — existing run is waiting for approval`
     )
-    return pending
+    return waiting
+  }
+
+  // Ask the core, not this window, whether we own this trigger. Every instance
+  // hears the same scheduler tick; only the one granted the claim runs it.
+  const dedupeParams = dedupeFingerprint(context)
+  const claim = await window.api.claimWorkflowRun({ workflowId: workflow.id, params: dedupeParams })
+  if (!claim.granted) {
+    console.warn(
+      `[workflow] skipping execution of "${workflow.name}" — trigger already claimed (params=${dedupeParams})`
+    )
+    const existing = useAppStore.getState().workflowExecutions.get(claim.runId)
+    if (existing) return existing
+    throw new Error(`Workflow "${workflow.name}" is already running for this trigger`)
   }
 
   const execution: WorkflowExecution = {
+    runId: claim.runId,
     workflowId: workflow.id,
     startedAt: new Date().toISOString(),
     status: 'running',
@@ -890,17 +1023,110 @@ export async function executeWorkflow(
       nodeId: n.id,
       status: n.type === 'trigger' ? 'success' : 'pending'
     })),
-    triggerTaskId: context?.task?.id
+    triggerTaskId: context?.task?.id,
+    dedupeParams
   }
 
   const actionNodeCount = workflow.nodes.filter((n) => n.type !== 'trigger').length
   console.log(
-    `[workflow] executeWorkflow "${workflow.name}" — ${actionNodeCount} action nodes, triggerTaskId=${context?.task?.id}`
+    `[workflow] executeWorkflow "${workflow.name}" — ${actionNodeCount} action nodes, run=${execution.runId}, triggerTaskId=${context?.task?.id}`
   )
 
-  persistExecution(workflow.id, execution)
+  persistExecution(execution)
 
   return runExecution(workflow, execution, context, options)
+}
+
+/** Live runs of one workflow, newest first. */
+function runsForWorkflow(workflowId: string): WorkflowExecution[] {
+  return Array.from(useAppStore.getState().workflowExecutions.values())
+    .filter((e) => e.workflowId === workflowId)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+}
+
+function latestRunForWorkflow(workflowId: string): WorkflowExecution | undefined {
+  return runsForWorkflow(workflowId)[0]
+}
+
+/**
+ * Stop a run: kill the agents it launched, then close it as `cancelled`.
+ *
+ * Worktrees are deliberately left on disk. A stopped run has usually done
+ * partial work, and discarding it silently is not something the user can undo.
+ */
+export async function stopWorkflowRun(runId: string): Promise<void> {
+  const handle = activeRuns.get(runId)
+  // Prefer the live object over the store's copy so the run the engine is
+  // driving sees the cancellation too, not just the snapshot the UI renders.
+  const execution = handle?.execution ?? useAppStore.getState().workflowExecutions.get(runId)
+  if (!execution && !handle) {
+    console.warn(`[workflow] stopWorkflowRun: no run ${runId}`)
+    return
+  }
+
+  handle?.abort.abort()
+
+  // Kill from the node states as well as the handle: a run rehydrated after a
+  // reload has sessions recorded but no in-memory handle.
+  const sessionIds = new Set<string>(handle?.sessionIds ?? [])
+  for (const ns of execution?.nodeStates ?? []) {
+    if (ns.sessionId && (ns.status === 'running' || ns.status === 'waiting')) {
+      sessionIds.add(ns.sessionId)
+    }
+  }
+  await Promise.allSettled(
+    Array.from(sessionIds).map((id) =>
+      Promise.resolve(window.api.killHeadlessSession(id)).catch((err) =>
+        console.warn(`[workflow] stop: failed to kill session ${id}`, err)
+      )
+    )
+  )
+
+  if (!execution) return
+
+  const now = new Date().toISOString()
+  for (const ns of execution.nodeStates) {
+    if (ns.status === 'running' || ns.status === 'pending' || ns.status === 'waiting') {
+      ns.status = ns.status === 'pending' ? 'skipped' : 'error'
+      ns.completedAt = now
+      ns.error = 'Stopped by user'
+    }
+    // Drop any armed approval timer for this run so it can't fire post-stop.
+    const timer = gateTimers.get(gateKey(runId, ns.nodeId))
+    if (timer) {
+      clearTimeout(timer)
+      gateTimers.delete(gateKey(runId, ns.nodeId))
+    }
+  }
+  execution.status = 'cancelled'
+  execution.completedAt = now
+  persistExecution(execution)
+
+  // Release immediately rather than at the dedupe window's expiry, so stopping
+  // a run and starting it again is not blocked by the run just stopped.
+  const workflow = (useAppStore.getState().config?.workflows || []).find(
+    (w) => w.id === execution.workflowId
+  )
+  await Promise.allSettled([
+    window.api.releaseWorkflowRun({
+      workflowId: execution.workflowId,
+      params: execution.dedupeParams,
+      runId
+    }),
+    window.api.reportWorkflowComplete({
+      workflowId: execution.workflowId,
+      workflowName: workflow?.name ?? execution.workflowId,
+      completedAt: now,
+      status: 'cancelled',
+      sessionsLaunched: sessionIds.size
+    })
+  ])
+  console.log(`[workflow] run ${runId} stopped by user`)
+}
+
+/** Whether a run can still be stopped — drives the Stop control's visibility. */
+export function isRunStoppable(execution: WorkflowExecution): boolean {
+  return execution.status === 'running'
 }
 
 async function runExecution(
@@ -909,11 +1135,21 @@ async function runExecution(
   context: WorkflowExecutionContext | undefined,
   options?: ExecuteWorkflowOptions
 ): Promise<WorkflowExecution> {
-  if (runningWorkflows.has(workflow.id)) {
-    console.warn(`[workflow] runExecution: ${workflow.id} already running, skipping`)
+  // Guards re-entry into *this* run (a gate approved twice, say). Other runs of
+  // the same workflow are free to proceed alongside it.
+  if (activeRuns.has(execution.runId)) {
+    console.warn(`[workflow] runExecution: run ${execution.runId} already active, skipping`)
     return execution
   }
-  runningWorkflows.add(workflow.id)
+  const active: ActiveRun = {
+    runId: execution.runId,
+    workflowId: workflow.id,
+    dedupeParams: execution.dedupeParams ?? 'manual',
+    abort: new AbortController(),
+    sessionIds: new Set(),
+    execution
+  }
+  activeRuns.set(execution.runId, active)
 
   const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]))
   const { successors: successorsMap, predecessors: predecessorsMap } = buildGraph(workflow.edges)
@@ -963,9 +1199,14 @@ async function runExecution(
 
   const actionNodeCount = workflow.nodes.filter((n) => n.type !== 'trigger').length
 
+  // A run parked on a gate is still live, so its claim stays held; only a run
+  // that reaches a terminal state gives the trigger back.
+  let parkedOnGate = false
+
   try {
     let wave = 0
     while (true) {
+      if (active.abort.signal.aborted) break
       rebuildCompletionSets()
       const ready = getReadyNodes()
       if (ready.length === 0) break
@@ -984,7 +1225,7 @@ async function runExecution(
       const promises = ready.map(async (node) => {
         running.add(node.id)
         try {
-          await executeNode(node, workflow, execution, context, stepOutputs)
+          await executeNode(node, workflow, execution, context, stepOutputs, active)
         } catch (err) {
           console.error(`[workflow] node "${node.label}" error:`, err)
           updateNodeState(execution, node.id, {
@@ -992,7 +1233,7 @@ async function runExecution(
             completedAt: new Date().toISOString(),
             error: err instanceof Error ? err.message : String(err)
           })
-          persistExecution(workflow.id, execution)
+          persistExecution(execution)
         }
         running.delete(node.id)
 
@@ -1017,7 +1258,7 @@ async function runExecution(
                   completedAt: new Date().toISOString()
                 })
               }
-              persistExecution(workflow.id, execution)
+              persistExecution(execution)
             }
           }
         }
@@ -1026,9 +1267,16 @@ async function runExecution(
       await Promise.all(promises)
     }
 
+    // Stopped mid-flight: stopWorkflowRun already wrote the terminal state, so
+    // leave it alone rather than recomputing it from the half-finished DAG.
+    if (active.abort.signal.aborted) {
+      return execution
+    }
+
     const hasWaiting = execution.nodeStates.some((ns) => ns.status === 'waiting')
     if (hasWaiting) {
-      persistExecution(workflow.id, execution)
+      parkedOnGate = true
+      persistExecution(execution)
       return execution
     }
 
@@ -1040,7 +1288,7 @@ async function runExecution(
         ns.completedAt = new Date().toISOString()
         ns.error = 'Skipped: predecessor nodes did not complete'
       }
-      persistExecution(workflow.id, execution)
+      persistExecution(execution)
     }
 
     const hasErrors = execution.nodeStates.some(
@@ -1060,7 +1308,18 @@ async function runExecution(
       }
     }
   } finally {
-    runningWorkflows.delete(workflow.id)
+    activeRuns.delete(execution.runId)
+    if (!parkedOnGate) {
+      // Hand the trigger back so an identical one can run again immediately
+      // instead of waiting out the dedupe window.
+      void window.api
+        .releaseWorkflowRun({
+          workflowId: workflow.id,
+          params: active.dedupeParams,
+          runId: execution.runId
+        })
+        .catch((err) => console.warn('[workflow] failed to release run claim:', err))
+    }
   }
 
   const state = useAppStore.getState()
@@ -1077,7 +1336,7 @@ async function runExecution(
     }
   }
 
-  persistExecution(workflow.id, execution)
+  persistExecution(execution)
 
   if (workflow.autoCleanupWorktrees) {
     // Skip 'inherited' worktrees: a contextual workflow reused the parent
@@ -1168,7 +1427,7 @@ function resolveWaitingGate(
     return null
   }
 
-  const key = gateKey(workflow.id, nodeId)
+  const key = gateKey(execution.runId, nodeId)
   const timer = gateTimers.get(key)
   if (timer) {
     clearTimeout(timer)
@@ -1193,7 +1452,7 @@ export async function approveWorkflowGate(
     completedAt: now,
     approvedAt: now
   })
-  persistExecution(workflow.id, execution)
+  persistExecution(execution)
 
   const context = rebuildContextForResume(execution)
   return runExecution(workflow, execution, context)
@@ -1230,7 +1489,7 @@ export async function rejectWorkflowGate(
     }
   }
 
-  persistExecution(workflow.id, execution)
+  persistExecution(execution)
 
   const context = rebuildContextForResume(execution)
   return runExecution(workflow, execution, context)

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -430,7 +430,12 @@ async function executeNode(
         if (id !== runId) return
         streamedLogs = appendBoundedLog(streamedLogs, data)
         updateNodeState(execution, node.id, { logs: streamedLogs })
-        useAppStore.getState().setWorkflowExecution(workflow.id, { ...execution })
+        // Keyed by the run, like every other write. Under the workflow id this
+        // both missed the real run — so streamed script logs never reached it —
+        // and inserted a second entry that runsForWorkflow reported as a
+        // duplicate run. Note `runId` in this scope is the script's, not the
+        // run's.
+        useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
       }
     )
 

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -218,8 +218,9 @@ export interface UISlice {
   setTaskDialogOpen: (open: boolean, defaultStatus?: TaskStatus) => void
   setEditingTask: (task: TaskConfig | null) => void
   setActiveTabId: (id: string | null) => void
+  /** Live runs keyed by run id — one workflow can have several at once. */
   workflowExecutions: Map<string, WorkflowExecution>
-  setWorkflowExecution: (id: string, execution: WorkflowExecution) => void
+  setWorkflowExecution: (runId: string, execution: WorkflowExecution) => void
   updateVersion: string | null
   setUpdateVersion: (version: string | null) => void
   worktreeCache: Map<string, WorktreeInfo[]>

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -288,10 +288,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   setActiveTabId: (id) => set({ activeTabId: id }),
 
   workflowExecutions: new Map(),
-  setWorkflowExecution: (id, execution) =>
+  setWorkflowExecution: (runId, execution) =>
     set((state) => {
       const next = new Map(state.workflowExecutions)
-      next.set(id, execution)
+      next.set(runId, execution)
       return { workflowExecutions: next }
     }),
 

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -208,14 +208,14 @@ describe('buildHeadlessSpawnArgs', () => {
     expect(result.args[result.args.length - 1]).toBe('-p')
   })
 
-  it('returns exec for codex', () => {
+  it('returns exec for codex, with the prompt on stdin', () => {
     const result = buildHeadlessSpawnArgs(
       makePayload({ agentType: 'codex', initialPrompt: 'fix' }),
       cmds,
       env
     )
     expect(result.args).toContain('exec')
-    expect(result.args).toContain('fix')
+    expect(result.stdin).toBe('fix')
   })
 
   it('returns run for opencode', () => {
@@ -295,9 +295,11 @@ describe('buildHeadlessSpawnArgs', () => {
 // Windows the headless spawn runs through `shell: true`, which word-splits
 // unquoted argv — the trigger for issue #374 (claude got only `#`) and the
 // equivalent copilot "extra words were treated as separate arguments" failure.
-// Every supported agent must therefore deliver the ENTIRE prompt as one unit:
-// claude on stdin (bare `-p`), everyone else as a single argv element that the
-// spawn site can quote. These tests lock that contract in per agent.
+//
+// Quoting fixes the word-splitting but NOT the newlines: a cmd.exe command line
+// cannot carry a literal LF, so any prompt passed on argv is still mangled
+// there. Agents that can take the prompt on stdin must therefore do so — that
+// route never touches the command line. These tests lock that in per agent.
 describe('buildHeadlessSpawnArgs — every agent delivers the whole prompt as one unit', () => {
   const PROMPT = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing with spaces.'
 
@@ -315,25 +317,86 @@ describe('buildHeadlessSpawnArgs — every agent delivers the whole prompt as on
     expect(result.args[result.args.length - 1]).toBe('-p')
   })
 
-  // For the arg-based agents the prompt must be exactly one array element so
-  // it can be quoted as a single token — never spread across several.
+  it('copilot delivers the prompt on stdin, with no -p to mangle', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ agentType: 'copilot', initialPrompt: PROMPT }),
+      cmds,
+      env
+    )
+    expect(result.command).toBe('copilot')
+    expect(result.stdin).toBe(PROMPT)
+    expect(result.args).not.toContain(PROMPT)
+    // `-p` must be absent: copilot only reads stdin when it isn't given one,
+    // and a `-p` whose value the shell ate leaves it blocking on stdin forever.
+    expect(result.args).not.toContain('-p')
+    expect(result.args).toContain('--allow-all')
+  })
+
+  // codex and opencode both read the prompt from stdin when no positional
+  // prompt is given, and both — like copilot — block forever on an open stdin
+  // when they have no prompt at all. Verified against the real CLIs.
   it.each([
-    { agentType: 'copilot' as const, command: 'copilot', flag: '--allow-all' },
-    { agentType: 'codex' as const, command: 'codex', flag: 'exec' },
-    { agentType: 'opencode' as const, command: 'opencode', flag: 'run' },
-    { agentType: 'gemini' as const, command: 'gemini', flag: '-y' }
-  ])('$agentType delivers the prompt as a single argv element', ({ agentType, command, flag }) => {
+    { agentType: 'codex' as const, command: 'codex', sub: 'exec' },
+    { agentType: 'opencode' as const, command: 'opencode', sub: 'run' }
+  ])('$agentType delivers the prompt on stdin, not on argv', ({ agentType, command, sub }) => {
     const result = buildHeadlessSpawnArgs(
       makePayload({ agentType, initialPrompt: PROMPT }),
       cmds,
       env
     )
     expect(result.command).toBe(command)
-    expect(result.stdin).toBeUndefined()
-    expect(result.args).toContain(flag)
-    // The full multi-word/multi-line prompt is a single element, not split.
-    expect(result.args).toContain(PROMPT)
-    expect(result.args.filter((a) => a === PROMPT)).toHaveLength(1)
+    expect(result.stdin).toBe(PROMPT)
+    expect(result.args).toContain(sub)
+    expect(result.args).not.toContain(PROMPT)
+    // The subcommand must be last: a positional after it would be read as the
+    // prompt, which demotes stdin to a separate block (codex) or wins outright.
+    expect(result.args[result.args.length - 1]).toBe(sub)
+  })
+
+  // gemini goes headless on its own when stdio is piped, and uses stdin as the
+  // input when no -p is given. Confirmed against its source and the installed
+  // build: with a stdin prompt it gets past input validation, whereas empty
+  // stdin exits on "No input provided via stdin".
+  it('gemini delivers the prompt on stdin, with no -p', () => {
+    const result = buildHeadlessSpawnArgs(
+      makePayload({ agentType: 'gemini', initialPrompt: PROMPT }),
+      cmds,
+      env
+    )
+    expect(result.command).toBe('gemini')
+    expect(result.stdin).toBe(PROMPT)
+    expect(result.args).toContain('-y')
+    expect(result.args).not.toContain(PROMPT)
+    expect(result.args).not.toContain('-p')
+  })
+
+  // With no prompt an agent must not be left reading stdin — that is the exact
+  // state in which copilot, codex and opencode wait forever, silently.
+  it.each(['claude', 'copilot', 'codex', 'opencode', 'gemini'] as const)(
+    '%s is given an explicit empty prompt rather than being left to read stdin',
+    (agentType) => {
+      const result = buildHeadlessSpawnArgs(
+        makePayload({ agentType, initialPrompt: '' }),
+        cmds,
+        env
+      )
+      expect(result.stdin).toBeUndefined()
+      expect(result.args[result.args.length - 1]).toBe('')
+    }
+  )
+
+  it('keeps the prompt off the Windows command line for every agent', () => {
+    // Guards the regression directly: a cmd.exe command line cannot carry a
+    // literal LF, so no agent may receive the prompt on argv.
+    for (const agentType of ['claude', 'copilot', 'codex', 'opencode', 'gemini'] as const) {
+      const result = buildHeadlessSpawnArgs(
+        makePayload({ agentType, initialPrompt: PROMPT }),
+        cmds,
+        env
+      )
+      expect(result.args.some((a) => a.includes('\n'))).toBe(false)
+      expect(result.stdin).toBe(PROMPT)
+    }
   })
 })
 

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -134,50 +134,76 @@ describe('headlessManager.createHeadless', () => {
 
     afterEach(() => setPlatform(realPlatform))
 
-    it('spawns through the shell with the prompt quoted so it is not word-split', () => {
+    // The prompt no longer rides on argv for any agent, but per-step args still
+    // do, and those can contain spaces — so the cmd.exe quoting still matters.
+    it('spawns through the shell with argv quoted so it is not word-split', () => {
       setPlatform('win32')
-      const prompt = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing with spaces.'
       const session = headlessManager.createHeadless({
-        agentType: 'codex', // arg-based agent — the prompt rides on argv
+        agentType: 'gemini',
         projectName: 'p',
         projectPath: '/p',
-        initialPrompt: prompt,
+        initialPrompt: 'hello',
+        args: ['--model', 'some model name'],
         headless: true
       })
 
       const [, args, options] = spawnMock.mock.calls[0] as [string, string[], { shell?: boolean }]
       expect(options.shell).toBe(true)
-      // The raw prompt must NOT appear as a bare element (that word-splits under
+      // The value must NOT appear as a bare element (that word-splits under
       // cmd.exe); it must be a single quoted token that still contains the text.
-      expect(args).not.toContain(prompt)
-      const promptArgs = args.filter((a) => a.includes('Do the thing with spaces.'))
-      expect(promptArgs).toHaveLength(1)
+      expect(args).not.toContain('some model name')
+      const quoted = args.filter((a) => a.includes('some model name'))
+      expect(quoted).toHaveLength(1)
       // cmd.exe quoting (double quotes) is used regardless of the machine's
       // default shell, since Node's shell:true always runs cmd.exe — not
       // PowerShell single-quotes, which cmd.exe wouldn't treat as quoting.
-      expect(promptArgs[0].startsWith('"')).toBe(true)
-      expect(promptArgs[0].endsWith('"')).toBe(true)
+      expect(quoted[0].startsWith('"')).toBe(true)
+      expect(quoted[0].endsWith('"')).toBe(true)
 
       headlessManager.killHeadless(session.id)
     })
 
     it('does not quote args on POSIX (no shell wrapper)', () => {
       setPlatform('linux')
-      const prompt = 'do a thing with spaces'
       const session = headlessManager.createHeadless({
-        agentType: 'codex',
+        agentType: 'gemini',
         projectName: 'p',
         projectPath: '/p',
-        initialPrompt: prompt,
+        initialPrompt: 'hello',
+        args: ['--model', 'some model name'],
         headless: true
       })
 
       const [, args, options] = spawnMock.mock.calls[0] as [string, string[], { shell?: boolean }]
       expect(options.shell).toBe(false)
       // Passed to execve verbatim — one unquoted element.
-      expect(args).toContain(prompt)
+      expect(args).toContain('some model name')
 
       headlessManager.killHeadless(session.id)
     })
+
+    // The hang this guards against: on Windows a multi-line prompt on the
+    // cmd.exe command line is truncated, and copilot, codex and opencode all
+    // then block on stdin producing no output at all — the step never ends.
+    it.each(['claude', 'copilot', 'codex', 'opencode', 'gemini'] as const)(
+      'keeps the %s prompt off the Windows command line entirely',
+      (agentType) => {
+        setPlatform('win32')
+        const prompt = '# Workflow: Demo\n\n**Step:** one\n\nDo the thing with spaces.'
+        const session = headlessManager.createHeadless({
+          agentType,
+          projectName: 'p',
+          projectPath: '/p',
+          initialPrompt: prompt,
+          headless: true
+        })
+
+        const [, args] = spawnMock.mock.calls[0] as [string, string[], { shell?: boolean }]
+        expect(args.some((a) => a.includes('Do the thing with spaces.'))).toBe(false)
+        expect(args.some((a) => a.includes('\n'))).toBe(false)
+
+        headlessManager.killHeadless(session.id)
+      }
+    )
   })
 })

--- a/tests/launch-agent-timeout-field.test.tsx
+++ b/tests/launch-agent-timeout-field.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'api', {
+    value: {
+      detectIDEs: () => Promise.resolve([]),
+      listShellExecutables: () => Promise.resolve([])
+    },
+    writable: true,
+    configurable: true
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+})
+
+vi.mock('../src/renderer/hooks/useAgentInstallStatus', () => ({
+  useAgentInstallStatus: () => ({
+    claude: true,
+    copilot: true,
+    codex: true,
+    opencode: true,
+    gemini: true
+  })
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { LaunchAgentConfigForm } from '../src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm'
+import type { LaunchAgentConfig } from '../src/shared/types'
+
+/**
+ * The per-step timeout. Without a bound, a step whose agent never exits holds
+ * its run open forever — which is what let one stuck agent block a workflow.
+ */
+
+const BASE = { headless: true, agentType: 'claude', prompt: 'do the thing' } as LaunchAgentConfig
+
+function renderForm(config: Partial<LaunchAgentConfig> = {}) {
+  const onChange = vi.fn()
+  render(<LaunchAgentConfigForm config={{ ...BASE, ...config }} onChange={onChange} />)
+  return onChange
+}
+
+/** The timeout input is the only number field on the form. */
+function timeoutInput(): HTMLInputElement {
+  return screen.getByPlaceholderText(/^\d+$/) as HTMLInputElement
+}
+
+beforeEach(() => {
+  useAppStore.setState({ config: { defaults: {}, projects: [], tasks: [] } as never })
+})
+afterEach(() => cleanup())
+
+describe('per-step timeout', () => {
+  it('stores minutes as milliseconds', () => {
+    const onChange = renderForm()
+    fireEvent.change(timeoutInput(), { target: { value: '20' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 20 * 60_000 }))
+  })
+
+  it('shows an existing timeout in minutes', () => {
+    renderForm({ timeoutMs: 45 * 60_000 })
+    expect(timeoutInput().value).toBe('45')
+  })
+
+  it('clears back to the default when emptied', () => {
+    // Blank means "use the setting", which is not the same as zero.
+    const onChange = renderForm({ timeoutMs: 30 * 60_000 })
+    fireEvent.change(timeoutInput(), { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: undefined }))
+  })
+
+  it('keeps zero, which means no limit', () => {
+    const onChange = renderForm()
+    fireEvent.change(timeoutInput(), { target: { value: '0' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 0 }))
+  })
+
+  it('ignores a negative timeout rather than storing one', () => {
+    const onChange = renderForm()
+    fireEvent.change(timeoutInput(), { target: { value: '-5' } })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('warns that no limit means a stuck agent holds the run open', () => {
+    renderForm({ timeoutMs: 0 })
+    expect(screen.getByText(/No limit/)).toBeInTheDocument()
+  })
+
+  it('offers no timeout for a step that is not headless', () => {
+    // Only headless steps are waited on by the engine.
+    renderForm({ headless: false })
+    expect(screen.queryByText('Timeout')).toBeNull()
+  })
+})

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -7,7 +7,9 @@ const approve = vi.fn()
 const reject = vi.fn()
 vi.mock('../src/renderer/lib/workflow-execution', () => ({
   approveWorkflowGate: (...args: unknown[]) => approve(...args),
-  rejectWorkflowGate: (...args: unknown[]) => reject(...args)
+  rejectWorkflowGate: (...args: unknown[]) => reject(...args),
+  isRunStoppable: (e: { status: string }) => e.status === 'running',
+  stopWorkflowRun: vi.fn()
 }))
 
 vi.mock('../src/renderer/components/Tooltip', () => ({
@@ -19,6 +21,7 @@ import type { WorkflowExecution, WorkflowNode } from '../src/shared/types'
 
 function makeExec(overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
   return {
+    runId: 'run-1',
     workflowId: 'wf-1',
     startedAt: '2026-04-20T10:00:00Z',
     status: 'running',

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -21,7 +21,8 @@ vi.mock('lucide-react', () => ({
   ChevronDown: (p: Record<string, unknown>) => <svg data-testid="chev-down" {...p} />,
   ChevronRight: (p: Record<string, unknown>) => <svg data-testid="chev-right" {...p} />,
   Maximize2: (p: Record<string, unknown>) => <svg data-testid="maximize" {...p} />,
-  RotateCcw: (p: Record<string, unknown>) => <svg data-testid="rotate-ccw" {...p} />
+  RotateCcw: (p: Record<string, unknown>) => <svg data-testid="rotate-ccw" {...p} />,
+  Square: (p: Record<string, unknown>) => <svg data-testid="square" {...p} />
 }))
 
 import { RunEntry } from '../src/renderer/components/workflow-editor/RunEntry'
@@ -29,6 +30,7 @@ import type { WorkflowExecution, WorkflowNode, NodeExecutionState } from '../src
 
 function makeExec(overrides: Partial<WorkflowExecution> = {}): WorkflowExecution {
   return {
+    runId: 'run-1',
     workflowId: 'wf-1',
     startedAt: '2026-04-20T10:00:00Z',
     completedAt: '2026-04-20T10:00:05Z',

--- a/tests/stop-run-button.test.tsx
+++ b/tests/stop-run-button.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowExecution } from '../src/shared/types'
+
+const stopWorkflowRun = vi.hoisted(() => vi.fn())
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  stopWorkflowRun,
+  isRunStoppable: (e: WorkflowExecution) => e.status === 'running'
+}))
+
+const toastError = vi.hoisted(() => vi.fn())
+vi.mock('../src/renderer/components/Toast', () => ({ toast: { error: toastError } }))
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+import { StopRunButton } from '../src/renderer/components/workflow-runs/StopRunButton'
+
+/**
+ * Ending a run that is still going. A run with no way to stop it is half of
+ * what turned one wedged step into a permanently blocked workflow.
+ */
+
+function run(status: WorkflowExecution['status']): WorkflowExecution {
+  return {
+    runId: 'run-1',
+    workflowId: 'wf-1',
+    startedAt: new Date().toISOString(),
+    status,
+    nodeStates: []
+  } as WorkflowExecution
+}
+
+beforeEach(() => {
+  stopWorkflowRun.mockReset()
+  stopWorkflowRun.mockResolvedValue(undefined)
+  toastError.mockReset()
+})
+afterEach(() => cleanup())
+
+describe('StopRunButton', () => {
+  it('stops the run it was given', async () => {
+    render(<StopRunButton execution={run('running')} />)
+    fireEvent.click(screen.getByLabelText('Stop run'))
+    await waitFor(() => expect(stopWorkflowRun).toHaveBeenCalledWith('run-1'))
+  })
+
+  it.each([['success'], ['error'], ['cancelled']] as const)(
+    'renders nothing for a %s run',
+    (status) => {
+      // Nothing left to stop, so the control should not be offered.
+      const { container } = render(<StopRunButton execution={run(status)} />)
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it('ignores a second click while the first is still stopping', async () => {
+    let release: () => void = () => {}
+    stopWorkflowRun.mockImplementation(() => new Promise<void>((r) => (release = r)))
+    render(<StopRunButton execution={run('running')} />)
+    const button = screen.getByLabelText('Stop run')
+    fireEvent.click(button)
+    fireEvent.click(button)
+    expect(stopWorkflowRun).toHaveBeenCalledTimes(1)
+    release()
+  })
+
+  it('keeps the click off the row it sits in', () => {
+    // The button lives inside a clickable run row, which would otherwise open
+    // the run at the same time as stopping it.
+    const onRowClick = vi.fn()
+    render(
+      <div onClick={onRowClick}>
+        <StopRunButton execution={run('running')} />
+      </div>
+    )
+    fireEvent.click(screen.getByLabelText('Stop run'))
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
+
+  it('says so when stopping fails', async () => {
+    // An async click handler that throws is an unhandled rejection, and the run
+    // just appears not to stop.
+    stopWorkflowRun.mockRejectedValue(new Error('core unreachable'))
+    render(<StopRunButton execution={run('running')} />)
+    fireEvent.click(screen.getByLabelText('Stop run'))
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(screen.getByLabelText('Stop run')).not.toBeDisabled()
+  })
+})

--- a/tests/workflow-item.test.tsx
+++ b/tests/workflow-item.test.tsx
@@ -213,3 +213,60 @@ describe('WorkflowItem', () => {
     mockStore.editingWorkflowId = null
   })
 })
+
+describe('a gate waiting for approval', () => {
+  beforeEach(() => {
+    mockStore.workflowExecutions = new Map<string, unknown>()
+  })
+
+  function runWith(runId: string, workflowId: string, statuses: string[]): [string, unknown] {
+    return [
+      runId,
+      { runId, workflowId, nodeStates: statuses.map((status, i) => ({ nodeId: `n${i}`, status })) }
+    ]
+  }
+
+  it('flags the workflow amber while any run waits', () => {
+    mockStore.workflowExecutions = new Map([runWith('r1', 'w1', ['waiting'])])
+    const { container } = render(
+      <WorkflowItem
+        workflow={makeManual()}
+        isCollapsed={false}
+        iconSize={14}
+        onContextMenu={vi.fn()}
+      />
+    )
+    expect(container.querySelector('.bg-amber-400')).toBeInTheDocument()
+  })
+
+  it('finds a gate in an older run, not only the newest', () => {
+    // Runs of one workflow now proceed in parallel, so the run needing
+    // attention is not necessarily the most recent one.
+    mockStore.workflowExecutions = new Map([
+      runWith('older', 'w1', ['waiting']),
+      runWith('newer', 'w1', ['running'])
+    ])
+    const { container } = render(
+      <WorkflowItem
+        workflow={makeManual()}
+        isCollapsed={false}
+        iconSize={14}
+        onContextMenu={vi.fn()}
+      />
+    )
+    expect(container.querySelector('.bg-amber-400')).toBeInTheDocument()
+  })
+
+  it('ignores a gate belonging to a different workflow', () => {
+    mockStore.workflowExecutions = new Map([runWith('other', 'w-other', ['waiting'])])
+    const { container } = render(
+      <WorkflowItem
+        workflow={makeManual()}
+        isCollapsed={false}
+        iconSize={14}
+        onContextMenu={vi.fn()}
+      />
+    )
+    expect(container.querySelector('.bg-amber-400')).toBeNull()
+  })
+})

--- a/tests/workflow-run-claims.test.ts
+++ b/tests/workflow-run-claims.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+import {
+  claimWorkflowRun,
+  releaseWorkflowRun,
+  resetWorkflowRunClaims,
+  DEFAULT_DEDUPE_WINDOW_MS
+} from '../packages/server/src/workflow-run-claims'
+
+beforeEach(() => {
+  resetWorkflowRunClaims()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('workflow run claims', () => {
+  it('grants the first claim and refuses an identical one in the same window', () => {
+    const first = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    const second = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+
+    expect(first.granted).toBe(true)
+    expect(second.granted).toBe(false)
+    // The loser learns which run won, so it can show that run instead.
+    expect(second.runId).toBe(first.runId)
+  })
+
+  it('runs the same workflow in parallel when the trigger parameters differ', () => {
+    // A connector poll fans out one run per new item: same workflow, different
+    // item. These are different work and must not suppress each other.
+    const itemA = claimWorkflowRun({ workflowId: 'wf-1', params: 'item:conn-1:issue-7' })
+    const itemB = claimWorkflowRun({ workflowId: 'wf-1', params: 'item:conn-1:issue-8' })
+
+    expect(itemA.granted).toBe(true)
+    expect(itemB.granted).toBe(true)
+    expect(itemA.runId).not.toBe(itemB.runId)
+  })
+
+  it('keeps claims for different workflows independent', () => {
+    expect(claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' }).granted).toBe(true)
+    expect(claimWorkflowRun({ workflowId: 'wf-2', params: 'manual' }).granted).toBe(true)
+  })
+
+  it('lets the trigger through again once the window lapses', () => {
+    const first = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    vi.advanceTimersByTime(DEFAULT_DEDUPE_WINDOW_MS + 1)
+
+    const later = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    expect(later.granted).toBe(true)
+    expect(later.runId).not.toBe(first.runId)
+  })
+
+  it('frees the trigger immediately when the holder releases it', () => {
+    const first = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    releaseWorkflowRun('wf-1', 'manual', first.runId)
+
+    // No time has passed, so only the release can explain this being granted.
+    expect(claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' }).granted).toBe(true)
+  })
+
+  it('ignores a release from a run that no longer holds the claim', () => {
+    const first = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    releaseWorkflowRun('wf-1', 'manual', first.runId)
+    const second = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+
+    // A late release from the superseded run must not hand away the claim its
+    // successor now owns.
+    releaseWorkflowRun('wf-1', 'manual', first.runId)
+
+    const third = claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' })
+    expect(third.granted).toBe(false)
+    expect(third.runId).toBe(second.runId)
+  })
+
+  it('treats a missing fingerprint as the manual trigger', () => {
+    claimWorkflowRun({ workflowId: 'wf-1' })
+    expect(claimWorkflowRun({ workflowId: 'wf-1', params: 'manual' }).granted).toBe(false)
+  })
+
+  it('does not let a fingerprint containing the key separator collide', () => {
+    // Fingerprints carry upstream text; a naive `id + sep + params` key would
+    // let these two land on the same entry.
+    const a = claimWorkflowRun({ workflowId: 'wf', params: 'x:y' })
+    const b = claimWorkflowRun({ workflowId: 'wf:x', params: 'y' })
+    expect(a.granted).toBe(true)
+    expect(b.granted).toBe(true)
+  })
+
+  it('honours a caller-supplied window', () => {
+    claimWorkflowRun({ workflowId: 'wf-1', params: 'manual', windowMs: 1000 })
+    vi.advanceTimersByTime(1500)
+    expect(claimWorkflowRun({ workflowId: 'wf-1', params: 'manual', windowMs: 1000 }).granted).toBe(
+      true
+    )
+  })
+})

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { WorkflowDefinition, WorkflowExecution } from '../src/shared/types'
+
+/**
+ * Covers what used to wedge a run permanently: a headless step whose exit event
+ * never arrives, or arrives before the step knows its own session id. Both left
+ * the step awaiting forever, and because the engine held a per-workflow lock for
+ * the duration, every later run of that workflow was dropped too.
+ */
+
+type ExitListener = (p: { id: string; exitCode: number }) => void
+
+const exitListeners = new Set<ExitListener>()
+
+function emitExit(id: string, exitCode: number): void {
+  for (const l of [...exitListeners]) l({ id, exitCode })
+}
+
+const claims = new Map<string, string>()
+let runSeq = 0
+let sessionSeq = 0
+
+/** Stands in for the core registry, with the same grant/release semantics. */
+const claimWorkflowRun = vi.fn(
+  ({ workflowId, params }: { workflowId: string; params?: string }) => {
+    const key = JSON.stringify([workflowId, params || 'manual'])
+    const held = claims.get(key)
+    if (held) return Promise.resolve({ granted: false, runId: held })
+    const runId = `run-${++runSeq}`
+    claims.set(key, runId)
+    return Promise.resolve({ granted: true, runId })
+  }
+)
+
+const releaseWorkflowRun = vi.fn(
+  ({ workflowId, params, runId }: { workflowId: string; params?: string; runId: string }) => {
+    const key = JSON.stringify([workflowId, params || 'manual'])
+    if (claims.get(key) === runId) claims.delete(key)
+    return Promise.resolve()
+  }
+)
+
+const killHeadlessSession = vi.fn(() => Promise.resolve())
+
+/** Resolves once the given session has been created, so tests can await launch. */
+let onSessionCreated: ((id: string) => void) | null = null
+
+const createHeadlessSession = vi.fn(() => {
+  const id = `sess-${++sessionSeq}`
+  queueMicrotask(() => onSessionCreated?.(id))
+  return Promise.resolve({ id, agentSessionId: undefined, worktreePath: undefined })
+})
+
+const mockState = {
+  config: {
+    defaults: { defaultAgent: 'claude', headlessStepTimeoutMinutes: 60 },
+    projects: [{ name: 'p', path: '/p' }],
+    tasks: [],
+    workflows: [] as WorkflowDefinition[]
+  },
+  workflowExecutions: new Map<string, WorkflowExecution>(),
+  terminals: new Map(),
+  headlessSessions: [] as { id: string; agentSessionId?: string }[],
+  setWorkflowExecution: (runId: string, execution: WorkflowExecution) => {
+    mockState.workflowExecutions.set(runId, execution)
+  },
+  addHeadlessSession: vi.fn(),
+  startTask: vi.fn(),
+  reopenTask: vi.fn(),
+  getNextTask: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  setWorkflowEditorOpen: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: { getState: () => mockState }
+}))
+
+vi.mock('../src/renderer/lib/notifications', () => ({
+  sendWorkflowGateNotification: vi.fn()
+}))
+
+const { executeWorkflow, stopWorkflowRun } = await import('../src/renderer/lib/workflow-execution')
+
+function makeWorkflow(id = 'wf-1'): WorkflowDefinition {
+  return {
+    id,
+    name: 'Test Workflow',
+    icon: 'Rocket',
+    enabled: true,
+    nodes: [
+      { id: 'trigger', type: 'trigger', label: 'Trigger', position: { x: 0, y: 0 }, config: {} },
+      {
+        id: 'agent',
+        type: 'launchAgent',
+        label: 'Agent',
+        position: { x: 0, y: 1 },
+        config: {
+          agentType: 'claude',
+          projectName: 'p',
+          projectPath: '/p',
+          headless: true,
+          prompt: 'do the thing'
+        }
+      }
+    ],
+    edges: [{ id: 'e1', source: 'trigger', target: 'agent' }]
+  } as unknown as WorkflowDefinition
+}
+
+/** Waits for the launched session id, so a test can drive its exit. */
+function nextSession(): Promise<string> {
+  return new Promise((resolve) => {
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      resolve(id)
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // The engine posts a desktop notification on completion; jsdom has no
+  // Notification constructor.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).Notification = { permission: 'denied' }
+  exitListeners.clear()
+  claims.clear()
+  runSeq = 0
+  sessionSeq = 0
+  onSessionCreated = null
+  mockState.workflowExecutions.clear()
+  mockState.config.workflows = []
+  mockState.config.defaults.headlessStepTimeoutMinutes = 60
+  claimWorkflowRun.mockClear()
+  releaseWorkflowRun.mockClear()
+  killHeadlessSession.mockClear()
+  createHeadlessSession.mockClear()
+
+  globalThis.window.api = {
+    claimWorkflowRun,
+    releaseWorkflowRun,
+    createHeadlessSession,
+    killHeadlessSession,
+    saveWorkflowRun: vi.fn(() => Promise.resolve()),
+    reportWorkflowComplete: vi.fn(() => Promise.resolve()),
+    runWorkflowManual: vi.fn(() => Promise.resolve()),
+    listSessionEventsBySession: vi.fn(() => Promise.resolve([])),
+    getWorktreeActiveSessions: vi.fn(() => Promise.resolve({ count: 0 })),
+    isWorktreeDirty: vi.fn(() => Promise.resolve(false)),
+    removeWorktree: vi.fn(() => Promise.resolve()),
+    onHeadlessData: () => () => {},
+    onHeadlessExit: (fn: ExitListener) => {
+      exitListeners.add(fn)
+      return () => exitListeners.delete(fn)
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('headless step completion', () => {
+  it('completes the run when the agent exits cleanly', async () => {
+    const wf = makeWorkflow()
+    const runPromise = executeWorkflow(wf)
+
+    const sessionId = await nextSession()
+    emitExit(sessionId, 0)
+
+    const execution = await runPromise
+    expect(execution.status).toBe('success')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.status).toBe('success')
+  })
+
+  it('does not lose an exit that arrives before the session id is known', async () => {
+    // The Windows headless path spawns through cmd.exe, so a failing shim can
+    // exit before createHeadlessSession's reply reaches the renderer. That exit
+    // used to be dropped, leaving the step awaiting forever.
+    const wf = makeWorkflow()
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      emitExit(id, 1)
+    }
+
+    const execution = await executeWorkflow(wf)
+
+    expect(execution.status).toBe('error')
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    expect(agent?.status).toBe('error')
+    expect(agent?.error).toBe('Exit code 1')
+  })
+
+  it('kills the agent and fails the step when no exit ever arrives', async () => {
+    const wf = makeWorkflow()
+    mockState.config.defaults.headlessStepTimeoutMinutes = 1
+    const runPromise = executeWorkflow(wf)
+
+    const sessionId = await nextSession()
+    await vi.advanceTimersByTimeAsync(60_000 + 10)
+
+    const execution = await runPromise
+    expect(killHeadlessSession).toHaveBeenCalledWith(sessionId)
+    expect(execution.status).toBe('error')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.error).toMatch(/timed out/i)
+  })
+
+  it('releases the trigger claim after a timed-out run, so the next one is not blocked', async () => {
+    const wf = makeWorkflow()
+    mockState.config.defaults.headlessStepTimeoutMinutes = 1
+    const runPromise = executeWorkflow(wf)
+
+    await nextSession()
+    await vi.advanceTimersByTimeAsync(60_000 + 10)
+    await runPromise
+
+    expect(releaseWorkflowRun).toHaveBeenCalled()
+    // The claim being free is what the old per-workflow lock never allowed.
+    const second = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    emitExit(sessionId, 0)
+    expect((await second).status).toBe('success')
+  })
+})
+
+describe('run concurrency', () => {
+  it('runs the same workflow in parallel for different trigger parameters', async () => {
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    const runA = executeWorkflow(wf, {
+      connectorItem: { connectionId: 'c1', externalId: 'issue-7', title: 'A', raw: {} }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    const runB = executeWorkflow(wf, {
+      connectorItem: { connectionId: 'c1', externalId: 'issue-8', title: 'B', raw: {} }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(ids).toHaveLength(2)
+
+    ids.forEach((id) => emitExit(id, 0))
+    const [a, b] = await Promise.all([runA, runB])
+
+    expect(a.runId).not.toBe(b.runId)
+    expect(a.status).toBe('success')
+    expect(b.status).toBe('success')
+  })
+
+  it('collapses two identical triggers fired at once into a single run', async () => {
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    const first = executeWorkflow(wf)
+    await vi.advanceTimersByTimeAsync(0)
+    // Second instance hearing the same tick.
+    const second = executeWorkflow(wf)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(ids).toHaveLength(1)
+    ids.forEach((id) => emitExit(id, 0))
+
+    const [a, b] = await Promise.all([first, second])
+    expect(b.runId).toBe(a.runId)
+    expect(createHeadlessSession).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('stopping a run', () => {
+  it('kills the run’s sessions and closes it as cancelled', async () => {
+    const wf = makeWorkflow()
+    mockState.config.workflows = [wf]
+    const runPromise = executeWorkflow(wf)
+
+    const sessionId = await nextSession()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const runId = [...mockState.workflowExecutions.keys()][0]
+    await stopWorkflowRun(runId)
+
+    const execution = await runPromise
+    expect(killHeadlessSession).toHaveBeenCalledWith(sessionId)
+    expect(execution.status).toBe('cancelled')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.error).toBe('Stopped by user')
+  })
+
+  it('frees the trigger so the workflow can be run again right away', async () => {
+    const wf = makeWorkflow()
+    mockState.config.workflows = [wf]
+    const runPromise = executeWorkflow(wf)
+    await nextSession()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const runId = [...mockState.workflowExecutions.keys()][0]
+    await stopWorkflowRun(runId)
+    await runPromise
+
+    const second = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    emitExit(sessionId, 0)
+    expect((await second).status).toBe('success')
+  })
+})


### PR DESCRIPTION
A workflow run that starts on Windows can run indefinitely, never return, and block every subsequent run of that workflow. This fixes the cause and removes the two things that turned it into a permanent wedge.

## Cause

A workflow prompt is always multi-line. On Windows the headless spawn goes through `shell: true`, so the prompt was embedded in a **cmd.exe command line** — which cannot carry a literal newline, quoted or not. The agent got a truncated value, or none.

`copilot`, `codex` and `opencode` all fall back to reading the prompt from **stdin** when they don't get one, and all three then block on it indefinitely while emitting no output at all. Measured against each CLI, spawning exactly as `headless-manager` does:

| agent | no prompt, stdin closed | no prompt, stdin open |
|---|---|---|
| copilot | exit 1 in 2.1s | **still running at 25s, 0 bytes out** |
| codex | exit 1 in 0.9s | **still running at 25s** |
| opencode | exit 1 in 0.7s | **still running at 25s, 0 bytes out** |
| gemini | exit 42 | exit 42 |

No output and no exit is exactly the reported symptom. `#380` fixed this class of bug for `claude` only; the other four were left passing the prompt on argv.

## Fix

Every agent now takes its prompt on stdin — the one route that never touches the command line.

```
copilot   --allow-all -p "<19 lines>"   ->  copilot --allow-all      + stdin
codex     -a never exec "<19 lines>"    ->  codex -a never exec      + stdin
opencode  run "<19 lines>"              ->  opencode run             + stdin
gemini    -y -p "<19 lines>"            ->  gemini -y                + stdin
```

Verified end to end against the real CLIs with a genuine 17-line workflow prompt: **copilot** and **opencode** reply and exit 0; **codex** echoes the prompt back complete. For **gemini**, both its source and the shipped bundle read stdin as the input when no `-p` is given, and piped stdio puts it in headless mode by itself — confirmed at runtime by its two distinct exit codes (prompt on stdin reaches auth; empty stdin exits 42, "No input provided via stdin").

`codex` only treats stdin as the instructions when no positional prompt is given — pass both and stdin is demoted to a separate `<stdin>` block. Its subcommand is pinned as the last argv element, with a test.

## Why one stuck step took everything with it

**No bound on a step.** A headless step waited on the agent's exit event and nothing else. Steps now carry a timeout — per step, or a new default in Settings — after which the agent is killed and the step fails with a readable reason.

**No way to stop a run.** A running run can now be stopped from the run list. It kills the agents it launched and closes the run as cancelled. Worktrees stay on disk, since a stopped run has usually done partial work.

**One lock per workflow.** The engine held a single lock for a run's entire duration, so a wedged run silently dropped every later run of that workflow. Runs are now keyed by run id, and duplicate suppression moved into the core — the only process that sees every window. One claim per (workflow, trigger parameters) in a short window: identical triggers fired at once collapse into a single run, while a connector poll's fan-out proceeds in parallel.

That last part also fixes a live bug: **connector-poll fan-out was being discarded after its first item**, because all N runs shared one workflow id. Two open windows also both acted on the same scheduler tick.

Also fixed: an exit event arriving before its step had learned its own session id was dropped, leaving the step waiting forever on an event already gone. There is a test reproducing it.

## Notes

- Run history needs no migration — rows were already keyed by workflow id and start time, which stays the fallback for runs written before run ids.
- Under gemini's own sandbox (`GEMINI_SANDBOX`), it reads stdin and re-injects it as `--prompt` on the relaunch command line, which would reintroduce the truncation. Vorn does not enable that sandbox; noted in a comment.

## Testing

`typecheck` and `lint` clean. **1963 tests across 189 files pass**, including new coverage for: prompt delivery per agent, an exit arriving before the session id is known, a step that never exits timing out and releasing its claim, stop killing sessions and cancelling, and parallel runs with differing trigger parameters versus identical ones deduping.
