### PR TITLE
feat(workflows): make a headless step account for itself

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -362,6 +362,7 @@ function createSchema(): void {
       project_name TEXT,
       project_path TEXT,
       approved_at TEXT,
+      diagnostics TEXT,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -691,7 +692,11 @@ function verifySchema(d: Database.Database): void {
         column: 'project_path',
         ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN project_path TEXT'
       },
-      { column: 'approved_at', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN approved_at TEXT' }
+      { column: 'approved_at', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN approved_at TEXT' },
+      {
+        column: 'diagnostics',
+        ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN diagnostics TEXT'
+      }
     ],
     tasks: [
       {
@@ -2128,8 +2133,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -2146,7 +2151,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         ns.agentType ?? null,
         ns.projectName ?? null,
         ns.projectPath ?? null,
-        ns.approvedAt ?? null
+        ns.approvedAt ?? null,
+        ns.diagnostics ?? null
       )
     }
 
@@ -2183,6 +2189,7 @@ type WorkflowRunNodeRow = {
   project_name: string | null
   project_path: string | null
   approved_at: string | null
+  diagnostics: string | null
 }
 
 function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
@@ -2199,7 +2206,8 @@ function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
     ...(n.agent_type != null && { agentType: n.agent_type as NodeExecutionState['agentType'] }),
     ...(n.project_name != null && { projectName: n.project_name }),
     ...(n.project_path != null && { projectPath: n.project_path }),
-    ...(n.approved_at != null && { approvedAt: n.approved_at })
+    ...(n.approved_at != null && { approvedAt: n.approved_at }),
+    ...(n.diagnostics != null && { diagnostics: n.diagnostics })
   }
 }
 

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -116,8 +116,13 @@ class HeadlessManager extends EventEmitter {
     const spawnArgList = useShell
       ? spawnArgs.args.map((a) => shellEscape(a, 'cmd'))
       : spawnArgs.args
+    // Not truncated: this line is the first thing anyone reads when a session
+    // produces no output, and the flag that explains it is as likely to be at
+    // the end as the start. The prompt isn't here — it goes to stdin.
+    const launchCommand = [spawnArgs.command, ...spawnArgList].join(' ')
     log.info(
-      `[headless] launching: ${spawnArgs.command} ${spawnArgList.join(' ').slice(0, 100)}...`
+      `[headless] launching in ${effectivePath}: ${launchCommand}` +
+        (spawnArgs.stdin != null ? ` (prompt on stdin, ${spawnArgs.stdin.length} chars)` : '')
     )
 
     const child = spawn(spawnArgs.command, spawnArgList, {
@@ -162,7 +167,8 @@ class HeadlessManager extends EventEmitter {
       startedAt: Date.now(),
       ...(payload.workflowId != null && { workflowId: payload.workflowId }),
       ...(payload.workflowName != null && { workflowName: payload.workflowName }),
-      ...(agentSessionId ? { agentSessionId } : {})
+      ...(agentSessionId ? { agentSessionId } : {}),
+      launchCommand
     }
     this.sessions.set(id, session)
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -664,6 +664,19 @@ export interface NodeExecutionState {
   worktreeOrigin?: 'created' | 'inherited'
   /** Timestamp when an approval gate was approved. */
   approvedAt?: string
+  /**
+   * What the engine did on this step's behalf, and when — what it launched,
+   * whether the agent ever produced anything, and how the step ended.
+   *
+   * Kept out of `logs` on purpose. `logs` is the agent's own stdout/stderr, and
+   * a typed step parses it for the declared JSON payload; mixing engine notes
+   * into it would both corrupt that parse and misreport what the agent said.
+   *
+   * This is the answer to "it hung and the output was empty, now what?" — an
+   * empty log with a full timeline still tells you whether the process was
+   * spawned and whether it ever wrote a byte.
+   */
+  diagnostics?: string
 }
 
 export interface WorkflowDefinition {
@@ -865,6 +878,12 @@ export interface HeadlessSession {
   /** The agent's own session id (pinned via --session-id for claude/copilot),
    *  enabling later --resume. Only set for agents that support pinning. */
   agentSessionId?: string
+  /**
+   * Exactly what was spawned, for diagnosing a session that produces nothing.
+   * Safe to display: every agent now takes its prompt on stdin, so the argv
+   * carries flags and ids only.
+   */
+  launchCommand?: string
 }
 
 export interface ResizePayload {

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -260,7 +260,7 @@ export function RunStepsList({
               </div>
             )}
 
-            {expandedNodeId === ns.nodeId && !ns.logs && !ns.error && (
+            {expandedNodeId === ns.nodeId && !ns.logs && !ns.error && !ns.diagnostics && (
               <div className="px-4 pb-2">
                 <p className="text-[11px] text-gray-600 italic">
                   {ns.status === 'running'
@@ -271,6 +271,23 @@ export function RunStepsList({
                         ? 'Step was skipped.'
                         : 'No output recorded.'}
                 </p>
+              </div>
+            )}
+
+            {/* What the engine did, as distinct from what the agent said. This
+                is the only thing left to read when a step produced no output,
+                so it renders even — especially — when the log is empty. */}
+            {expandedNodeId === ns.nodeId && ns.diagnostics && (
+              <div className="px-4 pb-2">
+                <p className="text-[10px] uppercase tracking-wider text-gray-600 mb-1">
+                  Diagnostics
+                </p>
+                <pre
+                  className="text-[11px] text-gray-500 bg-black/20 rounded p-2 max-h-[160px] overflow-auto
+                             font-mono whitespace-pre-wrap break-all leading-relaxed"
+                >
+                  {ns.diagnostics}
+                </pre>
               </div>
             )}
           </div>

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -296,6 +296,26 @@ function resolveStepTimeoutMs(config: LaunchAgentConfig): number {
   return minutes > 0 ? minutes * 60_000 : 0
 }
 
+/**
+ * Records what the engine did on a step's behalf, so a step that produced no
+ * output still accounts for itself. Times are relative to the step starting,
+ * because "the agent was spawned but had written nothing 60 minutes later" is
+ * the shape of the answer, not the wall-clock time it happened at.
+ */
+class StepDiagnostics {
+  private readonly lines: string[] = []
+  private readonly startedAt = Date.now()
+
+  note(message: string): void {
+    const seconds = ((Date.now() - this.startedAt) / 1000).toFixed(1)
+    this.lines.push(`[+${seconds}s] ${message}`)
+  }
+
+  toString(): string {
+    return this.lines.join('\n')
+  }
+}
+
 function updateNodeState(
   execution: WorkflowExecution,
   nodeId: string,
@@ -693,6 +713,21 @@ async function executeNode(
 
     let sessionId: string | null = null
     let logs = ''
+    let bytesFromAgent = 0
+
+    const diag = new StepDiagnostics()
+    diag.note(
+      `Launching ${effectiveAgent} in ${existingWorktreePath || effectiveProjectPath || '(no path)'}` +
+        (initialPrompt
+          ? ` with a ${initialPrompt.split('\n').length}-line prompt`
+          : ' with no prompt')
+    )
+    /** Publishes the timeline immediately, so it is readable while the step is still running. */
+    const publishDiagnostics = (): void => {
+      updateNodeState(execution, node.id, { diagnostics: diag.toString() })
+      useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
+    }
+    publishDiagnostics()
 
     // Logs only live in renderer memory until the node finishes — if the
     // window reloads (HMR, devtools refresh, crash) mid-run they vanish even
@@ -715,6 +750,13 @@ async function executeNode(
     const removeDataListener = window.api.onHeadlessData(
       ({ id, data }: { id: string; data: string }) => {
         if (sessionId && id === sessionId) {
+          if (bytesFromAgent === 0) {
+            // Whether the agent ever spoke at all is the single most useful
+            // fact when a step stalls, so mark the first byte specifically.
+            diag.note(`First output from the agent (${data.length} bytes)`)
+            updateNodeState(execution, node.id, { diagnostics: diag.toString() })
+          }
+          bytesFromAgent += data.length
           logs = appendBoundedLog(logs, data)
           updateNodeState(execution, node.id, { logs })
           useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
@@ -787,9 +829,20 @@ async function executeNode(
       active?.sessionIds.add(headlessSession.id)
       useAppStore.getState().addHeadlessSession(headlessSession)
 
+      diag.note(
+        `Session ${headlessSession.id} started (pid ${headlessSession.pid || 'unknown'})` +
+          (headlessSession.launchCommand ? `: ${headlessSession.launchCommand}` : '')
+      )
+      if (timeoutMs > 0) {
+        diag.note(`Will give up after ${Math.round(timeoutMs / 60_000)} min without an exit`)
+      }
+
       // Claim any exit that landed while we were still learning our id.
       const raced = exitsBeforeIdKnown.get(headlessSession.id)
-      if (raced !== undefined) settle({ kind: 'exit', code: raced })
+      if (raced !== undefined) {
+        diag.note(`Agent had already exited (code ${raced}) before its id reached us`)
+        settle({ kind: 'exit', code: raced })
+      }
       exitsBeforeIdKnown.clear()
 
       updateNodeState(execution, node.id, {
@@ -815,26 +868,38 @@ async function executeNode(
 
       // Stopped: stopWorkflowRun owns the node's terminal state and has already
       // killed the agent. Writing a status here would just fight it.
-      if (outcome.kind === 'stopped') return
+      if (outcome.kind === 'stopped') {
+        diag.note('Stopped by user')
+        updateNodeState(execution, node.id, { diagnostics: diag.toString() })
+        return
+      }
 
       if (outcome.kind === 'timeout') {
         const minutes = Math.round(outcome.afterMs / 60_000)
-        const reason = `Step timed out after ${minutes} minute${minutes === 1 ? '' : 's'} without the agent exiting`
+        // Silence and slowness are different failures with different fixes, and
+        // the log alone can't tell them apart when it's empty either way.
+        const reason =
+          bytesFromAgent === 0
+            ? `Step timed out after ${minutes} minute${minutes === 1 ? '' : 's'}. The agent was started but never produced any output, which usually means it never really ran or is waiting on input it will never get.`
+            : `Step timed out after ${minutes} minute${minutes === 1 ? '' : 's'} without the agent exiting, after ${bytesFromAgent} bytes of output.`
         console.warn(
           `[workflow] "${node.label}": ${reason} — killing session ${headlessSession.id}`
         )
-        logs += `\n${reason}`
+        diag.note(reason)
         try {
           await window.api.killHeadlessSession(headlessSession.id)
+          diag.note('Agent killed')
         } catch (err) {
           console.warn(`[workflow] failed to kill timed-out session ${headlessSession.id}`, err)
+          diag.note(`Could not kill the agent: ${err instanceof Error ? err.message : String(err)}`)
         }
         updateNodeState(execution, node.id, {
           status: 'error',
           completedAt: new Date().toISOString(),
           output: logs,
           logs,
-          error: reason
+          error: reason,
+          diagnostics: diag.toString()
         })
         persistExecution(execution)
         if (resolvedTaskId) useAppStore.getState().reopenTask(resolvedTaskId)
@@ -842,6 +907,10 @@ async function executeNode(
       }
 
       const exitCode = outcome.code
+      diag.note(
+        `Agent exited with code ${exitCode} after ${bytesFromAgent} bytes of output` +
+          (bytesFromAgent === 0 ? ' — it produced nothing at all' : '')
+      )
 
       if (exitCode !== 0) {
         logs += `\nProcess exited with code ${exitCode}`
@@ -859,8 +928,11 @@ async function executeNode(
         else schemaError = result.error || 'Agent output did not match the declared schema.'
       }
 
+      if (schemaError) diag.note(`Output did not match the declared schema: ${schemaError}`)
+
       const failed = exitCode !== 0 || !!schemaError
       updateNodeState(execution, node.id, {
+        diagnostics: diag.toString(),
         status: failed ? 'error' : 'success',
         completedAt: new Date().toISOString(),
         output: logs,
@@ -875,7 +947,16 @@ async function executeNode(
       if (failed && resolvedTaskId) {
         useAppStore.getState().reopenTask(resolvedTaskId)
       }
+    } catch (err) {
+      // The step never got as far as running — most often the worktree or the
+      // agent binary. Without this the timeline stops at "Launching…" and the
+      // reason lives only in the error string.
+      diag.note(`Could not start: ${err instanceof Error ? err.message : String(err)}`)
+      throw err
     } finally {
+      // In the finally so it survives the throw path too; the caller's error
+      // handler assigns over the node state and leaves this field intact.
+      updateNodeState(execution, node.id, { diagnostics: diag.toString() })
       removeDataListener()
       removeExitListener()
       active?.abort.signal.removeEventListener('abort', onAbort)

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -58,6 +58,25 @@ describe('workflow run persistence', () => {
     expect(state.approvedAt).toBe('2026-04-20T10:00:04Z')
   })
 
+  it('round-trips step diagnostics, which outlive the window that made them', () => {
+    // The timeline matters most for a run you come back to later, so it has to
+    // survive the reload rather than living only in renderer memory.
+    const timeline =
+      '[+0.0s] Launching claude in /abs/proj\n' +
+      '[+0.4s] Session sess-1 started (pid 4242): claude --dangerously-skip-permissions -p\n' +
+      '[+3600.0s] Step timed out. The agent was started but never produced any output.'
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-diag',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'error',
+      nodeStates: [{ nodeId: 'node-1', status: 'error', diagnostics: timeline }]
+    }
+
+    saveWorkflowRun(exec)
+    const runs = listWorkflowRuns('wf-diag')
+    expect(runs[0].nodeStates[0].diagnostics).toBe(timeline)
+  })
+
   it('omits fields that were not set', () => {
     const exec: WorkflowExecution = {
       workflowId: 'wf-2',

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -221,6 +221,49 @@ describe('RunEntry', () => {
     expect(getByText(/No output captured yet/)).toBeInTheDocument()
   })
 
+  it('shows diagnostics instead of a dead end when the step produced no output', () => {
+    // The failure this exists for: an agent that hung and wrote nothing. The
+    // log is empty, so the timeline is the only thing left to read.
+    const exec = makeExec({
+      status: 'error',
+      nodeStates: [
+        makeState({
+          status: 'error',
+          logs: undefined,
+          error:
+            'Step timed out after 60 minutes. The agent was started but never produced any output.',
+          diagnostics:
+            '[+0.0s] Launching claude in /p\n[+0.4s] Session sess-1 started (pid 4242): claude --dangerously-skip-permissions -p'
+        })
+      ]
+    })
+    const { getByText, queryByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+
+    expect(getByText('Diagnostics')).toBeInTheDocument()
+    expect(getByText(/Session sess-1 started \(pid 4242\)/)).toBeInTheDocument()
+    expect(queryByText(/No output recorded/)).not.toBeInTheDocument()
+  })
+
+  it('shows diagnostics alongside the log when the agent did produce output', () => {
+    const exec = makeExec({
+      nodeStates: [
+        makeState({
+          status: 'success',
+          logs: 'agent said this',
+          diagnostics: '[+0.0s] Launching claude in /p'
+        })
+      ]
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+    fireEvent.click(getByText('Run Claude').closest('button')!)
+
+    expect(getByText('agent said this')).toBeInTheDocument()
+    expect(getByText('Diagnostics')).toBeInTheDocument()
+  })
+
   it("shows the pending empty state for a step that hasn't started", () => {
     const exec = makeExec({
       status: 'running',

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -10,11 +10,17 @@ import type { WorkflowDefinition, WorkflowExecution } from '../src/shared/types'
  */
 
 type ExitListener = (p: { id: string; exitCode: number }) => void
+type DataListener = (p: { id: string; data: string }) => void
 
 const exitListeners = new Set<ExitListener>()
+const dataListeners = new Set<DataListener>()
 
 function emitExit(id: string, exitCode: number): void {
   for (const l of [...exitListeners]) l({ id, exitCode })
+}
+
+function emitData(id: string, data: string): void {
+  for (const l of [...dataListeners]) l({ id, data })
 }
 
 const claims = new Map<string, string>()
@@ -49,7 +55,13 @@ let onSessionCreated: ((id: string) => void) | null = null
 const createHeadlessSession = vi.fn(() => {
   const id = `sess-${++sessionSeq}`
   queueMicrotask(() => onSessionCreated?.(id))
-  return Promise.resolve({ id, agentSessionId: undefined, worktreePath: undefined })
+  return Promise.resolve({
+    id,
+    pid: 4242,
+    launchCommand: 'claude --dangerously-skip-permissions -p',
+    agentSessionId: undefined,
+    worktreePath: undefined
+  })
 })
 
 const mockState = {
@@ -126,6 +138,7 @@ beforeEach(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).Notification = { permission: 'denied' }
   exitListeners.clear()
+  dataListeners.clear()
   claims.clear()
   runSeq = 0
   sessionSeq = 0
@@ -150,7 +163,10 @@ beforeEach(() => {
     getWorktreeActiveSessions: vi.fn(() => Promise.resolve({ count: 0 })),
     isWorktreeDirty: vi.fn(() => Promise.resolve(false)),
     removeWorktree: vi.fn(() => Promise.resolve()),
-    onHeadlessData: () => () => {},
+    onHeadlessData: (fn: DataListener) => {
+      dataListeners.add(fn)
+      return () => dataListeners.delete(fn)
+    },
     onHeadlessExit: (fn: ExitListener) => {
       exitListeners.add(fn)
       return () => exitListeners.delete(fn)
@@ -305,5 +321,97 @@ describe('stopping a run', () => {
     const sessionId = await nextSession()
     emitExit(sessionId, 0)
     expect((await second).status).toBe('success')
+  })
+})
+
+describe('step diagnostics', () => {
+  /** The engine's own account of the step, distinct from the agent's output. */
+  function diagnosticsOf(execution: WorkflowExecution): string {
+    return execution.nodeStates.find((n) => n.nodeId === 'agent')?.diagnostics ?? ''
+  }
+
+  it('records what was launched, including the exact command', async () => {
+    const wf = makeWorkflow()
+    const runPromise = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    emitExit(sessionId, 0)
+
+    const diag = diagnosticsOf(await runPromise)
+    expect(diag).toContain('Launching claude')
+    expect(diag).toContain(sessionId)
+    expect(diag).toContain('pid 4242')
+    // Without the command line there is no way to tell a bad flag from a bad agent.
+    expect(diag).toContain('claude --dangerously-skip-permissions -p')
+  })
+
+  it('distinguishes a silent timeout from a slow one', async () => {
+    const wf = makeWorkflow()
+    mockState.config.defaults.headlessStepTimeoutMinutes = 1
+    const runPromise = executeWorkflow(wf)
+    await nextSession()
+    await vi.advanceTimersByTimeAsync(60_000 + 10)
+
+    const execution = await runPromise
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    // Silence is the diagnostic: it means the agent never really ran.
+    expect(agent?.error).toMatch(/never produced any output/i)
+    expect(diagnosticsOf(execution)).toMatch(/never produced any output/i)
+  })
+
+  it('reports how much the agent said when a timeout follows real output', async () => {
+    const wf = makeWorkflow()
+    mockState.config.defaults.headlessStepTimeoutMinutes = 1
+    const runPromise = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    await vi.advanceTimersByTimeAsync(0)
+    emitData(sessionId, 'thinking hard\n')
+    await vi.advanceTimersByTimeAsync(60_000 + 10)
+
+    const execution = await runPromise
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    expect(agent?.error).toContain('14 bytes of output')
+    expect(agent?.error).not.toMatch(/never produced any output/i)
+    expect(diagnosticsOf(execution)).toContain('First output from the agent')
+  })
+
+  it('keeps the timeline out of the agent log', async () => {
+    const wf = makeWorkflow()
+    const runPromise = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    await vi.advanceTimersByTimeAsync(0)
+    emitData(sessionId, '{"ok":true}')
+    emitExit(sessionId, 0)
+
+    const execution = await runPromise
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    // A typed step parses `logs` for its declared payload, so engine notes must
+    // never land there.
+    expect(agent?.logs).toBe('{"ok":true}')
+    expect(agent?.logs).not.toContain('Launching')
+    expect(agent?.diagnostics).toContain('Launching')
+  })
+
+  it('notes the exit code and that nothing was produced', async () => {
+    const wf = makeWorkflow()
+    const runPromise = executeWorkflow(wf)
+    const sessionId = await nextSession()
+    emitExit(sessionId, 1)
+
+    const diag = diagnosticsOf(await runPromise)
+    expect(diag).toContain('exited with code 1')
+    expect(diag).toContain('produced nothing at all')
+  })
+
+  it('explains a step that never got as far as launching', async () => {
+    const wf = makeWorkflow()
+    createHeadlessSession.mockImplementationOnce(() =>
+      Promise.reject(new Error('git worktree add failed'))
+    )
+
+    const execution = await executeWorkflow(wf)
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    expect(agent?.status).toBe('error')
+    // The timeline survives the throw path, so it still says how far it got.
+    expect(agent?.diagnostics).toContain('Could not start: git worktree add failed')
   })
 })


### PR DESCRIPTION
When a headless step hangs, the app currently tells you nothing. The expanded step says *"No output captured yet…"* and stops there — you can't tell whether the agent was spawned at all, what it was spawned as, or whether it ever wrote a byte. That is exactly what the Windows hang looked like: **zero bytes of output, forever.**

The only place that knew anything was `main.log`, and it truncated the command line to 100 characters.

## Each step now keeps a timeline

```
[+0.0s] Launching copilot in /tmp with a 17-line prompt
[+0.2s] Session sess-1 started (pid 55001): copilot --allow-all
[+0.2s] Will give up after 60 min without an exit
[+8.9s] First output from the agent (1 bytes)
[+10.2s] Agent exited with code 0 after 158 bytes of output
```

Captured from a real copilot run. Times are relative to the step, because the useful shape of the answer is *"it was spawned and had written nothing an hour later"*, not the wall clock it happened at. Note the **8.9 seconds of silence before the first byte** — invisible today.

## Deliberately not in `logs`

`logs` is the agent's own stdout/stderr, and a typed step parses it for the declared JSON payload. Engine notes mixed into it would corrupt that parse and misreport what the agent said. So the timeline is its own field, rendered as its own block in the expanded step — including, especially, when the log is empty. That replaces the dead end that was there before.

There's a test pinning this: a step whose agent emitted `{"ok":true}` has exactly that in `logs`, with the timeline nowhere near it.

## Timeouts now distinguish silence from slowness

Different failures, different fixes, and an empty log looks identical either way.

```
before:  Step timed out after 60 minutes without the agent exiting

after:   Step timed out after 60 minutes. The agent was started but never
         produced any output, which usually means it never really ran or is
         waiting on input it will never get.

         (or, when it did speak:)
         …without the agent exiting, after 4312 bytes of output.
```

## Also

- The exact spawn command is recorded on the session and no longer truncated in `main.log`. Without it, a bad flag and a missing agent look the same. Nothing sensitive is in there — every agent takes its prompt on stdin now.
- The timeline is written in a `finally`, so a step that failed *before* it launched (worktree creation, missing binary) still reports how far it got.
- It's persisted alongside the other node columns, so a run reviewed tomorrow reads the same as one watched live. New `diagnostics` column with a migration entry, following the existing `approved_at` pattern.

## Testing

`typecheck` and `lint` clean. **1998 tests across 191 files pass**, +9 new covering: the timeline records the launch command, pid and session id; a silent timeout says so and a noisy one reports its byte count; the timeline stays out of `logs`; a step that never launched still explains itself; diagnostics survive a persistence round-trip; and the UI renders them both alongside a log and in place of the empty-log dead end.
