### PR TITLE
fix(terminal): show the command that is running

### DIFF
--- a/src/renderer/components/RunningCommand.tsx
+++ b/src/renderer/components/RunningCommand.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { formatDuration, getRunningBlock, onCommandBlocksChange } from '../lib/command-blocks'
+
+/**
+ * The command running right now, between the finished blocks and the live
+ * terminal.
+ *
+ * Blocks only appear once a command has finished, so while one is running there
+ * was nothing at all to say so — and a command that never exits, `cat` with no
+ * arguments being the easy way to get one, looked exactly like a dead terminal.
+ * Everything typed afterwards goes to that command's stdin, which reads as the
+ * shell having stopped responding.
+ *
+ * The spine used to carry this. It is not drawn in block mode, since the
+ * terminal is cleared after each command and its marks would index nothing.
+ */
+
+/** Elapsed time is the whole point, so it has to tick on its own. */
+const TICK_MS = 1000
+
+export function RunningCommand({ terminalId }: { terminalId: string }) {
+  const [running, setRunning] = useState(() => getRunningBlock(terminalId))
+  const [elapsed, setElapsed] = useState('')
+
+  useEffect(() => {
+    return onCommandBlocksChange(terminalId, () => setRunning(getRunningBlock(terminalId)))
+  }, [terminalId])
+
+  useEffect(() => {
+    if (!running) return
+    // Read the clock here rather than while rendering: a render that calls
+    // Date.now() is not idempotent, and the elapsed value has to survive
+    // re-renders it did not cause.
+    const update = (): void => setElapsed(formatDuration(Math.max(0, Date.now() - running.since)))
+    const first = setTimeout(update, 0)
+    const id = setInterval(update, TICK_MS)
+    return () => {
+      clearTimeout(first)
+      clearInterval(id)
+    }
+  }, [running])
+
+  if (!running) return null
+
+  return (
+    <div className="flex shrink-0 items-baseline gap-2 border-t border-white/[0.06] py-1.5 pl-3 pr-3">
+      {/* Colour is spent here because this is status: something is happening
+          that the rest of the surface cannot show. */}
+      <span
+        aria-hidden
+        className="mt-[6px] h-[6px] w-[6px] shrink-0 animate-pulse rounded-full bg-blue-400"
+      />
+      <span className="min-w-0 flex-1 truncate font-mono text-[13px] font-semibold text-gray-100">
+        {running.command ?? 'Running'}
+      </span>
+      <span className="shrink-0 font-mono text-[10px] tabular-nums text-white/25">{elapsed}</span>
+      <span className="shrink-0 font-mono text-[10px] text-white/25">⌃C to interrupt</span>
+    </div>
+  )
+}

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -1,6 +1,7 @@
 import { TerminalSlot } from './TerminalSlot'
 import { CommandSpine } from './CommandSpine'
 import { BlockLog } from './BlockLog'
+import { RunningCommand } from './RunningCommand'
 import { registerBlockLogView } from '../lib/block-log'
 import { useLiveTerminalRows } from '../hooks/useLiveTerminalRows'
 import { hasShellIntegration, onCommandBlocksChange } from '../lib/command-blocks'
@@ -73,6 +74,7 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
     return (
       <div className="absolute inset-0 right-4 bottom-4 flex flex-col justify-end">
         <BlockLog terminalId={terminalId} className={logClass} />
+        {!fullScreen && <RunningCommand terminalId={terminalId} />}
         <TerminalSlot
           terminalId={terminalId}
           isFocused={isFocused}
@@ -114,6 +116,10 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
       // has run, rather than stranded at the top above empty space.
       <div className="flex h-full w-full flex-col justify-end">
         <BlockLog terminalId={terminalId} className={logClass} />
+        {/* Blocks only exist once a command has finished, so a running one
+            needs saying out loud — otherwise a command that never exits looks
+            like a terminal that stopped responding. */}
+        {!fullScreen && <RunningCommand terminalId={terminalId} />}
         {/* The live command only. Capped so a quiet session is mostly log,
             but tall enough that a running command has room to draw. */}
         <TerminalSlot

--- a/tests/running-command.test.tsx
+++ b/tests/running-command.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, act, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const state = vi.hoisted(() => ({
+  running: null as { command: string | null; since: number } | null,
+  listeners: new Set<() => void>()
+}))
+
+vi.mock('../src/renderer/lib/command-blocks', () => ({
+  getRunningBlock: () => state.running,
+  onCommandBlocksChange: (_id: string, cb: () => void) => {
+    state.listeners.add(cb)
+    return () => state.listeners.delete(cb)
+  },
+  formatDuration: (ms: number) => `${Math.round(ms / 1000)}s`
+}))
+
+import { RunningCommand } from '../src/renderer/components/RunningCommand'
+
+/**
+ * A block only appears once its command has finished. While one runs there was
+ * nothing to say so, and a command that never exits — `cat` with no arguments
+ * is the easy way to get one — looked exactly like a terminal that had stopped
+ * responding, because everything typed afterwards went to its stdin.
+ */
+
+function emit(): void {
+  act(() => {
+    for (const cb of state.listeners) cb()
+  })
+}
+
+beforeEach(() => {
+  state.running = null
+  state.listeners.clear()
+})
+afterEach(() => cleanup())
+
+describe('RunningCommand', () => {
+  it('draws nothing while the shell waits at its prompt', () => {
+    const { container } = render(<RunningCommand terminalId="t" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('names the command that is running', () => {
+    state.running = { command: 'cat', since: Date.now() }
+    render(<RunningCommand terminalId="t" />)
+    expect(screen.getByText('cat')).toBeInTheDocument()
+  })
+
+  it('says how to interrupt it, since that is the way out', () => {
+    state.running = { command: 'cat', since: Date.now() }
+    render(<RunningCommand terminalId="t" />)
+    expect(screen.getByText(/interrupt/)).toBeInTheDocument()
+  })
+
+  it('appears as soon as a command starts', () => {
+    render(<RunningCommand terminalId="t" />)
+    state.running = { command: 'yarn test', since: Date.now() }
+    emit()
+    expect(screen.getByText('yarn test')).toBeInTheDocument()
+  })
+
+  it('disappears once the command finishes', () => {
+    state.running = { command: 'yarn test', since: Date.now() }
+    const { container } = render(<RunningCommand terminalId="t" />)
+    state.running = null
+    emit()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('still reports a command whose text the shell could not name', () => {
+    // cmd.exe cannot report command text, but "something is running" is the
+    // fact that matters here.
+    state.running = { command: null, since: Date.now() }
+    render(<RunningCommand terminalId="t" />)
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  it('shows elapsed time, which is what tells you it is stuck', async () => {
+    // Measured off the clock in an effect, not during render — a render that
+    // reads the clock is not idempotent.
+    state.running = { command: 'cat', since: Date.now() - 12_000 }
+    render(<RunningCommand terminalId="t" />)
+    await waitFor(() => expect(screen.getByText('12s')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
A block only appears once its command has finished, so while one runs there was nothing on the surface saying so.

A command that never exits — `cat` with no arguments is the easy way to get one — then looks exactly like a terminal that has stopped responding. Everything typed afterwards goes to that command's stdin and is echoed back, so it reads as commands producing no output:

```
cat        <- still running, holding stdin
pwd        <- echoed by cat, never reached the shell
pwd
ls
ls
```

## Cause

`CommandSpine` carried this, and it is not drawn in block mode — the terminal is cleared after each command, so its marks would index nothing. Making blocks the default therefore removed the only running indicator there was.

## Fix

The running command sits between the finished blocks and the live terminal, with its elapsed time and how to interrupt it. It appears the moment a command starts and goes when it finishes.

Elapsed time is read off the clock in an effect rather than during render — a render that calls `Date.now()` is not idempotent, and the lint rule was right to reject it.

A shell that cannot report command text still says *something* is running, which is the fact that matters when the surface is otherwise silent.

## Not the cause

The live region resizes the pty mid-command now, which it never did when it was a fixed row count. I checked whether that broke block capture by driving a real xterm at 2, 10 and 24 rows and across a mid-command resize — capture held in every case. Worth recording, since it was the obvious suspect.

## Checks

7 new tests; full suite, typecheck, lint and format clean.