### PR TITLE
chore: guard yarn.lock against private registry leakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Completion index matches allowlist
         run: node scripts/check-completion-allowlist.mjs
 
+      - name: Lockfile has no private registry references
+        # Installs behind a corporate npm mirror make Yarn pin tarballs to that
+        # mirror via __archiveUrl, which leaks an internal host into this public
+        # repo and breaks installs for everyone else.
+        run: yarn lint:lockfile
+
       - name: Lint
         run: yarn lint
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "lint": "eslint .",
+    "lint:lockfile": "node scripts/check-lockfile.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
@@ -26,6 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "gen:completions": "node scripts/generate-completion-index.mjs",
     "ci:local": "bash scripts/ci-local.sh",
+    "deps:install": "bash scripts/yarn-install.sh",
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
@@ -33,6 +35,7 @@
     "pre-push": "yarn typecheck"
   },
   "lint-staged": {
+    "yarn.lock": "node scripts/check-lockfile.mjs --fix",
     "*.{ts,tsx}": [
       "eslint --max-warnings 0",
       "prettier --write"

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Guards yarn.lock against registry leakage.
+//
+// Public npm is unreachable on some machines (corporate proxies), so installs
+// run against a mirror. When the mirror serves tarballs from a different host
+// than the registry it advertises, Yarn pins that host into the locator:
+//
+//   resolution: "@scope/pkg@npm:2.0.11::__archiveUrl=https%3A%2F%2Finternal..."
+//
+// Committing that leaks an internal endpoint into a public repo and pins CI to
+// a host it cannot reach. The archive URL is redundant — the checksum already
+// identifies the tarball — so stripping it is safe and keeps `--immutable`
+// happy on the public registry.
+//
+// Usage: node scripts/check-lockfile.mjs [--fix]
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const LOCKFILE = join(dirname(fileURLToPath(import.meta.url)), '..', 'yarn.lock')
+
+// Hosts a lockfile in this repo may legitimately reference. Anything else is
+// assumed to be a private mirror that other clones and CI cannot resolve.
+const ALLOWED_HOSTS = new Set([
+  'registry.npmjs.org',
+  'registry.yarnpkg.com',
+  'github.com',
+  'codeload.github.com',
+  'raw.githubusercontent.com'
+])
+
+const fix = process.argv.includes('--fix')
+const original = readFileSync(LOCKFILE, 'utf8')
+
+// Yarn locators encode bindings as `base::key=value&key2=value2`. Operate on
+// the quoted locator itself, so dropping the trailing binding cannot swallow
+// the closing quote, and sibling bindings survive.
+const stripBindingFromLocator = (locator) => {
+  const [base, ...bindingParts] = locator.split('::')
+  if (bindingParts.length === 0) return locator
+
+  const kept = bindingParts
+    .join('::')
+    .split('&')
+    .filter((binding) => !binding.startsWith('__archiveUrl='))
+
+  return kept.length > 0 ? `${base}::${kept.join('&')}` : base
+}
+
+const stripArchiveUrl = (line) =>
+  line.replace(/"([^"]*)"/g, (match, locator) =>
+    locator.includes('__archiveUrl=') ? `"${stripBindingFromLocator(locator)}"` : match
+  )
+
+let archiveUrlCount = 0
+const fixed = original
+  .split('\n')
+  .map((line) => {
+    if (!line.includes('__archiveUrl=')) return line
+    archiveUrlCount += 1
+    return stripArchiveUrl(line)
+  })
+  .join('\n')
+
+if (archiveUrlCount > 0 && fix) {
+  writeFileSync(LOCKFILE, fixed)
+}
+
+const errors = []
+
+if (archiveUrlCount > 0 && !fix) {
+  errors.push(
+    `${archiveUrlCount} __archiveUrl binding(s) in yarn.lock pin tarballs to a private mirror.\n` +
+      `    Run 'yarn lint:lockfile --fix' (or use 'yarn deps:install') before committing.`
+  )
+}
+
+// Percent-encoded URLs hide inside locators, so normalise before scanning.
+const decoded = (fix ? fixed : original).replace(/%3A/gi, ':').replace(/%2F/gi, '/')
+for (const [, host] of decoded.matchAll(/https?:\/\/([^\s"/,&]+)/g)) {
+  const bareHost = host.replace(/:\d+$/, '').toLowerCase()
+  if (!ALLOWED_HOSTS.has(bareHost)) {
+    errors.push(
+      `yarn.lock references non-public host '${bareHost}'.\n` +
+        `    Regenerate the lockfile against the public npm registry, or add the host to\n` +
+        `    ALLOWED_HOSTS in scripts/check-lockfile.mjs if it is genuinely public.`
+    )
+    break
+  }
+}
+
+if (errors.length > 0) {
+  console.error('✗ yarn.lock validation failed:\n')
+  for (const error of errors) console.error(`  - ${error}\n`)
+  process.exit(1)
+}
+
+if (archiveUrlCount > 0) {
+  console.log(`✓ yarn.lock: stripped ${archiveUrlCount} private-mirror __archiveUrl binding(s)`)
+} else {
+  console.log('✓ yarn.lock: no private registry references')
+}

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -25,6 +25,9 @@ git diff --exit-code src/renderer/lib/completion-index
 # allowlist edited without regenerating.
 node scripts/check-completion-allowlist.mjs
 
+step "Lockfile has no private registry references"
+yarn lint:lockfile
+
 step "Lint"
 yarn lint
 

--- a/scripts/yarn-install.sh
+++ b/scripts/yarn-install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Installs dependencies on machines where public npm is firewalled.
+#
+# Yarn Berry ignores ~/.npmrc, so a mirror configured for npm is invisible to
+# it and `yarn install` fails with an opaque ENOTCONN/RequestError. This reads
+# the mirror from the local npm config (never committed — it is machine
+# specific) and hands it to Yarn, then strips the private archive URLs Yarn
+# pins into yarn.lock when the mirror serves tarballs from another host.
+#
+# Usage: yarn deps:install [extra yarn install args]
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+DEFAULT_REGISTRY="https://registry.npmjs.org"
+registry="$(npm config get registry 2>/dev/null || true)"
+registry="${registry%/}"
+
+if [ -n "$registry" ] && [ "$registry" != "undefined" ] && [ "$registry" != "$DEFAULT_REGISTRY" ]; then
+  printf "\033[1;36m▶ Using npm registry from local npm config: %s\033[0m\n" "$registry"
+  export YARN_NPM_REGISTRY_SERVER="$registry"
+else
+  printf "\033[1;36m▶ Using default public npm registry\033[0m\n"
+fi
+
+# Keep going on failure so the lockfile is still sanitised: Yarn writes the
+# updated lockfile during resolution, then may fail later in the fetch step if
+# the mirror has not ingested a newly published version yet.
+install_status=0
+yarn install "$@" || install_status=$?
+
+node scripts/check-lockfile.mjs --fix
+
+if [ "$install_status" -ne 0 ]; then
+  printf "\n\033[1;33m⚠  yarn install exited with status %s.\033[0m\n" "$install_status"
+  printf "   If this is a 404 on a recently published version, the mirror has not\n"
+  printf "   ingested it yet. CI resolves against public npm and is unaffected.\n"
+  exit "$install_status"
+fi
+
+printf "\n\033[1;32m✓ Dependencies installed and yarn.lock validated\033[0m\n"


### PR DESCRIPTION
Follow-up to #399, which hit this problem manually.

## Problem

Public npm is firewalled on some machines, so installs run against a corporate mirror. Two things go wrong:

1. **Yarn Berry ignores `~/.npmrc`**, so a mirror configured for npm is invisible to it and `yarn install` fails with an opaque `ENOTCONN` / `RequestError`.
2. Pointing Yarn at the mirror works, but when the mirror serves tarballs from a different host than the registry it advertises, Yarn pins that host into the locator:

```
resolution: "@scope/pkg@npm:2.0.11::__archiveUrl=https%3A%2F%2Finternal-host%2F..."
```

Committing that leaks an internal endpoint into this **public** repo and pins CI to a host it cannot reach. The mirror also load-balances (observed `ms-feed-2`, `ms-feed-3`, `ms-feed-12` across runs), so the value isn't even stable.

The archive URL is redundant — the checksum already identifies the tarball — so stripping it is safe and keeps `--immutable` happy on the public registry. This was verified in #399, whose CI passed against public npm with a stripped lockfile.

## Changes

**`scripts/check-lockfile.mjs`** — validates the lockfile, repairs it with `--fix`.
- Drops only the `__archiveUrl` binding, preserving sibling bindings (`&locator=...`) and the closing quote.
- Also scans for any URL host outside an allowlist of public hosts, to catch mirrors that leak some other way. Decodes percent-encoded URLs first, since they hide inside locators.

**`scripts/yarn-install.sh`** (`yarn deps:install`) — proxy-aware install wrapper.
- Reads the mirror from the local npm config instead of hardcoding it, so nothing machine-specific lands in this public repo and it works behind any corporate proxy.
- Sanitises the lockfile *even when the install fails*, because Yarn writes the lockfile during resolution and can still fail later in the fetch step when the mirror hasn't ingested a newly published version yet.

**Wiring** — `lint-staged` (which re-stages the repaired lockfile), `scripts/ci-local.sh`, and the CI workflow.

## Validation

- Reproduced the real leak end to end: forced a fresh resolution through the actual mirror with raw `yarn install`, confirmed `__archiveUrl` appeared, confirmed the check exits 1, confirmed `yarn deps:install` self-heals to a clean lockfile.
- Unit-tested all three leak shapes — sole binding, binding with a sibling, and a leak in a descriptor key rather than a resolution line — asserting the file is byte-identical to pristine afterwards and all quotes stay balanced.
- Caught and fixed a real bug this way: stripping the final binding originally swallowed the line's closing quote.
- `yarn lint` (0 errors), `yarn format:check`, and `yarn lint:lockfile` all pass.
