### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — six workspace package.json files, synced by `scripts/sync-versions.sh`.

A minor rather than a patch: the terminal gained command blocks and shell integration for four shells it did not previously support, and workflows gained the ability to stop a run and bound a step.

## Since v0.4.1

**Terminal**
- Finished shell commands render as elements rather than being approximated inside the character grid, so a block's padding, boundary, hover state and per-block copy are CSS (#385)
- Command boundaries now work in bash, fish, PowerShell and cmd, not just zsh — each injected the way that shell supports (#385)
- Settings picks a shell from what is actually installed, stating what each can report about a command (#385)
- Windows no longer defaults to cmd, the one shell that can report neither exit status nor command name (#385)
- `Ctrl+C` reaches a command started from the composer; previously a running command could not be interrupted without clicking into the terminal first (#386)

**Workflows**
- Headless runs no longer hang indefinitely on Windows. Every agent takes its prompt on stdin, the one route that never touches the cmd.exe command line — which cannot carry a literal newline (#387)
- A run can be stopped, and a step is bounded by a timeout, so one wedged agent no longer blocks every later run of its workflow (#387)
- Runs of one workflow proceed in parallel, keyed by run rather than by workflow (#387)
- Each step keeps a timeline of what the engine did on its behalf, so a step that produced no output still accounts for itself (#390)

**Dependencies**
- 22 security advisories closed, lockfile only (#388, #378)

## Checks

CI green on every commit in this range. Release artifacts build from the `v0.5.0` tag once this merges.