### PR TITLE
feat(connectors): add reliable pull ingestion

### DIFF
--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -206,6 +206,7 @@ interface GitHubIssue {
 
 interface GitHubSearchResponse {
   total_count: number
+  incomplete_results: boolean
   items: GitHubIssue[]
 }
 
@@ -216,6 +217,7 @@ interface GitHubPollCursor {
 
 const GITHUB_POLL_PAGE_SIZE = 100
 const GITHUB_SEARCH_MAX_PAGE = 10
+const GITHUB_SEARCH_INDEX_OVERLAP_MS = 5 * 60_000
 
 function parsePollCursor(cursor: string | undefined): GitHubPollCursor {
   if (cursor) {
@@ -245,10 +247,9 @@ function githubSearchTimestamp(value: string): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime()))
     throw new Error(`Invalid GitHub poll cursor timestamp: ${value}`)
-  // GitHub search qualifiers accept second-precision ISO-8601. Truncating
-  // milliseconds intentionally overlaps the previous boundary; the durable
-  // inbox removes those repeats.
-  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+  // GitHub compares at second precision with a strict lower bound. Replay the
+  // previous second so items sharing the cursor's second cannot be skipped.
+  return new Date(date.getTime() - 1_000).toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
 function githubSearchEndpoint(
@@ -287,7 +288,14 @@ function nextSearchCursor(
   pollStartedAt: string
 ): { cursor: string; hasMore: boolean } {
   const hasAnotherSearchPage = response.total_count > current.page * GITHUB_POLL_PAGE_SIZE
-  if (!hasAnotherSearchPage) return { cursor: pollStartedAt, hasMore: false }
+  if (!hasAnotherSearchPage) {
+    return {
+      cursor: new Date(
+        new Date(pollStartedAt).getTime() - GITHUB_SEARCH_INDEX_OVERLAP_MS
+      ).toISOString(),
+      hasMore: false
+    }
+  }
 
   if (current.page < GITHUB_SEARCH_MAX_PAGE) {
     return {
@@ -311,6 +319,12 @@ function nextSearchCursor(
     )
   }
   return { cursor: searchCursor({ since: overlap, page: 1 }), hasMore: true }
+}
+
+function assertCompleteSearch(response: GitHubSearchResponse): void {
+  if (response.incomplete_results) {
+    throw new Error('GitHub search returned incomplete results; retrying without advancing cursor')
+  }
 }
 
 function issueToExternalItem(issue: GitHubIssue): ExternalItem {
@@ -404,6 +418,7 @@ export const githubConnector: VornConnector = {
         const response = (await ghApi(
           githubSearchEndpoint(owner, repo, 'issue', parsedCursor, config.labels)
         )) as GitHubSearchResponse
+        assertCompleteSearch(response)
         const next = nextSearchCursor(parsedCursor, response, pollStartedAt)
         return {
           events: response.items.map((i) => ({
@@ -420,6 +435,7 @@ export const githubConnector: VornConnector = {
         const response = (await ghApi(
           githubSearchEndpoint(owner, repo, 'pr', parsedCursor, undefined)
         )) as GitHubSearchResponse
+        assertCompleteSearch(response)
         const next = nextSearchCursor(parsedCursor, response, pollStartedAt)
         return {
           events: response.items.map((pr) => ({

--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -6,7 +6,8 @@ import type {
   PollResult,
   ActionResult,
   ConnectorManifest,
-  TaskStatus
+  TaskStatus,
+  ExternalItemPage
 } from '@vornrun/shared/types'
 import log from '../logger'
 import { resolveGhPath, GhNotFoundError, getGhEnv } from './gh-cli'
@@ -200,6 +201,116 @@ interface GitHubIssue {
   labels: Array<{ name: string }>
   assignee: { login: string } | null
   pull_request?: unknown
+  user?: { login: string }
+}
+
+interface GitHubSearchResponse {
+  total_count: number
+  items: GitHubIssue[]
+}
+
+interface GitHubPollCursor {
+  since: string
+  page: number
+}
+
+const GITHUB_POLL_PAGE_SIZE = 100
+const GITHUB_SEARCH_MAX_PAGE = 10
+
+function parsePollCursor(cursor: string | undefined): GitHubPollCursor {
+  if (cursor) {
+    try {
+      const parsed = JSON.parse(cursor) as Partial<GitHubPollCursor>
+      if (
+        typeof parsed.since === 'string' &&
+        typeof parsed.page === 'number' &&
+        Number.isInteger(parsed.page) &&
+        parsed.page > 0
+      ) {
+        return { since: parsed.since, page: parsed.page }
+      }
+    } catch {
+      // Legacy cursors were plain ISO timestamps.
+    }
+    return { since: cursor, page: 1 }
+  }
+  return { since: new Date(Date.now() - 60_000).toISOString(), page: 1 }
+}
+
+function searchCursor(cursor: GitHubPollCursor): string {
+  return JSON.stringify(cursor)
+}
+
+function githubSearchTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime()))
+    throw new Error(`Invalid GitHub poll cursor timestamp: ${value}`)
+  // GitHub search qualifiers accept second-precision ISO-8601. Truncating
+  // milliseconds intentionally overlaps the previous boundary; the durable
+  // inbox removes those repeats.
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+function githubSearchEndpoint(
+  owner: string,
+  repo: string,
+  kind: 'issue' | 'pr',
+  cursor: GitHubPollCursor,
+  labels: unknown
+): string {
+  const terms = [
+    `repo:${owner}/${repo}`,
+    `is:${kind}`,
+    `created:>${githubSearchTimestamp(cursor.since)}`
+  ]
+  if (kind === 'issue' && typeof labels === 'string') {
+    for (const label of labels
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)) {
+      terms.push(`label:"${label.replaceAll('"', '\\"')}"`)
+    }
+  }
+  const params = new URLSearchParams({
+    q: terms.join(' '),
+    sort: 'created',
+    order: 'asc',
+    per_page: String(GITHUB_POLL_PAGE_SIZE),
+    page: String(cursor.page)
+  })
+  return `search/issues?${params}`
+}
+
+function nextSearchCursor(
+  current: GitHubPollCursor,
+  response: GitHubSearchResponse,
+  pollStartedAt: string
+): { cursor: string; hasMore: boolean } {
+  const hasAnotherSearchPage = response.total_count > current.page * GITHUB_POLL_PAGE_SIZE
+  if (!hasAnotherSearchPage) return { cursor: pollStartedAt, hasMore: false }
+
+  if (current.page < GITHUB_SEARCH_MAX_PAGE) {
+    return {
+      cursor: searchCursor({ since: current.since, page: current.page + 1 }),
+      hasMore: true
+    }
+  }
+
+  // GitHub Search caps accessible results at 1,000. Advance the time window
+  // and start again instead of attempting page 11. Overlap one second so
+  // equal-timestamp items are replayed into the deduplicating durable inbox
+  // rather than skipped at the boundary.
+  const lastTimestamp = response.items.at(-1)?.created_at
+  if (!lastTimestamp) {
+    throw new Error('GitHub search reported more results but returned an empty page')
+  }
+  const overlap = new Date(new Date(lastTimestamp).getTime() - 1_000).toISOString()
+  if (new Date(overlap).getTime() <= new Date(current.since).getTime()) {
+    throw new Error(
+      'GitHub search returned more than 1,000 items at one timestamp; cannot advance safely'
+    )
+  }
+  return { cursor: searchCursor({ since: overlap, page: 1 }), hasMore: true }
 }
 
 function issueToExternalItem(issue: GitHubIssue): ExternalItem {
@@ -216,6 +327,34 @@ function issueToExternalItem(issue: GitHubIssue): ExternalItem {
   }
 }
 
+async function listGitHubItemsPage(
+  filters: Record<string, unknown>,
+  cursor?: string
+): Promise<ExternalItemPage> {
+  const { owner, repo, state = 'open', labels, assignee } = filters
+  if (typeof owner !== 'string' || typeof repo !== 'string' || !owner || !repo) {
+    throw new Error('owner and repo are required')
+  }
+  const parsedPage = Number(cursor ?? '1')
+  const page = Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1
+  const params = new URLSearchParams({
+    state: String(state),
+    per_page: String(GITHUB_POLL_PAGE_SIZE),
+    page: String(page)
+  })
+  if (labels) params.set('labels', String(labels))
+  if (assignee) params.set('assignee', String(assignee))
+  const endpoint = `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues?${params}`
+  const raw = (await ghApi(endpoint)) as GitHubIssue[]
+  return {
+    items: raw.filter((item) => !item.pull_request).map(issueToExternalItem),
+    ...(raw.length === GITHUB_POLL_PAGE_SIZE && {
+      nextCursor: String(page + 1),
+      hasMore: true
+    })
+  }
+}
+
 export const githubConnector: VornConnector = {
   id: 'github',
   name: 'GitHub',
@@ -223,22 +362,10 @@ export const githubConnector: VornConnector = {
   capabilities: ['tasks', 'triggers', 'actions'],
 
   async listItems(filters: Record<string, unknown>): Promise<ExternalItem[]> {
-    const { owner, repo, state = 'open', labels, assignee, per_page = 50 } = filters
-    if (typeof owner !== 'string' || typeof repo !== 'string' || !owner || !repo) {
-      throw new Error('owner and repo are required')
-    }
-
-    const params = new URLSearchParams({
-      state: String(state),
-      per_page: String(per_page)
-    })
-    if (labels) params.set('labels', String(labels))
-    if (assignee) params.set('assignee', String(assignee))
-    const endpoint = `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues?${params}`
-    // Exclude pull requests (GitHub API returns PRs in issues endpoint)
-    const data = (await ghApi(endpoint)) as GitHubIssue[]
-    return data.filter((i) => !i.pull_request).map(issueToExternalItem)
+    return (await listGitHubItemsPage(filters)).items
   },
+
+  listItemsPage: listGitHubItemsPage,
 
   async getItem(
     externalId: string,
@@ -269,60 +396,47 @@ export const githubConnector: VornConnector = {
       return { events: [] }
     }
 
-    const since = cursor || new Date(Date.now() - 60_000).toISOString()
-    const PAGE_SIZE = 30
-    const repoPath = `repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+    const parsedCursor = parsePollCursor(cursor)
+    const pollStartedAt = new Date().toISOString()
 
     switch (triggerType) {
       case 'issueCreated': {
-        const endpoint = `${repoPath}/issues?state=open&sort=created&direction=desc&since=${encodeURIComponent(since)}&per_page=${PAGE_SIZE}`
-        const issues = (await ghApi(endpoint)) as GitHubIssue[]
-        const newIssues = issues.filter((i) => !i.pull_request && i.created_at > since)
-        // When we hit the page cap, advance the cursor only to the oldest
-        // item we actually saw — there may be older items between `since`
-        // and that point that got truncated by the per_page limit, and the
-        // next poll needs to pick them up rather than skip them.
-        const nextCursor =
-          newIssues.length >= PAGE_SIZE && newIssues.length > 0
-            ? newIssues[newIssues.length - 1].created_at
-            : new Date().toISOString()
+        const response = (await ghApi(
+          githubSearchEndpoint(owner, repo, 'issue', parsedCursor, config.labels)
+        )) as GitHubSearchResponse
+        const next = nextSearchCursor(parsedCursor, response, pollStartedAt)
         return {
-          events: newIssues.map((i) => ({
+          events: response.items.map((i) => ({
             id: String(i.number),
             type: 'issueCreated',
             data: issueToExternalItem(i) as unknown as Record<string, unknown>,
             timestamp: i.created_at
           })),
-          nextCursor
+          nextCursor: next.cursor,
+          hasMore: next.hasMore
         }
       }
       case 'prOpened': {
-        const endpoint = `${repoPath}/pulls?state=open&sort=created&direction=desc&per_page=${PAGE_SIZE}`
-        const prs = (await ghApi(endpoint)) as Array<{
-          number: number
-          title: string
-          html_url: string
-          created_at: string
-          user: { login: string }
-        }>
-        const newPrs = prs.filter((pr) => pr.created_at > since)
-        const nextCursor =
-          newPrs.length >= PAGE_SIZE && newPrs.length > 0
-            ? newPrs[newPrs.length - 1].created_at
-            : new Date().toISOString()
+        const response = (await ghApi(
+          githubSearchEndpoint(owner, repo, 'pr', parsedCursor, undefined)
+        )) as GitHubSearchResponse
+        const next = nextSearchCursor(parsedCursor, response, pollStartedAt)
         return {
-          events: newPrs.map((pr) => ({
+          events: response.items.map((pr) => ({
             id: String(pr.number),
             type: 'prOpened',
             data: {
               number: pr.number,
               title: pr.title,
               url: pr.html_url,
-              author: pr.user.login
+              description: pr.body || '',
+              state: pr.state,
+              author: pr.user?.login
             },
             timestamp: pr.created_at
           })),
-          nextCursor
+          nextCursor: next.cursor,
+          hasMore: next.hasMore
         }
       }
       default:

--- a/packages/server/src/connectors/paging.ts
+++ b/packages/server/src/connectors/paging.ts
@@ -1,0 +1,31 @@
+import type { ExternalItem, VornConnector } from '@vornrun/shared/types'
+
+const MAX_BACKFILL_PAGES = 1_000
+
+/**
+ * Drain every reconciliation page a connector exposes. Legacy connectors
+ * without `listItemsPage` still run once through `listItems`.
+ */
+export async function forEachConnectorItem(
+  connector: VornConnector,
+  filters: Record<string, unknown>,
+  visit: (item: ExternalItem) => void
+): Promise<void> {
+  if (!connector.listItems && !connector.listItemsPage) {
+    throw new Error(`Connector ${connector.id} does not support listItems()`)
+  }
+
+  let cursor: string | undefined
+  for (let page = 0; page < MAX_BACKFILL_PAGES; page++) {
+    const result = connector.listItemsPage
+      ? await connector.listItemsPage(filters, cursor)
+      : { items: await connector.listItems!(filters), hasMore: false }
+    result.items.forEach(visit)
+    if (!result.hasMore) return
+    if (!result.nextCursor || result.nextCursor === cursor) {
+      throw new Error(`Connector ${connector.id} did not advance its backfill cursor`)
+    }
+    cursor = result.nextCursor
+  }
+  throw new Error(`Connector ${connector.id} exceeded ${MAX_BACKFILL_PAGES} backfill pages`)
+}

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2,6 +2,7 @@ import Database from 'libsql'
 import path from 'node:path'
 import os from 'node:os'
 import fs from 'node:fs'
+import { randomUUID } from 'node:crypto'
 import log from './logger'
 import { getDefaultShell } from './process-utils'
 import {
@@ -346,7 +347,10 @@ function createSchema(): void {
       status TEXT NOT NULL DEFAULT 'running',
       trigger_task_id TEXT,
       inputs TEXT,
-      connector_inbox_id INTEGER
+      connector_item TEXT,
+      connector_inbox_id INTEGER,
+      connector_inbox_lease_token TEXT,
+      connector_inbox_disposition TEXT
     );
 
     CREATE TABLE IF NOT EXISTS workflow_run_nodes (
@@ -406,10 +410,11 @@ function createSchema(): void {
       attempts INTEGER NOT NULL DEFAULT 0,
       available_at TEXT NOT NULL,
       lease_until TEXT,
+      lease_token TEXT,
       last_error TEXT,
       created_at TEXT NOT NULL,
       processed_at TEXT,
-      UNIQUE (workflow_id, event_type, event_id)
+      UNIQUE (workflow_id, connection_id, event_type, event_id)
     );
 
     CREATE INDEX IF NOT EXISTS idx_connector_inbox_ready
@@ -420,6 +425,43 @@ function createSchema(): void {
 
   migrateSchema(d)
   verifySchema(d)
+  seedLegacyConnectorPollState(d)
+}
+
+function seedLegacyConnectorPollState(d: Database.Database): void {
+  const workflows = d.prepare('SELECT id, nodes FROM workflows').all() as Array<{
+    id: string
+    nodes: string
+  }>
+  const readConnection = d.prepare(
+    'SELECT sync_cursor, last_sync_at FROM source_connections WHERE id = ?'
+  )
+  const insertState = d.prepare(
+    `INSERT OR IGNORE INTO connector_poll_state (
+       workflow_id, connection_id, cursor, last_polled_at, last_error
+     ) VALUES (?, ?, ?, ?, NULL)`
+  )
+  for (const workflow of workflows) {
+    let nodes: Array<{
+      type?: string
+      config?: { triggerType?: string; connectionId?: string }
+    }>
+    try {
+      nodes = JSON.parse(workflow.nodes) as typeof nodes
+    } catch {
+      continue
+    }
+    const trigger = nodes.find(
+      (node) => node.type === 'trigger' && node.config?.triggerType === 'connectorPoll'
+    )
+    const connectionId = trigger?.config?.connectionId
+    if (!connectionId) continue
+    const connection = readConnection.get(connectionId) as
+      | { sync_cursor: string | null; last_sync_at: string | null }
+      | undefined
+    if (!connection) continue
+    insertState.run(workflow.id, connectionId, connection.sync_cursor, connection.last_sync_at)
+  }
 }
 
 function migrateSchema(d: Database.Database): void {
@@ -698,6 +740,15 @@ function migrateSchema(d: Database.Database): void {
       if (!runCols.some((column) => column.name === 'connector_inbox_id')) {
         d.exec('ALTER TABLE workflow_runs ADD COLUMN connector_inbox_id INTEGER')
       }
+      if (!runCols.some((column) => column.name === 'connector_item')) {
+        d.exec('ALTER TABLE workflow_runs ADD COLUMN connector_item TEXT')
+      }
+      if (!runCols.some((column) => column.name === 'connector_inbox_lease_token')) {
+        d.exec('ALTER TABLE workflow_runs ADD COLUMN connector_inbox_lease_token TEXT')
+      }
+      if (!runCols.some((column) => column.name === 'connector_inbox_disposition')) {
+        d.exec('ALTER TABLE workflow_runs ADD COLUMN connector_inbox_disposition TEXT')
+      }
       d.exec(`
         CREATE TABLE IF NOT EXISTS connector_poll_state (
           workflow_id TEXT PRIMARY KEY REFERENCES workflows(id) ON DELETE CASCADE,
@@ -720,6 +771,7 @@ function migrateSchema(d: Database.Database): void {
           attempts INTEGER NOT NULL DEFAULT 0,
           available_at TEXT NOT NULL,
           lease_until TEXT,
+          lease_token TEXT,
           last_error TEXT,
           created_at TEXT NOT NULL,
           processed_at TEXT,
@@ -736,6 +788,62 @@ function migrateSchema(d: Database.Database): void {
       ).run()
     })()
     log.info('[database] migrated schema to version 12 (durable connector ingestion)')
+  }
+
+  if (version < 13) {
+    d.transaction(() => {
+      const inboxCols = d.prepare('PRAGMA table_info(connector_inbox)').all() as Array<{
+        name: string
+      }>
+      if (!inboxCols.some((column) => column.name === 'lease_token')) {
+        d.exec('ALTER TABLE connector_inbox ADD COLUMN lease_token TEXT')
+      }
+      d.exec(`
+        ALTER TABLE connector_inbox RENAME TO connector_inbox_v12;
+
+        CREATE TABLE connector_inbox (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          workflow_id TEXT NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+          connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+          connector_id TEXT NOT NULL,
+          event_id TEXT NOT NULL,
+          event_type TEXT NOT NULL,
+          event_timestamp TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          attempts INTEGER NOT NULL DEFAULT 0,
+          available_at TEXT NOT NULL,
+          lease_until TEXT,
+          lease_token TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          processed_at TEXT,
+          UNIQUE (workflow_id, connection_id, event_type, event_id)
+        );
+
+        INSERT INTO connector_inbox (
+          id, workflow_id, connection_id, connector_id, event_id, event_type,
+          event_timestamp, payload, status, attempts, available_at, lease_until,
+          lease_token, last_error, created_at, processed_at
+        )
+        SELECT
+          id, workflow_id, connection_id, connector_id, event_id, event_type,
+          event_timestamp, payload, status, attempts, available_at, lease_until,
+          lease_token, last_error, created_at, processed_at
+        FROM connector_inbox_v12;
+
+        DROP TABLE connector_inbox_v12;
+
+        CREATE INDEX idx_connector_inbox_ready
+          ON connector_inbox(status, available_at, lease_until);
+        CREATE INDEX idx_connector_inbox_connection
+          ON connector_inbox(connection_id, created_at);
+      `)
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '13')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 13 (connection-scoped inbox)')
   }
 }
 
@@ -785,8 +893,26 @@ function verifySchema(d: Database.Database): void {
     workflow_runs: [
       { column: 'inputs', ddl: 'ALTER TABLE workflow_runs ADD COLUMN inputs TEXT' },
       {
+        column: 'connector_item',
+        ddl: 'ALTER TABLE workflow_runs ADD COLUMN connector_item TEXT'
+      },
+      {
         column: 'connector_inbox_id',
         ddl: 'ALTER TABLE workflow_runs ADD COLUMN connector_inbox_id INTEGER'
+      },
+      {
+        column: 'connector_inbox_lease_token',
+        ddl: 'ALTER TABLE workflow_runs ADD COLUMN connector_inbox_lease_token TEXT'
+      },
+      {
+        column: 'connector_inbox_disposition',
+        ddl: 'ALTER TABLE workflow_runs ADD COLUMN connector_inbox_disposition TEXT'
+      }
+    ],
+    connector_inbox: [
+      {
+        column: 'lease_token',
+        ddl: 'ALTER TABLE connector_inbox ADD COLUMN lease_token TEXT'
       }
     ],
     workflow_run_nodes: [
@@ -1052,7 +1178,7 @@ function loadWorkspaces(d: Database.Database): WorkspaceConfig[] {
 }
 
 // ---------------------------------------------------------------------------
-// Config: save (full replace inside a transaction)
+// Config: save inside a transaction
 // ---------------------------------------------------------------------------
 
 export function saveConfig(config: AppConfig): void {
@@ -1085,14 +1211,34 @@ export function saveConfig(config: AppConfig): void {
       )
     }
 
-    // Workflows
-    d.prepare('DELETE FROM workflows').run()
-    const insertWorkflow = d.prepare(
+    // Preserve existing workflow rows so foreign-key cascades do not erase
+    // connector inbox entries and poll cursors during ordinary config saves.
+    const workflows = config.workflows ?? []
+    const workflowIds = new Set(workflows.map((workflow) => workflow.id))
+    const existingWorkflowIds = d.prepare('SELECT id FROM workflows').all() as Array<{
+      id: string
+    }>
+    const deleteWorkflow = d.prepare('DELETE FROM workflows WHERE id = ?')
+    for (const { id } of existingWorkflowIds) {
+      if (!workflowIds.has(id)) deleteWorkflow.run(id)
+    }
+    const upsertWorkflow = d.prepare(
       `INSERT INTO workflows (id, name, icon, icon_color, nodes, edges, enabled, last_run_at, last_run_status, stagger_delay_ms, workspace_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         icon = excluded.icon,
+         icon_color = excluded.icon_color,
+         nodes = excluded.nodes,
+         edges = excluded.edges,
+         enabled = excluded.enabled,
+         last_run_at = excluded.last_run_at,
+         last_run_status = excluded.last_run_status,
+         stagger_delay_ms = excluded.stagger_delay_ms,
+         workspace_id = excluded.workspace_id`
     )
-    for (const w of config.workflows ?? []) {
-      insertWorkflow.run(
+    for (const w of workflows) {
+      upsertWorkflow.run(
         w.id,
         w.name,
         w.icon,
@@ -1486,6 +1632,7 @@ export function dbDeleteSourceConnection(id: string): void {
 
 export interface ConnectorInboxItem {
   id: number
+  leaseToken: string
   workflowId: string
   connectionId: string
   connectorId: string
@@ -1498,6 +1645,7 @@ export interface ConnectorInboxItem {
 
 interface ConnectorInboxRow {
   id: number
+  lease_token: string
   workflow_id: string
   connection_id: string
   connector_id: string
@@ -1511,6 +1659,7 @@ interface ConnectorInboxRow {
 function rowToConnectorInboxItem(row: ConnectorInboxRow): ConnectorInboxItem {
   return {
     id: row.id,
+    leaseToken: row.lease_token,
     workflowId: row.workflow_id,
     connectionId: row.connection_id,
     connectorId: row.connector_id,
@@ -1522,11 +1671,25 @@ function rowToConnectorInboxItem(row: ConnectorInboxRow): ConnectorInboxItem {
   }
 }
 
-export function dbGetConnectorPollCursor(workflowId: string): string | undefined {
+export function dbGetConnectorPollCursor(
+  workflowId: string,
+  connectionId: string
+): string | undefined {
   const row = getDb()
-    .prepare('SELECT cursor FROM connector_poll_state WHERE workflow_id = ?')
-    .get(workflowId) as { cursor: string | null } | undefined
+    .prepare('SELECT cursor FROM connector_poll_state WHERE workflow_id = ? AND connection_id = ?')
+    .get(workflowId, connectionId) as { cursor: string | null } | undefined
   return row?.cursor ?? undefined
+}
+
+export function dbCountActiveConnectorInboxLeases(now: string): number {
+  const row = getDb()
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM connector_inbox
+       WHERE status = 'leased' AND lease_until > ?`
+    )
+    .get(now) as { count: number }
+  return row.count
 }
 
 /**
@@ -1642,64 +1805,104 @@ export function dbClaimConnectorInbox(args: {
 
     const claim = d.prepare(
       `UPDATE connector_inbox
-       SET status = 'leased', attempts = attempts + 1, lease_until = ?
+       SET status = 'leased', attempts = attempts + 1, lease_until = ?, lease_token = ?
        WHERE id = ?`
     )
     const read = d.prepare(
       `SELECT id, workflow_id, connection_id, connector_id, event_id,
-              event_type, event_timestamp, payload, attempts
+              event_type, event_timestamp, payload, attempts, lease_token
        FROM connector_inbox WHERE id = ?`
     )
     return rows.map(({ id }) => {
-      claim.run(args.leaseUntil, id)
+      claim.run(args.leaseUntil, randomUUID(), id)
       return rowToConnectorInboxItem(read.get(id) as ConnectorInboxRow)
     })
   })()
 }
 
-export function dbCompleteConnectorInbox(id: number, processedAt: string): void {
-  getDb()
+export function dbCompleteConnectorInbox(
+  id: number,
+  leaseToken: string,
+  processedAt: string
+): boolean {
+  const result = getDb()
     .prepare(
       `UPDATE connector_inbox
-       SET status = 'processed', processed_at = ?, lease_until = NULL, last_error = NULL
-       WHERE id = ?`
+       SET status = 'processed', processed_at = ?, lease_until = NULL,
+           lease_token = NULL, last_error = NULL
+       WHERE id = ? AND status = 'leased' AND lease_token = ?`
     )
-    .run(processedAt, id)
+    .run(processedAt, id, leaseToken)
+  return result.changes === 1
 }
 
-export function dbRetryConnectorInbox(args: { id: number; error: string; now: string }): void {
+export function dbRetryConnectorInbox(args: {
+  id: number
+  leaseToken: string
+  error: string
+  now: string
+}): boolean {
   const d = getDb()
-  const row = d.prepare('SELECT attempts FROM connector_inbox WHERE id = ?').get(args.id) as
-    | { attempts: number }
-    | undefined
-  if (!row) return
+  const row = d
+    .prepare(
+      `SELECT attempts FROM connector_inbox
+       WHERE id = ? AND status = 'leased' AND lease_token = ?`
+    )
+    .get(args.id, args.leaseToken) as { attempts: number } | undefined
+  if (!row) return false
   const delayMs = Math.min(60_000 * 2 ** Math.max(0, row.attempts - 1), 60 * 60_000)
   const availableAt = new Date(Date.parse(args.now) + delayMs).toISOString()
-  d.prepare(
-    `UPDATE connector_inbox
-       SET status = 'pending', available_at = ?, lease_until = NULL, last_error = ?
-       WHERE id = ?`
-  ).run(availableAt, args.error, args.id)
+  const result = d
+    .prepare(
+      `UPDATE connector_inbox
+       SET status = 'pending', available_at = ?, lease_until = NULL,
+           lease_token = NULL, last_error = ?
+       WHERE id = ? AND status = 'leased' AND lease_token = ?`
+    )
+    .run(availableAt, args.error, args.id, args.leaseToken)
+  if (result.changes !== 1) return false
   d.prepare(
     `UPDATE source_connections
      SET last_sync_error = ?
      WHERE id = (SELECT connection_id FROM connector_inbox WHERE id = ?)`
   ).run(args.error, args.id)
+  return true
 }
 
 /** The renderer could not accept this event yet (for example, another run is
  * parked at an approval gate). This is not a workflow attempt or an error. */
-export function dbDeferConnectorInbox(id: number, availableAt: string): void {
-  getDb()
+export function dbDeferConnectorInbox(
+  id: number,
+  leaseToken: string,
+  availableAt: string
+): boolean {
+  const result = getDb()
     .prepare(
       `UPDATE connector_inbox
        SET status = 'pending',
            attempts = MAX(0, attempts - 1),
            available_at = ?,
-           lease_until = NULL
-       WHERE id = ?`
+           lease_until = NULL,
+           lease_token = NULL
+       WHERE id = ? AND status = 'leased' AND lease_token = ?`
     )
-    .run(availableAt, id)
+    .run(availableAt, id, leaseToken)
+  return result.changes === 1
+}
+
+export function dbRenewConnectorInboxLease(
+  id: number,
+  leaseToken: string,
+  leaseUntil: string
+): boolean {
+  const result = getDb()
+    .prepare(
+      `UPDATE connector_inbox
+       SET lease_until = ?
+       WHERE id = ? AND status = 'leased' AND lease_token = ?`
+    )
+    .run(leaseUntil, id, leaseToken)
+  return result.changes === 1
 }
 
 /** Server restarts invalidate every in-memory workflow owner, so leases from
@@ -1708,7 +1911,7 @@ export function dbReleaseConnectorInboxLeases(now: string): void {
   getDb()
     .prepare(
       `UPDATE connector_inbox
-       SET status = 'pending', available_at = ?, lease_until = NULL
+       SET status = 'pending', available_at = ?, lease_until = NULL, lease_token = NULL
        WHERE status = 'leased'`
     )
     .run(now)
@@ -2461,8 +2664,9 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare(
       `INSERT OR REPLACE INTO workflow_runs (
          id, workflow_id, started_at, completed_at, status, trigger_task_id,
-         inputs, connector_inbox_id
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+         inputs, connector_item, connector_inbox_id, connector_inbox_lease_token,
+         connector_inbox_disposition
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       runId,
       execution.workflowId,
@@ -2471,7 +2675,10 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
       execution.status,
       execution.triggerTaskId ?? null,
       execution.inputs ? JSON.stringify(execution.inputs) : null,
-      execution.connectorInboxId ?? null
+      execution.connectorItem ? JSON.stringify(execution.connectorItem) : null,
+      execution.connectorInboxId ?? null,
+      execution.connectorInboxLeaseToken ?? null,
+      execution.connectorInboxDisposition ?? null
     )
 
     // Delete existing nodes for this run (for upsert behavior)
@@ -2501,7 +2708,9 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
       )
     }
 
-    // Trim old runs for this workflow
+    // Keep active and unacknowledged connector runs available for restart
+    // recovery; only terminal history that no longer owns inbox work is safe
+    // to trim.
     const count = (
       d
         .prepare('SELECT COUNT(*) as c FROM workflow_runs WHERE workflow_id = ?')
@@ -2510,7 +2719,19 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     if (count > MAX_WORKFLOW_RUNS) {
       d.prepare(
         `DELETE FROM workflow_runs WHERE id IN (
-          SELECT id FROM workflow_runs WHERE workflow_id = ? ORDER BY started_at ASC LIMIT ?
+          SELECT id FROM workflow_runs
+          WHERE workflow_id = ?
+            AND status != 'running'
+            AND (
+              connector_inbox_id IS NULL
+              OR EXISTS (
+                SELECT 1 FROM connector_inbox
+                WHERE connector_inbox.id = workflow_runs.connector_inbox_id
+                  AND connector_inbox.status = 'processed'
+              )
+            )
+          ORDER BY started_at ASC
+          LIMIT ?
         )`
       ).run(execution.workflowId, count - MAX_WORKFLOW_RUNS)
     }
@@ -2583,7 +2804,10 @@ type RunRow = {
   status: string
   trigger_task_id: string | null
   inputs: string | null
+  connector_item: string | null
   connector_inbox_id: number | null
+  connector_inbox_lease_token: string | null
+  connector_inbox_disposition: string | null
   workflow_name?: string | null
 }
 
@@ -2610,6 +2834,7 @@ function mapRunRows(
 ): (WorkflowExecution & { workflowName?: string })[] {
   return rows.map((r) => {
     const inputs = parseRunInputs(r.inputs)
+    const connectorItem = parseRunInputs(r.connector_item) as ConnectorItemContext | undefined
     return {
       runId: r.id,
       workflowId: r.workflow_id,
@@ -2618,11 +2843,34 @@ function mapRunRows(
       status: r.status as WorkflowExecution['status'],
       ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
       ...(inputs && { inputs }),
+      ...(connectorItem && { connectorItem }),
       ...(r.connector_inbox_id != null && { connectorInboxId: r.connector_inbox_id }),
+      ...(r.connector_inbox_lease_token != null && {
+        connectorInboxLeaseToken: r.connector_inbox_lease_token
+      }),
+      ...(r.connector_inbox_disposition === 'processed' || r.connector_inbox_disposition === 'retry'
+        ? { connectorInboxDisposition: r.connector_inbox_disposition }
+        : {}),
       ...(r.workflow_name != null && { workflowName: r.workflow_name }),
       nodeStates: nodesByRun.get(r.id) ?? []
     }
   })
+}
+
+export function dbGetWorkflowRunByConnectorInboxId(
+  connectorInboxId: number
+): WorkflowExecution | null {
+  const d = getDb()
+  const row = d
+    .prepare(
+      `SELECT * FROM workflow_runs
+       WHERE connector_inbox_id = ?
+       ORDER BY started_at DESC
+       LIMIT 1`
+    )
+    .get(connectorInboxId) as RunRow | undefined
+  if (!row) return null
+  return mapRunRows([row], fetchNodesByRunIds(d, [row.id]))[0] ?? null
 }
 
 export function listWorkflowRuns(workflowId: string, limit = 20): WorkflowExecution[] {

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -26,7 +26,8 @@ import {
   SessionEvent,
   SessionEventType,
   SourceConnection,
-  TaskSourceLink
+  TaskSourceLink,
+  ConnectorItemContext
 } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { DEFAULT_TASK_WORKFLOW_ID, buildDefaultTaskWorkflow } from './default-workflows'
@@ -344,7 +345,8 @@ function createSchema(): void {
       completed_at TEXT,
       status TEXT NOT NULL DEFAULT 'running',
       trigger_task_id TEXT,
-      inputs TEXT
+      inputs TEXT,
+      connector_inbox_id INTEGER
     );
 
     CREATE TABLE IF NOT EXISTS workflow_run_nodes (
@@ -382,6 +384,38 @@ function createSchema(): void {
 
     CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(session_id, timestamp DESC);
     CREATE INDEX IF NOT EXISTS idx_session_events_type ON session_events(event_type, timestamp DESC);
+
+    CREATE TABLE IF NOT EXISTS connector_poll_state (
+      workflow_id TEXT PRIMARY KEY REFERENCES workflows(id) ON DELETE CASCADE,
+      connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+      cursor TEXT,
+      last_polled_at TEXT,
+      last_error TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS connector_inbox (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workflow_id TEXT NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+      connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+      connector_id TEXT NOT NULL,
+      event_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_timestamp TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      available_at TEXT NOT NULL,
+      lease_until TEXT,
+      last_error TEXT,
+      created_at TEXT NOT NULL,
+      processed_at TEXT,
+      UNIQUE (workflow_id, event_type, event_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_connector_inbox_ready
+      ON connector_inbox(status, available_at, lease_until);
+    CREATE INDEX IF NOT EXISTS idx_connector_inbox_connection
+      ON connector_inbox(connection_id, created_at);
   `)
 
   migrateSchema(d)
@@ -652,6 +686,57 @@ function migrateSchema(d: Database.Database): void {
     })()
     log.info('[database] migrated schema to version 11 (workflow run inputs)')
   }
+
+  // Version 11 is reserved by the workflow-run inputs change (PR #403).
+  // Keeping connector ingestion at 12 makes either merge order safe; every
+  // migration-added column is also covered by verifySchema.
+  if (version < 12) {
+    d.transaction(() => {
+      const runCols = d.prepare('PRAGMA table_info(workflow_runs)').all() as Array<{
+        name: string
+      }>
+      if (!runCols.some((column) => column.name === 'connector_inbox_id')) {
+        d.exec('ALTER TABLE workflow_runs ADD COLUMN connector_inbox_id INTEGER')
+      }
+      d.exec(`
+        CREATE TABLE IF NOT EXISTS connector_poll_state (
+          workflow_id TEXT PRIMARY KEY REFERENCES workflows(id) ON DELETE CASCADE,
+          connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+          cursor TEXT,
+          last_polled_at TEXT,
+          last_error TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS connector_inbox (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          workflow_id TEXT NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+          connection_id TEXT NOT NULL REFERENCES source_connections(id) ON DELETE CASCADE,
+          connector_id TEXT NOT NULL,
+          event_id TEXT NOT NULL,
+          event_type TEXT NOT NULL,
+          event_timestamp TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          attempts INTEGER NOT NULL DEFAULT 0,
+          available_at TEXT NOT NULL,
+          lease_until TEXT,
+          last_error TEXT,
+          created_at TEXT NOT NULL,
+          processed_at TEXT,
+          UNIQUE (workflow_id, event_type, event_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_connector_inbox_ready
+          ON connector_inbox(status, available_at, lease_until);
+        CREATE INDEX IF NOT EXISTS idx_connector_inbox_connection
+          ON connector_inbox(connection_id, created_at);
+      `)
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '12')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 12 (durable connector ingestion)')
+  }
 }
 
 /**
@@ -697,7 +782,13 @@ function verifySchema(d: Database.Database): void {
         ddl: 'ALTER TABLE agent_commands ADD COLUMN headless_args TEXT'
       }
     ],
-    workflow_runs: [{ column: 'inputs', ddl: 'ALTER TABLE workflow_runs ADD COLUMN inputs TEXT' }],
+    workflow_runs: [
+      { column: 'inputs', ddl: 'ALTER TABLE workflow_runs ADD COLUMN inputs TEXT' },
+      {
+        column: 'connector_inbox_id',
+        ddl: 'ALTER TABLE workflow_runs ADD COLUMN connector_inbox_id INTEGER'
+      }
+    ],
     workflow_run_nodes: [
       { column: 'agent_type', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN agent_type TEXT' },
       {
@@ -1387,6 +1478,240 @@ export function dbUpdateSourceConnection(id: string, updates: Partial<SourceConn
 
 export function dbDeleteSourceConnection(id: string): void {
   getDb().prepare('DELETE FROM source_connections WHERE id = ?').run(id)
+}
+
+// ---------------------------------------------------------------------------
+// Durable connector ingestion
+// ---------------------------------------------------------------------------
+
+export interface ConnectorInboxItem {
+  id: number
+  workflowId: string
+  connectionId: string
+  connectorId: string
+  eventId: string
+  eventType: string
+  eventTimestamp: string
+  connectorItem: ConnectorItemContext
+  attempts: number
+}
+
+interface ConnectorInboxRow {
+  id: number
+  workflow_id: string
+  connection_id: string
+  connector_id: string
+  event_id: string
+  event_type: string
+  event_timestamp: string
+  payload: string
+  attempts: number
+}
+
+function rowToConnectorInboxItem(row: ConnectorInboxRow): ConnectorInboxItem {
+  return {
+    id: row.id,
+    workflowId: row.workflow_id,
+    connectionId: row.connection_id,
+    connectorId: row.connector_id,
+    eventId: row.event_id,
+    eventType: row.event_type,
+    eventTimestamp: row.event_timestamp,
+    connectorItem: JSON.parse(row.payload) as ConnectorItemContext,
+    attempts: row.attempts
+  }
+}
+
+export function dbGetConnectorPollCursor(workflowId: string): string | undefined {
+  const row = getDb()
+    .prepare('SELECT cursor FROM connector_poll_state WHERE workflow_id = ?')
+    .get(workflowId) as { cursor: string | null } | undefined
+  return row?.cursor ?? undefined
+}
+
+/**
+ * Persist one remote page and its checkpoint in a single transaction.
+ * A crash can leave both absent or both present, never a cursor that points
+ * beyond events which were only held in memory.
+ */
+export function dbRecordConnectorPollPage(args: {
+  workflowId: string
+  connectionId: string
+  connectorId: string
+  cursor?: string
+  polledAt: string
+  events: Array<{
+    eventId: string
+    eventType: string
+    eventTimestamp: string
+    connectorItem: ConnectorItemContext
+  }>
+}): number {
+  const d = getDb()
+  return d.transaction(() => {
+    let inserted = 0
+    const insert = d.prepare(`
+      INSERT OR IGNORE INTO connector_inbox (
+        workflow_id, connection_id, connector_id, event_id, event_type,
+        event_timestamp, payload, status, attempts, available_at, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?)
+    `)
+    for (const event of args.events) {
+      const result = insert.run(
+        args.workflowId,
+        args.connectionId,
+        args.connectorId,
+        event.eventId,
+        event.eventType,
+        event.eventTimestamp,
+        JSON.stringify(event.connectorItem),
+        args.polledAt,
+        args.polledAt
+      )
+      inserted += result.changes
+    }
+
+    d.prepare(
+      `INSERT INTO connector_poll_state (
+         workflow_id, connection_id, cursor, last_polled_at, last_error
+       ) VALUES (?, ?, ?, ?, NULL)
+       ON CONFLICT(workflow_id) DO UPDATE SET
+         connection_id = excluded.connection_id,
+         cursor = excluded.cursor,
+         last_polled_at = excluded.last_polled_at,
+         last_error = NULL`
+    ).run(args.workflowId, args.connectionId, args.cursor ?? null, args.polledAt)
+
+    // Keep the connection-level fields current for the existing settings UI
+    // and as a one-time fallback for workflows created before per-poll state.
+    d.prepare(
+      `UPDATE source_connections
+       SET sync_cursor = ?, last_sync_at = ?, last_sync_error = NULL
+       WHERE id = ?`
+    ).run(args.cursor ?? null, args.polledAt, args.connectionId)
+
+    return inserted
+  })()
+}
+
+export function dbRecordConnectorPollError(args: {
+  workflowId: string
+  connectionId: string
+  error: string
+  polledAt: string
+}): void {
+  const d = getDb()
+  d.transaction(() => {
+    d.prepare(
+      `INSERT INTO connector_poll_state (
+         workflow_id, connection_id, cursor, last_polled_at, last_error
+       ) VALUES (?, ?, NULL, ?, ?)
+       ON CONFLICT(workflow_id) DO UPDATE SET
+         connection_id = excluded.connection_id,
+         last_polled_at = excluded.last_polled_at,
+         last_error = excluded.last_error`
+    ).run(args.workflowId, args.connectionId, args.polledAt, args.error)
+    d.prepare(
+      'UPDATE source_connections SET last_sync_at = ?, last_sync_error = ? WHERE id = ?'
+    ).run(args.polledAt, args.error, args.connectionId)
+  })()
+}
+
+/**
+ * Lease ready inbox rows before broadcasting them. Expired leases are
+ * reclaimable after a renderer/server crash. Retry backoff caps at one hour,
+ * but rows remain pending until they succeed or the user removes their source.
+ */
+export function dbClaimConnectorInbox(args: {
+  now: string
+  leaseUntil: string
+  limit: number
+}): ConnectorInboxItem[] {
+  const d = getDb()
+  return d.transaction(() => {
+    const rows = d
+      .prepare(
+        `SELECT id
+         FROM connector_inbox
+         WHERE (status = 'pending' AND available_at <= ?)
+            OR (status = 'leased' AND lease_until <= ?)
+         ORDER BY created_at, id
+         LIMIT ?`
+      )
+      .all(args.now, args.now, args.limit) as Array<{ id: number }>
+
+    const claim = d.prepare(
+      `UPDATE connector_inbox
+       SET status = 'leased', attempts = attempts + 1, lease_until = ?
+       WHERE id = ?`
+    )
+    const read = d.prepare(
+      `SELECT id, workflow_id, connection_id, connector_id, event_id,
+              event_type, event_timestamp, payload, attempts
+       FROM connector_inbox WHERE id = ?`
+    )
+    return rows.map(({ id }) => {
+      claim.run(args.leaseUntil, id)
+      return rowToConnectorInboxItem(read.get(id) as ConnectorInboxRow)
+    })
+  })()
+}
+
+export function dbCompleteConnectorInbox(id: number, processedAt: string): void {
+  getDb()
+    .prepare(
+      `UPDATE connector_inbox
+       SET status = 'processed', processed_at = ?, lease_until = NULL, last_error = NULL
+       WHERE id = ?`
+    )
+    .run(processedAt, id)
+}
+
+export function dbRetryConnectorInbox(args: { id: number; error: string; now: string }): void {
+  const d = getDb()
+  const row = d.prepare('SELECT attempts FROM connector_inbox WHERE id = ?').get(args.id) as
+    | { attempts: number }
+    | undefined
+  if (!row) return
+  const delayMs = Math.min(60_000 * 2 ** Math.max(0, row.attempts - 1), 60 * 60_000)
+  const availableAt = new Date(Date.parse(args.now) + delayMs).toISOString()
+  d.prepare(
+    `UPDATE connector_inbox
+       SET status = 'pending', available_at = ?, lease_until = NULL, last_error = ?
+       WHERE id = ?`
+  ).run(availableAt, args.error, args.id)
+  d.prepare(
+    `UPDATE source_connections
+     SET last_sync_error = ?
+     WHERE id = (SELECT connection_id FROM connector_inbox WHERE id = ?)`
+  ).run(args.error, args.id)
+}
+
+/** The renderer could not accept this event yet (for example, another run is
+ * parked at an approval gate). This is not a workflow attempt or an error. */
+export function dbDeferConnectorInbox(id: number, availableAt: string): void {
+  getDb()
+    .prepare(
+      `UPDATE connector_inbox
+       SET status = 'pending',
+           attempts = MAX(0, attempts - 1),
+           available_at = ?,
+           lease_until = NULL
+       WHERE id = ?`
+    )
+    .run(availableAt, id)
+}
+
+/** Server restarts invalidate every in-memory workflow owner, so leases from
+ * the previous process must be immediately reclaimable. */
+export function dbReleaseConnectorInboxLeases(now: string): void {
+  getDb()
+    .prepare(
+      `UPDATE connector_inbox
+       SET status = 'pending', available_at = ?, lease_until = NULL
+       WHERE status = 'leased'`
+    )
+    .run(now)
 }
 
 // ---------------------------------------------------------------------------
@@ -2134,8 +2459,10 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
 
   const run = d.transaction(() => {
     d.prepare(
-      `INSERT OR REPLACE INTO workflow_runs (id, workflow_id, started_at, completed_at, status, trigger_task_id, inputs)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
+      `INSERT OR REPLACE INTO workflow_runs (
+         id, workflow_id, started_at, completed_at, status, trigger_task_id,
+         inputs, connector_inbox_id
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       runId,
       execution.workflowId,
@@ -2143,7 +2470,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
       execution.completedAt ?? null,
       execution.status,
       execution.triggerTaskId ?? null,
-      execution.inputs ? JSON.stringify(execution.inputs) : null
+      execution.inputs ? JSON.stringify(execution.inputs) : null,
+      execution.connectorInboxId ?? null
     )
 
     // Delete existing nodes for this run (for upsert behavior)
@@ -2255,6 +2583,7 @@ type RunRow = {
   status: string
   trigger_task_id: string | null
   inputs: string | null
+  connector_inbox_id: number | null
   workflow_name?: string | null
 }
 
@@ -2289,6 +2618,7 @@ function mapRunRows(
       status: r.status as WorkflowExecution['status'],
       ...(r.trigger_task_id != null && { triggerTaskId: r.trigger_task_id }),
       ...(inputs && { inputs }),
+      ...(r.connector_inbox_id != null && { connectorInboxId: r.connector_inbox_id }),
       ...(r.workflow_name != null && { workflowName: r.workflow_name }),
       nodeStates: nodesByRun.get(r.id) ?? []
     }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1771,6 +1771,11 @@ export function dbRecordConnectorPollError(args: {
        ) VALUES (?, ?, NULL, ?, ?)
        ON CONFLICT(workflow_id) DO UPDATE SET
          connection_id = excluded.connection_id,
+         cursor = CASE
+           WHEN connector_poll_state.connection_id = excluded.connection_id
+             THEN connector_poll_state.cursor
+           ELSE NULL
+         END,
          last_polled_at = excluded.last_polled_at,
          last_error = excluded.last_error`
     ).run(args.workflowId, args.connectionId, args.polledAt, args.error)
@@ -1803,20 +1808,27 @@ export function dbClaimConnectorInbox(args: {
       )
       .all(args.now, args.now, args.limit) as Array<{ id: number }>
 
+    // Re-check claimability inside the UPDATE so a concurrent claimer cannot
+    // steal a lease it lost the race for and inflate that row's attempts.
     const claim = d.prepare(
       `UPDATE connector_inbox
        SET status = 'leased', attempts = attempts + 1, lease_until = ?, lease_token = ?
-       WHERE id = ?`
+       WHERE id = ?
+         AND ((status = 'pending' AND available_at <= ?)
+           OR (status = 'leased' AND lease_until <= ?))`
     )
     const read = d.prepare(
       `SELECT id, workflow_id, connection_id, connector_id, event_id,
               event_type, event_timestamp, payload, attempts, lease_token
        FROM connector_inbox WHERE id = ?`
     )
-    return rows.map(({ id }) => {
-      claim.run(args.leaseUntil, randomUUID(), id)
-      return rowToConnectorInboxItem(read.get(id) as ConnectorInboxRow)
-    })
+    const claimed: ConnectorInboxItem[] = []
+    for (const { id } of rows) {
+      const result = claim.run(args.leaseUntil, randomUUID(), id, args.now, args.now)
+      if (result.changes !== 1) continue
+      claimed.push(rowToConnectorInboxItem(read.get(id) as ConnectorInboxRow))
+    }
+    return claimed
   })()
 }
 
@@ -2709,8 +2721,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     }
 
     // Keep active and unacknowledged connector runs available for restart
-    // recovery; only terminal history that no longer owns inbox work is safe
-    // to trim.
+    // recovery; terminal history whose inbox work is done — or whose inbox row
+    // is already gone — is safe to trim.
     const count = (
       d
         .prepare('SELECT COUNT(*) as c FROM workflow_runs WHERE workflow_id = ?')
@@ -2724,10 +2736,10 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
             AND status != 'running'
             AND (
               connector_inbox_id IS NULL
-              OR EXISTS (
+              OR NOT EXISTS (
                 SELECT 1 FROM connector_inbox
                 WHERE connector_inbox.id = workflow_runs.connector_inbox_id
-                  AND connector_inbox.status = 'processed'
+                  AND connector_inbox.status != 'processed'
               )
             )
           ORDER BY started_at ASC

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -66,6 +66,7 @@ export async function startServer(
 
   app.get('/ws', { websocket: true }, (socket) => {
     handleConnection(socket)
+    scheduler.deliverPendingConnectorInbox()
   })
 
   app.get('/health', async () => ({ status: 'ok' }))
@@ -121,6 +122,7 @@ export async function startServer(
 
   // Register all RPC methods
   registerAllMethods()
+  scheduler.startInboxWorker()
 
   // Server shutdown method (callable from clients)
   registerMethod('server:shutdown', async () => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -686,8 +686,12 @@ export function registerAllMethods(): void {
     scheduler.triggerWorkflow(workflowId, inputs)
   })
 
-  registerMethod('connector:inboxComplete', ({ id, disposition, error }) => {
-    scheduler.completeConnectorInbox(id, disposition, error)
+  registerMethod('connector:inboxComplete', ({ id, leaseToken, disposition, error }) => {
+    scheduler.completeConnectorInbox(id, leaseToken, disposition, error)
+  })
+
+  registerMethod('connector:inboxRenew', ({ id, leaseToken }) => {
+    return scheduler.renewConnectorInbox(id, leaseToken)
   })
 
   // Runs execute in the renderer, but a scheduler tick reaches every connected

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -85,6 +85,7 @@ import {
 } from './connectors'
 import { MCP_CONNECTOR_ID } from './connectors/mcp'
 import { detectRepoSlug } from './connectors/github'
+import { forEachConnectorItem } from './connectors/paging'
 import { buildConnectorSeededWorkflow } from './default-workflows'
 import { connectorSeededWorkflowId, connectorSeededWorkflowIdPrefix } from '@vornrun/shared/types'
 import { executeScript, scriptRunnerEvents } from './script-runner'
@@ -685,6 +686,10 @@ export function registerAllMethods(): void {
     scheduler.triggerWorkflow(workflowId, inputs)
   })
 
+  registerMethod('connector:inboxComplete', ({ id, disposition, error }) => {
+    scheduler.completeConnectorInbox(id, disposition, error)
+  })
+
   // Runs execute in the renderer, but a scheduler tick reaches every connected
   // instance. Claiming here — in the one process they all share — is what stops
   // two open windows from launching the same agents twice.
@@ -772,7 +777,7 @@ export function registerAllMethods(): void {
     const conn = dbGetSourceConnection(connectionId)
     if (!conn) return { imported: 0, updated: 0, error: 'Connection not found' }
     const connector = connectorRegistry.get(conn.connectorId)
-    if (!connector?.listItems) {
+    if (!connector?.listItems && !connector?.listItemsPage) {
       return {
         imported: 0,
         updated: 0,
@@ -786,10 +791,9 @@ export function registerAllMethods(): void {
     const projectName = conn.executionProject || conn.name
 
     try {
-      const items = await connector.listItems(applyDecryptedCreds(conn))
-      for (const item of items) {
+      await forEachConnectorItem(connector, applyDecryptedCreds(conn), (item) => {
         const initialStatus = conn.statusMapping?.[item.status] || ('todo' as TaskStatus)
-        const result = upsertExternalItem(
+        const upserted = upsertExternalItem(
           conn,
           {
             externalId: item.externalId,
@@ -801,9 +805,9 @@ export function registerAllMethods(): void {
           },
           { projectName, initialStatus, now }
         )
-        if (result.created) imported++
+        if (upserted.created) imported++
         else updated++
-      }
+      })
       dbUpdateSourceConnection(conn.id, { lastSyncAt: now, lastSyncError: undefined })
       dbSignalChange()
       configManager.notifyChanged()

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -14,12 +14,15 @@ import { configManager } from './config-manager'
 import {
   dbClaimConnectorInbox,
   dbCompleteConnectorInbox,
+  dbCountActiveConnectorInboxLeases,
   dbDeferConnectorInbox,
   dbGetConnectorPollCursor,
   dbGetSourceConnection,
+  dbGetWorkflowRunByConnectorInboxId,
   dbRecordConnectorPollError,
   dbRecordConnectorPollPage,
   dbReleaseConnectorInboxLeases,
+  dbRenewConnectorInboxLease,
   dbRetryConnectorInbox
 } from './database'
 import { connectorRegistry, applyDecryptedCreds } from './connectors'
@@ -28,7 +31,7 @@ import { clientRegistry } from './broadcast'
 import log from './logger'
 
 const LOCK_DIR = path.join(os.homedir(), '.vorn')
-const INBOX_LEASE_MS = 24 * 60 * 60_000
+const INBOX_LEASE_MS = 5 * 60_000
 const INBOX_DRAIN_INTERVAL_MS = 30_000
 const INBOX_BATCH_SIZE = 50
 const MAX_POLL_PAGES_PER_TICK = 20
@@ -97,22 +100,32 @@ class Scheduler extends EventEmitter {
 
   completeConnectorInbox(
     id: number,
+    leaseToken: string,
     disposition: 'processed' | 'retry' | 'defer',
     error?: string
   ): void {
     const now = new Date().toISOString()
     if (disposition === 'processed') {
-      dbCompleteConnectorInbox(id, now)
+      dbCompleteConnectorInbox(id, leaseToken, now)
     } else if (disposition === 'retry') {
       dbRetryConnectorInbox({
         id,
+        leaseToken,
         error: error || 'Connector workflow failed',
         now
       })
     } else {
-      dbDeferConnectorInbox(id, new Date(Date.now() + 30_000).toISOString())
+      dbDeferConnectorInbox(id, leaseToken, new Date(Date.now() + 30_000).toISOString())
     }
     this.deliverPendingConnectorInbox()
+  }
+
+  renewConnectorInbox(id: number, leaseToken: string): boolean {
+    return dbRenewConnectorInboxLease(
+      id,
+      leaseToken,
+      new Date(Date.now() + INBOX_LEASE_MS).toISOString()
+    )
   }
 
   deliverPendingConnectorInbox(): void {
@@ -120,16 +133,36 @@ class Scheduler extends EventEmitter {
     // expires. Leave it pending and drain immediately when a client connects.
     if (clientRegistry.size === 0) return
     const now = Date.now()
+    const nowIso = new Date(now).toISOString()
+    const availableSlots = INBOX_BATCH_SIZE - dbCountActiveConnectorInboxLeases(nowIso)
+    if (availableSlots <= 0) return
     const claimed = dbClaimConnectorInbox({
-      now: new Date(now).toISOString(),
+      now: nowIso,
       leaseUntil: new Date(now + INBOX_LEASE_MS).toISOString(),
-      limit: INBOX_BATCH_SIZE
+      limit: availableSlots
     })
     for (const item of claimed) {
+      const existingExecution = dbGetWorkflowRunByConnectorInboxId(item.id)
+      if (
+        existingExecution &&
+        existingExecution.status !== 'running' &&
+        (existingExecution.connectorInboxDisposition === 'processed' ||
+          existingExecution.status === 'success' ||
+          existingExecution.status === 'cancelled')
+      ) {
+        dbCompleteConnectorInbox(item.id, item.leaseToken, new Date().toISOString())
+        continue
+      }
       this.emit('client-message', IPC.SCHEDULER_EXECUTE, {
         workflowId: item.workflowId,
-        connectorItem: { ...item.connectorItem, inboxId: item.id },
-        connectorInboxId: item.id
+        connectorItem: {
+          ...item.connectorItem,
+          inboxId: item.id,
+          inboxLeaseToken: item.leaseToken
+        },
+        connectorInboxId: item.id,
+        connectorInboxLeaseToken: item.leaseToken,
+        ...(existingExecution?.status === 'running' && { existingExecution })
       })
     }
   }
@@ -295,7 +328,7 @@ class Scheduler extends EventEmitter {
       return
     }
 
-    let cursor = dbGetConnectorPollCursor(workflowId) ?? conn.syncCursor
+    let cursor = dbGetConnectorPollCursor(workflowId, conn.id)
     const now = new Date().toISOString()
     try {
       for (let page = 0; page < MAX_POLL_PAGES_PER_TICK; page++) {

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -11,12 +11,27 @@ import {
   IPC
 } from '@vornrun/shared/types'
 import { configManager } from './config-manager'
-import { dbGetSourceConnection, dbUpdateSourceConnection } from './database'
+import {
+  dbClaimConnectorInbox,
+  dbCompleteConnectorInbox,
+  dbDeferConnectorInbox,
+  dbGetConnectorPollCursor,
+  dbGetSourceConnection,
+  dbRecordConnectorPollError,
+  dbRecordConnectorPollPage,
+  dbReleaseConnectorInboxLeases,
+  dbRetryConnectorInbox
+} from './database'
 import { connectorRegistry, applyDecryptedCreds } from './connectors'
 import { MCP_CONNECTOR_ID, MCP_POLL_EVENT, pollMcpConnection } from './connectors/mcp'
+import { clientRegistry } from './broadcast'
 import log from './logger'
 
 const LOCK_DIR = path.join(os.homedir(), '.vorn')
+const INBOX_LEASE_MS = 24 * 60 * 60_000
+const INBOX_DRAIN_INTERVAL_MS = 30_000
+const INBOX_BATCH_SIZE = 50
+const MAX_POLL_PAGES_PER_TICK = 20
 
 /**
  * Try to acquire an execution lock for a workflow run.
@@ -68,6 +83,56 @@ function getTriggerConfig(wf: WorkflowDefinition): TriggerConfig | null {
 class Scheduler extends EventEmitter {
   private cronJobs = new Map<string, ScheduledTask>()
   private timeouts = new Map<string, NodeJS.Timeout>()
+  private inboxTimer: NodeJS.Timeout | null = null
+
+  startInboxWorker(): void {
+    if (this.inboxTimer) return
+    dbReleaseConnectorInboxLeases(new Date().toISOString())
+    this.deliverPendingConnectorInbox()
+    this.inboxTimer = setInterval(
+      () => this.deliverPendingConnectorInbox(),
+      INBOX_DRAIN_INTERVAL_MS
+    )
+  }
+
+  completeConnectorInbox(
+    id: number,
+    disposition: 'processed' | 'retry' | 'defer',
+    error?: string
+  ): void {
+    const now = new Date().toISOString()
+    if (disposition === 'processed') {
+      dbCompleteConnectorInbox(id, now)
+    } else if (disposition === 'retry') {
+      dbRetryConnectorInbox({
+        id,
+        error: error || 'Connector workflow failed',
+        now
+      })
+    } else {
+      dbDeferConnectorInbox(id, new Date(Date.now() + 30_000).toISOString())
+    }
+    this.deliverPendingConnectorInbox()
+  }
+
+  deliverPendingConnectorInbox(): void {
+    // Claiming without a receiver would hide the row behind its lease until it
+    // expires. Leave it pending and drain immediately when a client connects.
+    if (clientRegistry.size === 0) return
+    const now = Date.now()
+    const claimed = dbClaimConnectorInbox({
+      now: new Date(now).toISOString(),
+      leaseUntil: new Date(now + INBOX_LEASE_MS).toISOString(),
+      limit: INBOX_BATCH_SIZE
+    })
+    for (const item of claimed) {
+      this.emit('client-message', IPC.SCHEDULER_EXECUTE, {
+        workflowId: item.workflowId,
+        connectorItem: { ...item.connectorItem, inboxId: item.id },
+        connectorInboxId: item.id
+      })
+    }
+  }
 
   syncSchedules(workflows: WorkflowDefinition[]): void {
     log.info(
@@ -191,12 +256,14 @@ class Scheduler extends EventEmitter {
   /**
    * Poll a connector and fan out one workflow execution per new item.
    *
-   * - Cursor lives on the connection row; advanced after a successful poll.
-   * - Per-item workflow failures do NOT stall the pipe — the cursor has
-   *   already advanced past them; the failure shows up in run history and in
-   *   the connection's lastSyncError field.
-   * - Connector-level failures (poll() throws) record lastSyncError, emit one
-   *   failed execution so run history surfaces it, and do not advance cursor.
+   * - Cursor lives per workflow, so subscriptions sharing a connection cannot
+   *   skip each other's events.
+   * - Each bounded remote page and its cursor are committed atomically to the
+   *   durable inbox before anything is broadcast.
+   * - Workflow failures release their lease with backoff; process crashes
+   *   leave the row reclaimable.
+   * - Connector-level failures record lastSyncError and do not advance beyond
+   *   the last page that was safely persisted.
    */
   private async dispatchConnectorPoll(
     workflowId: string,
@@ -228,56 +295,65 @@ class Scheduler extends EventEmitter {
       return
     }
 
-    const cursor = conn.syncCursor
+    let cursor = dbGetConnectorPollCursor(workflowId) ?? conn.syncCursor
     const now = new Date().toISOString()
-    let result
     try {
-      result = isMcp
-        ? await pollMcpConnection(conn, cursor)
-        : await connector!.poll!(trigger.event, applyDecryptedCreds(conn), cursor)
+      for (let page = 0; page < MAX_POLL_PAGES_PER_TICK; page++) {
+        const result = isMcp
+          ? await pollMcpConnection(conn, cursor)
+          : await connector!.poll!(trigger.event, applyDecryptedCreds(conn), cursor)
+        const nextCursor = result.nextCursor ?? cursor
+        if (result.hasMore && nextCursor === cursor) {
+          throw new Error(
+            `${conn.connectorId}.poll(${trigger.event}) returned hasMore without advancing its cursor`
+          )
+        }
+
+        const events = result.events.map((event) => {
+          const data = event.data as Record<string, unknown>
+          const connectorItem: ConnectorItemContext = {
+            connectionId: conn.id,
+            connectorId: conn.connectorId,
+            externalId: String(data.externalId ?? event.id),
+            externalUrl: typeof data.url === 'string' ? data.url : undefined,
+            title: typeof data.title === 'string' ? data.title : String(data.title ?? ''),
+            body: typeof data.description === 'string' ? data.description : undefined,
+            raw: data
+          }
+          return {
+            eventId: event.id,
+            eventType: event.type,
+            eventTimestamp: event.timestamp,
+            connectorItem
+          }
+        })
+
+        dbRecordConnectorPollPage({
+          workflowId,
+          connectionId: conn.id,
+          connectorId: conn.connectorId,
+          cursor: nextCursor,
+          polledAt: now,
+          events
+        })
+        cursor = nextCursor
+        if (!result.hasMore) break
+      }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err)
       log.error(
         `[scheduler] connectorPoll: ${conn.connectorId}.poll(${trigger.event}) failed: ${errorMsg}`
       )
-      dbUpdateSourceConnection(conn.id, { lastSyncAt: now, lastSyncError: errorMsg })
-      // Do not emit SCHEDULER_EXECUTE here. An event without a connectorItem
-      // would bounce back through the renderer's connectorPoll guard (which
-      // reroutes context-less runs via workflow:runManual), creating churn.
-      // The failure is already visible via the connection's lastSyncError.
-      return
-    }
-
-    // Advance cursor + clear last error atomically.
-    dbUpdateSourceConnection(conn.id, {
-      lastSyncAt: now,
-      lastSyncError: undefined,
-      syncCursor: result.nextCursor ?? cursor
-    })
-
-    if (result.events.length === 0) {
-      log.info(`[scheduler] connectorPoll: no new items for ${conn.connectorId}:${trigger.event}`)
-      return
-    }
-
-    log.info(
-      `[scheduler] connectorPoll: fanning out ${result.events.length} item(s) for ${conn.connectorId}:${trigger.event}`
-    )
-    for (const event of result.events) {
-      // Event data from the connector is the upstream item payload. The
-      // GitHub connector puts an ExternalItem-shaped object into `data`.
-      const data = event.data as Record<string, unknown>
-      const connectorItem: ConnectorItemContext = {
+      dbRecordConnectorPollError({
+        workflowId,
         connectionId: conn.id,
-        connectorId: conn.connectorId,
-        externalId: String(data.externalId ?? event.id),
-        externalUrl: typeof data.url === 'string' ? data.url : undefined,
-        title: typeof data.title === 'string' ? data.title : String(data.title ?? ''),
-        body: typeof data.description === 'string' ? data.description : undefined,
-        raw: data
-      }
-      this.emit('client-message', IPC.SCHEDULER_EXECUTE, { workflowId, connectorItem })
+        error: errorMsg,
+        polledAt: now
+      })
+      return
     }
+
+    this.deliverPendingConnectorInbox()
   }
 
   checkMissedSchedules(workflows: WorkflowDefinition[]): MissedSchedule[] {
@@ -331,6 +407,8 @@ class Scheduler extends EventEmitter {
     for (const [, timer] of this.timeouts) clearTimeout(timer)
     this.cronJobs.clear()
     this.timeouts.clear()
+    if (this.inboxTimer) clearInterval(this.inboxTimer)
+    this.inboxTimer = null
   }
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -281,6 +281,16 @@ export interface RequestMethods {
     }
     result: { taskId: string; created: boolean }
   }
+  /** A renderer accepted a durable connector event and finished its workflow.
+   * Failures are retried with bounded exponential backoff. */
+  'connector:inboxComplete': {
+    params: {
+      id: number
+      disposition: 'processed' | 'retry' | 'defer'
+      error?: string
+    }
+    result: void
+  }
   'connection:getSourceLink': {
     params: string
     result: TaskSourceLink | null

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -13,7 +13,6 @@ import type {
   RecentSession,
   PermissionRequestInfo,
   WidgetAgentInfo,
-  WorkflowDefinition,
   SSHKey,
   SSHKeyMeta,
   SessionEvent,
@@ -286,10 +285,15 @@ export interface RequestMethods {
   'connector:inboxComplete': {
     params: {
       id: number
+      leaseToken: string
       disposition: 'processed' | 'retry' | 'defer'
       error?: string
     }
     result: void
+  }
+  'connector:inboxRenew': {
+    params: { id: number; leaseToken: string }
+    result: boolean
   }
   'connection:getSourceLink': {
     params: string
@@ -333,12 +337,15 @@ export interface ServerNotifications {
   }
   'scheduler:execute': {
     workflowId: string
-    workflow: WorkflowDefinition
+    inputs?: Record<string, unknown>
     /** Populated when the scheduler fan-outs a connector-poll result. One
      *  scheduler:execute is emitted per new item, each carrying its own item
      *  context. Consumed by createTaskFromItem nodes (and any downstream
      *  nodes that reference context.connectorItem). */
     connectorItem?: ConnectorItemContext
+    connectorInboxId?: number
+    connectorInboxLeaseToken?: string
+    existingExecution?: WorkflowExecution
   }
   'scheduler:missed': Array<{
     workflowId: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -405,6 +405,8 @@ export interface SessionEvent {
 export interface ConnectorItemContext {
   /** Durable delivery row. Internal to Vorn; connectors do not set it. */
   inboxId?: number
+  /** Identifies the current delivery lease so stale windows cannot acknowledge it. */
+  inboxLeaseToken?: string
   connectionId: string
   connectorId: string
   externalId: string
@@ -786,15 +788,21 @@ export interface WorkflowExecution {
    * as well, which is what lets fan-out run in parallel while a double-fire
    * (two app instances, one scheduler tick) collapses to a single run.
    */
-   dedupeParams?: string
-   /**
-    * Values this run was started with, keyed by `WorkflowInputDef.key`. Kept on
+  dedupeParams?: string
+  /**
+   * Values this run was started with, keyed by `WorkflowInputDef.key`. Kept on
    * the run (not just the live context) so Run History can show what a run was
    * launched with long after it finished.
    */
   inputs?: Record<string, unknown>
+  /** Connector payload retained so approval-gated runs can resume downstream steps. */
+  connectorItem?: ConnectorItemContext
   /** Durable connector event acknowledged only when this run finishes. */
   connectorInboxId?: number
+  /** Ownership token for the connector inbox lease. */
+  connectorInboxLeaseToken?: string
+  /** Durable terminal handling for restart recovery. */
+  connectorInboxDisposition?: 'processed' | 'retry'
 }
 
 /** Stable identity for a run row, tolerating history written before `runId`. */
@@ -1140,6 +1148,7 @@ export const IPC = {
   CONNECTOR_STATUS: 'connector:status',
   CONNECTION_UPSERT_FROM_ITEM: 'connection:upsertFromItem',
   CONNECTOR_INBOX_COMPLETE: 'connector:inboxComplete',
+  CONNECTOR_INBOX_RENEW: 'connector:inboxRenew',
   WORKFLOW_RUN_MANUAL: 'workflow:runManual',
   CONNECTION_BACKFILL: 'connection:backfill',
   CREDENTIALS_SET_DECRYPTED: 'credentials:setDecrypted',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -243,9 +243,18 @@ export interface ExternalItem {
   metadata?: Record<string, unknown>
 }
 
+export interface ExternalItemPage {
+  items: ExternalItem[]
+  nextCursor?: string
+  hasMore?: boolean
+}
+
 export interface PollResult {
   events: TriggerEvent[]
   nextCursor?: string
+  /** More remote pages are immediately available. The scheduler keeps
+   * pulling bounded pages while the connector advances `nextCursor`. */
+  hasMore?: boolean
 }
 
 export interface TriggerEvent {
@@ -337,6 +346,9 @@ export interface VornConnector {
   readonly capabilities: ('tasks' | 'triggers' | 'actions')[]
 
   listItems?(filters: Record<string, unknown>): Promise<ExternalItem[]>
+  /** Bounded reconciliation page. Connectors that implement this let manual
+   * backfill drain the complete remote result set without one huge response. */
+  listItemsPage?(filters: Record<string, unknown>, cursor?: string): Promise<ExternalItemPage>
   getItem?(externalId: string, filters: Record<string, unknown>): Promise<ExternalItem | null>
   poll?(triggerType: string, config: Record<string, unknown>, cursor?: string): Promise<PollResult>
   execute?(actionType: string, args: Record<string, unknown>): Promise<ActionResult>
@@ -391,6 +403,8 @@ export interface SessionEvent {
  *  workflow execution. Kept small and serializable so the engine's existing
  *  persist-and-resume pattern keeps working. */
 export interface ConnectorItemContext {
+  /** Durable delivery row. Internal to Vorn; connectors do not set it. */
+  inboxId?: number
   connectionId: string
   connectorId: string
   externalId: string
@@ -772,13 +786,15 @@ export interface WorkflowExecution {
    * as well, which is what lets fan-out run in parallel while a double-fire
    * (two app instances, one scheduler tick) collapses to a single run.
    */
-  dedupeParams?: string
-  /**
-   * Values this run was started with, keyed by `WorkflowInputDef.key`. Kept on
+   dedupeParams?: string
+   /**
+    * Values this run was started with, keyed by `WorkflowInputDef.key`. Kept on
    * the run (not just the live context) so Run History can show what a run was
    * launched with long after it finished.
    */
   inputs?: Record<string, unknown>
+  /** Durable connector event acknowledged only when this run finishes. */
+  connectorInboxId?: number
 }
 
 /** Stable identity for a run row, tolerating history written before `runId`. */
@@ -1123,6 +1139,7 @@ export const IPC = {
   CONNECTOR_SEED_WORKFLOW: 'connector:seedWorkflow',
   CONNECTOR_STATUS: 'connector:status',
   CONNECTION_UPSERT_FROM_ITEM: 'connection:upsertFromItem',
+  CONNECTOR_INBOX_COMPLETE: 'connector:inboxComplete',
   WORKFLOW_RUN_MANUAL: 'workflow:runManual',
   CONNECTION_BACKFILL: 'connection:backfill',
   CREDENTIALS_SET_DECRYPTED: 'credentials:setDecrypted',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -368,15 +368,21 @@ export function createApiShim(wsUrl: string) {
         workflowId: string
         connectorItem?: import('../../shared/src/types').ConnectorItemContext
         connectorInboxId?: number
+        connectorInboxLeaseToken?: string
+        inputs?: Record<string, unknown>
+        existingExecution?: import('../../shared/src/types').WorkflowExecution
       }) => void
     ) => rpc.on('scheduler:execute', callback as (p: unknown) => void),
     onSchedulerMissed: (callback: (missed: unknown[]) => void) =>
       rpc.on('scheduler:missed', callback as (p: unknown) => void),
     completeConnectorInbox: (params: {
       id: number
+      leaseToken: string
       disposition: 'processed' | 'retry' | 'defer'
       error?: string
     }) => rpc.invoke('connector:inboxComplete', params),
+    renewConnectorInbox: (params: { id: number; leaseToken: string }) =>
+      rpc.invoke('connector:inboxRenew', params),
 
     // ── Window Controls (no-op in web) ──
     windowMinimize: () => {},

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -363,10 +363,20 @@ export function createApiShim(wsUrl: string) {
     // ── Scheduler ──
     getScheduleLog: (workflowId?: string) => rpc.invoke('scheduler:getLog', workflowId),
     getScheduleNextRun: (workflowId: string) => rpc.invoke('scheduler:getNextRun', workflowId),
-    onSchedulerExecute: (callback: (event: { workflowId: string }) => void) =>
-      rpc.on('scheduler:execute', callback as (p: unknown) => void),
+    onSchedulerExecute: (
+      callback: (event: {
+        workflowId: string
+        connectorItem?: import('../../shared/src/types').ConnectorItemContext
+        connectorInboxId?: number
+      }) => void
+    ) => rpc.on('scheduler:execute', callback as (p: unknown) => void),
     onSchedulerMissed: (callback: (missed: unknown[]) => void) =>
       rpc.on('scheduler:missed', callback as (p: unknown) => void),
+    completeConnectorInbox: (params: {
+      id: number
+      disposition: 'processed' | 'retry' | 'defer'
+      error?: string
+    }) => rpc.invoke('connector:inboxComplete', params),
 
     // ── Window Controls (no-op in web) ──
     windowMinimize: () => {},

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -195,6 +195,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONNECTION_UPSERT_FROM_ITEM, (_, params) =>
     requireBridge().request(IPC.CONNECTION_UPSERT_FROM_ITEM, params)
   )
+  safeHandle(IPC.CONNECTOR_INBOX_COMPLETE, (_, params) =>
+    requireBridge().request(IPC.CONNECTOR_INBOX_COMPLETE, params)
+  )
   safeHandle(IPC.WORKFLOW_RUN_MANUAL, (_, params) =>
     requireBridge().request(IPC.WORKFLOW_RUN_MANUAL, params)
   )

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -198,6 +198,9 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONNECTOR_INBOX_COMPLETE, (_, params) =>
     requireBridge().request(IPC.CONNECTOR_INBOX_COMPLETE, params)
   )
+  safeHandle(IPC.CONNECTOR_INBOX_RENEW, (_, params) =>
+    requireBridge().request(IPC.CONNECTOR_INBOX_RENEW, params)
+  )
   safeHandle(IPC.WORKFLOW_RUN_MANUAL, (_, params) =>
     requireBridge().request(IPC.WORKFLOW_RUN_MANUAL, params)
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -298,6 +298,8 @@ const api = {
       connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
       inputs?: Record<string, unknown>
       connectorInboxId?: number
+      connectorInboxLeaseToken?: string
+      existingExecution?: import('../../packages/shared/src/types').WorkflowExecution
     }) => void
   ) => {
     const listener = (
@@ -307,6 +309,8 @@ const api = {
         connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
         inputs?: Record<string, unknown>
         connectorInboxId?: number
+        connectorInboxLeaseToken?: string
+        existingExecution?: import('../../packages/shared/src/types').WorkflowExecution
       }
     ): void => callback(event)
     ipcRenderer.on(IPC.SCHEDULER_EXECUTE, listener)
@@ -538,9 +542,13 @@ const api = {
 
   completeConnectorInbox: (params: {
     id: number
+    leaseToken: string
     disposition: 'processed' | 'retry' | 'defer'
     error?: string
   }): Promise<void> => ipcRenderer.invoke(IPC.CONNECTOR_INBOX_COMPLETE, params),
+
+  renewConnectorInbox: (params: { id: number; leaseToken: string }): Promise<boolean> =>
+    ipcRenderer.invoke(IPC.CONNECTOR_INBOX_RENEW, params),
 
   getTaskSourceLink: (taskId: string): Promise<TaskSourceLink | null> =>
     ipcRenderer.invoke(IPC.CONNECTION_GET_SOURCE_LINK, taskId),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -297,6 +297,7 @@ const api = {
       workflowId: string
       connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
       inputs?: Record<string, unknown>
+      connectorInboxId?: number
     }) => void
   ) => {
     const listener = (
@@ -305,6 +306,7 @@ const api = {
         workflowId: string
         connectorItem?: import('../../packages/shared/src/types').ConnectorItemContext
         inputs?: Record<string, unknown>
+        connectorInboxId?: number
       }
     ): void => callback(event)
     ipcRenderer.on(IPC.SCHEDULER_EXECUTE, listener)
@@ -533,6 +535,12 @@ const api = {
     project?: string
   }): Promise<{ taskId: string; created: boolean }> =>
     ipcRenderer.invoke(IPC.CONNECTION_UPSERT_FROM_ITEM, params),
+
+  completeConnectorInbox: (params: {
+    id: number
+    disposition: 'processed' | 'retry' | 'defer'
+    error?: string
+  }): Promise<void> => ipcRenderer.invoke(IPC.CONNECTOR_INBOX_COMPLETE, params),
 
   getTaskSourceLink: (taskId: string): Promise<TaskSourceLink | null> =>
     ipcRenderer.invoke(IPC.CONNECTION_GET_SOURCE_LINK, taskId),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -292,13 +292,37 @@ export function App() {
 
     // Scheduler: auto-execute workflows when triggered
     const removeSchedulerListener = window.api.onSchedulerExecute(
-      async ({ workflowId, connectorItem, inputs }) => {
+      async ({ workflowId, connectorItem, connectorInboxId, inputs }) => {
         const state = useAppStore.getState()
         const workflow = state.config?.workflows?.find((w) => w.id === workflowId)
-        if (!workflow) return
+        if (!workflow) {
+          if (connectorInboxId !== undefined) {
+            await window.api.completeConnectorInbox({
+              id: connectorInboxId,
+              disposition: 'defer'
+            })
+          }
+          return
+        }
 
         const context = connectorItem || inputs ? { connectorItem, inputs } : undefined
-        await runWorkflow(workflow, context, { source: 'scheduler' })
+        try {
+          const execution = await runWorkflow(workflow, context, { source: 'scheduler' })
+          // A different run may be parked on an approval gate. It did not
+          // accept this event, so release the row for a short retry instead of
+          // holding its full delivery lease.
+          if (connectorInboxId !== undefined && execution.connectorInboxId !== connectorInboxId) {
+            await window.api.completeConnectorInbox({
+              id: connectorInboxId,
+              disposition: 'defer'
+            })
+          }
+        } catch (err) {
+          // Another renderer may have won the workflow claim. It will
+          // acknowledge the shared inbox row; otherwise the lease expires and
+          // the server retries it.
+          console.warn('[connector] scheduled workflow did not complete:', err)
+        }
       }
     )
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,6 +19,7 @@ const WorkflowsLandingView = lazy(() =>
   }))
 )
 import {
+  adoptConnectorInboxLease,
   executeWorkflow as runWorkflow,
   rescheduleWaitingGateTimers,
   reconcileRunningExecutions
@@ -292,16 +293,31 @@ export function App() {
 
     // Scheduler: auto-execute workflows when triggered
     const removeSchedulerListener = window.api.onSchedulerExecute(
-      async ({ workflowId, connectorItem, connectorInboxId, inputs }) => {
+      async ({
+        workflowId,
+        connectorItem,
+        connectorInboxId,
+        connectorInboxLeaseToken,
+        existingExecution,
+        inputs
+      }) => {
         const state = useAppStore.getState()
         const workflow = state.config?.workflows?.find((w) => w.id === workflowId)
         if (!workflow) {
-          if (connectorInboxId !== undefined) {
+          if (connectorInboxId !== undefined && connectorInboxLeaseToken) {
             await window.api.completeConnectorInbox({
               id: connectorInboxId,
+              leaseToken: connectorInboxLeaseToken,
               disposition: 'defer'
             })
           }
+          return
+        }
+
+        if (existingExecution && connectorItem) {
+          await adoptConnectorInboxLease(existingExecution, connectorItem)
+          rescheduleWaitingGateTimers([existingExecution], [workflow])
+          await reconcileRunningExecutions([existingExecution])
           return
         }
 
@@ -311,11 +327,22 @@ export function App() {
           // A different run may be parked on an approval gate. It did not
           // accept this event, so release the row for a short retry instead of
           // holding its full delivery lease.
-          if (connectorInboxId !== undefined && execution.connectorInboxId !== connectorInboxId) {
+          if (
+            connectorInboxId !== undefined &&
+            connectorInboxLeaseToken &&
+            execution.connectorInboxId !== connectorInboxId
+          ) {
             await window.api.completeConnectorInbox({
               id: connectorInboxId,
+              leaseToken: connectorInboxLeaseToken,
               disposition: 'defer'
             })
+          } else if (
+            connectorItem &&
+            connectorInboxLeaseToken &&
+            execution.connectorInboxLeaseToken !== connectorInboxLeaseToken
+          ) {
+            await adoptConnectorInboxLease(execution, connectorItem)
           }
         } catch (err) {
           // Another renderer may have won the workflow claim. It will

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1129,6 +1129,7 @@ export async function executeWorkflow(
       status: n.type === 'trigger' ? 'success' : 'pending'
     })),
     triggerTaskId: context?.task?.id,
+    connectorInboxId: context?.connectorItem?.inboxId,
     dedupeParams,
     inputs: context?.inputs
   }
@@ -1225,7 +1226,18 @@ export async function stopWorkflowRun(runId: string): Promise<void> {
       completedAt: now,
       status: 'cancelled',
       sessionsLaunched: sessionIds.size
-    })
+    }),
+    ...(execution.connectorInboxId !== undefined
+      ? [
+          window.api.completeConnectorInbox({
+            id: execution.connectorInboxId,
+            // Stop is an explicit user decision, not a transient failure that
+            // should relaunch the agents after backoff.
+            disposition: 'processed',
+            error: 'Workflow stopped by user'
+          })
+        ]
+      : [])
   ])
   console.log(`[workflow] run ${runId} stopped by user`)
 }
@@ -1480,14 +1492,27 @@ async function runExecution(
   }
 
   // Report completion to main process for schedule log + workflow status update
-  await window.api.reportWorkflowComplete({
-    workflowId: workflow.id,
-    workflowName: workflow.name,
-    completedAt: execution.completedAt!,
-    status: execution.status,
-    sessionsLaunched: actionNodeCount,
-    source: options?.source
-  })
+  await Promise.all([
+    window.api.reportWorkflowComplete({
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      completedAt: execution.completedAt!,
+      status: execution.status,
+      sessionsLaunched: actionNodeCount,
+      source: options?.source
+    }),
+    ...(execution.connectorInboxId !== undefined
+      ? [
+          window.api.completeConnectorInbox({
+            id: execution.connectorInboxId,
+            disposition: execution.status === 'success' ? 'processed' : 'retry',
+            ...(execution.status !== 'success' && {
+              error: `Workflow finished with status ${execution.status}`
+            })
+          })
+        ]
+      : [])
+  ])
 
   if (Notification.permission === 'granted') {
     new Notification('Vorn', {

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -13,6 +13,7 @@ import {
   CreateTaskFromItemConfig,
   CallConnectorActionConfig,
   TaskConfig,
+  ConnectorItemContext,
   getProjectRemoteHostId
 } from '../../shared/types'
 import { resolveContextField, resolveTemplateVars, StepOutputs } from './template-vars'
@@ -49,6 +50,79 @@ interface ActiveRun {
 }
 
 const activeRuns = new Map<string, ActiveRun>()
+const connectorLeaseHeartbeats = new Map<string, ReturnType<typeof setInterval>>()
+const restoredConnectorMonitors = new Map<string, ReturnType<typeof setInterval>>()
+const terminalConnectorDecisions = new Set<string>()
+const CONNECTOR_LEASE_RENEW_INTERVAL_MS = 60_000
+const RESTORED_CONNECTOR_POLL_INTERVAL_MS = 5_000
+
+function startConnectorLeaseHeartbeat(execution: WorkflowExecution): void {
+  const inboxId = execution.connectorInboxId
+  const leaseToken = execution.connectorInboxLeaseToken
+  if (inboxId === undefined || !leaseToken || connectorLeaseHeartbeats.has(execution.runId)) {
+    return
+  }
+  const timer = setInterval(() => {
+    void window.api
+      .renewConnectorInbox({
+        id: inboxId,
+        leaseToken
+      })
+      .then((renewed) => {
+        if (!renewed) stopConnectorLeaseHeartbeat(execution.runId)
+      })
+      .catch((err) => console.warn('[connector] failed to renew inbox lease:', err))
+  }, CONNECTOR_LEASE_RENEW_INTERVAL_MS)
+  connectorLeaseHeartbeats.set(execution.runId, timer)
+}
+
+function stopConnectorLeaseHeartbeat(runId: string): void {
+  const timer = connectorLeaseHeartbeats.get(runId)
+  if (timer) clearInterval(timer)
+  connectorLeaseHeartbeats.delete(runId)
+}
+
+function stopRestoredConnectorMonitor(runId: string): void {
+  const timer = restoredConnectorMonitors.get(runId)
+  if (timer) clearInterval(timer)
+  restoredConnectorMonitors.delete(runId)
+}
+
+function monitorRestoredConnectorExecution(execution: WorkflowExecution): void {
+  if (
+    execution.connectorInboxId === undefined ||
+    !execution.connectorInboxLeaseToken ||
+    restoredConnectorMonitors.has(execution.runId)
+  ) {
+    return
+  }
+  let reconciling = false
+  const timer = setInterval(() => {
+    if (reconciling) return
+    reconciling = true
+    void reconcileRunningExecutions([execution]).finally(() => {
+      reconciling = false
+    })
+  }, RESTORED_CONNECTOR_POLL_INTERVAL_MS)
+  restoredConnectorMonitors.set(execution.runId, timer)
+}
+
+async function acknowledgeReconciledConnectorExecution(
+  execution: WorkflowExecution
+): Promise<void> {
+  if (execution.connectorInboxId === undefined || !execution.connectorInboxLeaseToken) return
+  await window.api.completeConnectorInbox({
+    id: execution.connectorInboxId,
+    leaseToken: execution.connectorInboxLeaseToken,
+    disposition:
+      execution.connectorInboxDisposition ??
+      (execution.status === 'success' ? 'processed' : 'retry'),
+    ...(execution.status !== 'success' &&
+      execution.connectorInboxDisposition !== 'processed' && {
+        error: `Workflow recovered with status ${execution.status}`
+      })
+  })
+}
 
 /** Default ceiling for a headless step that never reports an exit. */
 export const DEFAULT_STEP_TIMEOUT_MINUTES = 60
@@ -118,7 +192,13 @@ export async function reconcileRunningExecutions(
   executions: Iterable<WorkflowExecution>
 ): Promise<void> {
   for (const execution of executions) {
-    if (execution.completedAt && execution.status !== 'running') continue
+    if (execution.completedAt && execution.status !== 'running') {
+      stopConnectorLeaseHeartbeat(execution.runId)
+      stopRestoredConnectorMonitor(execution.runId)
+      await acknowledgeReconciledConnectorExecution(execution)
+      continue
+    }
+    startConnectorLeaseHeartbeat(execution)
 
     let dirty = false
     let anyStillRunning = false
@@ -151,6 +231,7 @@ export async function reconcileRunningExecutions(
         ns.error = 'Run abandoned (no session id recorded)'
         ns.completedAt = new Date().toISOString()
         dirty = true
+        anyResolvedHere = true
       } else if (probe.kind === 'exited') {
         const meta = (probe.exitEvent.metadata as { exitCode?: number } | undefined) ?? {}
         const exitCode = typeof meta.exitCode === 'number' ? meta.exitCode : 0
@@ -187,9 +268,30 @@ export async function reconcileRunningExecutions(
       dirty = true
     }
 
+    const hasWaitingGate = execution.nodeStates.some((ns) => ns.status === 'waiting')
+    if (runningNodes.length === 0 && !hasWaitingGate && execution.status === 'running') {
+      for (const ns of execution.nodeStates) {
+        if (ns.status === 'pending') {
+          ns.status = 'error'
+          ns.completedAt = new Date().toISOString()
+          ns.error = 'Renderer reload abandoned this run; re-run to continue'
+        }
+      }
+      execution.status = 'error'
+      execution.completedAt = new Date().toISOString()
+      dirty = true
+    }
+
     if (dirty) {
       useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
       await window.api.saveWorkflowRun(execution)
+    }
+    if (execution.status !== 'running') {
+      stopConnectorLeaseHeartbeat(execution.runId)
+      stopRestoredConnectorMonitor(execution.runId)
+      await acknowledgeReconciledConnectorExecution(execution)
+    } else if (anyStillRunning) {
+      monitorRestoredConnectorExecution(execution)
     }
   }
 }
@@ -205,6 +307,7 @@ export function rescheduleWaitingGateTimers(
 ): void {
   const now = Date.now()
   for (const execution of executions) {
+    if (execution.status === 'running') startConnectorLeaseHeartbeat(execution)
     const workflow = workflows.find((w) => w.id === execution.workflowId)
     if (!workflow) continue
     for (const ns of execution.nodeStates) {
@@ -1129,7 +1232,9 @@ export async function executeWorkflow(
       status: n.type === 'trigger' ? 'success' : 'pending'
     })),
     triggerTaskId: context?.task?.id,
+    connectorItem: context?.connectorItem,
     connectorInboxId: context?.connectorItem?.inboxId,
+    connectorInboxLeaseToken: context?.connectorItem?.inboxLeaseToken,
     dedupeParams,
     inputs: context?.inputs
   }
@@ -1207,6 +1312,9 @@ export async function stopWorkflowRun(runId: string): Promise<void> {
   }
   execution.status = 'cancelled'
   execution.completedAt = now
+  execution.connectorInboxDisposition = 'processed'
+  stopConnectorLeaseHeartbeat(runId)
+  stopRestoredConnectorMonitor(runId)
   persistExecution(execution)
 
   // Release immediately rather than at the dedupe window's expiry, so stopping
@@ -1227,10 +1335,11 @@ export async function stopWorkflowRun(runId: string): Promise<void> {
       status: 'cancelled',
       sessionsLaunched: sessionIds.size
     }),
-    ...(execution.connectorInboxId !== undefined
+    ...(execution.connectorInboxId !== undefined && execution.connectorInboxLeaseToken
       ? [
           window.api.completeConnectorInbox({
             id: execution.connectorInboxId,
+            leaseToken: execution.connectorInboxLeaseToken,
             // Stop is an explicit user decision, not a transient failure that
             // should relaunch the agents after backoff.
             disposition: 'processed',
@@ -1268,6 +1377,7 @@ async function runExecution(
     execution
   }
   activeRuns.set(execution.runId, active)
+  startConnectorLeaseHeartbeat(execution)
 
   const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]))
   const { successors: successorsMap, predecessors: predecessorsMap } = buildGraph(workflow.edges)
@@ -1454,7 +1564,15 @@ async function runExecution(
     }
   }
 
+  if (execution.connectorInboxId !== undefined) {
+    execution.connectorInboxDisposition =
+      execution.status === 'success' || terminalConnectorDecisions.has(execution.runId)
+        ? 'processed'
+        : 'retry'
+  }
   persistExecution(execution)
+  stopConnectorLeaseHeartbeat(execution.runId)
+  stopRestoredConnectorMonitor(execution.runId)
 
   if (workflow.autoCleanupWorktrees) {
     // Skip 'inherited' worktrees: a contextual workflow reused the parent
@@ -1501,18 +1619,21 @@ async function runExecution(
       sessionsLaunched: actionNodeCount,
       source: options?.source
     }),
-    ...(execution.connectorInboxId !== undefined
+    ...(execution.connectorInboxId !== undefined && execution.connectorInboxLeaseToken
       ? [
           window.api.completeConnectorInbox({
             id: execution.connectorInboxId,
-            disposition: execution.status === 'success' ? 'processed' : 'retry',
-            ...(execution.status !== 'success' && {
-              error: `Workflow finished with status ${execution.status}`
-            })
+            leaseToken: execution.connectorInboxLeaseToken,
+            disposition: execution.connectorInboxDisposition ?? 'retry',
+            ...(execution.status !== 'success' &&
+              !terminalConnectorDecisions.has(execution.runId) && {
+                error: `Workflow finished with status ${execution.status}`
+              })
           })
         ]
       : [])
   ])
+  terminalConnectorDecisions.delete(execution.runId)
 
   if (Notification.permission === 'granted') {
     new Notification('Vorn', {
@@ -1523,18 +1644,34 @@ async function runExecution(
   return execution
 }
 
-/**
- * Only `triggerTaskId` is persisted — trigger.fromStatus/toStatus aren't,
- * so `{{trigger.fromStatus}}` template vars in post-gate nodes are empty on resume.
- */
+/** Rebuild persisted trigger context for steps after an approval gate. */
 function rebuildContextForResume(
   execution: WorkflowExecution
 ): WorkflowExecutionContext | undefined {
-  if (!execution.triggerTaskId) return undefined
-  const task = (useAppStore.getState().config?.tasks || []).find(
-    (t) => t.id === execution.triggerTaskId
-  )
-  return task ? { task } : undefined
+  const task = execution.triggerTaskId
+    ? (useAppStore.getState().config?.tasks || []).find((t) => t.id === execution.triggerTaskId)
+    : undefined
+  if (!task && !execution.connectorItem && !execution.inputs) return undefined
+  return { task, connectorItem: execution.connectorItem, inputs: execution.inputs }
+}
+
+export async function adoptConnectorInboxLease(
+  execution: WorkflowExecution,
+  connectorItem: ConnectorItemContext
+): Promise<void> {
+  if (
+    connectorItem.inboxId === undefined ||
+    !connectorItem.inboxLeaseToken ||
+    execution.connectorInboxId !== connectorItem.inboxId
+  ) {
+    return
+  }
+  stopConnectorLeaseHeartbeat(execution.runId)
+  execution.connectorItem = connectorItem
+  execution.connectorInboxLeaseToken = connectorItem.inboxLeaseToken
+  useAppStore.getState().setWorkflowExecution(execution.runId, { ...execution })
+  await window.api.saveWorkflowRun(execution)
+  startConnectorLeaseHeartbeat(execution)
 }
 
 function resolveWaitingGate(
@@ -1597,6 +1734,10 @@ export async function rejectWorkflowGate(
   const resolved = resolveWaitingGate(execution, nodeId, 'reject')
   if (!resolved) return execution
   const { workflow } = resolved
+  if (reason === 'Rejected by user') {
+    terminalConnectorDecisions.add(execution.runId)
+    execution.connectorInboxDisposition = 'processed'
+  }
 
   const now = new Date().toISOString()
   updateNodeState(execution, nodeId, {

--- a/tests/connector-paging.test.ts
+++ b/tests/connector-paging.test.ts
@@ -62,4 +62,27 @@ describe('forEachConnectorItem', () => {
       )
     ).rejects.toThrow(/did not advance/)
   })
+
+  it('rejects a connector that cannot list items at all', async () => {
+    await expect(forEachConnectorItem(connector({}), {}, () => {})).rejects.toThrow(
+      /does not support listItems/
+    )
+  })
+
+  it('stops an endlessly paging connector instead of looping forever', async () => {
+    let page = 0
+    await expect(
+      forEachConnectorItem(
+        connector({
+          listItemsPage: vi.fn().mockImplementation(async () => ({
+            items: [],
+            nextCursor: `page-${++page}`,
+            hasMore: true
+          }))
+        }),
+        {},
+        () => {}
+      )
+    ).rejects.toThrow(/exceeded 1000 backfill pages/)
+  })
 })

--- a/tests/connector-paging.test.ts
+++ b/tests/connector-paging.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ExternalItem, VornConnector } from '../packages/shared/src/types'
+import { forEachConnectorItem } from '../packages/server/src/connectors/paging'
+
+const item = (id: string): ExternalItem => ({
+  externalId: id,
+  url: `https://example.test/${id}`,
+  title: id,
+  description: '',
+  status: 'open',
+  updatedAt: '2026-08-04T00:00:00Z'
+})
+
+const connector = (overrides: Partial<VornConnector>): VornConnector => ({
+  id: 'test',
+  name: 'Test',
+  icon: 'plug',
+  capabilities: ['tasks'],
+  describe: () => ({ auth: [] }),
+  ...overrides
+})
+
+describe('forEachConnectorItem', () => {
+  it('drains every bounded page in order', async () => {
+    const listItemsPage = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [item('1')], nextCursor: 'page-2', hasMore: true })
+      .mockResolvedValueOnce({ items: [item('2')], hasMore: false })
+    const seen: string[] = []
+
+    await forEachConnectorItem(connector({ listItemsPage }), {}, (value) =>
+      seen.push(value.externalId)
+    )
+
+    expect(seen).toEqual(['1', '2'])
+    expect(listItemsPage).toHaveBeenNthCalledWith(1, {}, undefined)
+    expect(listItemsPage).toHaveBeenNthCalledWith(2, {}, 'page-2')
+  })
+
+  it('supports a legacy one-shot listItems connector', async () => {
+    const seen: string[] = []
+    await forEachConnectorItem(
+      connector({ listItems: vi.fn().mockResolvedValue([item('1')]) }),
+      {},
+      (value) => seen.push(value.externalId)
+    )
+    expect(seen).toEqual(['1'])
+  })
+
+  it('rejects a paged connector that cannot make progress', async () => {
+    await expect(
+      forEachConnectorItem(
+        connector({
+          listItemsPage: vi.fn().mockResolvedValue({
+            items: [],
+            nextCursor: 'same',
+            hasMore: true
+          })
+        }),
+        {},
+        () => {}
+      )
+    ).rejects.toThrow(/did not advance/)
+  })
+})

--- a/tests/database-connector-inbox.test.ts
+++ b/tests/database-connector-inbox.test.ts
@@ -14,7 +14,9 @@ import {
   dbRecordConnectorPollPage,
   dbReleaseConnectorInboxLeases,
   dbRetryConnectorInbox,
-  initTestDatabase
+  initTestDatabase,
+  loadConfig,
+  saveConfig
 } from '../packages/server/src/database'
 
 let teardown: () => void
@@ -75,7 +77,7 @@ afterEach(() => teardown())
 describe('durable connector inbox', () => {
   it('persists events and their cursor as one poll page', () => {
     expect(record('wf-issues', 'cursor-1', ['1', '2'])).toBe(2)
-    expect(dbGetConnectorPollCursor('wf-issues')).toBe('cursor-1')
+    expect(dbGetConnectorPollCursor('wf-issues', connection.id)).toBe('cursor-1')
 
     const claimed = dbClaimConnectorInbox({
       now: '2026-08-04T01:00:00.000Z',
@@ -89,7 +91,7 @@ describe('durable connector inbox', () => {
   it('deduplicates an overlapping remote page without losing the checkpoint', () => {
     expect(record('wf-issues', 'cursor-1', ['1', '2'])).toBe(2)
     expect(record('wf-issues', 'cursor-2', ['2', '3'])).toBe(1)
-    expect(dbGetConnectorPollCursor('wf-issues')).toBe('cursor-2')
+    expect(dbGetConnectorPollCursor('wf-issues', connection.id)).toBe('cursor-2')
 
     const claimed = dbClaimConnectorInbox({
       now: '2026-08-04T01:00:00.000Z',
@@ -102,8 +104,33 @@ describe('durable connector inbox', () => {
   it('keeps independent cursors for workflows on one connection', () => {
     record('wf-issues', 'issue-cursor', [])
     record('wf-prs', 'pr-cursor', [])
-    expect(dbGetConnectorPollCursor('wf-issues')).toBe('issue-cursor')
-    expect(dbGetConnectorPollCursor('wf-prs')).toBe('pr-cursor')
+    expect(dbGetConnectorPollCursor('wf-issues', connection.id)).toBe('issue-cursor')
+    expect(dbGetConnectorPollCursor('wf-prs', connection.id)).toBe('pr-cursor')
+  })
+
+  it('resets the cursor and dedupe scope when a workflow changes connection', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const secondConnection = { ...connection, id: 'conn-2', name: 'owner/other' }
+    dbInsertSourceConnection(secondConnection)
+
+    expect(dbGetConnectorPollCursor('wf-issues', secondConnection.id)).toBeUndefined()
+    expect(
+      dbRecordConnectorPollPage({
+        workflowId: 'wf-issues',
+        connectionId: secondConnection.id,
+        connectorId: secondConnection.connectorId,
+        cursor: 'cursor-2',
+        polledAt: '2026-08-04T02:00:00.000Z',
+        events: [
+          {
+            eventId: '1',
+            eventType: 'issueCreated',
+            eventTimestamp: '2026-08-04T01:30:00.000Z',
+            connectorItem: { ...item('1'), connectionId: secondConnection.id }
+          }
+        ]
+      })
+    ).toBe(1)
   })
 
   it('does not reclaim a completed item', () => {
@@ -113,7 +140,7 @@ describe('durable connector inbox', () => {
       leaseUntil: '2026-08-04T02:00:00.000Z',
       limit: 10
     })
-    dbCompleteConnectorInbox(claimed.id, '2026-08-04T01:01:00.000Z')
+    dbCompleteConnectorInbox(claimed.id, claimed.leaseToken, '2026-08-04T01:01:00.000Z')
     expect(
       dbClaimConnectorInbox({
         now: '2026-08-04T03:00:00.000Z',
@@ -132,6 +159,7 @@ describe('durable connector inbox', () => {
     })
     dbRetryConnectorInbox({
       id: claimed.id,
+      leaseToken: claimed.leaseToken,
       error: 'workflow failed',
       now: '2026-08-04T01:00:00.000Z'
     })
@@ -160,7 +188,7 @@ describe('durable connector inbox', () => {
       limit: 10
     })
     expect(claimed.attempts).toBe(1)
-    dbDeferConnectorInbox(claimed.id, '2026-08-04T01:00:30.000Z')
+    dbDeferConnectorInbox(claimed.id, claimed.leaseToken, '2026-08-04T01:00:30.000Z')
     const [reclaimed] = dbClaimConnectorInbox({
       now: '2026-08-04T01:00:30.000Z',
       leaseUntil: '2026-08-05T01:00:00.000Z',
@@ -184,5 +212,45 @@ describe('durable connector inbox', () => {
         limit: 10
       })[0].attempts
     ).toBe(2)
+  })
+
+  it('ignores acknowledgements from an expired lease owner', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const [first] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T01:01:00.000Z',
+      limit: 10
+    })
+    const [second] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:01:00.000Z',
+      leaseUntil: '2026-08-04T01:06:00.000Z',
+      limit: 10
+    })
+
+    expect(second.leaseToken).not.toBe(first.leaseToken)
+    expect(dbDeferConnectorInbox(first.id, first.leaseToken, '2026-08-04T01:01:30.000Z')).toBe(
+      false
+    )
+    expect(dbCompleteConnectorInbox(second.id, second.leaseToken, '2026-08-04T01:02:00.000Z')).toBe(
+      true
+    )
+  })
+
+  it('preserves inbox rows and poll cursors when saving an existing workflow', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const config = loadConfig()
+    config.workflows = config.workflows?.map((entry) =>
+      entry.id === 'wf-issues' ? { ...entry, name: 'Renamed' } : entry
+    )
+    saveConfig(config)
+
+    expect(dbGetConnectorPollCursor('wf-issues', connection.id)).toBe('cursor-1')
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T01:00:00.000Z',
+        leaseUntil: '2026-08-04T01:05:00.000Z',
+        limit: 10
+      })
+    ).toHaveLength(1)
   })
 })

--- a/tests/database-connector-inbox.test.ts
+++ b/tests/database-connector-inbox.test.ts
@@ -7,16 +7,22 @@ import type {
 import {
   dbClaimConnectorInbox,
   dbCompleteConnectorInbox,
+  dbCountActiveConnectorInboxLeases,
   dbDeferConnectorInbox,
   dbGetConnectorPollCursor,
+  dbGetWorkflowRunByConnectorInboxId,
   dbInsertSourceConnection,
   dbInsertWorkflow,
+  dbListSourceConnections,
+  dbRecordConnectorPollError,
   dbRecordConnectorPollPage,
   dbReleaseConnectorInboxLeases,
+  dbRenewConnectorInboxLease,
   dbRetryConnectorInbox,
   initTestDatabase,
   loadConfig,
-  saveConfig
+  saveConfig,
+  saveWorkflowRun
 } from '../packages/server/src/database'
 
 let teardown: () => void
@@ -252,5 +258,69 @@ describe('durable connector inbox', () => {
         limit: 10
       })
     ).toHaveLength(1)
+  })
+
+  it('renews only the lease its current owner holds', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const [claimed] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T01:05:00.000Z',
+      limit: 10
+    })
+
+    expect(
+      dbRenewConnectorInboxLease(claimed.id, claimed.leaseToken, '2026-08-04T01:10:00.000Z')
+    ).toBe(true)
+    expect(dbRenewConnectorInboxLease(claimed.id, 'stale-token', '2026-08-04T01:20:00.000Z')).toBe(
+      false
+    )
+    // The renewal held the row past the original expiry.
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T01:06:00.000Z',
+        leaseUntil: '2026-08-04T01:11:00.000Z',
+        limit: 10
+      })
+    ).toEqual([])
+  })
+
+  it('counts only unexpired leases so delivery stays within capacity', () => {
+    record('wf-issues', 'cursor-1', ['1', '2'])
+    dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T01:05:00.000Z',
+      limit: 10
+    })
+
+    expect(dbCountActiveConnectorInboxLeases('2026-08-04T01:01:00.000Z')).toBe(2)
+    expect(dbCountActiveConnectorInboxLeases('2026-08-04T01:06:00.000Z')).toBe(0)
+  })
+
+  it('records a poll failure without disturbing the last good cursor', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    dbRecordConnectorPollError({
+      workflowId: 'wf-issues',
+      connectionId: connection.id,
+      error: 'rate limited',
+      polledAt: '2026-08-04T01:05:00.000Z'
+    })
+
+    expect(dbGetConnectorPollCursor('wf-issues', connection.id)).toBe('cursor-1')
+    expect(dbListSourceConnections()[0].lastSyncError).toBe('rate limited')
+  })
+
+  it('finds the run that already owns an inbox row', () => {
+    saveWorkflowRun({
+      runId: 'run-inbox-9',
+      workflowId: 'wf-issues',
+      startedAt: '2026-08-04T01:00:00.000Z',
+      status: 'running',
+      connectorInboxId: 9,
+      connectorInboxLeaseToken: 'lease-9',
+      nodeStates: []
+    })
+
+    expect(dbGetWorkflowRunByConnectorInboxId(9)?.runId).toBe('run-inbox-9')
+    expect(dbGetWorkflowRunByConnectorInboxId(404)).toBeNull()
   })
 })

--- a/tests/database-connector-inbox.test.ts
+++ b/tests/database-connector-inbox.test.ts
@@ -309,6 +309,39 @@ describe('durable connector inbox', () => {
     expect(dbListSourceConnections()[0].lastSyncError).toBe('rate limited')
   })
 
+  it('drops the old cursor when the first poll on a new connection fails', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const secondConnection = { ...connection, id: 'conn-2', name: 'owner/other' }
+    dbInsertSourceConnection(secondConnection)
+
+    dbRecordConnectorPollError({
+      workflowId: 'wf-issues',
+      connectionId: secondConnection.id,
+      error: 'unauthorized',
+      polledAt: '2026-08-04T01:05:00.000Z'
+    })
+
+    expect(dbGetConnectorPollCursor('wf-issues', secondConnection.id)).toBeUndefined()
+  })
+
+  it('leases each ready row at most once per claim window', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const first = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T01:05:00.000Z',
+      limit: 10
+    })
+    const second = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T01:05:00.000Z',
+      limit: 10
+    })
+
+    expect(first).toHaveLength(1)
+    expect(second).toEqual([])
+    expect(first[0].attempts).toBe(1)
+  })
+
   it('finds the run that already owns an inbox row', () => {
     saveWorkflowRun({
       runId: 'run-inbox-9',

--- a/tests/database-connector-inbox.test.ts
+++ b/tests/database-connector-inbox.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type {
+  ConnectorItemContext,
+  SourceConnection,
+  WorkflowDefinition
+} from '../packages/shared/src/types'
+import {
+  dbClaimConnectorInbox,
+  dbCompleteConnectorInbox,
+  dbDeferConnectorInbox,
+  dbGetConnectorPollCursor,
+  dbInsertSourceConnection,
+  dbInsertWorkflow,
+  dbRecordConnectorPollPage,
+  dbReleaseConnectorInboxLeases,
+  dbRetryConnectorInbox,
+  initTestDatabase
+} from '../packages/server/src/database'
+
+let teardown: () => void
+
+const workflow = (id: string): WorkflowDefinition => ({
+  id,
+  name: id,
+  icon: 'Plug',
+  iconColor: '#fff',
+  enabled: true,
+  nodes: [],
+  edges: []
+})
+
+const connection: SourceConnection = {
+  id: 'conn-1',
+  connectorId: 'github',
+  name: 'owner/repo',
+  filters: { owner: 'owner', repo: 'repo' },
+  syncIntervalMinutes: 5,
+  statusMapping: {},
+  createdAt: '2026-08-04T00:00:00.000Z'
+}
+
+const item = (externalId: string): ConnectorItemContext => ({
+  connectionId: connection.id,
+  connectorId: connection.connectorId,
+  externalId,
+  title: `Item ${externalId}`,
+  raw: { externalId, title: `Item ${externalId}` }
+})
+
+function record(workflowId: string, cursor: string, externalIds: string[]): number {
+  return dbRecordConnectorPollPage({
+    workflowId,
+    connectionId: connection.id,
+    connectorId: connection.connectorId,
+    cursor,
+    polledAt: '2026-08-04T01:00:00.000Z',
+    events: externalIds.map((externalId) => ({
+      eventId: externalId,
+      eventType: 'issueCreated',
+      eventTimestamp: '2026-08-04T00:30:00.000Z',
+      connectorItem: item(externalId)
+    }))
+  })
+}
+
+beforeEach(() => {
+  teardown = initTestDatabase()
+  dbInsertSourceConnection(connection)
+  dbInsertWorkflow(workflow('wf-issues'))
+  dbInsertWorkflow(workflow('wf-prs'))
+})
+
+afterEach(() => teardown())
+
+describe('durable connector inbox', () => {
+  it('persists events and their cursor as one poll page', () => {
+    expect(record('wf-issues', 'cursor-1', ['1', '2'])).toBe(2)
+    expect(dbGetConnectorPollCursor('wf-issues')).toBe('cursor-1')
+
+    const claimed = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T02:00:00.000Z',
+      limit: 10
+    })
+    expect(claimed.map((entry) => entry.connectorItem.externalId)).toEqual(['1', '2'])
+    expect(claimed.every((entry) => entry.attempts === 1)).toBe(true)
+  })
+
+  it('deduplicates an overlapping remote page without losing the checkpoint', () => {
+    expect(record('wf-issues', 'cursor-1', ['1', '2'])).toBe(2)
+    expect(record('wf-issues', 'cursor-2', ['2', '3'])).toBe(1)
+    expect(dbGetConnectorPollCursor('wf-issues')).toBe('cursor-2')
+
+    const claimed = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T02:00:00.000Z',
+      limit: 10
+    })
+    expect(claimed.map((entry) => entry.connectorItem.externalId)).toEqual(['1', '2', '3'])
+  })
+
+  it('keeps independent cursors for workflows on one connection', () => {
+    record('wf-issues', 'issue-cursor', [])
+    record('wf-prs', 'pr-cursor', [])
+    expect(dbGetConnectorPollCursor('wf-issues')).toBe('issue-cursor')
+    expect(dbGetConnectorPollCursor('wf-prs')).toBe('pr-cursor')
+  })
+
+  it('does not reclaim a completed item', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const [claimed] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T02:00:00.000Z',
+      limit: 10
+    })
+    dbCompleteConnectorInbox(claimed.id, '2026-08-04T01:01:00.000Z')
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T03:00:00.000Z',
+        leaseUntil: '2026-08-04T04:00:00.000Z',
+        limit: 10
+      })
+    ).toEqual([])
+  })
+
+  it('retries a failed item only after its backoff', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const [claimed] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T02:00:00.000Z',
+      limit: 10
+    })
+    dbRetryConnectorInbox({
+      id: claimed.id,
+      error: 'workflow failed',
+      now: '2026-08-04T01:00:00.000Z'
+    })
+
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T01:00:59.000Z',
+        leaseUntil: '2026-08-04T02:00:00.000Z',
+        limit: 10
+      })
+    ).toEqual([])
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T01:01:00.000Z',
+        leaseUntil: '2026-08-04T02:00:00.000Z',
+        limit: 10
+      })[0].attempts
+    ).toBe(2)
+  })
+
+  it('defers an unaccepted item without counting a workflow attempt', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    const [claimed] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-05T01:00:00.000Z',
+      limit: 10
+    })
+    expect(claimed.attempts).toBe(1)
+    dbDeferConnectorInbox(claimed.id, '2026-08-04T01:00:30.000Z')
+    const [reclaimed] = dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:30.000Z',
+      leaseUntil: '2026-08-05T01:00:00.000Z',
+      limit: 10
+    })
+    expect(reclaimed.attempts).toBe(1)
+  })
+
+  it('releases leases immediately after a server restart', () => {
+    record('wf-issues', 'cursor-1', ['1'])
+    dbClaimConnectorInbox({
+      now: '2026-08-04T01:00:00.000Z',
+      leaseUntil: '2026-08-04T02:00:00.000Z',
+      limit: 10
+    })
+    dbReleaseConnectorInboxLeases('2026-08-04T01:01:00.000Z')
+    expect(
+      dbClaimConnectorInbox({
+        now: '2026-08-04T01:01:00.000Z',
+        leaseUntil: '2026-08-04T02:00:00.000Z',
+        limit: 10
+      })[0].attempts
+    ).toBe(2)
+  })
+})

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -83,11 +83,29 @@ describe('workflow run persistence', () => {
       startedAt: '2026-04-20T10:00:00Z',
       status: 'running',
       connectorInboxId: 73,
+      connectorInboxLeaseToken: 'lease-73',
+      connectorItem: {
+        inboxId: 73,
+        inboxLeaseToken: 'lease-73',
+        connectionId: 'conn-1',
+        connectorId: 'github',
+        externalId: 'issue-73',
+        title: 'Persist me',
+        raw: { number: 73 }
+      },
       nodeStates: [{ nodeId: 'approval', status: 'waiting' }]
     }
 
     saveWorkflowRun(exec)
-    expect(listWorkflowRuns('wf-connector')[0].connectorInboxId).toBe(73)
+    expect(listWorkflowRuns('wf-connector')[0]).toMatchObject({
+      connectorInboxId: 73,
+      connectorInboxLeaseToken: 'lease-73',
+      connectorItem: {
+        externalId: 'issue-73',
+        title: 'Persist me',
+        raw: { number: 73 }
+      }
+    })
   })
 
   it('omits fields that were not set', () => {
@@ -104,6 +122,32 @@ describe('workflow run persistence', () => {
     expect(state.agentType).toBeUndefined()
     expect(state.projectName).toBeUndefined()
     expect(state.projectPath).toBeUndefined()
+  })
+
+  it('never trims a running connector execution needed for restart recovery', () => {
+    saveWorkflowRun({
+      runId: 'active-connector-run',
+      workflowId: 'wf-trim',
+      startedAt: '2026-04-20T00:00:00Z',
+      status: 'running',
+      connectorInboxId: 500,
+      connectorInboxLeaseToken: 'lease-500',
+      nodeStates: [{ nodeId: 'agent', status: 'running' }]
+    })
+    for (let index = 0; index < 50; index++) {
+      saveWorkflowRun({
+        runId: `completed-${index}`,
+        workflowId: 'wf-trim',
+        startedAt: `2026-04-21T00:${String(index).padStart(2, '0')}:00Z`,
+        completedAt: `2026-04-21T00:${String(index).padStart(2, '0')}:30Z`,
+        status: 'success',
+        nodeStates: []
+      })
+    }
+
+    expect(
+      listWorkflowRuns('wf-trim', 100).some((run) => run.runId === 'active-connector-run')
+    ).toBe(true)
   })
 })
 

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -77,6 +77,19 @@ describe('workflow run persistence', () => {
     expect(runs[0].nodeStates[0].diagnostics).toBe(timeline)
   })
 
+  it('round-trips the connector inbox row across approval-gate resumes', () => {
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-connector',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'running',
+      connectorInboxId: 73,
+      nodeStates: [{ nodeId: 'approval', status: 'waiting' }]
+    }
+
+    saveWorkflowRun(exec)
+    expect(listWorkflowRuns('wf-connector')[0].connectorInboxId).toBe(73)
+  })
+
   it('omits fields that were not set', () => {
     const exec: WorkflowExecution = {
       workflowId: 'wf-2',

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -149,6 +149,32 @@ describe('workflow run persistence', () => {
       listWorkflowRuns('wf-trim', 100).some((run) => run.runId === 'active-connector-run')
     ).toBe(true)
   })
+
+  it('trims a finished connector run whose inbox row is already gone', () => {
+    saveWorkflowRun({
+      runId: 'orphan-connector-run',
+      workflowId: 'wf-orphan',
+      startedAt: '2026-04-20T00:00:00Z',
+      completedAt: '2026-04-20T00:00:30Z',
+      status: 'success',
+      connectorInboxId: 900,
+      nodeStates: []
+    })
+    for (let index = 0; index < 60; index++) {
+      saveWorkflowRun({
+        runId: `later-${index}`,
+        workflowId: 'wf-orphan',
+        startedAt: `2026-04-21T00:${String(index).padStart(2, '0')}:00Z`,
+        completedAt: `2026-04-21T00:${String(index).padStart(2, '0')}:30Z`,
+        status: 'success',
+        nodeStates: []
+      })
+    }
+
+    const runs = listWorkflowRuns('wf-orphan', 200)
+    expect(runs.some((run) => run.runId === 'orphan-connector-run')).toBe(false)
+    expect(runs.length).toBeLessThanOrEqual(51)
+  })
 })
 
 function configWithWorkflows(

--- a/tests/github-connector.test.ts
+++ b/tests/github-connector.test.ts
@@ -172,6 +172,28 @@ describe('github connector — listItems()', () => {
     const items = await gh.listItems!({ owner: 'owner', repo: 'repo' })
     expect(items.map((i) => i.title)).toEqual(['Real issue'])
   })
+
+  it('exposes resumable pages for complete reconciliation', async () => {
+    const raw = Array.from({ length: 100 }, (_, index) => ({
+      number: index + 1,
+      title: `Issue ${index + 1}`,
+      body: '',
+      state: 'open',
+      html_url: '',
+      updated_at: '2026-08-04T00:00:00Z',
+      created_at: '2026-08-04T00:00:00Z',
+      labels: [],
+      assignee: null
+    }))
+    setExecFileResponse(JSON.stringify(raw))
+    const gh = await importGithub()
+    const page = await gh.listItemsPage!({ owner: 'o', repo: 'r' }, '2')
+    expect(page.items).toHaveLength(100)
+    expect(page).toMatchObject({ hasMore: true, nextCursor: '3' })
+    const endpoint = execFileMock.mock.calls[0][1][1] as string
+    expect(endpoint).toContain('per_page=100')
+    expect(endpoint).toContain('page=2')
+  })
 })
 
 describe('github connector — getItem()', () => {
@@ -220,64 +242,85 @@ describe('github connector — poll()', () => {
     expect(result.events).toEqual([])
   })
 
-  it('issueCreated: filters to new items and advances cursor to now when under page cap', async () => {
+  it('issueCreated: includes items closed while offline and advances when caught up', async () => {
     setExecFileResponse(
-      JSON.stringify([
-        {
-          number: 1,
-          title: 'New',
-          body: 'b',
-          state: 'open',
-          html_url: '',
-          updated_at: '2026-04-24T10:05:00Z',
-          created_at: '2026-04-24T10:05:00Z',
-          labels: [],
-          assignee: null
-        }
-      ])
+      JSON.stringify({
+        total_count: 1,
+        items: [
+          {
+            number: 1,
+            title: 'New, then closed',
+            body: 'b',
+            state: 'closed',
+            html_url: '',
+            updated_at: '2026-04-24T10:06:00Z',
+            created_at: '2026-04-24T10:05:00Z',
+            labels: [],
+            assignee: null
+          }
+        ]
+      })
     )
     const gh = await importGithub()
     const result = await gh.poll!('issueCreated', { owner: 'o', repo: 'r' }, '2026-04-24T10:00:00Z')
     expect(result.events).toHaveLength(1)
     expect(result.events[0].id).toBe('1')
-    // No page cap → advance cursor to now (any ISO timestamp).
+    expect(result.events[0].data.status).toBe('closed')
+    expect(result.hasMore).toBe(false)
     expect(typeof result.nextCursor).toBe('string')
     expect(result.nextCursor).not.toBe('2026-04-24T10:05:00Z')
+    const endpoint = execFileMock.mock.calls[0][1][1] as string
+    expect(endpoint).toContain('search/issues?')
+    expect(decodeURIComponent(endpoint)).toContain('is:issue')
+    expect(decodeURIComponent(endpoint)).toContain('created:>2026-04-24T10:00:00Z')
   })
 
-  it('issueCreated: advances cursor only to the oldest seen item when page cap fills', async () => {
-    // Construct 30 items, descending by created_at. Newest at index 0, oldest at index 29.
-    const items = Array.from({ length: 30 }, (_, i) => ({
-      number: 30 - i,
-      title: `issue ${30 - i}`,
+  it('issueCreated: returns a resumable next page instead of skipping a backlog', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      title: `issue ${i + 1}`,
       body: '',
       state: 'open',
       html_url: '',
       updated_at: '',
-      created_at: `2026-04-24T10:${String(30 - i).padStart(2, '0')}:00Z`,
+      created_at: `2026-04-24T10:${String(Math.floor(i / 60)).padStart(2, '0')}:${String(
+        i % 60
+      ).padStart(2, '0')}Z`,
       labels: [],
       assignee: null
     }))
-    setExecFileResponse(JSON.stringify(items))
+    setExecFileResponse(JSON.stringify({ total_count: 250, items }))
 
     const gh = await importGithub()
     const result = await gh.poll!('issueCreated', { owner: 'o', repo: 'r' }, '2026-04-24T09:59:00Z')
-    expect(result.events).toHaveLength(30)
-    // Oldest of the processed items is the last in descending order.
-    expect(result.nextCursor).toBe('2026-04-24T10:01:00Z')
+    expect(result.events).toHaveLength(100)
+    expect(result.hasMore).toBe(true)
+    expect(JSON.parse(result.nextCursor!)).toEqual({
+      since: '2026-04-24T09:59:00Z',
+      page: 2
+    })
   })
 
   it('prOpened: maps PRs into trigger events', async () => {
     setExecFileResponse(
-      JSON.stringify([
-        {
-          number: 7,
-          title: 'Cool PR',
-          html_url: 'https://github.com/o/r/pull/7',
-          created_at: '2026-04-24T11:00:00Z',
-          user: { login: 'dev' }
-        }
-      ])
+      JSON.stringify({
+        total_count: 1,
+        items: [
+          {
+            number: 7,
+            title: 'Cool PR',
+            body: 'description',
+            state: 'merged',
+            html_url: 'https://github.com/o/r/pull/7',
+            updated_at: '2026-04-24T12:00:00Z',
+            created_at: '2026-04-24T11:00:00Z',
+            labels: [],
+            assignee: null,
+            user: { login: 'dev' },
+            pull_request: {}
+          }
+        ]
+      })
     )
     const gh = await importGithub()
     // Pin the `since` cursor so the test stays deterministic regardless of
@@ -289,8 +332,30 @@ describe('github connector — poll()', () => {
     expect(result.events[0].data).toMatchObject({
       number: 7,
       title: 'Cool PR',
+      state: 'merged',
       author: 'dev'
     })
+  })
+
+  it('resumes the exact search page encoded in the cursor', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 150, items: [] }))
+    const gh = await importGithub()
+    await gh.poll!(
+      'issueCreated',
+      { owner: 'o', repo: 'r' },
+      JSON.stringify({ since: '2026-04-24T10:00:00Z', page: 2 })
+    )
+    const endpoint = execFileMock.mock.calls[0][1][1] as string
+    expect(endpoint).toContain('page=2')
+  })
+
+  it('normalizes cursor timestamps to GitHub search precision', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 0, items: [] }))
+    const gh = await importGithub()
+    await gh.poll!('issueCreated', { owner: 'o', repo: 'r' }, '2026-04-24T10:00:00.987Z')
+    const endpoint = decodeURIComponent(execFileMock.mock.calls[0][1][1] as string)
+    expect(endpoint).toContain('created:>2026-04-24T10:00:00Z')
+    expect(endpoint).not.toContain('.987Z')
   })
 
   it('unknown trigger type returns empty', async () => {

--- a/tests/github-connector.test.ts
+++ b/tests/github-connector.test.ts
@@ -358,6 +358,92 @@ describe('github connector — poll()', () => {
     expect(endpoint).not.toContain('.987Z')
   })
 
+  it('scopes the search query with quoted label filters', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 0, items: [] }))
+    const gh = await importGithub()
+    await gh.poll!(
+      'issueCreated',
+      { owner: 'o', repo: 'r', labels: 'bug, needs "triage" ' },
+      '2026-04-24T10:00:00Z'
+    )
+    const endpoint = decodeURIComponent(execFileMock.mock.calls[0][1][1] as string)
+    expect(endpoint).toContain('label:"bug"')
+    expect(endpoint).toContain('label:"needs+\\"triage\\""')
+  })
+
+  it('rolls the time window over once the 1,000-result search cap is reached', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      title: `issue ${i + 1}`,
+      body: '',
+      state: 'open',
+      html_url: '',
+      updated_at: '',
+      created_at: i === 99 ? '2026-04-24T11:00:10Z' : '2026-04-24T10:30:00Z',
+      labels: [],
+      assignee: null
+    }))
+    setExecFileResponse(JSON.stringify({ total_count: 5000, items }))
+    const gh = await importGithub()
+    const result = await gh.poll!(
+      'issueCreated',
+      { owner: 'o', repo: 'r' },
+      JSON.stringify({ since: '2026-04-24T10:00:00Z', page: 10 })
+    )
+    expect(result.hasMore).toBe(true)
+    expect(JSON.parse(result.nextCursor!)).toEqual({
+      since: '2026-04-24T11:00:09.000Z',
+      page: 1
+    })
+  })
+
+  it('fails loudly when the capped search page comes back empty', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 5000, items: [] }))
+    const gh = await importGithub()
+    await expect(
+      gh.poll!(
+        'issueCreated',
+        { owner: 'o', repo: 'r' },
+        JSON.stringify({ since: '2026-04-24T10:00:00Z', page: 10 })
+      )
+    ).rejects.toThrow(/empty page/)
+  })
+
+  it('fails loudly when more than 1,000 items share the cursor timestamp', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      title: `issue ${i + 1}`,
+      body: '',
+      state: 'open',
+      html_url: '',
+      updated_at: '',
+      created_at: '2026-04-24T10:00:00Z',
+      labels: [],
+      assignee: null
+    }))
+    setExecFileResponse(JSON.stringify({ total_count: 5000, items }))
+    const gh = await importGithub()
+    await expect(
+      gh.poll!(
+        'issueCreated',
+        { owner: 'o', repo: 'r' },
+        JSON.stringify({ since: '2026-04-24T10:00:00Z', page: 10 })
+      )
+    ).rejects.toThrow(/cannot advance safely/)
+  })
+
+  it('rejects a corrupt cursor timestamp instead of querying everything', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 0, items: [] }))
+    const gh = await importGithub()
+    await expect(
+      gh.poll!(
+        'issueCreated',
+        { owner: 'o', repo: 'r' },
+        JSON.stringify({ since: 'not-a-timestamp', page: 1 })
+      )
+    ).rejects.toThrow(/Invalid GitHub poll cursor timestamp/)
+  })
+
   it('does not advance when GitHub reports incomplete search results', async () => {
     setExecFileResponse(JSON.stringify({ total_count: 1, incomplete_results: true, items: [] }))
     const gh = await importGithub()

--- a/tests/github-connector.test.ts
+++ b/tests/github-connector.test.ts
@@ -272,7 +272,7 @@ describe('github connector — poll()', () => {
     const endpoint = execFileMock.mock.calls[0][1][1] as string
     expect(endpoint).toContain('search/issues?')
     expect(decodeURIComponent(endpoint)).toContain('is:issue')
-    expect(decodeURIComponent(endpoint)).toContain('created:>2026-04-24T10:00:00Z')
+    expect(decodeURIComponent(endpoint)).toContain('created:>2026-04-24T09:59:59Z')
   })
 
   it('issueCreated: returns a resumable next page instead of skipping a backlog', async () => {
@@ -349,13 +349,21 @@ describe('github connector — poll()', () => {
     expect(endpoint).toContain('page=2')
   })
 
-  it('normalizes cursor timestamps to GitHub search precision', async () => {
+  it('overlaps the previous second at GitHub search precision', async () => {
     setExecFileResponse(JSON.stringify({ total_count: 0, items: [] }))
     const gh = await importGithub()
     await gh.poll!('issueCreated', { owner: 'o', repo: 'r' }, '2026-04-24T10:00:00.987Z')
     const endpoint = decodeURIComponent(execFileMock.mock.calls[0][1][1] as string)
-    expect(endpoint).toContain('created:>2026-04-24T10:00:00Z')
+    expect(endpoint).toContain('created:>2026-04-24T09:59:59Z')
     expect(endpoint).not.toContain('.987Z')
+  })
+
+  it('does not advance when GitHub reports incomplete search results', async () => {
+    setExecFileResponse(JSON.stringify({ total_count: 1, incomplete_results: true, items: [] }))
+    const gh = await importGithub()
+    await expect(
+      gh.poll!('issueCreated', { owner: 'o', repo: 'r' }, '2026-04-24T10:00:00Z')
+    ).rejects.toThrow(/incomplete results/)
   })
 
   it('unknown trigger type returns empty', async () => {

--- a/tests/scheduler-connector-poll.test.ts
+++ b/tests/scheduler-connector-poll.test.ts
@@ -13,12 +13,15 @@ const {
   loadConfigMock,
   dbGetSourceConnectionMock,
   dbGetConnectorPollCursorMock,
+  dbGetWorkflowRunByConnectorInboxIdMock,
   dbRecordConnectorPollPageMock,
   dbRecordConnectorPollErrorMock,
   dbClaimConnectorInboxMock,
+  dbCountActiveConnectorInboxLeasesMock,
   dbCompleteConnectorInboxMock,
   dbRetryConnectorInboxMock,
   dbDeferConnectorInboxMock,
+  dbRenewConnectorInboxLeaseMock,
   clientRegistryMock,
   connectorGetMock,
   pollMcpConnectionMock
@@ -26,12 +29,15 @@ const {
   loadConfigMock: vi.fn(),
   dbGetSourceConnectionMock: vi.fn(),
   dbGetConnectorPollCursorMock: vi.fn(),
+  dbGetWorkflowRunByConnectorInboxIdMock: vi.fn(),
   dbRecordConnectorPollPageMock: vi.fn(),
   dbRecordConnectorPollErrorMock: vi.fn(),
   dbClaimConnectorInboxMock: vi.fn(),
+  dbCountActiveConnectorInboxLeasesMock: vi.fn(),
   dbCompleteConnectorInboxMock: vi.fn(),
   dbRetryConnectorInboxMock: vi.fn(),
   dbDeferConnectorInboxMock: vi.fn(),
+  dbRenewConnectorInboxLeaseMock: vi.fn(),
   clientRegistryMock: { size: 1 },
   connectorGetMock: vi.fn(),
   pollMcpConnectionMock: vi.fn()
@@ -58,12 +64,15 @@ vi.mock('../packages/server/src/database', async (importOriginal) => {
     ...actual,
     dbGetSourceConnection: dbGetSourceConnectionMock,
     dbGetConnectorPollCursor: dbGetConnectorPollCursorMock,
+    dbGetWorkflowRunByConnectorInboxId: dbGetWorkflowRunByConnectorInboxIdMock,
     dbRecordConnectorPollPage: dbRecordConnectorPollPageMock,
     dbRecordConnectorPollError: dbRecordConnectorPollErrorMock,
     dbClaimConnectorInbox: dbClaimConnectorInboxMock,
+    dbCountActiveConnectorInboxLeases: dbCountActiveConnectorInboxLeasesMock,
     dbCompleteConnectorInbox: dbCompleteConnectorInboxMock,
     dbRetryConnectorInbox: dbRetryConnectorInboxMock,
-    dbDeferConnectorInbox: dbDeferConnectorInboxMock
+    dbDeferConnectorInbox: dbDeferConnectorInboxMock,
+    dbRenewConnectorInboxLease: dbRenewConnectorInboxLeaseMock
   }
 })
 vi.mock('../packages/server/src/connectors', async (importOriginal) => {
@@ -133,13 +142,18 @@ beforeEach(() => {
   dbGetSourceConnectionMock.mockReset()
   dbGetConnectorPollCursorMock.mockReset()
   dbGetConnectorPollCursorMock.mockReturnValue(undefined)
+  dbGetWorkflowRunByConnectorInboxIdMock.mockReset()
+  dbGetWorkflowRunByConnectorInboxIdMock.mockReturnValue(null)
   dbRecordConnectorPollPageMock.mockReset()
   dbRecordConnectorPollErrorMock.mockReset()
   dbClaimConnectorInboxMock.mockReset()
   dbClaimConnectorInboxMock.mockReturnValue([])
+  dbCountActiveConnectorInboxLeasesMock.mockReset()
+  dbCountActiveConnectorInboxLeasesMock.mockReturnValue(0)
   dbCompleteConnectorInboxMock.mockReset()
   dbRetryConnectorInboxMock.mockReset()
   dbDeferConnectorInboxMock.mockReset()
+  dbRenewConnectorInboxLeaseMock.mockReset()
   clientRegistryMock.size = 1
   connectorGetMock.mockReset()
   pollMcpConnectionMock.mockReset()
@@ -243,6 +257,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     dbClaimConnectorInboxMock.mockReturnValue([
       {
         id: 11,
+        leaseToken: 'lease-11',
         workflowId: 'wf-items',
         connectorItem: {
           connectionId: 'conn-1',
@@ -254,6 +269,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
       },
       {
         id: 12,
+        leaseToken: 'lease-12',
         workflowId: 'wf-items',
         connectorItem: {
           connectionId: 'conn-1',
@@ -269,6 +285,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
       workflowId: string
       connectorItem?: unknown
       connectorInboxId?: number
+      connectorInboxLeaseToken?: string
     }> = []
     const listener = (
       _ch: string,
@@ -286,6 +303,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     expect(emitted[0].connectorItem).toMatchObject({ externalId: '1', title: 'A' })
     expect(emitted[1].connectorItem).toMatchObject({ externalId: '2', title: 'B' })
     expect(emitted.map((event) => event.connectorInboxId)).toEqual([11, 12])
+    expect(emitted.map((event) => event.connectorInboxLeaseToken)).toEqual(['lease-11', 'lease-12'])
   })
 
   it('drains every bounded remote page before dispatching the inbox', async () => {
@@ -336,6 +354,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     const wf = makePollWorkflow('wf-stuck')
     loadConfigMock.mockReturnValue({ workflows: [wf] })
     dbGetSourceConnectionMock.mockReturnValue(makeConn({ syncCursor: 'same' }))
+    dbGetConnectorPollCursorMock.mockReturnValue('same')
     connectorGetMock.mockReturnValue({
       poll: vi.fn().mockResolvedValue({ events: [], nextCursor: 'same', hasMore: true })
     })
@@ -350,22 +369,103 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
   })
 
   it('acknowledges success and backs off workflow failures', () => {
-    scheduler.completeConnectorInbox(41, 'processed')
-    expect(dbCompleteConnectorInboxMock).toHaveBeenCalledWith(41, expect.any(String))
+    scheduler.completeConnectorInbox(41, 'lease-41', 'processed')
+    expect(dbCompleteConnectorInboxMock).toHaveBeenCalledWith(41, 'lease-41', expect.any(String))
 
-    scheduler.completeConnectorInbox(42, 'retry', 'agent failed')
+    scheduler.completeConnectorInbox(42, 'lease-42', 'retry', 'agent failed')
     expect(dbRetryConnectorInboxMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 42, error: 'agent failed' })
+      expect.objectContaining({ id: 42, leaseToken: 'lease-42', error: 'agent failed' })
     )
 
-    scheduler.completeConnectorInbox(43, 'defer')
-    expect(dbDeferConnectorInboxMock).toHaveBeenCalledWith(43, expect.any(String))
+    scheduler.completeConnectorInbox(43, 'lease-43', 'defer')
+    expect(dbDeferConnectorInboxMock).toHaveBeenCalledWith(43, 'lease-43', expect.any(String))
   })
 
   it('leaves inbox rows unclaimed while no renderer is connected', () => {
     clientRegistryMock.size = 0
     scheduler.deliverPendingConnectorInbox()
     expect(dbClaimConnectorInboxMock).not.toHaveBeenCalled()
+  })
+
+  it('claims only the remaining global delivery capacity', () => {
+    dbCountActiveConnectorInboxLeasesMock.mockReturnValue(49)
+
+    scheduler.deliverPendingConnectorInbox()
+
+    expect(dbClaimConnectorInboxMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 1 }))
+  })
+
+  it('redelivers a leased row with its persisted running execution', () => {
+    dbClaimConnectorInboxMock.mockReturnValue([
+      {
+        id: 51,
+        leaseToken: 'lease-51',
+        workflowId: 'wf-items',
+        connectorItem: {
+          connectionId: 'conn-1',
+          connectorId: 'github',
+          externalId: '51',
+          title: 'A',
+          raw: {}
+        }
+      }
+    ])
+    dbGetWorkflowRunByConnectorInboxIdMock.mockReturnValue({
+      runId: 'run-51',
+      workflowId: 'wf-items',
+      startedAt: '2026-04-24T10:00:00Z',
+      status: 'running',
+      connectorInboxId: 51,
+      nodeStates: [{ nodeId: 'approval', status: 'waiting' }]
+    })
+    const listener = vi.fn()
+    scheduler.on('client-message', listener)
+
+    scheduler.deliverPendingConnectorInbox()
+
+    scheduler.off('client-message', listener)
+    expect(listener).toHaveBeenCalledWith(
+      'scheduler:execute',
+      expect.objectContaining({
+        connectorInboxLeaseToken: 'lease-51',
+        existingExecution: expect.objectContaining({ runId: 'run-51' })
+      })
+    )
+  })
+
+  it('finishes a redelivered row whose persisted run already succeeded', () => {
+    dbClaimConnectorInboxMock.mockReturnValue([
+      {
+        id: 52,
+        leaseToken: 'lease-52',
+        workflowId: 'wf-items',
+        connectorItem: {
+          connectionId: 'conn-1',
+          connectorId: 'github',
+          externalId: '52',
+          title: 'B',
+          raw: {}
+        }
+      }
+    ])
+    dbGetWorkflowRunByConnectorInboxIdMock.mockReturnValue({
+      runId: 'run-52',
+      workflowId: 'wf-items',
+      startedAt: '2026-04-24T10:00:00Z',
+      completedAt: '2026-04-24T10:01:00Z',
+      status: 'success',
+      connectorInboxId: 52,
+      connectorInboxDisposition: 'processed',
+      nodeStates: []
+    })
+    const listener = vi.fn()
+    scheduler.on('client-message', listener)
+
+    scheduler.deliverPendingConnectorInbox()
+
+    scheduler.off('client-message', listener)
+    expect(dbCompleteConnectorInboxMock).toHaveBeenCalledWith(52, 'lease-52', expect.any(String))
+    expect(listener).not.toHaveBeenCalled()
   })
 
   it('skips silently when the connection was deleted between scheduling and firing', async () => {
@@ -434,7 +534,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     // pollMcpConnection called with the full connection + cursor.
     expect(pollMcpConnectionMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'conn-1', connectorId: 'mcp' }),
-      'c0'
+      undefined
     )
     expect(dbRecordConnectorPollPageMock).toHaveBeenCalledWith(
       expect.objectContaining({ workflowId: 'wf-mcp', connectionId: 'conn-1', cursor: 't1' })

--- a/tests/scheduler-connector-poll.test.ts
+++ b/tests/scheduler-connector-poll.test.ts
@@ -12,13 +12,27 @@ import type {
 const {
   loadConfigMock,
   dbGetSourceConnectionMock,
-  dbUpdateSourceConnectionMock,
+  dbGetConnectorPollCursorMock,
+  dbRecordConnectorPollPageMock,
+  dbRecordConnectorPollErrorMock,
+  dbClaimConnectorInboxMock,
+  dbCompleteConnectorInboxMock,
+  dbRetryConnectorInboxMock,
+  dbDeferConnectorInboxMock,
+  clientRegistryMock,
   connectorGetMock,
   pollMcpConnectionMock
 } = vi.hoisted(() => ({
   loadConfigMock: vi.fn(),
   dbGetSourceConnectionMock: vi.fn(),
-  dbUpdateSourceConnectionMock: vi.fn(),
+  dbGetConnectorPollCursorMock: vi.fn(),
+  dbRecordConnectorPollPageMock: vi.fn(),
+  dbRecordConnectorPollErrorMock: vi.fn(),
+  dbClaimConnectorInboxMock: vi.fn(),
+  dbCompleteConnectorInboxMock: vi.fn(),
+  dbRetryConnectorInboxMock: vi.fn(),
+  dbDeferConnectorInboxMock: vi.fn(),
+  clientRegistryMock: { size: 1 },
   connectorGetMock: vi.fn(),
   pollMcpConnectionMock: vi.fn()
 }))
@@ -35,12 +49,21 @@ vi.mock('node-cron', () => ({
 vi.mock('../packages/server/src/config-manager', () => ({
   configManager: { loadConfig: loadConfigMock, saveConfig: vi.fn(), notifyChanged: vi.fn() }
 }))
+vi.mock('../packages/server/src/broadcast', () => ({
+  clientRegistry: clientRegistryMock
+}))
 vi.mock('../packages/server/src/database', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     dbGetSourceConnection: dbGetSourceConnectionMock,
-    dbUpdateSourceConnection: dbUpdateSourceConnectionMock
+    dbGetConnectorPollCursor: dbGetConnectorPollCursorMock,
+    dbRecordConnectorPollPage: dbRecordConnectorPollPageMock,
+    dbRecordConnectorPollError: dbRecordConnectorPollErrorMock,
+    dbClaimConnectorInbox: dbClaimConnectorInboxMock,
+    dbCompleteConnectorInbox: dbCompleteConnectorInboxMock,
+    dbRetryConnectorInbox: dbRetryConnectorInboxMock,
+    dbDeferConnectorInbox: dbDeferConnectorInboxMock
   }
 })
 vi.mock('../packages/server/src/connectors', async (importOriginal) => {
@@ -108,7 +131,16 @@ function makePollWorkflow(id = 'wf-1'): WorkflowDefinition {
 beforeEach(() => {
   loadConfigMock.mockReset()
   dbGetSourceConnectionMock.mockReset()
-  dbUpdateSourceConnectionMock.mockReset()
+  dbGetConnectorPollCursorMock.mockReset()
+  dbGetConnectorPollCursorMock.mockReturnValue(undefined)
+  dbRecordConnectorPollPageMock.mockReset()
+  dbRecordConnectorPollErrorMock.mockReset()
+  dbClaimConnectorInboxMock.mockReset()
+  dbClaimConnectorInboxMock.mockReturnValue([])
+  dbCompleteConnectorInboxMock.mockReset()
+  dbRetryConnectorInboxMock.mockReset()
+  dbDeferConnectorInboxMock.mockReset()
+  clientRegistryMock.size = 1
   connectorGetMock.mockReset()
   pollMcpConnectionMock.mockReset()
   // Clean up any stale lock files from previous tests to avoid the minute-key
@@ -147,9 +179,12 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     // dispatchConnectorPoll is async; flush microtasks.
     await new Promise((r) => setImmediate(r))
 
-    expect(dbUpdateSourceConnectionMock).toHaveBeenCalledWith(
-      'conn-1',
-      expect.objectContaining({ syncCursor: '2026-04-24T10:05:00Z', lastSyncError: undefined })
+    expect(dbRecordConnectorPollPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'wf-ok',
+        connectionId: 'conn-1',
+        cursor: '2026-04-24T10:05:00Z'
+      })
     )
   })
 
@@ -172,9 +207,12 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     scheduler.off('client-message', listener)
 
     // Scheduler should record the error without emitting a bounce event.
-    expect(dbUpdateSourceConnectionMock).toHaveBeenCalledWith(
-      'conn-1',
-      expect.objectContaining({ lastSyncError: 'gh network down' })
+    expect(dbRecordConnectorPollErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'wf-err',
+        connectionId: 'conn-1',
+        error: 'gh network down'
+      })
     )
     expect(emitted.length).toBe(0)
   })
@@ -202,8 +240,36 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
         nextCursor: 'now'
       })
     })
+    dbClaimConnectorInboxMock.mockReturnValue([
+      {
+        id: 11,
+        workflowId: 'wf-items',
+        connectorItem: {
+          connectionId: 'conn-1',
+          connectorId: 'github',
+          externalId: '1',
+          title: 'A',
+          raw: {}
+        }
+      },
+      {
+        id: 12,
+        workflowId: 'wf-items',
+        connectorItem: {
+          connectionId: 'conn-1',
+          connectorId: 'github',
+          externalId: '2',
+          title: 'B',
+          raw: {}
+        }
+      }
+    ])
 
-    const emitted: Array<{ workflowId: string; connectorItem?: unknown }> = []
+    const emitted: Array<{
+      workflowId: string
+      connectorItem?: unknown
+      connectorInboxId?: number
+    }> = []
     const listener = (
       _ch: string,
       payload: { workflowId: string; connectorItem?: unknown }
@@ -219,6 +285,87 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     expect(emitted).toHaveLength(2)
     expect(emitted[0].connectorItem).toMatchObject({ externalId: '1', title: 'A' })
     expect(emitted[1].connectorItem).toMatchObject({ externalId: '2', title: 'B' })
+    expect(emitted.map((event) => event.connectorInboxId)).toEqual([11, 12])
+  })
+
+  it('drains every bounded remote page before dispatching the inbox', async () => {
+    const wf = makePollWorkflow('wf-pages')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(makeConn())
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({
+        events: [{ id: '1', type: 'issueCreated', data: { title: 'A' }, timestamp: 't1' }],
+        nextCursor: 'page-2',
+        hasMore: true
+      })
+      .mockResolvedValueOnce({
+        events: [{ id: '2', type: 'issueCreated', data: { title: 'B' }, timestamp: 't2' }],
+        nextCursor: 'caught-up',
+        hasMore: false
+      })
+    connectorGetMock.mockReturnValue({ poll })
+
+    scheduler.triggerWorkflow('wf-pages')
+    await new Promise((r) => setImmediate(r))
+
+    expect(poll).toHaveBeenNthCalledWith(1, 'issueCreated', expect.anything(), undefined)
+    expect(poll).toHaveBeenNthCalledWith(2, 'issueCreated', expect.anything(), 'page-2')
+    expect(dbRecordConnectorPollPageMock).toHaveBeenCalledTimes(2)
+    expect(dbRecordConnectorPollPageMock.mock.calls[1][0]).toMatchObject({
+      cursor: 'caught-up',
+      events: [expect.objectContaining({ eventId: '2' })]
+    })
+  })
+
+  it('uses the workflow cursor instead of another subscription’s connection cursor', async () => {
+    const wf = makePollWorkflow('wf-own-cursor')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(makeConn({ syncCursor: 'legacy-shared' }))
+    dbGetConnectorPollCursorMock.mockReturnValue('workflow-specific')
+    const poll = vi.fn().mockResolvedValue({ events: [], nextCursor: 'next' })
+    connectorGetMock.mockReturnValue({ poll })
+
+    scheduler.triggerWorkflow('wf-own-cursor')
+    await new Promise((r) => setImmediate(r))
+
+    expect(poll).toHaveBeenCalledWith('issueCreated', expect.anything(), 'workflow-specific')
+  })
+
+  it('rejects hasMore when the connector does not advance its cursor', async () => {
+    const wf = makePollWorkflow('wf-stuck')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(makeConn({ syncCursor: 'same' }))
+    connectorGetMock.mockReturnValue({
+      poll: vi.fn().mockResolvedValue({ events: [], nextCursor: 'same', hasMore: true })
+    })
+
+    scheduler.triggerWorkflow('wf-stuck')
+    await new Promise((r) => setImmediate(r))
+
+    expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
+    expect(dbRecordConnectorPollErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: 'wf-stuck', error: expect.stringContaining('hasMore') })
+    )
+  })
+
+  it('acknowledges success and backs off workflow failures', () => {
+    scheduler.completeConnectorInbox(41, 'processed')
+    expect(dbCompleteConnectorInboxMock).toHaveBeenCalledWith(41, expect.any(String))
+
+    scheduler.completeConnectorInbox(42, 'retry', 'agent failed')
+    expect(dbRetryConnectorInboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42, error: 'agent failed' })
+    )
+
+    scheduler.completeConnectorInbox(43, 'defer')
+    expect(dbDeferConnectorInboxMock).toHaveBeenCalledWith(43, expect.any(String))
+  })
+
+  it('leaves inbox rows unclaimed while no renderer is connected', () => {
+    clientRegistryMock.size = 0
+    scheduler.deliverPendingConnectorInbox()
+    expect(dbClaimConnectorInboxMock).not.toHaveBeenCalled()
   })
 
   it('skips silently when the connection was deleted between scheduling and firing', async () => {
@@ -229,7 +376,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     scheduler.triggerWorkflow('wf-gone')
     await new Promise((r) => setImmediate(r))
 
-    expect(dbUpdateSourceConnectionMock).not.toHaveBeenCalled()
+    expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
     expect(connectorGetMock).not.toHaveBeenCalled()
   })
 
@@ -242,7 +389,7 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     scheduler.triggerWorkflow('wf-nopoll')
     await new Promise((r) => setImmediate(r))
 
-    expect(dbUpdateSourceConnectionMock).not.toHaveBeenCalled()
+    expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
   })
 
   // --- MCP connections are routed through pollMcpConnection, not connector.poll ---
@@ -289,9 +436,8 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
       expect.objectContaining({ id: 'conn-1', connectorId: 'mcp' }),
       'c0'
     )
-    expect(dbUpdateSourceConnectionMock).toHaveBeenCalledWith(
-      'conn-1',
-      expect.objectContaining({ syncCursor: 't1' })
+    expect(dbRecordConnectorPollPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: 'wf-mcp', connectionId: 'conn-1', cursor: 't1' })
     )
   })
 
@@ -307,6 +453,6 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     await new Promise((r) => setImmediate(r))
 
     expect(pollMcpConnectionMock).not.toHaveBeenCalled()
-    expect(dbUpdateSourceConnectionMock).not.toHaveBeenCalled()
+    expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -40,7 +40,9 @@ vi.mock('../packages/server/src/database', () => ({
   listWorkflowRunsByTask: vi.fn(() => []),
   updateWorkflowRunStatus: vi.fn(),
   dbReleaseConnectorInboxLeases: vi.fn(),
+  dbCountActiveConnectorInboxLeases: vi.fn(() => 0),
   dbClaimConnectorInbox: vi.fn(() => []),
+  dbGetWorkflowRunByConnectorInboxId: vi.fn(() => null),
   loadWorkspaces: vi.fn(() => [])
 }))
 

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -39,6 +39,8 @@ vi.mock('../packages/server/src/database', () => ({
   listWorkflowRuns: vi.fn(() => []),
   listWorkflowRunsByTask: vi.fn(() => []),
   updateWorkflowRunStatus: vi.fn(),
+  dbReleaseConnectorInboxLeases: vi.fn(),
+  dbClaimConnectorInbox: vi.fn(() => []),
   loadWorkspaces: vi.fn(() => [])
 }))
 

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -158,6 +158,7 @@ beforeEach(() => {
     killHeadlessSession,
     saveWorkflowRun: vi.fn(() => Promise.resolve()),
     reportWorkflowComplete: vi.fn(() => Promise.resolve()),
+    completeConnectorInbox: vi.fn(() => Promise.resolve()),
     runWorkflowManual: vi.fn(() => Promise.resolve()),
     listSessionEventsBySession: vi.fn(() => Promise.resolve([])),
     getWorktreeActiveSessions: vi.fn(() => Promise.resolve({ count: 0 })),
@@ -243,6 +244,30 @@ describe('headless step completion', () => {
 })
 
 describe('run concurrency', () => {
+  it('acknowledges a durable connector event only after its workflow succeeds', async () => {
+    const wf = makeWorkflow()
+    const run = executeWorkflow(wf, {
+      connectorItem: {
+        inboxId: 73,
+        connectionId: 'conn-1',
+        connectorId: 'github',
+        externalId: 'issue-7',
+        title: 'A',
+        raw: {}
+      }
+    })
+    const sessionId = await nextSession()
+
+    expect(window.api.completeConnectorInbox).not.toHaveBeenCalled()
+    emitExit(sessionId, 0)
+    await vi.runAllTimersAsync()
+    expect((await run).status).toBe('success')
+    expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
+      id: 73,
+      disposition: 'processed'
+    })
+  })
+
   it('runs the same workflow in parallel for different trigger parameters', async () => {
     const wf = makeWorkflow()
     const ids: string[] = []
@@ -387,7 +412,16 @@ describe('stopping a run', () => {
   it('kills the run’s sessions and closes it as cancelled', async () => {
     const wf = makeWorkflow()
     mockState.config.workflows = [wf]
-    const runPromise = executeWorkflow(wf)
+    const runPromise = executeWorkflow(wf, {
+      connectorItem: {
+        inboxId: 74,
+        connectionId: 'conn-1',
+        connectorId: 'github',
+        externalId: 'issue-8',
+        title: 'B',
+        raw: {}
+      }
+    })
 
     const sessionId = await nextSession()
     await vi.advanceTimersByTimeAsync(0)
@@ -399,6 +433,11 @@ describe('stopping a run', () => {
     expect(killHeadlessSession).toHaveBeenCalledWith(sessionId)
     expect(execution.status).toBe('cancelled')
     expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.error).toBe('Stopped by user')
+    expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
+      id: 74,
+      disposition: 'processed',
+      error: 'Workflow stopped by user'
+    })
   })
 
   it('frees the trigger so the workflow can be run again right away', async () => {

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -93,7 +93,14 @@ vi.mock('../src/renderer/lib/notifications', () => ({
   sendWorkflowGateNotification: vi.fn()
 }))
 
-const { executeWorkflow, stopWorkflowRun } = await import('../src/renderer/lib/workflow-execution')
+const {
+  adoptConnectorInboxLease,
+  approveWorkflowGate,
+  executeWorkflow,
+  reconcileRunningExecutions,
+  rejectWorkflowGate,
+  stopWorkflowRun
+} = await import('../src/renderer/lib/workflow-execution')
 
 function makeWorkflow(id = 'wf-1'): WorkflowDefinition {
   return {
@@ -159,6 +166,7 @@ beforeEach(() => {
     saveWorkflowRun: vi.fn(() => Promise.resolve()),
     reportWorkflowComplete: vi.fn(() => Promise.resolve()),
     completeConnectorInbox: vi.fn(() => Promise.resolve()),
+    renewConnectorInbox: vi.fn(() => Promise.resolve(true)),
     runWorkflowManual: vi.fn(() => Promise.resolve()),
     listSessionEventsBySession: vi.fn(() => Promise.resolve([])),
     getWorktreeActiveSessions: vi.fn(() => Promise.resolve({ count: 0 })),
@@ -249,6 +257,7 @@ describe('run concurrency', () => {
     const run = executeWorkflow(wf, {
       connectorItem: {
         inboxId: 73,
+        inboxLeaseToken: 'lease-73',
         connectionId: 'conn-1',
         connectorId: 'github',
         externalId: 'issue-7',
@@ -264,6 +273,7 @@ describe('run concurrency', () => {
     expect((await run).status).toBe('success')
     expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
       id: 73,
+      leaseToken: 'lease-73',
       disposition: 'processed'
     })
   })
@@ -415,6 +425,7 @@ describe('stopping a run', () => {
     const runPromise = executeWorkflow(wf, {
       connectorItem: {
         inboxId: 74,
+        inboxLeaseToken: 'lease-74',
         connectionId: 'conn-1',
         connectorId: 'github',
         externalId: 'issue-8',
@@ -435,6 +446,7 @@ describe('stopping a run', () => {
     expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.error).toBe('Stopped by user')
     expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
       id: 74,
+      leaseToken: 'lease-74',
       disposition: 'processed',
       error: 'Workflow stopped by user'
     })
@@ -455,6 +467,130 @@ describe('stopping a run', () => {
     const sessionId = await nextSession()
     emitExit(sessionId, 0)
     expect((await second).status).toBe('success')
+  })
+})
+
+describe('rejecting an approval gate', () => {
+  it('restores connector context for steps after approval', async () => {
+    const base = makeWorkflow()
+    const agent = {
+      ...base.nodes.find((node) => node.id === 'agent')!,
+      config: {
+        ...(base.nodes.find((node) => node.id === 'agent')!.config as Record<string, unknown>),
+        prompt: 'Handle {{connectorItem.title}}'
+      }
+    }
+    const workflow = {
+      ...base,
+      nodes: [
+        base.nodes.find((node) => node.id === 'trigger')!,
+        {
+          id: 'approval',
+          type: 'approval',
+          label: 'Approve',
+          position: { x: 0, y: 1 },
+          config: {}
+        },
+        agent
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'approval' },
+        { id: 'e2', source: 'approval', target: 'agent' }
+      ]
+    } as unknown as WorkflowDefinition
+    mockState.config.workflows = [workflow]
+    const waiting = await executeWorkflow(workflow, {
+      connectorItem: {
+        inboxId: 90,
+        inboxLeaseToken: 'lease-90',
+        connectionId: 'conn-1',
+        connectorId: 'github',
+        externalId: 'issue-90',
+        title: 'Context survives',
+        raw: {}
+      }
+    })
+
+    const resumed = approveWorkflowGate(waiting, 'approval')
+    const sessionId = await nextSession()
+    emitExit(sessionId, 0)
+    await resumed
+
+    expect(createHeadlessSession.mock.calls.at(-1)?.[0].initialPrompt).toContain(
+      'Handle Context survives'
+    )
+  })
+
+  it('treats explicit rejection as a terminal connector decision', async () => {
+    const workflow = {
+      ...makeWorkflow(),
+      nodes: [
+        {
+          id: 'trigger',
+          type: 'trigger',
+          label: 'Trigger',
+          position: { x: 0, y: 0 },
+          config: {}
+        },
+        {
+          id: 'approval',
+          type: 'approval',
+          label: 'Approve',
+          position: { x: 0, y: 1 },
+          config: {}
+        }
+      ],
+      edges: [{ id: 'e1', source: 'trigger', target: 'approval' }]
+    } as unknown as WorkflowDefinition
+    mockState.config.workflows = [workflow]
+
+    const waiting = await executeWorkflow(workflow, {
+      connectorItem: {
+        inboxId: 91,
+        inboxLeaseToken: 'lease-91',
+        connectionId: 'conn-1',
+        connectorId: 'github',
+        externalId: 'issue-91',
+        title: 'Needs approval',
+        raw: {}
+      }
+    })
+    expect(waiting.nodeStates.find((node) => node.nodeId === 'approval')?.status).toBe('waiting')
+
+    await adoptConnectorInboxLease(waiting, {
+      ...waiting.connectorItem!,
+      inboxLeaseToken: 'lease-92'
+    })
+    const rejected = await rejectWorkflowGate(waiting, 'approval')
+    expect(rejected.status).toBe('error')
+    expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
+      id: 91,
+      leaseToken: 'lease-92',
+      disposition: 'processed'
+    })
+  })
+})
+
+describe('connector run recovery', () => {
+  it('acknowledges a terminal run restored after persistence', async () => {
+    const execution: WorkflowExecution = {
+      runId: 'run-restored',
+      workflowId: 'wf-restored',
+      startedAt: '2026-04-20T10:00:00Z',
+      completedAt: '2026-04-20T10:01:00Z',
+      status: 'success',
+      connectorInboxId: 101,
+      connectorInboxLeaseToken: 'lease-101',
+      nodeStates: [{ nodeId: 'agent', status: 'success' }]
+    }
+
+    await reconcileRunningExecutions([execution])
+
+    expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
+      id: 101,
+      leaseToken: 'lease-101',
+      disposition: 'processed'
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- persist connector poll pages and per-workflow cursors atomically in a durable inbox
- add bounded paging, retries, deferred delivery, renewable lease ownership, and restart reconciliation
- make GitHub issue/PR polling catch up across pagination, closed items, indexing lag, and incomplete search responses
- preserve connector state across config saves and scope cursor/deduplication state to each workflow connection

## Validation
- `npx vitest run` (199 files, 2132 tests)
- `yarn typecheck`
- strict ESLint and Prettier checks on changed files