### PR TITLE
ci: build on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable
@@ -149,7 +149,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable
@@ -210,7 +210,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable
@@ -271,7 +271,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
Follow-up to #396, which bumped `@testing-library/jest-dom` to v7.

## Why

jest-dom v7 declares a minimum of **Node 22**, while `ci.yml` and all four `release.yml` jobs pinned Node 20. Tests passed anyway — the `engines` field is advisory, not enforced — but the floor should be real rather than relying on that.

Node 22 also lines up with two things the repo already assumes:

- `build:server` runs `tsup --target node22`
- Electron 41 embeds Node 22

So the build toolchain now matches the runtime it produces artifacts for, instead of building a node22 target on a node20 toolchain.

## Compatibility check

Scanned every installed package's `engines.node` for an upper bound below 22 — there are none. Several already require a Node 22 *minor*, which Node 20 never satisfied:

| Requirement | Packages |
|---|---|
| `^22.13.0` | eslint, jsdom |
| `>=22.12.0` | vite, rolldown, electron-vite, @vitejs/plugin-react |
| `>=22.9.0` | npm tooling (cacache, make-fetch-happen, …) |

All are satisfied by the latest 22.x that `actions/setup-node` resolves for `node-version: 22`.

## Scope

5 lines: `ci.yml` (1) and `release.yml` (4 — macOS, Windows, and both Linux jobs). CI exercises typecheck, lint, the full test suite, the server CJS bundle, the production Electron build and the preload artifact checks, so a green run covers the release path's build steps too.
