### PR TITLE
feat(workflows): user-supplied inputs for manual runs

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2265,7 +2265,11 @@ function parseRunInputs(raw: string | null): Record<string, unknown> | undefined
   if (!raw) return undefined
   try {
     const parsed = JSON.parse(raw)
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined
+    // Arrays are `typeof 'object'` but would surface as numeric-keyed rows in
+    // run history, so they're rejected alongside scalars and null.
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined
   } catch {
     return undefined
   }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -343,7 +343,8 @@ function createSchema(): void {
       started_at TEXT NOT NULL,
       completed_at TEXT,
       status TEXT NOT NULL DEFAULT 'running',
-      trigger_task_id TEXT
+      trigger_task_id TEXT,
+      inputs TEXT
     );
 
     CREATE TABLE IF NOT EXISTS workflow_run_nodes (
@@ -637,6 +638,20 @@ function migrateSchema(d: Database.Database): void {
     })()
     log.info('[database] migrated schema to version 10 (drop session_logs)')
   }
+
+  if (version < 11) {
+    d.transaction(() => {
+      const runCols = d.prepare('PRAGMA table_info(workflow_runs)').all() as Array<{ name: string }>
+      if (!runCols.some((c) => c.name === 'inputs')) {
+        d.exec('ALTER TABLE workflow_runs ADD COLUMN inputs TEXT')
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '11')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 11 (workflow run inputs)')
+  }
 }
 
 /**
@@ -682,6 +697,7 @@ function verifySchema(d: Database.Database): void {
         ddl: 'ALTER TABLE agent_commands ADD COLUMN headless_args TEXT'
       }
     ],
+    workflow_runs: [{ column: 'inputs', ddl: 'ALTER TABLE workflow_runs ADD COLUMN inputs TEXT' }],
     workflow_run_nodes: [
       { column: 'agent_type', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN agent_type TEXT' },
       {
@@ -2118,15 +2134,16 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
 
   const run = d.transaction(() => {
     d.prepare(
-      `INSERT OR REPLACE INTO workflow_runs (id, workflow_id, started_at, completed_at, status, trigger_task_id)
-       VALUES (?, ?, ?, ?, ?, ?)`
+      `INSERT OR REPLACE INTO workflow_runs (id, workflow_id, started_at, completed_at, status, trigger_task_id, inputs)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
     ).run(
       runId,
       execution.workflowId,
       execution.startedAt,
       execution.completedAt ?? null,
       execution.status,
-      execution.triggerTaskId ?? null
+      execution.triggerTaskId ?? null,
+      execution.inputs ? JSON.stringify(execution.inputs) : null
     )
 
     // Delete existing nodes for this run (for upsert behavior)
@@ -2237,23 +2254,41 @@ type RunRow = {
   completed_at: string | null
   status: string
   trigger_task_id: string | null
+  inputs: string | null
   workflow_name?: string | null
+}
+
+/** Run inputs are stored as a JSON blob. A row written before the column
+ *  existed — or by a build that wrote something unparseable — must not take
+ *  the whole run's history down with it. */
+function parseRunInputs(raw: string | null): Record<string, unknown> | undefined {
+  if (!raw) return undefined
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function mapRunRows(
   rows: RunRow[],
   nodesByRun: Map<string, NodeExecutionState[]>
 ): (WorkflowExecution & { workflowName?: string })[] {
-  return rows.map((r) => ({
-    runId: r.id,
-    workflowId: r.workflow_id,
-    startedAt: r.started_at,
-    ...(r.completed_at != null && { completedAt: r.completed_at }),
-    status: r.status as WorkflowExecution['status'],
-    ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
-    ...(r.workflow_name != null && { workflowName: r.workflow_name }),
-    nodeStates: nodesByRun.get(r.id) ?? []
-  }))
+  return rows.map((r) => {
+    const inputs = parseRunInputs(r.inputs)
+    return {
+      runId: r.id,
+      workflowId: r.workflow_id,
+      startedAt: r.started_at,
+      ...(r.completed_at != null && { completedAt: r.completed_at }),
+      status: r.status as WorkflowExecution['status'],
+      ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
+      ...(inputs && { inputs }),
+      ...(r.workflow_name != null && { workflowName: r.workflow_name }),
+      nodeStates: nodesByRun.get(r.id) ?? []
+    }
+  })
 }
 
 export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecution[] {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -681,8 +681,8 @@ export function registerAllMethods(): void {
     configManager.notifyChanged()
   })
 
-  registerMethod('workflow:runManual', ({ workflowId }) => {
-    scheduler.triggerWorkflow(workflowId)
+  registerMethod('workflow:runManual', ({ workflowId, inputs }) => {
+    scheduler.triggerWorkflow(workflowId, inputs)
   })
 
   // Runs execute in the renderer, but a scheduler tick reaches every connected

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -156,7 +156,7 @@ class Scheduler extends EventEmitter {
     }
   }
 
-  private executeWorkflow(workflowId: string): void {
+  private executeWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
     if (!acquireExecutionLock(workflowId)) {
       log.info(`[scheduler] skipping workflow ${workflowId} — already executed by another instance`)
       this.timeouts.delete(workflowId)
@@ -184,7 +184,7 @@ class Scheduler extends EventEmitter {
     }
 
     log.info(`[scheduler] executing workflow ${workflowId}`)
-    this.emit('client-message', IPC.SCHEDULER_EXECUTE, { workflowId })
+    this.emit('client-message', IPC.SCHEDULER_EXECUTE, { workflowId, inputs })
     this.timeouts.delete(workflowId)
   }
 
@@ -318,9 +318,12 @@ class Scheduler extends EventEmitter {
    * in settings for connector-seeded workflows: the same dispatch path as
    * cron, so no hidden logic — just a forced tick. The minute-key lock still
    * applies so repeated clicks within the same minute fold into one run.
+   *
+   * `inputs` carries the values a manual run was started with, forwarded to
+   * the renderer so `{{inputs.*}}` resolves the same as a direct run.
    */
-  triggerWorkflow(workflowId: string): void {
-    this.executeWorkflow(workflowId)
+  triggerWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
+    this.executeWorkflow(workflowId, inputs)
   }
 
   stopAll(): void {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -236,7 +236,7 @@ export interface RequestMethods {
   /** Trigger a workflow manually via the scheduler — same dispatch path as
    *  cron, so connectorPoll triggers do their full poll+fan-out. */
   'workflow:runManual': {
-    params: { workflowId: string }
+    params: { workflowId: string; inputs?: Record<string, unknown> }
     result: void
   }
   /** Main→server push of decrypted credential fields. Called after main

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -415,6 +415,16 @@ export interface WorkflowExecutionContext {
     toStatus?: TaskStatus
   }
   connectorItem?: ConnectorItemContext
+  /**
+   * Values the user supplied when starting the run, keyed by
+   * `WorkflowInputDef.key`. Drives the `{{inputs.*}}` namespace.
+   *
+   * Values are `unknown` rather than `string` on purpose: a scalar input
+   * resolves to a scalar, but a resource-backed input (a GitHub issue picked
+   * from a connection) stores the whole item so templates can reach into it
+   * with `{{inputs.issue.number}}`.
+   */
+  inputs?: Record<string, unknown>
 }
 
 export type WorkflowNodeType =
@@ -431,6 +441,46 @@ export interface WorkflowNodePosition {
   y: number
 }
 
+/**
+ * Field types a manual-run input can take. The scalar types render as plain
+ * form controls; `project` and `branch` reuse the pickers the run dialog
+ * already has.
+ *
+ * A connection-backed picker (a GitHub issue / PR / repo) is intended next.
+ * It is deliberately absent from this union until it has a producer: input
+ * values are already `unknown`, so storing a whole resolved item needs no
+ * type change here, and a member no editor can create would force every
+ * future exhaustive switch to carry an untestable branch.
+ */
+export type WorkflowInputType =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'select'
+  | 'boolean'
+  | 'project'
+  | 'branch'
+
+/**
+ * One parameter the user fills in when starting a manual run. Declared on the
+ * trigger, so it travels with the workflow definition and needs no schema
+ * change; supplied values land in `WorkflowExecutionContext.inputs` and expand
+ * as `{{inputs.<key>}}` anywhere a template is accepted.
+ */
+export interface WorkflowInputDef {
+  /** Template key — `{{inputs.<key>}}`. Must be a valid identifier. */
+  key: string
+  label: string
+  type: WorkflowInputType
+  required?: boolean
+  /** Pre-filled value in the run dialog, as authored in the editor. */
+  defaultValue?: string
+  /** Choices for `type: 'select'`. Ignored otherwise. */
+  options?: { value: string; label: string }[]
+  placeholder?: string
+  description?: string
+}
+
 // Trigger configs (discriminated union)
 export interface ManualTriggerConfig {
   triggerType: 'manual'
@@ -441,6 +491,12 @@ export interface ManualTriggerConfig {
    * prompted for the source via SourcePromptDialog.
    */
   contextual?: boolean
+  /**
+   * Parameters the user is prompted for before the run starts. A workflow
+   * that declares any of these always opens the run dialog, contextual or
+   * not — there is no other moment at which the values could be supplied.
+   */
+  inputs?: WorkflowInputDef[]
 }
 export interface OnceTriggerConfig {
   triggerType: 'once'
@@ -717,6 +773,12 @@ export interface WorkflowExecution {
    * (two app instances, one scheduler tick) collapses to a single run.
    */
   dedupeParams?: string
+  /**
+   * Values this run was started with, keyed by `WorkflowInputDef.key`. Kept on
+   * the run (not just the live context) so Run History can show what a run was
+   * launched with long after it finished.
+   */
+  inputs?: Record<string, unknown>
 }
 
 /** Stable identity for a run row, tolerating history written before `runId`. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -296,6 +296,7 @@ const api = {
     callback: (event: {
       workflowId: string
       connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
+      inputs?: Record<string, unknown>
     }) => void
   ) => {
     const listener = (
@@ -303,6 +304,7 @@ const api = {
       event: {
         workflowId: string
         connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
+        inputs?: Record<string, unknown>
       }
     ): void => callback(event)
     ipcRenderer.on(IPC.SCHEDULER_EXECUTE, listener)
@@ -495,8 +497,8 @@ const api = {
 
   deleteConnection: (id: string): Promise<void> => ipcRenderer.invoke(IPC.CONNECTION_DELETE, id),
 
-  runWorkflowManual: (workflowId: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.WORKFLOW_RUN_MANUAL, { workflowId }),
+  runWorkflowManual: (workflowId: string, inputs?: Record<string, unknown>): Promise<void> =>
+    ipcRenderer.invoke(IPC.WORKFLOW_RUN_MANUAL, { workflowId, inputs }),
 
   backfillConnection: (
     connectionId: string

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -292,12 +292,12 @@ export function App() {
 
     // Scheduler: auto-execute workflows when triggered
     const removeSchedulerListener = window.api.onSchedulerExecute(
-      async ({ workflowId, connectorItem }) => {
+      async ({ workflowId, connectorItem, inputs }) => {
         const state = useAppStore.getState()
         const workflow = state.config?.workflows?.find((w) => w.id === workflowId)
         if (!workflow) return
 
-        const context = connectorItem ? { connectorItem } : undefined
+        const context = connectorItem || inputs ? { connectorItem, inputs } : undefined
         await runWorkflow(workflow, context, { source: 'scheduler' })
       }
     )

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
   createSessionFromProject,
   createShellInProject
 } from '../lib/session-utils'
-import { runWorkflowFromGlobalSurface } from '../lib/workflow-menu-items'
+import { startManualRun } from '../lib/workflow-menu-items'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import {
   Search,
@@ -338,7 +338,7 @@ function useCommands(
           .map((n) => (n.config as unknown as Record<string, unknown>)?.projectName as string)
           .filter(Boolean),
         onExecute: () => {
-          runWorkflowFromGlobalSurface(wf)
+          startManualRun(wf)
         }
       })
     }

--- a/src/renderer/components/SourcePromptDialog.tsx
+++ b/src/renderer/components/SourcePromptDialog.tsx
@@ -5,6 +5,9 @@ import { useAppStore } from '../stores'
 import { ProjectPicker } from './ProjectPicker'
 import { executeWorkflow } from '../lib/workflow-execution'
 import { containsContextRef, isContextRef } from '../lib/template-vars'
+import { getWorkflowInputs, isContextualWorkflow } from '../lib/workflow-helpers'
+import { WorkflowInputFields } from './WorkflowInputFields'
+import { areInputsValid, initialInputValues } from '../lib/workflow-inputs'
 import type {
   LaunchAgentConfig,
   ScriptConfig,
@@ -66,8 +69,10 @@ function detectRequiredFields(workflow: WorkflowDefinition): {
 }
 
 export function SourcePromptDialog() {
-  const pendingId = useAppStore((s) => s.pendingContextualWorkflowId)
-  const setPendingId = useAppStore((s) => s.setPendingContextualWorkflowId)
+  const pendingRun = useAppStore((s) => s.pendingWorkflowRun)
+  const pendingId = pendingRun?.workflowId ?? null
+  const pendingContext = pendingRun?.context ?? null
+  const setPendingId = useAppStore((s) => s.setPendingWorkflowRun)
   const config = useAppStore((s) => s.config)
   const workflow = useAppStore((s) =>
     pendingId ? (s.config?.workflows ?? []).find((w) => w.id === pendingId) : undefined
@@ -77,13 +82,22 @@ export function SourcePromptDialog() {
   const [projectPath, setProjectPath] = useState('')
   const [branch, setBranch] = useState('')
   const [useWorktree, setUseWorktree] = useState(false)
+  const [inputValues, setInputValues] = useState<Record<string, unknown>>({})
 
+  const inputDefs = useMemo(() => (workflow ? getWorkflowInputs(workflow) : []), [workflow])
+  // The caller already supplied a source (card / terminal right-click), so the
+  // only thing still missing is the declared inputs.
+  const hasCallerContext = !!(pendingContext?.task || pendingContext?.source)
+  const contextual = workflow ? isContextualWorkflow(workflow) : false
+
+  // A non-contextual workflow reaches this dialog only to collect inputs — it
+  // has no source to ask about, so none of the context fields apply.
   const required = useMemo(
     () =>
-      workflow
+      workflow && contextual && !hasCallerContext
         ? detectRequiredFields(workflow)
-        : { needsProject: true, needsBranch: false, needsWorktree: false },
-    [workflow]
+        : { needsProject: false, needsBranch: false, needsWorktree: false },
+    [workflow, contextual, hasCallerContext]
   )
 
   // Reset state and seed sensible defaults each time the dialog opens for a
@@ -91,34 +105,53 @@ export function SourcePromptDialog() {
   // mid-edit on any unrelated config change.
   useEffect(() => {
     if (!pendingId) return
-    const first = (useAppStore.getState().config?.projects ?? [])[0]
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    const state = useAppStore.getState()
+    const first = (state.config?.projects ?? [])[0]
+    const wf = (state.config?.workflows ?? []).find((w) => w.id === pendingId)
+    /* eslint-disable react-hooks/set-state-in-effect */
     setProjectName(first?.name ?? '')
     setProjectPath(first?.path ?? '')
     setBranch('')
     setUseWorktree(false)
+    setInputValues(wf ? initialInputValues(getWorkflowInputs(wf)) : {})
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [pendingId])
 
   if (!pendingId || !workflow) return null
 
   const close = () => setPendingId(null)
 
+  const canSubmit =
+    !(required.needsProject && (!projectName || !projectPath)) &&
+    areInputsValid(inputDefs, inputValues)
+
   const submit = () => {
-    if (required.needsProject && (!projectName || !projectPath)) return
-    // Synthesize a TerminalSession-shaped source for the resolver. Fields
-    // the dialog doesn't capture (id, status, etc.) are placeholders.
-    const source: TerminalSession = {
-      id: `prompt:${pendingId}:${Date.now()}`,
-      agentType: 'shell',
-      projectName,
-      projectPath,
-      status: 'idle',
-      createdAt: Date.now(),
-      pid: 0,
-      branch: branch || undefined,
-      isWorktree: useWorktree
-    }
-    void executeWorkflow(workflow, { source }, { source: 'manual' })
+    if (!canSubmit) return
+    const inputs = inputDefs.length > 0 ? inputValues : undefined
+    // Three cases, one launch: the caller's context if it supplied one, a
+    // source synthesized from the fields if this workflow needs one, and
+    // nothing but the inputs otherwise (pendingContext is null there, so the
+    // spread collapses to `{ inputs }`).
+    const base = hasCallerContext
+      ? pendingContext
+      : contextual
+        ? {
+            // Synthesize a TerminalSession-shaped source for the resolver.
+            // Fields the dialog doesn't capture are placeholders.
+            source: {
+              id: `prompt:${pendingId}:${Date.now()}`,
+              agentType: 'shell',
+              projectName,
+              projectPath,
+              status: 'idle',
+              createdAt: Date.now(),
+              pid: 0,
+              branch: branch || undefined,
+              isWorktree: useWorktree
+            } satisfies TerminalSession
+          }
+        : null
+    void executeWorkflow(workflow, { ...base, inputs }, { source: 'manual' })
     close()
   }
 
@@ -146,7 +179,9 @@ export function SourcePromptDialog() {
             Run "{workflow.name}"
           </div>
           <p className="text-[12px] text-gray-500 mt-1">
-            This contextual workflow needs a source. Pick the folder it should run against.
+            {contextual
+              ? 'This contextual workflow needs a source. Pick the folder it should run against.'
+              : 'This workflow needs a few details before it runs.'}
           </p>
         </div>
 
@@ -201,6 +236,12 @@ export function SourcePromptDialog() {
               <span className="text-[13px] text-gray-300">Run in a new worktree</span>
             </label>
           )}
+
+          <WorkflowInputFields
+            defs={inputDefs}
+            values={inputValues}
+            onChange={(key, value) => setInputValues((prev) => ({ ...prev, [key]: value }))}
+          />
         </div>
 
         <div className="px-6 py-3 border-t border-white/[0.06] flex justify-end gap-2">
@@ -213,7 +254,7 @@ export function SourcePromptDialog() {
           </button>
           <button
             onClick={submit}
-            disabled={required.needsProject && !projectName}
+            disabled={!canSubmit}
             className="px-4 py-1.5 text-[13px] text-white bg-white/[0.1] hover:bg-white/[0.15]
                        rounded-md transition-colors disabled:opacity-40 disabled:pointer-events-none"
           >

--- a/src/renderer/components/SourcePromptDialog.tsx
+++ b/src/renderer/components/SourcePromptDialog.tsx
@@ -92,13 +92,15 @@ export function SourcePromptDialog() {
 
   // A non-contextual workflow reaches this dialog only to collect inputs — it
   // has no source to ask about, so none of the context fields apply.
-  const required = useMemo(
-    () =>
-      workflow && contextual && !hasCallerContext
-        ? detectRequiredFields(workflow)
-        : { needsProject: false, needsBranch: false, needsWorktree: false },
-    [workflow, contextual, hasCallerContext]
-  )
+  const required = useMemo(() => {
+    if (!workflow || !contextual || hasCallerContext) {
+      return { needsProject: false, needsBranch: false, needsWorktree: false }
+    }
+    // A contextual workflow always executes against a source. When a global
+    // launcher did not supply one, expose the project choice instead of
+    // silently synthesizing a source from the first configured project.
+    return { ...detectRequiredFields(workflow), needsProject: true }
+  }, [workflow, contextual, hasCallerContext])
 
   // Reset state and seed sensible defaults each time the dialog opens for a
   // new workflow. Depending on `config` here would clobber user input

--- a/src/renderer/components/WorkflowInputFields.tsx
+++ b/src/renderer/components/WorkflowInputFields.tsx
@@ -1,0 +1,125 @@
+import { GitBranch } from 'lucide-react'
+import { useAppStore } from '../stores'
+import { ProjectPicker } from './ProjectPicker'
+import { SelectPicker } from './SelectPicker'
+import type { WorkflowInputDef } from '../../shared/types'
+
+const INPUT_CLASS =
+  'w-full px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md ' +
+  'text-white placeholder-gray-600 focus:outline-none focus:border-white/[0.2]'
+
+interface Props {
+  defs: WorkflowInputDef[]
+  values: Record<string, unknown>
+  onChange: (key: string, value: unknown) => void
+}
+
+export function WorkflowInputFields({ defs, values, onChange }: Props) {
+  const projects = useAppStore((s) => s.config?.projects)
+
+  if (defs.length === 0) return null
+
+  return (
+    <>
+      {defs.map((def) => {
+        const value = values[def.key]
+        const label = def.label || def.key
+        return (
+          <div key={def.key}>
+            {def.type !== 'boolean' && (
+              <label className="text-[11px] font-medium text-gray-500 uppercase tracking-wider mb-2 block">
+                {label}
+                {def.required && <span className="text-red-400 ml-1">*</span>}
+              </label>
+            )}
+
+            {def.type === 'textarea' && (
+              <textarea
+                value={String(value ?? '')}
+                onChange={(e) => onChange(def.key, e.target.value)}
+                placeholder={def.placeholder}
+                aria-label={label}
+                rows={3}
+                className={`${INPUT_CLASS} resize-y`}
+              />
+            )}
+
+            {def.type === 'number' && (
+              <input
+                type="number"
+                value={value === '' || value == null ? '' : String(value)}
+                onChange={(e) =>
+                  onChange(def.key, e.target.value === '' ? '' : Number(e.target.value))
+                }
+                placeholder={def.placeholder}
+                aria-label={label}
+                className={INPUT_CLASS}
+              />
+            )}
+
+            {def.type === 'select' && (
+              <SelectPicker
+                value={String(value ?? '')}
+                options={def.options ?? []}
+                onChange={(v) => onChange(def.key, v)}
+                placeholder={def.placeholder || 'Select...'}
+                variant="form"
+              />
+            )}
+
+            {def.type === 'boolean' && (
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={value === true}
+                  aria-label={label}
+                  onChange={(e) => onChange(def.key, e.target.checked)}
+                  className="accent-white/80"
+                />
+                <span className="text-[13px] text-gray-300">{label}</span>
+              </label>
+            )}
+
+            {def.type === 'project' && (
+              <ProjectPicker
+                currentProject={String(value ?? '')}
+                projects={projects ?? []}
+                onChange={(name) => onChange(def.key, name)}
+                variant="form"
+                allowNone={!def.required}
+              />
+            )}
+
+            {def.type === 'branch' && (
+              <div className="flex items-center gap-1.5 px-3 py-2 bg-white/[0.06] border border-white/[0.1] rounded-md">
+                <GitBranch size={12} className="text-gray-500 shrink-0" />
+                <input
+                  type="text"
+                  value={String(value ?? '')}
+                  onChange={(e) => onChange(def.key, e.target.value)}
+                  placeholder={def.placeholder || 'branch name'}
+                  aria-label={label}
+                  className="flex-1 min-w-0 bg-transparent text-[13px] text-white placeholder-gray-600
+                             focus:outline-none border-none px-0"
+                />
+              </div>
+            )}
+
+            {def.type === 'text' && (
+              <input
+                type="text"
+                value={String(value ?? '')}
+                onChange={(e) => onChange(def.key, e.target.value)}
+                placeholder={def.placeholder}
+                aria-label={label}
+                className={INPUT_CLASS}
+              />
+            )}
+
+            {def.description && <p className="text-[11px] text-gray-500 mt-1">{def.description}</p>}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/src/renderer/components/WorkflowInputFields.tsx
+++ b/src/renderer/components/WorkflowInputFields.tsx
@@ -2,6 +2,7 @@ import { GitBranch } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { ProjectPicker } from './ProjectPicker'
 import { SelectPicker } from './SelectPicker'
+import { parseNumberInput } from '../lib/workflow-inputs'
 import type { WorkflowInputDef } from '../../shared/types'
 
 const INPUT_CLASS =
@@ -48,9 +49,7 @@ export function WorkflowInputFields({ defs, values, onChange }: Props) {
               <input
                 type="number"
                 value={value === '' || value == null ? '' : String(value)}
-                onChange={(e) =>
-                  onChange(def.key, e.target.value === '' ? '' : Number(e.target.value))
-                }
+                onChange={(e) => onChange(def.key, parseNumberInput(e.target.value))}
                 placeholder={def.placeholder}
                 aria-label={label}
                 className={INPUT_CLASS}

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -4,7 +4,7 @@ import { parseConnectorWorkflowId } from '../../../shared/types'
 import { ICON_MAP } from './icon-map'
 import { useAppStore } from '../../stores'
 import { isScheduledWorkflow } from '../../lib/workflow-helpers'
-import { runWorkflowFromGlobalSurface } from '../../lib/workflow-menu-items'
+import { startManualRun } from '../../lib/workflow-menu-items'
 import { useConnectorIdFor } from '../../lib/use-connections'
 import { Workflow, Play, MoreHorizontal } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
@@ -122,7 +122,7 @@ export function WorkflowItem({
               aria-label={`Run workflow ${workflow.name}`}
               onClick={(e) => {
                 e.stopPropagation()
-                runWorkflowFromGlobalSurface(workflow)
+                startManualRun(workflow)
               }}
               className="opacity-0 group-hover/wf:opacity-100 focus:opacity-100 text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0"
             >

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -63,6 +63,17 @@ interface RunStepsListProps {
   ) => void
 }
 
+const MAX_INPUT_PREVIEW = 60
+
+/** One-line preview of a run input. Object-valued inputs (a picked connector
+ *  item) get JSON-serialized and clipped so a large payload can't push the
+ *  steps off screen. */
+function formatInputValue(value: unknown): string {
+  const text =
+    value == null ? '' : typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return text.length > MAX_INPUT_PREVIEW ? `${text.slice(0, MAX_INPUT_PREVIEW)}…` : text
+}
+
 export function RunStepsList({
   execution,
   nodes,
@@ -85,6 +96,15 @@ export function RunStepsList({
 
   return (
     <div className="border-t border-white/[0.06]">
+      {execution.inputs && Object.keys(execution.inputs).length > 0 && (
+        <div className="px-4 py-2 border-b border-white/[0.04] flex flex-wrap gap-x-3 gap-y-1">
+          {Object.entries(execution.inputs).map(([key, value]) => (
+            <span key={key} className="text-[11px] text-gray-500 font-mono">
+              {key}=<span className="text-gray-400">{formatInputValue(value)}</span>
+            </span>
+          ))}
+        </div>
+      )}
       {actionStates.map((ns, i) => {
         const nodeTask = ns.taskId && tasks ? tasks.find((t) => t.id === ns.taskId) : undefined
         const node = nodes.find((n) => n.id === ns.nodeId)

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -48,13 +48,14 @@ import {
   removeNode,
   getWorktreeMode
 } from '../../lib/workflow-helpers'
-import { executeWorkflow } from '../../lib/workflow-execution'
+import { startManualRun } from '../../lib/workflow-menu-items'
 import { toast } from '../Toast'
 import {
   slugify,
   ensureUniqueSlug,
   getAncestorNodes,
-  buildStepGroups
+  buildStepGroups,
+  buildInputVars
 } from '../../lib/template-vars'
 
 const EMPTY_TASKS: import('../../../shared/types').TaskConfig[] = []
@@ -102,18 +103,18 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     [nodes, selectedNodeId]
   )
 
-  const triggerType = useMemo(() => {
-    const triggerNode = nodes.find((n) => n.type === 'trigger')
-    if (!triggerNode) return undefined
-    return (triggerNode.config as TriggerConfig).triggerType
-  }, [nodes])
+  const triggerNode = useMemo(() => nodes.find((n) => n.type === 'trigger') ?? null, [nodes])
+  const triggerConfig = triggerNode?.config as TriggerConfig | undefined
 
-  const isContextualTrigger = useMemo(() => {
-    const triggerNode = nodes.find((n) => n.type === 'trigger')
-    if (!triggerNode) return false
-    const cfg = triggerNode.config as TriggerConfig
-    return cfg.triggerType === 'manual' && cfg.contextual === true
-  }, [nodes])
+  const triggerType = triggerConfig?.triggerType
+  const isContextualTrigger =
+    triggerConfig?.triggerType === 'manual' && triggerConfig.contextual === true
+  /** Autocomplete entries for the trigger's declared run inputs. */
+  const inputVars = useMemo(
+    () =>
+      buildInputVars(triggerConfig?.triggerType === 'manual' ? triggerConfig.inputs : undefined),
+    [triggerConfig]
+  )
 
   // Disabled state for the cleanup toggle: when every LaunchAgent inherits
   // its worktree from context, there's nothing for autoCleanupWorktrees to
@@ -347,10 +348,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     if (!inline) handleClose()
   }, [persistWorkflow, editingId, inline, handleClose])
 
-  const handleRun = useCallback(async () => {
+  const handleRun = useCallback(() => {
     const workflow = persistWorkflow()
     if (!inline) handleClose()
-    await executeWorkflow(workflow)
+    startManualRun(workflow)
   }, [persistWorkflow, inline, handleClose])
 
   const handleDelete = useCallback(() => {
@@ -757,6 +758,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             onClose={() => setSelectedNodeId(null)}
             triggerType={triggerType}
             isContextualTrigger={isContextualTrigger}
+            inputVars={inputVars}
             stepGroups={stepGroups}
           />
         )}
@@ -770,10 +772,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             autoCleanupWorktrees={autoCleanupWorktrees}
             onCleanupChange={setAutoCleanupWorktrees}
             cleanupDisabled={allWorktreesInherited}
-            triggerNode={nodes.find((n) => n.type === 'trigger') ?? null}
+            triggerNode={triggerNode}
             onSelectTrigger={() => {
-              const t = nodes.find((n) => n.type === 'trigger')
-              if (t) setSelectedNodeId(t.id)
+              if (triggerNode) setSelectedNodeId(triggerNode.id)
             }}
             lastRun={executionHistory[0] ?? null}
             onClose={() => setShowProperties(false)}

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -7,13 +7,14 @@ import type {
 } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
 import { ConnectorIcon } from '../../ConnectorIcon'
-import { TEMPLATE_VARIABLES, StepVariableGroup } from '../../../lib/template-vars'
+import { TEMPLATE_VARIABLES, StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 import { VariableAutocomplete } from './VariableAutocomplete'
 
 interface Props {
   config: CallConnectorActionConfig
   onChange: (config: CallConnectorActionConfig) => void
   triggerType?: TriggerConfig['triggerType']
+  inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
 }
 
@@ -21,6 +22,7 @@ export function CallConnectorActionNodeForm({
   config,
   onChange,
   triggerType,
+  inputVars = [],
   stepGroups = []
 }: Props) {
   const [connections, setConnections] = useState<SourceConnection[]>([])
@@ -60,7 +62,7 @@ export function CallConnectorActionNodeForm({
       return triggerType === 'taskStatusChanged'
     }
     return false
-  })
+  }).concat(inputVars)
 
   const selectedConn = connections.find((c) => c.id === config.connectionId)
   const selectedAction: ConnectorActionDef | undefined = actions.find(

--- a/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
@@ -1,5 +1,5 @@
 import { ConditionConfig, ConditionOperator, TriggerConfig } from '../../../../shared/types'
-import { TEMPLATE_VARIABLES, StepVariableGroup } from '../../../lib/template-vars'
+import { TEMPLATE_VARIABLES, StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 import { VariableAutocomplete } from './VariableAutocomplete'
 import { SelectPicker } from '../../SelectPicker'
 
@@ -7,6 +7,7 @@ interface Props {
   config: ConditionConfig
   onChange: (config: ConditionConfig) => void
   triggerType?: TriggerConfig['triggerType']
+  inputVars?: TemplateVariable[]
   stepGroups: StepVariableGroup[]
 }
 
@@ -21,7 +22,13 @@ const OPERATORS = [
 
 const hiddenValueOperators: ConditionOperator[] = ['isEmpty', 'isNotEmpty']
 
-export function ConditionConfigForm({ config, onChange, triggerType, stepGroups }: Props) {
+export function ConditionConfigForm({
+  config,
+  onChange,
+  triggerType,
+  inputVars = [],
+  stepGroups
+}: Props) {
   const contextVars = TEMPLATE_VARIABLES.filter((v) => {
     if (v.category === 'task') {
       return triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
@@ -30,7 +37,7 @@ export function ConditionConfigForm({ config, onChange, triggerType, stepGroups 
       return triggerType === 'taskStatusChanged'
     }
     return false
-  })
+  }).concat(inputVars)
 
   return (
     <div className="space-y-5">

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -10,6 +10,7 @@ import {
 import { useAppStore } from '../../../stores'
 import {
   StepVariableGroup,
+  TemplateVariable,
   CONTEXT_REF,
   getAvailableContextVars,
   isContextRef
@@ -29,6 +30,7 @@ interface Props {
   onChange: (config: LaunchAgentConfig) => void
   triggerType?: TriggerConfig['triggerType']
   isContextualTrigger?: boolean
+  inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
   currentNodeId?: string
   allNodes?: WorkflowNode[]
@@ -48,6 +50,7 @@ export function LaunchAgentConfigForm({
   onChange,
   triggerType,
   isContextualTrigger = false,
+  inputVars = [],
   stepGroups = [],
   currentNodeId,
   allNodes
@@ -114,7 +117,8 @@ export function LaunchAgentConfigForm({
   const worktreeMode = getWorktreeMode(config)
   const promptSource = config.taskId ? 'task' : config.taskFromQueue ? 'queue' : 'inline'
   const isTaskTrigger = triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
-  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger || isContextualTrigger
+  const hasTemplateVars =
+    stepGroups.length > 0 || isTaskTrigger || isContextualTrigger || inputVars.length > 0
   const hasBranch = !isRemote && !!(config.branch && config.branch.trim())
   const isHeadless = !!config.headless
   const canUseFromTask = isTaskTrigger || promptSource === 'task' || promptSource === 'queue'
@@ -151,7 +155,10 @@ export function LaunchAgentConfigForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isContextualTrigger])
 
-  const contextVars = getAvailableContextVars({ triggerType, isContextualTrigger })
+  const contextVars = [
+    ...getAvailableContextVars({ triggerType, isContextualTrigger }),
+    ...inputVars
+  ]
 
   return (
     <div className="space-y-5">

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -30,7 +30,7 @@ import { ConditionConfigForm } from './ConditionConfigForm'
 import { ApprovalConfigForm } from './ApprovalConfigForm'
 import { CreateTaskFromItemNodeForm } from './CreateTaskFromItemNodeForm'
 import { CallConnectorActionNodeForm } from './CallConnectorActionNodeForm'
-import type { StepVariableGroup } from '../../../lib/template-vars'
+import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 
 const NODE_TYPE_CONFIG: Record<
   WorkflowNode['type'],
@@ -69,6 +69,8 @@ interface Props {
   onClose: () => void
   triggerType?: TriggerConfig['triggerType']
   isContextualTrigger?: boolean
+  /** Autocomplete entries for the workflow's declared manual-run inputs. */
+  inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
 }
 
@@ -81,6 +83,7 @@ export function NodeConfigPanel({
   onClose,
   triggerType,
   isContextualTrigger,
+  inputVars,
   stepGroups
 }: Props) {
   const [showMenu, setShowMenu] = useState(false)
@@ -187,6 +190,7 @@ export function NodeConfigPanel({
 
         {node.type === 'launchAgent' && (
           <LaunchAgentConfigForm
+            inputVars={inputVars}
             config={node.config as LaunchAgentConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
@@ -199,6 +203,7 @@ export function NodeConfigPanel({
 
         {node.type === 'script' && (
           <ScriptConfigForm
+            inputVars={inputVars}
             config={node.config as ScriptConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
@@ -209,6 +214,7 @@ export function NodeConfigPanel({
 
         {node.type === 'condition' && (
           <ConditionConfigForm
+            inputVars={inputVars}
             config={node.config as ConditionConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
@@ -232,6 +238,7 @@ export function NodeConfigPanel({
 
         {node.type === 'callConnectorAction' && (
           <CallConnectorActionNodeForm
+            inputVars={inputVars}
             config={node.config as CallConnectorActionConfig}
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}

--- a/src/renderer/components/workflow-editor/panels/ScriptConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ScriptConfigForm.tsx
@@ -5,6 +5,7 @@ import { ScriptConfig, TriggerConfig } from '../../../../shared/types'
 import { useAppStore } from '../../../stores'
 import {
   StepVariableGroup,
+  TemplateVariable,
   CONTEXT_REF,
   getAvailableContextVars,
   isContextRef
@@ -18,6 +19,7 @@ interface Props {
   onChange: (config: ScriptConfig) => void
   triggerType?: TriggerConfig['triggerType']
   isContextualTrigger?: boolean
+  inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
 }
 
@@ -39,13 +41,18 @@ export function ScriptConfigForm({
   onChange,
   triggerType,
   isContextualTrigger = false,
+  inputVars = [],
   stepGroups = []
 }: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(!!config.args?.length)
   const projects = useAppStore((s) => s.config?.projects ?? EMPTY_PROJECTS)
   const isTaskTrigger = triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
-  const hasTemplateVars = stepGroups.length > 0 || isTaskTrigger || isContextualTrigger
-  const contextVars = getAvailableContextVars({ triggerType, isContextualTrigger })
+  const hasTemplateVars =
+    stepGroups.length > 0 || isTaskTrigger || isContextualTrigger || inputVars.length > 0
+  const contextVars = [
+    ...getAvailableContextVars({ triggerType, isContextualTrigger }),
+    ...inputVars
+  ]
   const cwdIsFromContext =
     isContextRef(config.cwd) || isContextRef(config.projectName) || isContextRef(config.projectPath)
 

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -4,6 +4,7 @@ import { TriggerConfig, TaskStatus } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
 import { ProjectPicker } from '../../ProjectPicker'
 import { ConnectorPollTriggerForm } from './ConnectorPollTriggerForm'
+import { WorkflowInputsEditor } from './WorkflowInputsEditor'
 
 interface Props {
   config: TriggerConfig
@@ -106,47 +107,55 @@ export function TriggerConfigForm({ config, onChange }: Props) {
         (() => {
           const isContextual = config.contextual === true
           return (
-            <button
-              role="switch"
-              aria-checked={isContextual}
-              onClick={() =>
-                onChange({
-                  triggerType: 'manual',
-                  contextual: isContextual ? undefined : true
-                })
-              }
-              className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg border transition-all ${
-                isContextual
-                  ? 'border-white/[0.1] bg-white/[0.04]'
-                  : 'border-white/[0.04] bg-white/[0.02] hover:border-white/[0.1]'
-              }`}
-            >
-              <div
-                className={`w-7 h-[16px] rounded-full transition-colors relative shrink-0 ${
-                  isContextual ? 'bg-gray-400' : 'bg-white/[0.1]'
+            <>
+              <button
+                role="switch"
+                aria-checked={isContextual}
+                onClick={() =>
+                  onChange({
+                    ...config,
+                    contextual: isContextual ? undefined : true
+                  })
+                }
+                className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg border transition-all ${
+                  isContextual
+                    ? 'border-white/[0.1] bg-white/[0.04]'
+                    : 'border-white/[0.04] bg-white/[0.02] hover:border-white/[0.1]'
                 }`}
               >
                 <div
-                  className={`absolute top-[2px] w-[12px] h-[12px] rounded-full bg-white transition-transform ${
-                    isContextual ? 'translate-x-[13px]' : 'translate-x-[2px]'
+                  className={`w-7 h-[16px] rounded-full transition-colors relative shrink-0 ${
+                    isContextual ? 'bg-gray-400' : 'bg-white/[0.1]'
                   }`}
-                />
-              </div>
-              <div className="text-left min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <Zap size={12} className={isContextual ? 'text-gray-300' : 'text-gray-500'} />
-                  <span
-                    className={`text-[12px] ${isContextual ? 'text-gray-200' : 'text-gray-400'}`}
-                  >
-                    Contextual
-                  </span>
+                >
+                  <div
+                    className={`absolute top-[2px] w-[12px] h-[12px] rounded-full bg-white transition-transform ${
+                      isContextual ? 'translate-x-[13px]' : 'translate-x-[2px]'
+                    }`}
+                  />
                 </div>
-                <p className="text-[11px] text-gray-500 mt-0.5">
-                  Run this workflow directly from any card or terminal, against that session's
-                  folder and branch.
-                </p>
-              </div>
-            </button>
+                <div className="text-left min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <Zap size={12} className={isContextual ? 'text-gray-300' : 'text-gray-500'} />
+                    <span
+                      className={`text-[12px] ${isContextual ? 'text-gray-200' : 'text-gray-400'}`}
+                    >
+                      Contextual
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-gray-500 mt-0.5">
+                    Run this workflow directly from any card or terminal, against that session's
+                    folder and branch.
+                  </p>
+                </div>
+              </button>
+              <WorkflowInputsEditor
+                inputs={config.inputs ?? []}
+                onChange={(inputs) =>
+                  onChange({ ...config, inputs: inputs.length > 0 ? inputs : undefined })
+                }
+              />
+            </>
           )
         })()}
 

--- a/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
+++ b/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
@@ -21,6 +21,29 @@ interface Props {
   mono?: boolean
 }
 
+/**
+ * How each variable category is presented in the picker, in display order.
+ *
+ * A Record over the category union rather than a loop per category: the picker
+ * previously listed three categories by hand, so anything else a form passed
+ * in — connector item fields, and later run inputs — was silently dropped from
+ * the dropdown while still resolving at run time. Adding a category to
+ * TemplateVariable now fails to compile until it is given a group here.
+ */
+const VAR_CATEGORY_GROUPS: Record<
+  TemplateVariable['category'],
+  { group: string; description: string }
+> = {
+  task: { group: 'Task', description: '' },
+  trigger: { group: 'Trigger', description: '' },
+  context: { group: 'Context', description: 'Resolved from the launching card or terminal' },
+  inputs: { group: 'Run Inputs', description: 'Entered when the run is started' },
+  connectorItem: {
+    group: 'Connector Item',
+    description: 'The upstream item that triggered this run'
+  }
+}
+
 interface DropdownItem {
   group: string
   groupId: string
@@ -66,37 +89,20 @@ export function VariableAutocomplete({
       }
     }
 
-    for (const v of contextVars.filter((v) => v.category === 'task')) {
-      items.push({
-        group: 'Task',
-        groupId: 'task',
-        key: v.key,
-        label: v.label,
-        description: '',
-        pattern: v.key
-      })
-    }
-
-    for (const v of contextVars.filter((v) => v.category === 'trigger')) {
-      items.push({
-        group: 'Trigger',
-        groupId: 'trigger',
-        key: v.key,
-        label: v.label,
-        description: '',
-        pattern: v.key
-      })
-    }
-
-    for (const v of contextVars.filter((v) => v.category === 'context')) {
-      items.push({
-        group: 'Context',
-        groupId: 'context',
-        key: v.key,
-        label: v.label,
-        description: 'Resolved from the launching card or terminal',
-        pattern: v.key
-      })
+    for (const [category, { group, description }] of Object.entries(VAR_CATEGORY_GROUPS) as [
+      TemplateVariable['category'],
+      { group: string; description: string }
+    ][]) {
+      for (const v of contextVars.filter((v) => v.category === category)) {
+        items.push({
+          group,
+          groupId: category,
+          key: v.key,
+          label: v.label,
+          description,
+          pattern: v.key
+        })
+      }
     }
 
     return items

--- a/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
+++ b/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
@@ -29,6 +29,14 @@ function normalizeKey(raw: string): string {
 }
 
 export function WorkflowInputsEditor({ inputs, onChange }: Props) {
+  // Two inputs sharing a key silently lose one of their values when the run
+  // dialog builds its value map, and make `{{inputs.<key>}}` ambiguous. The
+  // key is flagged rather than auto-renamed: rewriting a key mid-keystroke
+  // would fight anyone typing a name that is briefly a prefix of another.
+  const duplicateKeys = new Set(
+    inputs.map((i) => i.key).filter((key, i, all) => key && all.indexOf(key) !== i)
+  )
+
   const update = (index: number, patch: Partial<WorkflowInputDef>) => {
     onChange(inputs.map((input, i) => (i === index ? { ...input, ...patch } : input)))
   }
@@ -60,7 +68,10 @@ export function WorkflowInputsEditor({ inputs, onChange }: Props) {
                 onChange={(e) => update(index, { key: normalizeKey(e.target.value) })}
                 placeholder="key"
                 aria-label="Input key"
-                className={`${FIELD_CLASS} font-mono flex-1`}
+                aria-invalid={duplicateKeys.has(input.key) || undefined}
+                className={`${FIELD_CLASS} font-mono flex-1 ${
+                  duplicateKeys.has(input.key) ? 'border-red-500/60' : ''
+                }`}
               />
               <button
                 onClick={() => onChange(inputs.filter((_, i) => i !== index))}
@@ -71,6 +82,13 @@ export function WorkflowInputsEditor({ inputs, onChange }: Props) {
                 <Trash2 size={12} />
               </button>
             </div>
+
+            {duplicateKeys.has(input.key) && (
+              <p className="text-[11px] text-red-400">
+                Duplicate key — only one input named <code className="font-mono">{input.key}</code>{' '}
+                will reach the run.
+              </p>
+            )}
 
             <input
               type="text"

--- a/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
+++ b/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
@@ -104,14 +104,19 @@ export function WorkflowInputsEditor({ inputs, onChange }: Props) {
                 <SelectPicker
                   value={input.type}
                   options={INPUT_TYPES}
-                  onChange={(v) =>
+                  onChange={(v) => {
+                    const type = v as WorkflowInputType
+                    // Options only mean something for a select, and the
+                    // default field is hidden for select and toggle; carrying
+                    // either across a type change leaves config the editor
+                    // can no longer show but the run dialog would still seed.
+                    const keepsDefault = type !== 'boolean' && type !== 'select'
                     update(index, {
-                      type: v as WorkflowInputType,
-                      // Options only mean something for a select; carrying
-                      // them across a type change leaves dead config behind.
-                      options: v === 'select' ? (input.options ?? []) : undefined
+                      type,
+                      options: type === 'select' ? (input.options ?? []) : undefined,
+                      defaultValue: keepsDefault ? input.defaultValue : undefined
                     })
-                  }
+                  }}
                   variant="form"
                 />
               </div>

--- a/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
+++ b/src/renderer/components/workflow-editor/panels/WorkflowInputsEditor.tsx
@@ -1,0 +1,154 @@
+import { Plus, Trash2 } from 'lucide-react'
+import { SelectPicker } from '../../SelectPicker'
+import { ensureUniqueSlug } from '../../../lib/template-vars'
+import type { WorkflowInputDef, WorkflowInputType } from '../../../../shared/types'
+
+interface Props {
+  inputs: WorkflowInputDef[]
+  onChange: (inputs: WorkflowInputDef[]) => void
+}
+
+const INPUT_TYPES: { value: WorkflowInputType; label: string }[] = [
+  { value: 'text', label: 'Text' },
+  { value: 'textarea', label: 'Long text' },
+  { value: 'number', label: 'Number' },
+  { value: 'select', label: 'Select' },
+  { value: 'boolean', label: 'Toggle' },
+  { value: 'project', label: 'Project' },
+  { value: 'branch', label: 'Branch' }
+]
+
+const FIELD_CLASS =
+  'w-full px-2.5 py-1.5 text-[12px] bg-white/[0.06] border border-white/[0.1] rounded-md ' +
+  'text-white placeholder:text-gray-600 focus:outline-none focus:border-white/[0.2]'
+
+/** Keys become `{{inputs.<key>}}`, so they must survive the template regex
+ *  (identifier-first, no dots or spaces). */
+function normalizeKey(raw: string): string {
+  return raw.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^(\d)/, '_$1')
+}
+
+export function WorkflowInputsEditor({ inputs, onChange }: Props) {
+  const update = (index: number, patch: Partial<WorkflowInputDef>) => {
+    onChange(inputs.map((input, i) => (i === index ? { ...input, ...patch } : input)))
+  }
+
+  const add = () => {
+    const taken = new Set(inputs.map((i) => i.key))
+    const key = ensureUniqueSlug('input', taken)
+    onChange([...inputs, { key, label: '', type: 'text' }])
+  }
+
+  return (
+    <div>
+      <label className="text-[13px] text-gray-400 font-medium block mb-2">Run Inputs</label>
+      <p className="text-[11px] text-gray-500 mb-2">
+        Values the user is asked for before the run starts. Use them anywhere as{' '}
+        <code className="font-mono text-gray-400">{'{{inputs.key}}'}</code>.
+      </p>
+
+      <div className="space-y-2">
+        {inputs.map((input, index) => (
+          <div
+            key={index}
+            className="p-2.5 rounded-lg border border-white/[0.06] bg-white/[0.02] space-y-2"
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={input.key}
+                onChange={(e) => update(index, { key: normalizeKey(e.target.value) })}
+                placeholder="key"
+                aria-label="Input key"
+                className={`${FIELD_CLASS} font-mono flex-1`}
+              />
+              <button
+                onClick={() => onChange(inputs.filter((_, i) => i !== index))}
+                aria-label={`Remove input ${input.key}`}
+                className="p-1.5 text-gray-500 hover:text-red-400 rounded-md hover:bg-white/[0.06]
+                           transition-colors shrink-0"
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+
+            <input
+              type="text"
+              value={input.label}
+              onChange={(e) => update(index, { label: e.target.value })}
+              placeholder="Label shown in the run dialog"
+              aria-label="Input label"
+              className={FIELD_CLASS}
+            />
+
+            <div className="flex items-center gap-2">
+              <div className="flex-1 min-w-0">
+                <SelectPicker
+                  value={input.type}
+                  options={INPUT_TYPES}
+                  onChange={(v) =>
+                    update(index, {
+                      type: v as WorkflowInputType,
+                      // Options only mean something for a select; carrying
+                      // them across a type change leaves dead config behind.
+                      options: v === 'select' ? (input.options ?? []) : undefined
+                    })
+                  }
+                  variant="form"
+                />
+              </div>
+              <label className="flex items-center gap-1.5 cursor-pointer shrink-0">
+                <input
+                  type="checkbox"
+                  checked={input.required === true}
+                  onChange={(e) => update(index, { required: e.target.checked || undefined })}
+                  className="accent-white/80"
+                />
+                <span className="text-[12px] text-gray-400">Required</span>
+              </label>
+            </div>
+
+            {input.type === 'select' && (
+              <input
+                type="text"
+                value={(input.options ?? []).map((o) => o.value).join(', ')}
+                onChange={(e) =>
+                  update(index, {
+                    options: e.target.value
+                      .split(',')
+                      .map((s) => s.trim())
+                      .filter(Boolean)
+                      .map((value) => ({ value, label: value }))
+                  })
+                }
+                placeholder="Comma-separated choices"
+                aria-label="Input choices"
+                className={FIELD_CLASS}
+              />
+            )}
+
+            {input.type !== 'boolean' && input.type !== 'select' && (
+              <input
+                type="text"
+                value={input.defaultValue == null ? '' : String(input.defaultValue)}
+                onChange={(e) => update(index, { defaultValue: e.target.value || undefined })}
+                placeholder="Default value (optional)"
+                aria-label="Input default value"
+                className={FIELD_CLASS}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={add}
+        className="mt-2 flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] text-gray-400
+                   hover:text-white rounded-md hover:bg-white/[0.06] transition-colors"
+      >
+        <Plus size={12} />
+        Add input
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -6,7 +6,8 @@ import {
   WorkflowEdge,
   CallConnectorActionConfig,
   LaunchAgentConfig,
-  ConnectorActionDef
+  ConnectorActionDef,
+  WorkflowInputDef
 } from '../../shared/types'
 import { schemaProperties, schemaTypeHint } from '../../shared/json-schema-utils'
 
@@ -60,7 +61,7 @@ export interface StepVariableGroup {
 export interface TemplateVariable {
   key: string
   label: string
-  category: 'task' | 'trigger' | 'connectorItem' | 'context'
+  category: 'task' | 'trigger' | 'connectorItem' | 'context' | 'inputs'
 }
 
 export const TEMPLATE_VARIABLES: TemplateVariable[] = [
@@ -119,6 +120,21 @@ export function getAvailableContextVars(opts: {
     if (opts.isContextualTrigger && v.category === 'context') return true
     return false
   })
+}
+
+/**
+ * Autocomplete entries for the workflow's declared manual-run inputs. Built
+ * per workflow rather than listed in TEMPLATE_VARIABLES because the keys are
+ * whatever the user named them.
+ */
+export function buildInputVars(inputs: WorkflowInputDef[] | undefined): TemplateVariable[] {
+  return (inputs ?? [])
+    .filter((i) => i.key)
+    .map((i) => ({
+      key: `{{inputs.${i.key}}}`,
+      label: i.label || i.key,
+      category: 'inputs' as const
+    }))
 }
 
 /** Whether `value` contains a `{{context.<field>}}` reference anywhere. */
@@ -299,6 +315,13 @@ export function resolveTemplateVars(
     }
     if (ns === 'connectorItem' && context?.connectorItem) {
       return stringifyResolved(walkPath(context.connectorItem, rest))
+    }
+    if (ns === 'inputs' && context?.inputs) {
+      const [key, ...keyPath] = rest
+      const value = context.inputs[key]
+      if (value === undefined) return ''
+      if (keyPath.length === 0) return stringifyResolved(value)
+      return stringifyResolved(walkPath(value, keyPath))
     }
     if (ns === 'context' && rest.length === 1 && context) {
       const resolved = resolveContextField(rest[0], context)

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -280,14 +280,17 @@ function persistExecution(execution: WorkflowExecution): void {
  * run its items in parallel while a genuine double-fire collapses to one run.
  */
 function dedupeFingerprint(context?: WorkflowExecutionContext): string {
-  const item = context?.connectorItem
-  if (item) return `item:${item.connectionId}:${item.externalId}`
-  if (context?.task) return `task:${context.task.id}`
-  if (context?.source) return `session:${context.source.id}`
-  // Two manual runs started with different parameters are different triggers.
-  // Without this they would collapse into one and the second would be dropped.
+  // Two runs started with different parameters are different triggers, so the
+  // inputs qualify every fingerprint rather than only the context-less one —
+  // a workflow launched twice from the same card with different answers is
+  // still two distinct runs.
   const inputs = fingerprintInputs(context?.inputs)
-  return inputs ? `manual:${inputs}` : 'manual'
+  const params = inputs ? `:inputs:${inputs}` : ''
+  const item = context?.connectorItem
+  if (item) return `item:${item.connectionId}:${item.externalId}${params}`
+  if (context?.task) return `task:${context.task.id}${params}`
+  if (context?.source) return `session:${context.source.id}${params}`
+  return `manual${params}`
 }
 
 /** Stable serialization of run inputs — key-sorted so object ordering can't

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -284,7 +284,23 @@ function dedupeFingerprint(context?: WorkflowExecutionContext): string {
   if (item) return `item:${item.connectionId}:${item.externalId}`
   if (context?.task) return `task:${context.task.id}`
   if (context?.source) return `session:${context.source.id}`
-  return 'manual'
+  // Two manual runs started with different parameters are different triggers.
+  // Without this they would collapse into one and the second would be dropped.
+  const inputs = fingerprintInputs(context?.inputs)
+  return inputs ? `manual:${inputs}` : 'manual'
+}
+
+/** Stable serialization of run inputs — key-sorted so object ordering can't
+ *  make two identical parameter sets look like different triggers. */
+function fingerprintInputs(inputs: Record<string, unknown> | undefined): string {
+  if (!inputs) return ''
+  const keys = Object.keys(inputs).sort()
+  if (keys.length === 0) return ''
+  // No try/catch: values are already required to be JSON-serializable, since
+  // saveWorkflowRun persists them the same way. Falling back to a key-only
+  // digest would silently collapse two different parameter sets into one
+  // fingerprint — exactly the dedupe bug this function exists to prevent.
+  return JSON.stringify(keys.map((k) => [k, inputs[k]]))
 }
 
 /** Resolved step ceiling: the node's own value, else the configured default. 0 disables. */
@@ -1058,7 +1074,7 @@ export async function executeWorkflow(
     !context?.connectorItem &&
     options?.source !== 'scheduler'
   ) {
-    await window.api.runWorkflowManual(workflow.id)
+    await window.api.runWorkflowManual(workflow.id, context?.inputs)
     const existing = latestRunForWorkflow(workflow.id)
     if (existing) return existing
     // Return a minimal synthetic execution so callers don't break. The real
@@ -1110,7 +1126,8 @@ export async function executeWorkflow(
       status: n.type === 'trigger' ? 'success' : 'pending'
     })),
     triggerTaskId: context?.task?.id,
-    dedupeParams
+    dedupeParams,
+    inputs: context?.inputs
   }
 
   const actionNodeCount = workflow.nodes.filter((n) => n.type !== 'trigger').length

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -7,7 +7,10 @@ import {
   ScriptConfig,
   ConditionConfig,
   ApprovalConfig,
-  WorkflowNodePosition
+  WorkflowNodePosition,
+  WorkflowInputDef,
+  TaskConfig,
+  TerminalSession
 } from '../../shared/types'
 import { slugify } from './template-vars'
 
@@ -130,6 +133,38 @@ export function isScheduledWorkflow(wf: WorkflowDefinition): boolean {
 export function isContextualWorkflow(wf: WorkflowDefinition): boolean {
   const trigger = getTriggerConfig(wf)
   return trigger?.triggerType === 'manual' && trigger.contextual === true
+}
+
+/** Manual-run parameters the workflow declares on its trigger, if any. */
+export function getWorkflowInputs(wf: WorkflowDefinition): WorkflowInputDef[] {
+  const trigger = getTriggerConfig(wf)
+  if (trigger?.triggerType !== 'manual') return []
+  return (trigger.inputs ?? []).filter((i) => i.key)
+}
+
+/**
+ * What a launching surface already knows about the run. A card or terminal
+ * right-click supplies these; a sidebar or palette launch does not.
+ */
+export interface ManualRunContext {
+  task?: TaskConfig
+  source?: TerminalSession
+}
+
+/**
+ * Whether starting this workflow requires asking the user for something first.
+ *
+ * Contextual workflows need a source folder/branch — unless the launching
+ * surface already supplied one. Declared run inputs always need the user,
+ * since a run is the only moment those values can be supplied.
+ *
+ * Takes the launch context so there is exactly one definition of "must
+ * prompt": call sites that pass a source and call sites that don't share this
+ * predicate rather than each hand-rolling half of it.
+ */
+export function needsRunPrompt(wf: WorkflowDefinition, ctx?: ManualRunContext): boolean {
+  const hasSource = !!(ctx?.task || ctx?.source)
+  return (isContextualWorkflow(wf) && !hasSource) || getWorkflowInputs(wf).length > 0
 }
 
 export type WorktreeMode = 'none' | 'new' | 'fromStep' | 'existing' | 'fromContext'

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -139,7 +139,10 @@ export function isContextualWorkflow(wf: WorkflowDefinition): boolean {
 export function getWorkflowInputs(wf: WorkflowDefinition): WorkflowInputDef[] {
   const trigger = getTriggerConfig(wf)
   if (trigger?.triggerType !== 'manual') return []
-  return (trigger.inputs ?? []).filter((i) => i.key)
+  // Match the template parser's identifier grammar. Invalid or half-authored
+  // keys cannot be referenced as `{{inputs.<key>}}`, so they must not cause a
+  // run prompt or enter the values map.
+  return (trigger.inputs ?? []).filter((i) => /^[a-zA-Z_]\w*$/.test(i.key))
 }
 
 /**

--- a/src/renderer/lib/workflow-inputs.ts
+++ b/src/renderer/lib/workflow-inputs.ts
@@ -10,10 +10,34 @@ import type { WorkflowInputDef } from '../../shared/types'
  * otherwise the empty value for the field's type — booleans need `false`
  * rather than `''` so a toggle renders unchecked instead of indeterminate.
  */
+/**
+ * Starting value for one declared input. `defaultValue` wins when present;
+ * otherwise the empty value for the field's type — booleans need `false`
+ * rather than `''` so a toggle renders unchecked instead of indeterminate.
+ *
+ * Defaults are authored as text, so a number field's default is parsed here.
+ * Without that, submitting an untouched field persists `'42'` while touching
+ * it first persists `42`, and the two dedupe as different runs.
+ */
 function defaultInputValue(def: WorkflowInputDef): unknown {
+  if (def.type === 'number') {
+    return def.defaultValue !== undefined ? parseNumberInput(def.defaultValue) : ''
+  }
   if (def.defaultValue !== undefined) return def.defaultValue
   if (def.type === 'boolean') return false
   return ''
+}
+
+/**
+ * Parse text from a number field. Blank and unparseable text both mean "no
+ * value": `NaN` and `Infinity` don't survive JSON, so letting them through
+ * would corrupt the persisted run, the template expansion and the dedupe
+ * fingerprint alike.
+ */
+export function parseNumberInput(raw: string): number | '' {
+  if (raw.trim() === '') return ''
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : ''
 }
 
 export function initialInputValues(defs: WorkflowInputDef[]): Record<string, unknown> {
@@ -26,13 +50,12 @@ export function initialInputValues(defs: WorkflowInputDef[]): Record<string, unk
  */
 export function areInputsValid(defs: WorkflowInputDef[], values: Record<string, unknown>): boolean {
   return defs.every((def) => {
-    if (!def.required || def.type === 'boolean') return true
     const value = values[def.key]
+    // Checked ahead of the `required` shortcut: a non-finite number breaks
+    // persistence and dedupe whether or not the field had to be answered.
+    if (typeof value === 'number' && !Number.isFinite(value)) return false
+    if (!def.required || def.type === 'boolean') return true
     if (value === undefined || value === null) return false
-    // A number field that failed to parse is missing, not answered —
-    // String(NaN) is 'NaN', which would otherwise sail through as non-empty
-    // and reach templates, persistence and the dedupe fingerprint.
-    if (typeof value === 'number' && Number.isNaN(value)) return false
     return String(value).trim() !== ''
   })
 }

--- a/src/renderer/lib/workflow-inputs.ts
+++ b/src/renderer/lib/workflow-inputs.ts
@@ -28,6 +28,11 @@ export function areInputsValid(defs: WorkflowInputDef[], values: Record<string, 
   return defs.every((def) => {
     if (!def.required || def.type === 'boolean') return true
     const value = values[def.key]
-    return value !== undefined && value !== null && String(value).trim() !== ''
+    if (value === undefined || value === null) return false
+    // A number field that failed to parse is missing, not answered —
+    // String(NaN) is 'NaN', which would otherwise sail through as non-empty
+    // and reach templates, persistence and the dedupe fingerprint.
+    if (typeof value === 'number' && Number.isNaN(value)) return false
+    return String(value).trim() !== ''
   })
 }

--- a/src/renderer/lib/workflow-inputs.ts
+++ b/src/renderer/lib/workflow-inputs.ts
@@ -49,8 +49,10 @@ export function areInputsValid(defs: WorkflowInputDef[], values: Record<string, 
     // Checked ahead of the `required` shortcut: a non-finite number breaks
     // persistence and dedupe whether or not the field had to be answered.
     if (typeof value === 'number' && !Number.isFinite(value)) return false
-    if (!def.required || def.type === 'boolean') return true
+    if (!def.required) return true
     if (value === undefined || value === null) return false
+    // A required toggle must be present, but false is a real answer.
+    if (def.type === 'boolean') return typeof value === 'boolean'
     return String(value).trim() !== ''
   })
 }

--- a/src/renderer/lib/workflow-inputs.ts
+++ b/src/renderer/lib/workflow-inputs.ts
@@ -6,26 +6,21 @@ import type { WorkflowInputDef } from '../../shared/types'
  */
 
 /**
- * Starting value for one declared input. `defaultValue` wins when present;
- * otherwise the empty value for the field's type — booleans need `false`
- * rather than `''` so a toggle renders unchecked instead of indeterminate.
- */
-/**
- * Starting value for one declared input. `defaultValue` wins when present;
- * otherwise the empty value for the field's type — booleans need `false`
- * rather than `''` so a toggle renders unchecked instead of indeterminate.
+ * Starting value for one declared input: the authored default where it makes
+ * sense, otherwise the empty value for the field's type.
  *
- * Defaults are authored as text, so a number field's default is parsed here.
- * Without that, submitting an untouched field persists `'42'` while touching
- * it first persists `42`, and the two dedupe as different runs.
+ * Type is checked before `defaultValue` because a default left behind by an
+ * earlier type must not leak through. A toggle seeds `false` so it renders
+ * unchecked rather than indeterminate, and a number's default is parsed —
+ * defaults are authored as text, and left as a string an untouched field
+ * would submit `'42'` where a touched one submits `42`, deduping as two runs.
  */
 function defaultInputValue(def: WorkflowInputDef): unknown {
+  if (def.type === 'boolean') return def.defaultValue === 'true'
   if (def.type === 'number') {
     return def.defaultValue !== undefined ? parseNumberInput(def.defaultValue) : ''
   }
-  if (def.defaultValue !== undefined) return def.defaultValue
-  if (def.type === 'boolean') return false
-  return ''
+  return def.defaultValue ?? ''
 }
 
 /**

--- a/src/renderer/lib/workflow-inputs.ts
+++ b/src/renderer/lib/workflow-inputs.ts
@@ -1,0 +1,33 @@
+import type { WorkflowInputDef } from '../../shared/types'
+
+/**
+ * Value helpers for manual-run inputs. Kept out of WorkflowInputFields.tsx so
+ * that file exports only its component — mixing the two breaks Fast Refresh.
+ */
+
+/**
+ * Starting value for one declared input. `defaultValue` wins when present;
+ * otherwise the empty value for the field's type — booleans need `false`
+ * rather than `''` so a toggle renders unchecked instead of indeterminate.
+ */
+function defaultInputValue(def: WorkflowInputDef): unknown {
+  if (def.defaultValue !== undefined) return def.defaultValue
+  if (def.type === 'boolean') return false
+  return ''
+}
+
+export function initialInputValues(defs: WorkflowInputDef[]): Record<string, unknown> {
+  return Object.fromEntries(defs.map((d) => [d.key, defaultInputValue(d)]))
+}
+
+/**
+ * Whether every required input has a value. Booleans are always satisfied —
+ * `false` is a real answer, not a missing one.
+ */
+export function areInputsValid(defs: WorkflowInputDef[], values: Record<string, unknown>): boolean {
+  return defs.every((def) => {
+    if (!def.required || def.type === 'boolean') return true
+    const value = values[def.key]
+    return value !== undefined && value !== null && String(value).trim() !== ''
+  })
+}

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -2,9 +2,10 @@ import { type ReactNode } from 'react'
 import { Workflow } from 'lucide-react'
 import { ICON_MAP } from '../components/project-sidebar/icon-map'
 import { executeWorkflow } from './workflow-execution'
-import { isContextualWorkflow } from './workflow-helpers'
+import { isContextualWorkflow, needsRunPrompt } from './workflow-helpers'
+import type { ManualRunContext } from './workflow-helpers'
 import { useAppStore } from '../stores'
-import type { TaskConfig, TerminalSession, WorkflowDefinition } from '../../shared/types'
+import type { WorkflowDefinition } from '../../shared/types'
 
 export interface WorkflowMenuItem {
   id: string
@@ -23,23 +24,27 @@ export interface WorkflowMenuItem {
  * right-click) it lists only non-contextual workflows so users don't see
  * actions that would dead-end on a missing source.
  */
-export interface WorkflowMenuContext {
-  task?: TaskConfig
-  source?: TerminalSession
-}
+export type WorkflowMenuContext = ManualRunContext
 
 /**
- * Routes a workflow run from a non-contextual surface (sidebar, palette).
- * Contextual workflows open SourcePromptDialog so the user picks the source;
- * everything else launches immediately. Centralized here so each call site
- * doesn't need to repeat the gating logic.
+ * The single door for starting a workflow from the UI.
+ *
+ * Anything the user still has to supply — a source folder, or declared run
+ * inputs — opens the run dialog first; everything else launches immediately.
+ * Every manual surface (sidebar, palette, card/terminal menus, the editor's
+ * Run button) must go through here rather than calling `executeWorkflow`
+ * directly: skipping the prompt is silent, and produces a run whose
+ * `{{inputs.*}}` templates reach the agent unresolved.
+ *
+ * `executeWorkflow` itself stays unguarded because the scheduler, connector
+ * triggers and missed-schedule recovery legitimately run without a user.
  */
-export function runWorkflowFromGlobalSurface(workflow: WorkflowDefinition): void {
-  if (isContextualWorkflow(workflow)) {
-    useAppStore.getState().setPendingContextualWorkflowId(workflow.id)
+export function startManualRun(workflow: WorkflowDefinition, ctx?: ManualRunContext): void {
+  if (needsRunPrompt(workflow, ctx)) {
+    useAppStore.getState().setPendingWorkflowRun(workflow.id, ctx)
     return
   }
-  void executeWorkflow(workflow, undefined, { source: 'manual' })
+  void executeWorkflow(workflow, ctx, { source: 'manual' })
 }
 
 export function buildWorkflowMenuItems(
@@ -59,10 +64,9 @@ export function buildWorkflowMenuItems(
       label: wf.name,
       onClick: () => {
         onSelect()
-        executeWorkflow(
+        startManualRun(
           wf,
-          hasContext ? { task: context?.task, source: context?.source } : undefined,
-          { source: 'manual' }
+          hasContext ? { task: context?.task, source: context?.source } : undefined
         )
       }
     }

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -128,12 +128,22 @@ export interface UISlice {
   isWorkflowEditorOpen: boolean
   editingWorkflowId: string | null
   /**
-   * A contextual workflow whose run was triggered from a non-contextual
-   * surface (sidebar, command palette). The SourcePromptDialog renders when
-   * this is set and asks the user to pick a folder/branch before launching.
-   * Cleared when the user submits or cancels.
+   * A workflow whose manual run is waiting on the user. Set when the run was
+   * triggered from a surface that can't supply everything the workflow needs —
+   * a contextual workflow started from the sidebar / command palette (no
+   * folder), or any workflow declaring run inputs. The SourcePromptDialog
+   * renders while this is set. Cleared when the user submits or cancels.
+   *
+   * `context` is what the launching surface already knew (a card or terminal
+   * right-click), letting the dialog prompt only for what's genuinely missing
+   * instead of re-asking for a folder the caller already has. It lives inside
+   * this object rather than beside it so a stale context can't outlive the
+   * run it belongs to.
    */
-  pendingContextualWorkflowId: string | null
+  pendingWorkflowRun: {
+    workflowId: string
+    context?: { task?: TaskConfig; source?: TerminalSession }
+  } | null
   editingProject: ProjectConfig | null
   isCommandPaletteOpen: boolean
   isShortcutsPanelOpen: boolean
@@ -181,7 +191,10 @@ export interface UISlice {
   setNewAgentDialogOpen: (open: boolean) => void
   setAddProjectDialogOpen: (open: boolean) => void
   setWorkflowEditorOpen: (open: boolean) => void
-  setPendingContextualWorkflowId: (id: string | null) => void
+  setPendingWorkflowRun: (
+    workflowId: string | null,
+    context?: { task?: TaskConfig; source?: TerminalSession }
+  ) => void
   setEditingWorkflowId: (id: string | null) => void
   setEditingProject: (project: ProjectConfig | null) => void
   setCommandPaletteOpen: (open: boolean) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -76,7 +76,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   isAddProjectDialogOpen: false,
   isWorkflowEditorOpen: false,
   editingWorkflowId: null,
-  pendingContextualWorkflowId: null,
+  pendingWorkflowRun: null,
   editingProject: null,
   isCommandPaletteOpen: false,
   isShortcutsPanelOpen: false,
@@ -151,7 +151,8 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   setWorkflowEditorOpen: (open) => set({ isWorkflowEditorOpen: open }),
 
-  setPendingContextualWorkflowId: (id) => set({ pendingContextualWorkflowId: id }),
+  setPendingWorkflowRun: (workflowId, context) =>
+    set({ pendingWorkflowRun: workflowId ? { workflowId, context } : null }),
 
   setEditingWorkflowId: (id) => set({ editingWorkflowId: id }),
 

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -247,6 +247,22 @@ describe('workflow run inputs persistence', () => {
     expect(run.inputs).toEqual({ issue: 'gh-42', count: 3, item: { number: 7 } })
   })
 
+  it('ignores a non-object inputs blob rather than surfacing numeric keys', () => {
+    saveWorkflowRun({
+      runId: 'run-inputs-3',
+      workflowId: 'wf-bad',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      nodeStates: [],
+      // An array survives JSON.parse and is `typeof 'object'`, so without an
+      // explicit check it would render as a row of numeric keys.
+      inputs: ['a', 'b'] as unknown as Record<string, unknown>
+    })
+
+    const [run] = listWorkflowRuns('wf-bad')
+    expect(run.inputs).toBeUndefined()
+  })
+
   it('omits inputs entirely for a run that had none', () => {
     saveWorkflowRun({
       runId: 'run-inputs-2',

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -230,3 +230,33 @@ describe('listAllWorkflowRuns', () => {
     expect(listAllWorkflowRuns()).toHaveLength(1)
   })
 })
+
+describe('workflow run inputs persistence', () => {
+  it('round-trips the values a manual run was started with', () => {
+    const exec: WorkflowExecution = {
+      runId: 'run-inputs-1',
+      workflowId: 'wf-inputs',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      nodeStates: [{ nodeId: 'n1', status: 'success' }],
+      inputs: { issue: 'gh-42', count: 3, item: { number: 7 } }
+    }
+    saveWorkflowRun(exec)
+
+    const [run] = listWorkflowRuns('wf-inputs')
+    expect(run.inputs).toEqual({ issue: 'gh-42', count: 3, item: { number: 7 } })
+  })
+
+  it('omits inputs entirely for a run that had none', () => {
+    saveWorkflowRun({
+      runId: 'run-inputs-2',
+      workflowId: 'wf-none',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'success',
+      nodeStates: []
+    })
+
+    const [run] = listWorkflowRuns('wf-none')
+    expect(run.inputs).toBeUndefined()
+  })
+})

--- a/tests/launch-agent-config-form.test.tsx
+++ b/tests/launch-agent-config-form.test.tsx
@@ -539,4 +539,18 @@ describe('LaunchAgentConfigForm — contextual workflow surface', () => {
     )
     expect(container.querySelector('[data-testid="variable-autocomplete"]')).toBeTruthy()
   })
+
+  it('offers the variable picker on a plain manual workflow that declares inputs', () => {
+    // Without inputVars in hasTemplateVars this fell back to RichMarkdownEditor,
+    // leaving no {} button to insert {{inputs.*}} in the agent prompt.
+    const { container } = render(
+      <LaunchAgentConfigForm
+        config={baseConfig()}
+        onChange={vi.fn()}
+        triggerType="manual"
+        inputVars={[{ key: '{{inputs.pr}}', label: 'PR', category: 'inputs' }]}
+      />
+    )
+    expect(container.querySelector('[data-testid="variable-autocomplete"]')).toBeTruthy()
+  })
 })

--- a/tests/manual-run-entry-point.test.ts
+++ b/tests/manual-run-entry-point.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * `executeWorkflow` runs a workflow with whatever context it is handed. A UI
+ * surface that calls it directly silently skips the run dialog, so a workflow
+ * declaring inputs launches with `context.inputs` undefined and sends
+ * `{{inputs.*}}` to the agent as literal text. That shipped once already, from
+ * the workflow editor's Run button.
+ *
+ * `startManualRun` is the single door that gates on `needsRunPrompt`. This
+ * pins the allowlist so a new surface reaching for `executeWorkflow` fails
+ * here instead of in production, where the failure is invisible.
+ */
+const ALLOWED = new Set([
+  // The dialog itself — it runs the workflow after collecting what's missing.
+  'src/renderer/components/SourcePromptDialog.tsx',
+  // The single manual-run entry point.
+  'src/renderer/lib/workflow-menu-items.tsx',
+  // Non-manual paths: no user is present to prompt.
+  'src/renderer/lib/workflow-triggers.ts',
+  'src/renderer/components/MissedScheduleDialog.tsx',
+  // The scheduler's SCHEDULER_EXECUTE handler.
+  'src/renderer/App.tsx'
+])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+describe('manual workflow runs go through one entry point', () => {
+  it('has no unexpected direct callers of executeWorkflow', () => {
+    const root = join(__dirname, '..')
+    const callers = walk(join(root, 'src/renderer'))
+      .filter((f) => {
+        const src = readFileSync(f, 'utf8')
+        // The import site is what matters; the definition lives elsewhere.
+        return /\bexecuteWorkflow\b/.test(src) && /from '.*workflow-execution'/.test(src)
+      })
+      .map((f) => f.slice(root.length + 1).replace(/\\/g, '/'))
+
+    expect(new Set(callers)).toEqual(ALLOWED)
+  })
+})

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -294,3 +294,54 @@ describe('RunEntry', () => {
     expect(getByText(/Step was skipped/)).toBeInTheDocument()
   })
 })
+
+describe('RunEntry — run inputs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-20T10:00:10Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function expand(getByText: (m: RegExp) => HTMLElement): void {
+    fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
+  }
+
+  it('shows what the run was launched with', () => {
+    const exec = makeExec({
+      nodeStates: [makeState()],
+      inputs: { issue: 'gh-42', force: false }
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    expand(getByText)
+
+    expect(getByText('gh-42')).toBeInTheDocument()
+    expect(getByText('false')).toBeInTheDocument()
+  })
+
+  it('clips a large object-valued input instead of flooding the row', () => {
+    const exec = makeExec({
+      nodeStates: [makeState()],
+      inputs: { item: { body: 'x'.repeat(200) } }
+    })
+    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    expand(getByText)
+
+    const rendered = getByText(/^\{"body"/)
+    expect(rendered.textContent!.length).toBeLessThanOrEqual(61)
+    expect(rendered.textContent!.endsWith('…')).toBe(true)
+  })
+
+  it('renders no inputs row for a run that had none', () => {
+    const exec = makeExec({ nodeStates: [makeState()] })
+    const { getByText, queryByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    expand(getByText)
+
+    // Queried the same way as the positive case above: the row renders the
+    // value in its own node, so a regex over `key=value` would match nothing
+    // even when the row *is* present and the assertion could never fail.
+    expect(queryByText('gh-42')).not.toBeInTheDocument()
+    expect(queryByText('issue')).not.toBeInTheDocument()
+  })
+})

--- a/tests/source-prompt-dialog.test.tsx
+++ b/tests/source-prompt-dialog.test.tsx
@@ -154,6 +154,35 @@ describe('SourcePromptDialog', () => {
     expect(screen.queryByText('Branch')).not.toBeInTheDocument()
   })
 
+  it('always shows the project choice for a global contextual run', () => {
+    const wf = makeWorkflow({
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger',
+          config: { triggerType: 'manual', contextual: true },
+          position: { x: 0, y: 0 },
+          label: 'Manual'
+        },
+        {
+          id: 'a',
+          type: 'launchAgent',
+          config: { agentType: 'claude', prompt: 'No context references' },
+          position: { x: 0, y: 0 },
+          label: 'Run'
+        }
+      ]
+    })
+    useAppStore.setState({
+      pendingWorkflowRun: { workflowId: wf.id },
+      config: { ...useAppStore.getState().config!, workflows: [wf] }
+    })
+
+    render(<SourcePromptDialog />)
+
+    expect(screen.getByTestId('project-picker')).toBeInTheDocument()
+  })
+
   it('shows a worktree checkbox when an agent uses useWorktree: fromContext', () => {
     const wf = makeWorkflow({
       nodes: [

--- a/tests/source-prompt-dialog.test.tsx
+++ b/tests/source-prompt-dialog.test.tsx
@@ -78,7 +78,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   projectPickerProps.length = 0
   useAppStore.setState({
-    pendingContextualWorkflowId: null,
+    pendingWorkflowRun: null,
     config: {
       projects: [
         { name: 'Vorn', path: '/repo/vorn', preferredAgents: [], icon: '', iconColor: '' }
@@ -102,7 +102,7 @@ describe('SourcePromptDialog', () => {
   it('renders the workflow name in its title when pending', () => {
     const wf = makeWorkflow()
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: {
         ...useAppStore.getState().config!,
         workflows: [wf]
@@ -137,7 +137,7 @@ describe('SourcePromptDialog', () => {
       ]
     })
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
@@ -147,7 +147,7 @@ describe('SourcePromptDialog', () => {
   it('hides the branch input when nothing references {{context.branch}}', () => {
     const wf = makeWorkflow()
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
@@ -179,7 +179,7 @@ describe('SourcePromptDialog', () => {
       ]
     })
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
@@ -189,19 +189,19 @@ describe('SourcePromptDialog', () => {
   it('clears the pending id and does not run on Cancel', () => {
     const wf = makeWorkflow()
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
     fireEvent.click(screen.getByText('Cancel'))
-    expect(useAppStore.getState().pendingContextualWorkflowId).toBeNull()
+    expect(useAppStore.getState().pendingWorkflowRun).toBeNull()
     expect(mockExecuteWorkflow).not.toHaveBeenCalled()
   })
 
   it('runs executeWorkflow with a synthesized source on submit', () => {
     const wf = makeWorkflow()
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
@@ -218,7 +218,7 @@ describe('SourcePromptDialog', () => {
       }),
       { source: 'manual' }
     )
-    expect(useAppStore.getState().pendingContextualWorkflowId).toBeNull()
+    expect(useAppStore.getState().pendingWorkflowRun).toBeNull()
   })
 
   it('detects context references in script nodes (cwd / projectName / projectPath)', () => {
@@ -247,7 +247,7 @@ describe('SourcePromptDialog', () => {
       ]
     })
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)
@@ -277,7 +277,7 @@ describe('SourcePromptDialog', () => {
       ]
     })
     useAppStore.setState({
-      pendingContextualWorkflowId: wf.id,
+      pendingWorkflowRun: { workflowId: wf.id },
       config: { ...useAppStore.getState().config!, workflows: [wf] }
     })
     render(<SourcePromptDialog />)

--- a/tests/template-vars.test.ts
+++ b/tests/template-vars.test.ts
@@ -9,6 +9,7 @@ import {
   isContextRef,
   containsContextRef,
   getAvailableContextVars,
+  buildInputVars,
   CONTEXT_REF
 } from '../src/renderer/lib/template-vars'
 import type {
@@ -439,5 +440,63 @@ describe('getAvailableContextVars', () => {
   it('returns empty list for plain manual non-contextual trigger', () => {
     const vars = getAvailableContextVars({ triggerType: 'manual', isContextualTrigger: false })
     expect(vars).toEqual([])
+  })
+})
+
+describe('inputs namespace', () => {
+  const context: WorkflowExecutionContext = {
+    inputs: {
+      issue: 'gh-42',
+      count: 3,
+      force: false,
+      item: { number: 7, url: 'https://example.test/7' }
+    }
+  }
+
+  it('resolves a scalar input', () => {
+    expect(resolveTemplateVars('issue {{inputs.issue}}', context)).toBe('issue gh-42')
+  })
+
+  it('stringifies non-string scalars', () => {
+    expect(resolveTemplateVars('{{inputs.count}}/{{inputs.force}}', context)).toBe('3/false')
+  })
+
+  it('walks into an object-valued input', () => {
+    expect(resolveTemplateVars('#{{inputs.item.number}}', context)).toBe('#7')
+  })
+
+  it('serializes an object input referenced whole', () => {
+    expect(resolveTemplateVars('{{inputs.item}}', context)).toBe(
+      '{"number":7,"url":"https://example.test/7"}'
+    )
+  })
+
+  it('resolves an undeclared key to empty rather than leaking the placeholder', () => {
+    expect(resolveTemplateVars('[{{inputs.missing}}]', context)).toBe('[]')
+  })
+
+  it('leaves the placeholder intact when the run supplied no inputs', () => {
+    expect(resolveTemplateVars('{{inputs.issue}}', { task: undefined })).toBe('{{inputs.issue}}')
+  })
+})
+
+describe('buildInputVars', () => {
+  it('builds an autocomplete entry per declared input', () => {
+    const vars = buildInputVars([
+      { key: 'issue', label: 'Issue URL', type: 'text' },
+      { key: 'force', label: '', type: 'boolean' }
+    ])
+    expect(vars).toEqual([
+      { key: '{{inputs.issue}}', label: 'Issue URL', category: 'inputs' },
+      { key: '{{inputs.force}}', label: 'force', category: 'inputs' }
+    ])
+  })
+
+  it('skips half-written inputs with no key yet', () => {
+    expect(buildInputVars([{ key: '', label: 'wip', type: 'text' }])).toEqual([])
+  })
+
+  it('returns empty for a workflow declaring none', () => {
+    expect(buildInputVars(undefined)).toEqual([])
   })
 })

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -125,3 +125,80 @@ describe('TriggerConfigForm — contextual toggle', () => {
     expect(onChange).toHaveBeenCalledWith({ triggerType: 'manual', contextual: undefined })
   })
 })
+
+describe('TriggerConfigForm — run inputs', () => {
+  it('offers the inputs editor only for the manual trigger type', () => {
+    const { unmount } = render(
+      <TriggerConfigForm config={{ triggerType: 'manual' }} onChange={vi.fn()} />
+    )
+    expect(screen.getByText('Run Inputs')).toBeInTheDocument()
+    unmount()
+
+    render(<TriggerConfigForm config={{ triggerType: 'taskCreated' }} onChange={vi.fn()} />)
+    expect(screen.queryByText('Run Inputs')).not.toBeInTheDocument()
+  })
+
+  it('adds an input with a usable default key', () => {
+    const onChange = vi.fn()
+    render(<TriggerConfigForm config={{ triggerType: 'manual' }} onChange={onChange} />)
+    fireEvent.click(screen.getByText('Add input'))
+
+    expect(onChange).toHaveBeenCalledWith({
+      triggerType: 'manual',
+      inputs: [{ key: 'input', label: '', type: 'text' }]
+    })
+  })
+
+  it('does not clobber the contextual flag when adding an input', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm config={{ triggerType: 'manual', contextual: true }} onChange={onChange} />
+    )
+    fireEvent.click(screen.getByText('Add input'))
+
+    expect(onChange.mock.calls[0][0]).toMatchObject({ contextual: true })
+  })
+
+  it('normalizes a typed key so it survives the template syntax', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm
+        config={{ triggerType: 'manual', inputs: [{ key: 'a', label: '', type: 'text' }] }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Input key'), {
+      target: { value: 'issue url.x' }
+    })
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ inputs: [expect.objectContaining({ key: 'issue_url_x' })] })
+    )
+  })
+
+  it('names a second input uniquely rather than colliding with the first', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm
+        config={{ triggerType: 'manual', inputs: [{ key: 'input', label: '', type: 'text' }] }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByText('Add input'))
+
+    expect(onChange.mock.calls[0][0].inputs[1].key).toBe('input_2')
+  })
+
+  it('drops the inputs key entirely when the last input is removed', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm
+        config={{ triggerType: 'manual', inputs: [{ key: 'issue', label: '', type: 'text' }] }}
+        onChange={onChange}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Remove input issue'))
+
+    expect(onChange).toHaveBeenCalledWith({ triggerType: 'manual', inputs: undefined })
+  })
+})

--- a/tests/variable-autocomplete.test.tsx
+++ b/tests/variable-autocomplete.test.tsx
@@ -19,4 +19,38 @@ describe('VariableAutocomplete', () => {
     fireEvent.change(textarea, { target: { value: '{{' } })
     expect(getByText('Context')).toBeInTheDocument()
   })
+
+  it('offers declared run inputs so they can be inserted from the picker', () => {
+    const contextVars: TemplateVariable[] = [
+      { key: '{{inputs.pr_number}}', label: 'PR number', category: 'inputs' }
+    ]
+    const onChange = vi.fn()
+    const { container, getByText } = render(
+      <VariableAutocomplete
+        value=""
+        onChange={onChange}
+        stepGroups={[]}
+        contextVars={contextVars}
+      />
+    )
+    const textarea = container.querySelector('textarea')!
+    fireEvent.change(textarea, { target: { value: '{{' } })
+
+    expect(getByText('Run Inputs')).toBeInTheDocument()
+    fireEvent.click(getByText('PR number'))
+    // Inserting by hand is what produced unresolvable single-brace text before.
+    expect(onChange).toHaveBeenCalledWith('{{inputs.pr_number}}')
+  })
+
+  it('offers connector item variables, which the picker used to drop', () => {
+    const contextVars: TemplateVariable[] = [
+      { key: '{{connectorItem.title}}', label: 'title', category: 'connectorItem' }
+    ]
+    const { container, getByText } = render(
+      <VariableAutocomplete value="" onChange={vi.fn()} stepGroups={[]} contextVars={contextVars} />
+    )
+    const textarea = container.querySelector('textarea')!
+    fireEvent.change(textarea, { target: { value: '{{' } })
+    expect(getByText('Connector Item')).toBeInTheDocument()
+  })
 })

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -50,6 +50,7 @@ const mockState = {
   updateWorkflow: vi.fn(),
   removeWorkflow: vi.fn(),
   config: { workflows: [], tasks: [], projects: [], defaults: {} },
+  setPendingWorkflowRun: vi.fn(),
   addTerminal: vi.fn(),
   setFocusedTerminal: vi.fn(),
   setSelectedTaskId: vi.fn(),
@@ -128,6 +129,56 @@ describe('WorkflowEditor', () => {
     ) as HTMLInputElement
     fireEvent.change(nameInput, { target: { value: 'New name' } })
     expect(nameInput.value).toBe('New name')
+  })
+
+  it('prompts for run inputs instead of launching the workflow blind', async () => {
+    // Running straight from the editor used to skip the prompt entirely, so
+    // {{inputs.*}} reached the agent unresolved.
+    const { executeWorkflow } = await import('../src/renderer/lib/workflow-execution')
+    vi.mocked(executeWorkflow).mockClear()
+    mockState.setPendingWorkflowRun.mockClear()
+    mockState.editingWorkflowId = 'wf-inputs' as unknown as null
+    mockState.config.workflows = [
+      {
+        id: 'wf-inputs',
+        name: 'Needs inputs',
+        enabled: true,
+        nodes: [
+          {
+            id: 'trigger',
+            type: 'trigger',
+            label: 'Trigger',
+            position: { x: 0, y: 0 },
+            config: {
+              triggerType: 'manual',
+              inputs: [{ key: 'pr_number', label: 'PR number', type: 'text' }]
+            }
+          }
+        ],
+        edges: []
+      }
+    ] as unknown as never[]
+
+    const { container } = render(<WorkflowEditor />)
+    fireEvent.click(container.querySelector('button[aria-label="Run workflow"]')!)
+
+    expect(mockState.setPendingWorkflowRun).toHaveBeenCalledWith('wf-inputs', undefined)
+    expect(executeWorkflow).not.toHaveBeenCalled()
+
+    mockState.editingWorkflowId = null
+    mockState.config.workflows = []
+  })
+
+  it('runs a workflow with no declared inputs directly', async () => {
+    const { executeWorkflow } = await import('../src/renderer/lib/workflow-execution')
+    vi.mocked(executeWorkflow).mockClear()
+    mockState.setPendingWorkflowRun.mockClear()
+
+    const { container } = render(<WorkflowEditor />)
+    fireEvent.click(container.querySelector('button[aria-label="Run workflow"]')!)
+
+    expect(executeWorkflow).toHaveBeenCalled()
+    expect(mockState.setPendingWorkflowRun).not.toHaveBeenCalled()
   })
 
   it('renders the back button which closes the editor', () => {

--- a/tests/workflow-helpers.test.ts
+++ b/tests/workflow-helpers.test.ts
@@ -38,7 +38,9 @@ import {
   insertNodeBetween,
   insertConditionBetween,
   addParallelBranch,
-  computeFlowLayout
+  computeFlowLayout,
+  getWorkflowInputs,
+  needsRunPrompt
 } from '../src/renderer/lib/workflow-helpers'
 
 beforeEach(() => {
@@ -498,5 +500,51 @@ describe('computeFlowLayout', () => {
     const orphan = makeActionNode('orphan')
     const rows = computeFlowLayout([t, orphan], [])
     expect(rows).toHaveLength(2)
+  })
+})
+
+describe('run inputs helpers', () => {
+  function wfWith(config: TriggerConfig): WorkflowDefinition {
+    return {
+      id: 'wf',
+      name: 'wf',
+      icon: 'Zap',
+      iconColor: '#fff',
+      nodes: [
+        { id: 'trigger-1', type: 'trigger', label: 'Manual', config, position: { x: 0, y: 0 } }
+      ],
+      edges: [],
+      enabled: true
+    }
+  }
+
+  it('reads inputs off a manual trigger', () => {
+    const wf = wfWith({
+      triggerType: 'manual',
+      inputs: [{ key: 'issue', label: 'Issue', type: 'text' }]
+    })
+    expect(getWorkflowInputs(wf)).toHaveLength(1)
+    expect(needsRunPrompt(wf)).toBe(true)
+  })
+
+  it('drops half-written inputs with no key', () => {
+    const wf = wfWith({
+      triggerType: 'manual',
+      inputs: [{ key: '', label: 'wip', type: 'text' }]
+    })
+    expect(getWorkflowInputs(wf)).toEqual([])
+    expect(needsRunPrompt(wf)).toBe(false)
+  })
+
+  it('ignores inputs on a non-manual trigger', () => {
+    expect(getWorkflowInputs(wfWith({ triggerType: 'recurring', cron: '0 9 * * *' }))).toEqual([])
+  })
+
+  it('still prompts for a contextual workflow declaring no inputs', () => {
+    expect(needsRunPrompt(wfWith({ triggerType: 'manual', contextual: true }))).toBe(true)
+  })
+
+  it('does not prompt for a plain manual workflow', () => {
+    expect(needsRunPrompt(wfWith({ triggerType: 'manual' }))).toBe(false)
   })
 })

--- a/tests/workflow-helpers.test.ts
+++ b/tests/workflow-helpers.test.ts
@@ -536,6 +536,19 @@ describe('run inputs helpers', () => {
     expect(needsRunPrompt(wf)).toBe(false)
   })
 
+  it('drops input keys that cannot be referenced by the template parser', () => {
+    const wf = wfWith({
+      triggerType: 'manual',
+      inputs: [
+        { key: '   ', label: 'Whitespace', type: 'text' },
+        { key: 'issue-number', label: 'Punctuation', type: 'text' },
+        { key: '2issue', label: 'Leading digit', type: 'text' },
+        { key: '_issue2', label: 'Valid', type: 'text' }
+      ]
+    })
+    expect(getWorkflowInputs(wf).map((input) => input.key)).toEqual(['_issue2'])
+  })
+
   it('ignores inputs on a non-manual trigger', () => {
     expect(getWorkflowInputs(wfWith({ triggerType: 'recurring', cron: '0 9 * * *' }))).toEqual([])
   })

--- a/tests/workflow-input-fields.test.tsx
+++ b/tests/workflow-input-fields.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/components/ProjectPicker', () => ({
+  ProjectPicker: (props: Record<string, unknown>) => (
+    <button
+      data-testid="project-picker"
+      data-allow-none={String(props.allowNone)}
+      data-current={String(props.currentProject)}
+      onClick={() => (props.onChange as (v: string) => void)('Vorn')}
+    />
+  )
+}))
+
+vi.mock('../src/renderer/components/SelectPicker', () => ({
+  SelectPicker: (props: Record<string, unknown>) => (
+    <button
+      data-testid="select-picker"
+      data-current={String(props.value)}
+      data-count={String((props.options as unknown[]).length)}
+      onClick={() => (props.onChange as (v: string) => void)('b')}
+    />
+  )
+}))
+
+const mockState = { config: { projects: [{ name: 'Vorn', path: '/p' }] } }
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (s: unknown) => unknown) => (selector ? selector(mockState) : mockState)
+}))
+
+const { WorkflowInputFields } = await import('../src/renderer/components/WorkflowInputFields')
+
+type Def = Parameters<typeof WorkflowInputFields>[0]['defs'][number]
+
+function renderField(def: Def, value: unknown = '') {
+  const onChange = vi.fn()
+  const utils = render(
+    <WorkflowInputFields defs={[def]} values={{ [def.key]: value }} onChange={onChange} />
+  )
+  return { ...utils, onChange }
+}
+
+describe('WorkflowInputFields', () => {
+  it('renders nothing when there are no declared inputs', () => {
+    const { container } = render(<WorkflowInputFields defs={[]} values={{}} onChange={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('falls back to the key when no label was given, and marks required fields', () => {
+    const { getByText, getByLabelText } = renderField({
+      key: 'pr_number',
+      label: '',
+      type: 'text',
+      required: true
+    })
+    expect(getByLabelText('pr_number')).toBeInTheDocument()
+    expect(getByText('*')).toBeInTheDocument()
+  })
+
+  it('renders a description under the control when one is declared', () => {
+    const { getByText } = renderField({
+      key: 'k',
+      label: 'K',
+      type: 'text',
+      description: 'why this matters'
+    })
+    expect(getByText('why this matters')).toBeInTheDocument()
+  })
+
+  it('edits a text input', () => {
+    const { getByLabelText, onChange } = renderField({ key: 'k', label: 'K', type: 'text' })
+    fireEvent.change(getByLabelText('K'), { target: { value: 'hello' } })
+    expect(onChange).toHaveBeenCalledWith('k', 'hello')
+  })
+
+  it('edits a textarea', () => {
+    const { getByLabelText, onChange } = renderField({ key: 'k', label: 'K', type: 'textarea' })
+    fireEvent.change(getByLabelText('K'), { target: { value: 'long text' } })
+    expect(onChange).toHaveBeenCalledWith('k', 'long text')
+  })
+
+  it('coerces a number field to a number', () => {
+    const { getByLabelText, onChange } = renderField({ key: 'n', label: 'N', type: 'number' })
+    fireEvent.change(getByLabelText('N'), { target: { value: '42' } })
+    // Not '42' — templates and dedupe both compare the raw value.
+    expect(onChange).toHaveBeenCalledWith('n', 42)
+  })
+
+  it('reports a cleared number field as empty rather than NaN', () => {
+    const { getByLabelText, onChange } = renderField({ key: 'n', label: 'N', type: 'number' }, 7)
+    fireEvent.change(getByLabelText('N'), { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith('n', '')
+  })
+
+  it('renders a number field with an existing value without stringifying null', () => {
+    const { getByLabelText } = renderField({ key: 'n', label: 'N', type: 'number' }, 7)
+    expect(getByLabelText('N')).toHaveValue(7)
+  })
+
+  it('edits a select through the shared picker', () => {
+    const { getByTestId, onChange } = renderField({
+      key: 's',
+      label: 'S',
+      type: 'select',
+      options: [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' }
+      ]
+    })
+    expect(getByTestId('select-picker')).toHaveAttribute('data-count', '2')
+    fireEvent.click(getByTestId('select-picker'))
+    expect(onChange).toHaveBeenCalledWith('s', 'b')
+  })
+
+  it('toggles a boolean and shows its label beside the checkbox', () => {
+    const { getByLabelText, onChange } = renderField(
+      { key: 'f', label: 'Force', type: 'boolean' },
+      false
+    )
+    const box = getByLabelText('Force')
+    expect(box).not.toBeChecked()
+    fireEvent.click(box)
+    expect(onChange).toHaveBeenCalledWith('f', true)
+  })
+
+  it('lets an optional project input be cleared but a required one not', () => {
+    const opt = renderField({ key: 'p', label: 'P', type: 'project' })
+    expect(opt.getByTestId('project-picker')).toHaveAttribute('data-allow-none', 'true')
+    opt.unmount()
+
+    const req = renderField({ key: 'p', label: 'P', type: 'project', required: true })
+    expect(req.getByTestId('project-picker')).toHaveAttribute('data-allow-none', 'false')
+
+    fireEvent.click(req.getByTestId('project-picker'))
+    expect(req.onChange).toHaveBeenCalledWith('p', 'Vorn')
+  })
+
+  it('edits a branch input', () => {
+    const { getByLabelText, onChange } = renderField({ key: 'b', label: 'Branch', type: 'branch' })
+    fireEvent.change(getByLabelText('Branch'), { target: { value: 'main' } })
+    expect(onChange).toHaveBeenCalledWith('b', 'main')
+  })
+})

--- a/tests/workflow-inputs-editor.test.tsx
+++ b/tests/workflow-inputs-editor.test.tsx
@@ -46,6 +46,43 @@ describe('WorkflowInputsEditor', () => {
     expect(onChange).toHaveBeenCalledWith([{ key: '_2_pr_num_', label: 'PR', type: 'text' }])
   })
 
+  it('flags a key that collides with another input', () => {
+    // Colliding keys silently lose one value when the run dialog builds its
+    // value map, and make {{inputs.pr}} ambiguous.
+    const { getAllByLabelText, getAllByText } = setup([
+      { key: 'pr', label: 'A', type: 'text' },
+      { key: 'pr', label: 'B', type: 'text' }
+    ])
+    expect(getAllByText(/Duplicate key/)).toHaveLength(2)
+    for (const field of getAllByLabelText('Input key')) {
+      expect(field).toHaveAttribute('aria-invalid', 'true')
+    }
+  })
+
+  it('leaves distinct keys unflagged', () => {
+    const { queryByText, getAllByLabelText } = setup([
+      { key: 'pr', label: 'A', type: 'text' },
+      { key: 'repo', label: 'B', type: 'text' }
+    ])
+    expect(queryByText(/Duplicate key/)).not.toBeInTheDocument()
+    for (const field of getAllByLabelText('Input key')) {
+      expect(field).not.toHaveAttribute('aria-invalid')
+    }
+  })
+
+  it('does not rewrite a key that is briefly a prefix of another while typing', () => {
+    // Auto-renaming on collision would fight anyone typing a longer name.
+    const { getAllByLabelText, onChange } = setup([
+      { key: 'pr', label: 'A', type: 'text' },
+      { key: 'x', label: 'B', type: 'text' }
+    ])
+    fireEvent.change(getAllByLabelText('Input key')[1], { target: { value: 'pr' } })
+    expect(onChange).toHaveBeenCalledWith([
+      { key: 'pr', label: 'A', type: 'text' },
+      { key: 'pr', label: 'B', type: 'text' }
+    ])
+  })
+
   it('removes the right input', () => {
     const { getByLabelText, onChange } = setup([
       ...oneText,

--- a/tests/workflow-inputs-editor.test.tsx
+++ b/tests/workflow-inputs-editor.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import type { WorkflowInputDef } from '../src/shared/types'
+
+// Exposes the option list so type-change behavior can be driven directly.
+vi.mock('../src/renderer/components/SelectPicker', () => ({
+  SelectPicker: (props: Record<string, unknown>) => (
+    <select
+      data-testid="type-picker"
+      value={props.value as string}
+      onChange={(e) => (props.onChange as (v: string) => void)(e.target.value)}
+    >
+      {(props.options as { value: string; label: string }[]).map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )
+}))
+
+const { WorkflowInputsEditor } =
+  await import('../src/renderer/components/workflow-editor/panels/WorkflowInputsEditor')
+
+function setup(inputs: WorkflowInputDef[]) {
+  const onChange = vi.fn()
+  const utils = render(<WorkflowInputsEditor inputs={inputs} onChange={onChange} />)
+  return { ...utils, onChange }
+}
+
+const oneText: WorkflowInputDef[] = [{ key: 'pr', label: 'PR', type: 'text' }]
+
+describe('WorkflowInputsEditor', () => {
+  it('edits the label', () => {
+    const { getByLabelText, onChange } = setup(oneText)
+    fireEvent.change(getByLabelText('Input label'), { target: { value: 'PR number' } })
+    expect(onChange).toHaveBeenCalledWith([{ key: 'pr', label: 'PR number', type: 'text' }])
+  })
+
+  it('normalizes an edited key so it stays a usable template identifier', () => {
+    const { getByLabelText, onChange } = setup(oneText)
+    fireEvent.change(getByLabelText('Input key'), { target: { value: '2 pr num!' } })
+    expect(onChange).toHaveBeenCalledWith([{ key: '_2_pr_num_', label: 'PR', type: 'text' }])
+  })
+
+  it('removes the right input', () => {
+    const { getByLabelText, onChange } = setup([
+      ...oneText,
+      { key: 'env', label: 'Env', type: 'text' }
+    ])
+    fireEvent.click(getByLabelText('Remove input env'))
+    expect(onChange).toHaveBeenCalledWith(oneText)
+  })
+
+  it('toggles required, dropping the flag entirely when unchecked', () => {
+    const { container, onChange } = setup([{ ...oneText[0], required: true }])
+    const box = container.querySelector('input[type="checkbox"]')!
+    expect(box).toBeChecked()
+    fireEvent.click(box)
+    // `undefined` rather than `false` keeps the stored workflow JSON clean.
+    expect(onChange).toHaveBeenCalledWith([{ key: 'pr', label: 'PR', type: 'text' }])
+  })
+
+  it('seeds an options list when switching to select', () => {
+    const { getByTestId, onChange } = setup(oneText)
+    fireEvent.change(getByTestId('type-picker'), { target: { value: 'select' } })
+    expect(onChange).toHaveBeenCalledWith([{ key: 'pr', label: 'PR', type: 'select', options: [] }])
+  })
+
+  it('drops stale options when switching away from select', () => {
+    const { getByTestId, onChange } = setup([
+      { key: 'e', label: 'E', type: 'select', options: [{ value: 'a', label: 'a' }] }
+    ])
+    fireEvent.change(getByTestId('type-picker'), { target: { value: 'text' } })
+    expect(onChange).toHaveBeenCalledWith([
+      { key: 'e', label: 'E', type: 'text', options: undefined }
+    ])
+  })
+
+  it('parses comma-separated choices, ignoring blanks and padding', () => {
+    const { getByLabelText, onChange } = setup([{ key: 'e', label: 'E', type: 'select' }])
+    fireEvent.change(getByLabelText('Input choices'), { target: { value: 'dev, , prod ,' } })
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        key: 'e',
+        label: 'E',
+        type: 'select',
+        options: [
+          { value: 'dev', label: 'dev' },
+          { value: 'prod', label: 'prod' }
+        ]
+      }
+    ])
+  })
+
+  it('shows existing choices back as a comma-separated string', () => {
+    const { getByLabelText } = setup([
+      {
+        key: 'e',
+        label: 'E',
+        type: 'select',
+        options: [
+          { value: 'dev', label: 'dev' },
+          { value: 'prod', label: 'prod' }
+        ]
+      }
+    ])
+    expect(getByLabelText('Input choices')).toHaveValue('dev, prod')
+  })
+
+  it('edits the default value, clearing it to undefined when emptied', () => {
+    const { getByLabelText, onChange } = setup([{ ...oneText[0], defaultValue: 'x' }])
+    fireEvent.change(getByLabelText('Input default value'), { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith([{ key: 'pr', label: 'PR', type: 'text' }])
+  })
+
+  it('offers no choices or default field for a boolean', () => {
+    const { queryByLabelText } = setup([{ key: 'f', label: 'F', type: 'boolean' }])
+    expect(queryByLabelText('Input choices')).not.toBeInTheDocument()
+    // A toggle's default is expressed by `required`/unchecked, not free text.
+    expect(queryByLabelText('Input default value')).not.toBeInTheDocument()
+  })
+})

--- a/tests/workflow-inputs-editor.test.tsx
+++ b/tests/workflow-inputs-editor.test.tsx
@@ -117,6 +117,27 @@ describe('WorkflowInputsEditor', () => {
     ])
   })
 
+  it('drops a stale default when switching to a type that hides the field', () => {
+    // boolean and select hide the default field, so a leftover value would be
+    // invisible in the editor yet still seed the run dialog.
+    for (const type of ['boolean', 'select']) {
+      const { getByTestId, onChange, unmount } = setup([
+        { key: 'pr', label: 'PR', type: 'text', defaultValue: 'stale' }
+      ])
+      fireEvent.change(getByTestId('type-picker'), { target: { value: type } })
+      expect(onChange.mock.calls.at(-1)?.[0][0].defaultValue).toBeUndefined()
+      unmount()
+    }
+  })
+
+  it('keeps the default when switching between types that show the field', () => {
+    const { getByTestId, onChange } = setup([
+      { key: 'pr', label: 'PR', type: 'text', defaultValue: '42' }
+    ])
+    fireEvent.change(getByTestId('type-picker'), { target: { value: 'number' } })
+    expect(onChange.mock.calls.at(-1)?.[0][0].defaultValue).toBe('42')
+  })
+
   it('parses comma-separated choices, ignoring blanks and padding', () => {
     const { getByLabelText, onChange } = setup([{ key: 'e', label: 'E', type: 'select' }])
     fireEvent.change(getByLabelText('Input choices'), { target: { value: 'dev, , prod ,' } })

--- a/tests/workflow-inputs.test.ts
+++ b/tests/workflow-inputs.test.ts
@@ -22,6 +22,20 @@ describe('initialInputValues', () => {
     expect(initialInputValues([def({ type: 'boolean' })])).toEqual({ k: false })
   })
 
+  it('seeds a toggle from a declared default', () => {
+    expect(initialInputValues([def({ type: 'boolean', defaultValue: 'true' })])).toEqual({
+      k: true
+    })
+  })
+
+  it('never seeds a toggle with a stale default left by an earlier type', () => {
+    // Switching an input to boolean hides the default field, so a leftover
+    // string must not reach the run as a non-boolean value.
+    expect(initialInputValues([def({ type: 'boolean', defaultValue: 'hello' })])).toEqual({
+      k: false
+    })
+  })
+
   it('seeds everything else as empty string', () => {
     expect(initialInputValues([def({ type: 'number' })])).toEqual({ k: '' })
   })

--- a/tests/workflow-inputs.test.ts
+++ b/tests/workflow-inputs.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { initialInputValues, areInputsValid } from '../src/renderer/lib/workflow-inputs'
+import {
+  initialInputValues,
+  areInputsValid,
+  parseNumberInput
+} from '../src/renderer/lib/workflow-inputs'
 import type { WorkflowInputDef } from '../src/shared/types'
 
 const def = (over: Partial<WorkflowInputDef> = {}): WorkflowInputDef => ({
@@ -20,6 +24,35 @@ describe('initialInputValues', () => {
 
   it('seeds everything else as empty string', () => {
     expect(initialInputValues([def({ type: 'number' })])).toEqual({ k: '' })
+  })
+
+  it('parses a number default so an untouched field submits a number', () => {
+    // Defaults are authored as text. Left as a string, submitting without
+    // touching the field would persist '42' while touching it persists 42,
+    // and the two would dedupe as different runs.
+    expect(initialInputValues([def({ type: 'number', defaultValue: '42' })])).toEqual({ k: 42 })
+  })
+
+  it('drops a number default that does not parse', () => {
+    expect(initialInputValues([def({ type: 'number', defaultValue: 'abc' })])).toEqual({ k: '' })
+  })
+})
+
+describe('parseNumberInput', () => {
+  it('parses a number', () => {
+    expect(parseNumberInput('42')).toBe(42)
+    expect(parseNumberInput('-1.5')).toBe(-1.5)
+  })
+
+  it('treats blank as no value', () => {
+    expect(parseNumberInput('')).toBe('')
+    expect(parseNumberInput('  ')).toBe('')
+  })
+
+  it('treats unparseable and overflowing text as no value', () => {
+    // Neither NaN nor Infinity survives JSON, so they must never be stored.
+    expect(parseNumberInput('abc')).toBe('')
+    expect(parseNumberInput('1e999')).toBe('')
   })
 })
 
@@ -50,6 +83,12 @@ describe('areInputsValid', () => {
     // String(NaN) is 'NaN', which would otherwise pass the non-empty check and
     // leak into templates, persistence and the dedupe fingerprint.
     expect(areInputsValid([def({ type: 'number', required: true })], { k: NaN })).toBe(false)
+  })
+
+  it('rejects a non-finite number even on an optional field', () => {
+    // Optional fields still reach persistence and the dedupe fingerprint.
+    expect(areInputsValid([def({ type: 'number' })], { k: Infinity })).toBe(false)
+    expect(areInputsValid([def({ type: 'number' })], { k: NaN })).toBe(false)
   })
 
   it('accepts a required input holding a resolved object', () => {

--- a/tests/workflow-inputs.test.ts
+++ b/tests/workflow-inputs.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { initialInputValues, areInputsValid } from '../src/renderer/lib/workflow-inputs'
+import type { WorkflowInputDef } from '../src/shared/types'
+
+const def = (over: Partial<WorkflowInputDef> = {}): WorkflowInputDef => ({
+  key: 'k',
+  label: 'K',
+  type: 'text',
+  ...over
+})
+
+describe('initialInputValues', () => {
+  it('seeds a declared default', () => {
+    expect(initialInputValues([def({ defaultValue: 'x' })])).toEqual({ k: 'x' })
+  })
+
+  it('seeds a toggle as false so it renders unchecked, not indeterminate', () => {
+    expect(initialInputValues([def({ type: 'boolean' })])).toEqual({ k: false })
+  })
+
+  it('seeds everything else as empty string', () => {
+    expect(initialInputValues([def({ type: 'number' })])).toEqual({ k: '' })
+  })
+})
+
+describe('areInputsValid', () => {
+  it('accepts an optional input left blank', () => {
+    expect(areInputsValid([def()], { k: '' })).toBe(true)
+  })
+
+  it('rejects a required input left blank or whitespace', () => {
+    expect(areInputsValid([def({ required: true })], { k: '' })).toBe(false)
+    expect(areInputsValid([def({ required: true })], { k: '   ' })).toBe(false)
+  })
+
+  it('rejects a required input that is missing entirely', () => {
+    expect(areInputsValid([def({ required: true })], {})).toBe(false)
+  })
+
+  it('treats a required toggle as answered even when false', () => {
+    // `false` is a real answer, not a missing one.
+    expect(areInputsValid([def({ type: 'boolean', required: true })], { k: false })).toBe(true)
+  })
+
+  it('accepts a required number of zero', () => {
+    expect(areInputsValid([def({ type: 'number', required: true })], { k: 0 })).toBe(true)
+  })
+
+  it('rejects a required number that failed to parse', () => {
+    // String(NaN) is 'NaN', which would otherwise pass the non-empty check and
+    // leak into templates, persistence and the dedupe fingerprint.
+    expect(areInputsValid([def({ type: 'number', required: true })], { k: NaN })).toBe(false)
+  })
+
+  it('accepts a required input holding a resolved object', () => {
+    expect(areInputsValid([def({ required: true })], { k: { number: 7 } })).toBe(true)
+  })
+})

--- a/tests/workflow-inputs.test.ts
+++ b/tests/workflow-inputs.test.ts
@@ -89,6 +89,12 @@ describe('areInputsValid', () => {
     expect(areInputsValid([def({ type: 'boolean', required: true })], { k: false })).toBe(true)
   })
 
+  it('rejects a required toggle that is missing or not a boolean', () => {
+    const defs = [def({ type: 'boolean', required: true })]
+    expect(areInputsValid(defs, {})).toBe(false)
+    expect(areInputsValid(defs, { k: 'false' })).toBe(false)
+  })
+
   it('accepts a required number of zero', () => {
     expect(areInputsValid([def({ type: 'number', required: true })], { k: 0 })).toBe(true)
   })

--- a/tests/workflow-menu-items.test.tsx
+++ b/tests/workflow-menu-items.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../src/renderer/lib/workflow-execution', () => ({
 const mockSetPending = vi.fn()
 vi.mock('../src/renderer/stores', () => {
   const state = {
-    setPendingContextualWorkflowId: (id: string | null) => mockSetPending(id)
+    setPendingWorkflowRun: (...args: unknown[]) => mockSetPending(...args)
   }
   return {
     useAppStore: Object.assign(
@@ -20,10 +20,7 @@ vi.mock('../src/renderer/stores', () => {
   }
 })
 
-import {
-  buildWorkflowMenuItems,
-  runWorkflowFromGlobalSurface
-} from '../src/renderer/lib/workflow-menu-items'
+import { buildWorkflowMenuItems, startManualRun } from '../src/renderer/lib/workflow-menu-items'
 import type { TaskConfig, TerminalSession, WorkflowDefinition } from '../src/shared/types'
 
 function makeWorkflow(id: string, contextual: boolean): WorkflowDefinition {
@@ -123,20 +120,66 @@ describe('buildWorkflowMenuItems', () => {
   })
 })
 
-describe('runWorkflowFromGlobalSurface', () => {
+describe('startManualRun', () => {
   it('opens SourcePromptDialog for contextual workflows', () => {
-    runWorkflowFromGlobalSurface(makeWorkflow('a', true))
-    expect(mockSetPending).toHaveBeenCalledWith('a')
+    startManualRun(makeWorkflow('a', true))
+    expect(mockSetPending).toHaveBeenCalledWith('a', undefined)
     expect(mockExecuteWorkflow).not.toHaveBeenCalled()
   })
 
   it('runs non-contextual workflows directly', () => {
-    runWorkflowFromGlobalSurface(makeWorkflow('b', false))
+    startManualRun(makeWorkflow('b', false))
     expect(mockExecuteWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'b' }),
       undefined,
       { source: 'manual' }
     )
     expect(mockSetPending).not.toHaveBeenCalled()
+  })
+})
+
+function withInputs(wf: WorkflowDefinition): WorkflowDefinition {
+  const [trigger, ...rest] = wf.nodes
+  return {
+    ...wf,
+    nodes: [
+      {
+        ...trigger,
+        config: {
+          ...(trigger.config as Record<string, unknown>),
+          triggerType: 'manual',
+          inputs: [{ key: 'issue', label: 'Issue', type: 'text' }]
+        } as WorkflowDefinition['nodes'][number]['config']
+      },
+      ...rest
+    ]
+  }
+}
+
+describe('workflows declaring run inputs', () => {
+  it('prompts instead of launching from a global surface', () => {
+    startManualRun(withInputs(makeWorkflow('wf-i', false)))
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled()
+    expect(mockSetPending).toHaveBeenCalledWith('wf-i', undefined)
+  })
+
+  it('prompts from a card menu too, forwarding the card as context', () => {
+    const items = buildWorkflowMenuItems([withInputs(makeWorkflow('wf-i', true))], () => {}, {
+      task: someTask
+    })
+    items[0].onClick()
+
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled()
+    expect(mockSetPending).toHaveBeenCalledWith('wf-i', { task: someTask, source: undefined })
+  })
+
+  it('still launches straight away when no inputs are declared', () => {
+    const items = buildWorkflowMenuItems([makeWorkflow('wf-plain', true)], () => {}, {
+      task: someTask
+    })
+    items[0].onClick()
+
+    expect(mockSetPending).not.toHaveBeenCalled()
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/workflow-run-inputs-dialog.test.tsx
+++ b/tests/workflow-run-inputs-dialog.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('../src/renderer/components/ProjectPicker', () => ({
+  ProjectPicker: (props: Record<string, unknown>) => (
+    <button
+      data-testid="project-picker"
+      onClick={() => (props.onChange as (n: string) => void)('Vorn')}
+    >
+      {String(props.currentProject) || 'pick'}
+    </button>
+  )
+}))
+
+const mockExecuteWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args)
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { SourcePromptDialog } from '../src/renderer/components/SourcePromptDialog'
+import type { WorkflowDefinition, WorkflowInputDef } from '../src/shared/types'
+
+function makeWorkflow(
+  inputs: WorkflowInputDef[],
+  opts: { contextual?: boolean } = {}
+): WorkflowDefinition {
+  return {
+    id: 'wf-inputs',
+    name: 'Inputs Workflow',
+    icon: 'Zap',
+    iconColor: '#fff',
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        config: { triggerType: 'manual', contextual: opts.contextual, inputs },
+        position: { x: 0, y: 0 },
+        label: 'Manual'
+      },
+      {
+        id: 'script-1',
+        type: 'script',
+        config: { scriptType: 'bash', scriptContent: 'echo {{inputs.issue}}' },
+        position: { x: 0, y: 0 },
+        label: 'Run'
+      }
+    ],
+    edges: [],
+    enabled: true,
+    workspaceId: 'personal'
+  }
+}
+
+function openWith(wf: WorkflowDefinition, context?: { task?: unknown; source?: unknown }): void {
+  useAppStore.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pendingWorkflowRun: { workflowId: wf.id, context } as any,
+    config: { ...useAppStore.getState().config!, workflows: [wf] }
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useAppStore.setState({
+    pendingWorkflowRun: null,
+    config: {
+      projects: [
+        { name: 'Vorn', path: '/repo/vorn', preferredAgents: [], icon: '', iconColor: '' }
+      ],
+      workflows: [],
+      defaults: { defaultAgent: 'claude' as const, rowHeight: 208 },
+      remoteHosts: [],
+      workspaces: [],
+      tasks: []
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+  })
+})
+
+describe('SourcePromptDialog — run inputs', () => {
+  it('renders a field per declared input', () => {
+    openWith(
+      makeWorkflow([
+        { key: 'issue', label: 'Issue URL', type: 'text' },
+        { key: 'notes', label: 'Notes', type: 'textarea' }
+      ])
+    )
+    render(<SourcePromptDialog />)
+    expect(screen.getByText('Issue URL')).toBeInTheDocument()
+    expect(screen.getByText('Notes')).toBeInTheDocument()
+  })
+
+  it('does not ask for a source when the workflow is not contextual', () => {
+    openWith(makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text' }]))
+    render(<SourcePromptDialog />)
+    expect(screen.queryByTestId('project-picker')).not.toBeInTheDocument()
+  })
+
+  it('passes entered values to executeWorkflow as context.inputs', () => {
+    openWith(makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text' }]))
+    render(<SourcePromptDialog />)
+
+    fireEvent.change(screen.getByLabelText('Issue URL'), { target: { value: 'gh-42' } })
+    fireEvent.click(screen.getByText('Run'))
+
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1)
+    const [, context] = mockExecuteWorkflow.mock.calls[0]
+    expect(context).toEqual({ inputs: { issue: 'gh-42' } })
+  })
+
+  it('seeds defaults and submits them untouched', () => {
+    openWith(makeWorkflow([{ key: 'branch', label: 'Branch', type: 'text', defaultValue: 'main' }]))
+    render(<SourcePromptDialog />)
+    fireEvent.click(screen.getByText('Run'))
+
+    const [, context] = mockExecuteWorkflow.mock.calls[0]
+    expect(context).toEqual({ inputs: { branch: 'main' } })
+  })
+
+  it('blocks Run until every required input has a value', () => {
+    openWith(makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text', required: true }]))
+    render(<SourcePromptDialog />)
+
+    const run = screen.getByText('Run')
+    expect(run).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Issue URL'), { target: { value: '42' } })
+    expect(run).not.toBeDisabled()
+  })
+
+  it('treats an unchecked toggle as answered, not missing', () => {
+    openWith(makeWorkflow([{ key: 'force', label: 'Force', type: 'boolean', required: true }]))
+    render(<SourcePromptDialog />)
+
+    fireEvent.click(screen.getByText('Run'))
+    const [, context] = mockExecuteWorkflow.mock.calls[0]
+    expect(context).toEqual({ inputs: { force: false } })
+  })
+
+  it('keeps the caller-supplied context and adds inputs to it', () => {
+    const wf = makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text' }], {
+      contextual: true
+    })
+    const task = { id: 'task-1', title: 'Fix bug' }
+    openWith(wf, { task })
+    render(<SourcePromptDialog />)
+
+    // The caller already knows the folder, so the dialog must not re-ask.
+    expect(screen.queryByTestId('project-picker')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Issue URL'), { target: { value: 'gh-7' } })
+    fireEvent.click(screen.getByText('Run'))
+
+    const [, context] = mockExecuteWorkflow.mock.calls[0]
+    expect(context).toEqual({ task, inputs: { issue: 'gh-7' } })
+  })
+
+  it('clears entered values when the dialog reopens for another workflow', () => {
+    openWith(makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text' }]))
+    const { rerender } = render(<SourcePromptDialog />)
+    fireEvent.change(screen.getByLabelText('Issue URL'), { target: { value: 'stale' } })
+
+    const other = { ...makeWorkflow([{ key: 'issue', label: 'Issue URL', type: 'text' }]) }
+    other.id = 'wf-other'
+    act(() => openWith(other))
+    rerender(<SourcePromptDialog />)
+
+    expect((screen.getByLabelText('Issue URL') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -52,7 +52,7 @@ const killHeadlessSession = vi.fn(() => Promise.resolve())
 /** Resolves once the given session has been created, so tests can await launch. */
 let onSessionCreated: ((id: string) => void) | null = null
 
-const createHeadlessSession = vi.fn(() => {
+const createHeadlessSession = vi.fn((_opts: { initialPrompt?: string }) => {
   const id = `sess-${++sessionSeq}`
   queueMicrotask(() => onSessionCreated?.(id))
   return Promise.resolve({
@@ -266,6 +266,63 @@ describe('run concurrency', () => {
     expect(a.runId).not.toBe(b.runId)
     expect(a.status).toBe('success')
     expect(b.status).toBe('success')
+  })
+
+  it('runs in parallel for manual triggers started with different inputs', async () => {
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    const runA = executeWorkflow(wf, { inputs: { issue: 'gh-7' } })
+    const runB = executeWorkflow(wf, { inputs: { issue: 'gh-8' } })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(ids).toHaveLength(2)
+
+    ids.forEach((id) => emitExit(id, 0))
+    const [a, b] = await Promise.all([runA, runB])
+
+    expect(a.runId).not.toBe(b.runId)
+    expect(a.inputs).toEqual({ issue: 'gh-7' })
+    expect(b.inputs).toEqual({ issue: 'gh-8' })
+  })
+
+  it('substitutes run inputs into the agent prompt it launches', async () => {
+    const wf = makeWorkflow('wf-tmpl')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(wf.nodes[1].config as any).prompt = 'Review PR {{inputs.pr_number}} in {{inputs.repo}}'
+    mockState.config.workflows = [wf]
+
+    const run = executeWorkflow(wf, { inputs: { pr_number: 42, repo: 'vorn-run/vorn' } })
+    const sess = await nextSession()
+    // Drive the run to completion before asserting: a throw here would
+    // otherwise leave the run pending and strand the shared fake timers.
+    emitData(sess, 'done')
+    emitExit(sess, 0)
+    await vi.runAllTimersAsync()
+    await run
+
+    const launch = createHeadlessSession.mock.calls.at(-1)?.[0]
+    expect(launch?.initialPrompt).toContain('Review PR 42 in vorn-run/vorn')
+    expect(launch?.initialPrompt).not.toContain('{{inputs.')
+  })
+
+  it('collapses two manual triggers carrying the same inputs into a single run', async () => {
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    // Key order differs, but the parameters are the same trigger.
+    const first = executeWorkflow(wf, { inputs: { a: '1', b: '2' } })
+    await vi.advanceTimersByTimeAsync(0)
+    const second = executeWorkflow(wf, { inputs: { b: '2', a: '1' } })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(ids).toHaveLength(1)
+    ids.forEach((id) => emitExit(id, 0))
+
+    const [a, b] = await Promise.all([first, second])
+    expect(b.runId).toBe(a.runId)
   })
 
   it('collapses two identical triggers fired at once into a single run', async () => {

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -287,6 +287,44 @@ describe('run concurrency', () => {
     expect(b.inputs).toEqual({ issue: 'gh-8' })
   })
 
+  it('runs in parallel when one context is launched with different inputs', async () => {
+    // The context alone used to decide the fingerprint, so two runs from the
+    // same card with different answers collapsed into one.
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const task = { id: 'task-1', title: 'T' } as any
+    const runA = executeWorkflow(wf, { task, inputs: { issue: 'gh-7' } })
+    const runB = executeWorkflow(wf, { task, inputs: { issue: 'gh-8' } })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(ids).toHaveLength(2)
+
+    ids.forEach((id) => emitExit(id, 0))
+    const [a, b] = await Promise.all([runA, runB])
+    expect(a.runId).not.toBe(b.runId)
+  })
+
+  it('still collapses a double-fire of one context with identical inputs', async () => {
+    const wf = makeWorkflow()
+    const ids: string[] = []
+    onSessionCreated = (id) => ids.push(id)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const task = { id: 'task-2', title: 'T' } as any
+    const runA = executeWorkflow(wf, { task, inputs: { issue: 'gh-7' } })
+    const runB = executeWorkflow(wf, { task, inputs: { issue: 'gh-7' } })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(ids).toHaveLength(1)
+
+    ids.forEach((id) => emitExit(id, 0))
+    const [a, b] = await Promise.all([runA, runB])
+    expect(a.runId).toBe(b.runId)
+  })
+
   it('substitutes run inputs into the agent prompt it launches', async () => {
     const wf = makeWorkflow('wf-tmpl')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

Manual workflow runs could only be parameterized by whatever the launching surface happened to know — a task, a terminal, or a connector item. There was no way to ask the user for a value at run time, so a workflow needing one (a PR number, an environment, a free-form note) had to hardcode it or be duplicated per value.

Workflows can now **declare inputs on their manual trigger**. They're collected by the run dialog before the run starts, resolve in templates as `{{inputs.<key>}}`, and are persisted with the run so history shows what it was launched with.

Types: text, long text, number, select, toggle, project, branch.

## Design notes

**Definitions need no schema change.** Input *definitions* live on `ManualTriggerConfig`, inside the workflows table's existing `nodes` JSON blob. Only run *values* required a new column (`workflow_runs.inputs`, migration v11), because history queries read them back.

**Values are `unknown`, not `string`.** Deliberate, so a connection-backed picker can later store a whole resolved item and templates can reach `{{inputs.issue.number}}`. `stringifyResolved` already JSON-serializes objects referenced whole.

**Dedupe had to learn about inputs.** `dedupeFingerprint` now includes a key-sorted digest. Without it the claim registry collapses two manual runs carrying different parameters into one and silently drops the second.

**One door for manual runs.** `startManualRun` gates on `needsRunPrompt`, which takes the launch context so surfaces that supply a source and surfaces that don't share a single predicate. `executeWorkflow` stays unguarded, because the scheduler, connector triggers and missed-schedule recovery legitimately run with no user present.

That contract is enforced by `tests/manual-run-entry-point.test.ts`, which pins the allowlist of direct `executeWorkflow` callers. Worth having, because skipping the prompt fails *silently* — the run proceeds and sends `{{inputs.*}}` to the agent as literal text.

## Two pre-existing bugs fixed on the way

- **`VariableAutocomplete` dropped whole variable categories.** It built its dropdown from three hardcoded category checks, so `connectorItem` variables resolved fine at run time but never appeared in the `{}` picker. Now a `Record` over the category union, which makes a new category a compile error until it's given a display group.
- **`LaunchAgentConfigForm.hasTemplateVars` ignored input vars**, so a plain manual workflow's prompt field fell back to the plain editor with no `{}` button at all.

## Testing

- `yarn typecheck` clean
- `npx vitest run` — **2050 passing**, 194 files (+45)
- `yarn lint` — 0 errors; all touched files pass at `--max-warnings 0`

New coverage includes an end-to-end assertion that a real run's launched prompt contains the substituted value and no leftover `{{inputs.`, plus the entry-point guard above (verified to fail when the original bug is reintroduced).

## Follow-up

A connection-backed input type (GitHub issue/PR/repo picker) is the intended next step. It's deliberately **absent** from `WorkflowInputType` until it has a producer, so exhaustive switches don't carry an untestable branch — the `unknown` value shape already accommodates it.
