### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — six workspace package.json files, synced by `scripts/sync-versions.sh`.

Carries everything intended for 0.5.0 plus #392, which restores the running-command indicator that block rendering had removed.

0.5.0 is skipped rather than reused: its tag was briefly published before being withdrawn, and two different builds must never share a version.

## Since v0.4.1

**Terminal**
- Finished shell commands render as elements rather than being approximated inside the character grid (#385)
- Command boundaries work in bash, fish, PowerShell and cmd, not just zsh — each injected the way that shell supports (#385)
- Settings picks a shell from what is installed, stating what each can report about a command (#385)
- Windows no longer defaults to cmd, the one shell that can report neither exit status nor command name (#385)
- `Ctrl+C` reaches a command started from the composer (#386)
- The command currently running is shown, with its elapsed time and how to interrupt it. Blocks only appear once a command finishes, so a command that never exits previously looked like a terminal that had stopped responding (#392)

**Workflows**
- Headless runs no longer hang indefinitely on Windows: every agent takes its prompt on stdin, the one route that never touches the cmd.exe command line (#387)
- A run can be stopped and a step is bounded by a timeout, so one wedged agent no longer blocks every later run of its workflow (#387)
- Runs of one workflow proceed in parallel, keyed by run rather than by workflow (#387)
- Each step keeps a timeline of what the engine did on its behalf (#390)

**Dependencies**
- 22 security advisories closed, lockfile only (#388, #378)