### PR TITLE
chore(deps): bump @hono/node-server resolution to ^2.0.11 (fixes GHSA-frvp-7c67-39w9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "serialize-javascript": "^7.0.5",
     "@xmldom/xmldom": "^0.8.10",
     "hono": "^4.12.31",
-    "@hono/node-server": "^1.19.14",
+    "@hono/node-server": "^2.0.11",
     "lodash": "^4.18.1",
     "flatted": "^3.4.2",
     "tar": "^7.5.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,12 +2392,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:^1.19.14":
-  version: 1.19.14
-  resolution: "@hono/node-server@npm:1.19.14"
+"@hono/node-server@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@hono/node-server@npm:2.0.11"
   peerDependencies:
     hono: ^4
-  checksum: 10c0/41a099bb3705d96aac44b7a8db8805f2a22ce8a0f767a27b6d10b74a9964925df01c5f35d3631e882f8bcdeee3518884c30f40588ac8c960d88bf71048ba0df3
+  checksum: 10c0/eedfff2122bcb23b368f4a785c2f8d93ecd653c14ecdbf47422fedeb559fb7201c183b10020c3cc01457d856cdda6868fdc5e8f60c3af1d6c6ddd77291689736
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Supersedes #394.

### Why not #394?

Dependabot's #394 bumps the `@hono/node-server` resolution `1.19.14 → 1.19.17`, but the advisory **GHSA-frvp-7c67-39w9** has a vulnerable range of `< 2.0.5`. So 1.19.17 does not clear the alert.

#394 also only touched `package.json` and never regenerated `yarn.lock`, so CI failed the `--immutable` check — twice, including after a `@dependabot recreate`. This is a known Yarn Berry limitation with `resolutions` entries.

### This PR

Bumps the resolution to `^2.0.11` and regenerates `yarn.lock`.

### Compatibility review

- **API**: v2.0.0 is a performance-focused major — upstream states "the public API stays the same". `getRequestListener` (the only symbol used, via `@modelcontextprotocol/sdk`'s `streamableHttp`), plus `serve`, `createAdaptorServer` and `RequestError` are all still exported. v2 additionally adds `upgradeWebSocket`.
- **Removed export**: only the `./vercel` subpath. Not referenced anywhere in this repo, nor in `@modelcontextprotocol/sdk`.
- **Peer deps**: `hono: ^4` — unchanged, and the repo pins `hono: ^4.12.31`.
- **Engines**: v1 `>=18.14.1` → v2 `>=20`. CI runs Node 20. ✅
- **Consumer**: `@modelcontextprotocol/sdk@1.29.0` requests `^1.19.9`; the `resolutions` override intentionally forces 2.x, which is the only way to reach the patched version.

Closes the open Dependabot alert.
