### PR TITLE
feat(connectors): connector SDK for shareable pull connectors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,9 +256,17 @@ jobs:
           fi
           [ -f dist/latest-linux.yml ] && gh release upload "$tag" dist/latest-linux.yml --clobber
 
-  publish-mcp:
+  publish-npm:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: '@vornrun/mcp'
+            directory: packages/mcp
+          - name: '@vornrun/connector-sdk'
+            directory: packages/connector-sdk
     steps:
       - uses: actions/checkout@v7
 
@@ -279,16 +287,16 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Sync MCP version from tag
+      - name: Sync version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          cd packages/mcp && npm pkg set version="$VERSION"
+          cd "${{ matrix.directory }}" && npm pkg set version="$VERSION"
 
-      - name: Build MCP package
-        run: yarn workspace @vornrun/mcp build
+      - name: Build package
+        run: yarn workspace ${{ matrix.name }} build
 
       - name: Publish to npm
-        working-directory: packages/mcp
+        working-directory: ${{ matrix.directory }}
         run: |
           VERSION=$(node -p 'require("./package.json").version')
           TAG="${GITHUB_REF_NAME}"
@@ -299,12 +307,12 @@ jobs:
             NPM_TAG="beta"
           fi
 
-          PUBLISHED=$(npm view @vornrun/mcp version 2>/dev/null || echo "none")
+          PUBLISHED=$(npm view "${{ matrix.name }}@$VERSION" version 2>/dev/null || echo "none")
           if [ "$VERSION" = "$PUBLISHED" ]; then
             echo "Version $VERSION already published, skipping"
           else
             yarn npm publish --access public --tag "$NPM_TAG"
-            echo "Published @vornrun/mcp@$VERSION with dist-tag '$NPM_TAG'"
+            echo "Published ${{ matrix.name }}@$VERSION with dist-tag '$NPM_TAG'"
           fi
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -1,0 +1,213 @@
+# @vornrun/connector-sdk
+
+Build a Vorn pull connector in TypeScript and share it as an ordinary npm
+package. No marketplace, no plugin host, no changes to Vorn itself: a connector
+built with this SDK runs as an MCP stdio server, and Vorn's generic MCP
+connector already knows how to talk to one.
+
+```bash
+npm install @vornrun/connector-sdk
+```
+
+## Write a connector
+
+```ts
+// src/index.ts
+import { defineConnector } from '@vornrun/connector-sdk'
+
+export default defineConnector({
+  id: 'acme',
+  name: 'Acme Tickets',
+  version: '1.0.0',
+  config: [
+    { key: 'apiToken', label: 'API token', required: true, secret: true },
+    { key: 'baseUrl', label: 'Base URL', default: 'https://api.acme.test' }
+  ],
+  triggers: [
+    {
+      type: 'newTicket',
+      label: 'New ticket',
+      async poll({ config, since, limit }) {
+        const url = new URL('/tickets', config.baseUrl)
+        if (since) url.searchParams.set('updated_after', since)
+        url.searchParams.set('per_page', String(limit ?? 100))
+
+        const response = await fetch(url, {
+          headers: { authorization: `Bearer ${config.apiToken}` }
+        })
+        if (!response.ok) throw new Error(`Acme returned ${response.status}`)
+        const tickets = (await response.json()) as AcmeTicket[]
+
+        return {
+          items: tickets.map((ticket) => ({
+            externalId: ticket.id,
+            title: ticket.subject,
+            url: ticket.html_url,
+            description: ticket.body,
+            status: ticket.state,
+            updatedAt: ticket.updated_at,
+            data: { priority: ticket.priority }
+          }))
+        }
+      }
+    }
+  ],
+  actions: [
+    {
+      type: 'closeTicket',
+      label: 'Close ticket',
+      inputs: [{ key: 'id', label: 'Ticket id', required: true }],
+      // Optional: declared outputs show up in Vorn's `{{steps.…}}` autocomplete.
+      // Undeclared fields are still returned.
+      outputs: [{ key: 'closed' }],
+      async run({ id }, { config }) {
+        await fetch(`${config.baseUrl}/tickets/${id}/close`, {
+          method: 'POST',
+          headers: { authorization: `Bearer ${config.apiToken}` }
+        })
+        return { closed: id }
+      }
+    }
+  ]
+})
+```
+
+Then a two-line bin:
+
+```ts
+// src/bin.ts
+import { serveConnector } from '@vornrun/connector-sdk'
+import connector from './index'
+
+await serveConnector(connector)
+```
+
+Publish it like any other package (`"bin": { "acme-connector": "dist/bin.js" }`).
+
+## Poll a database instead of an API
+
+Nothing about a trigger is HTTP-specific — it just returns items. A SQL pull
+connector is the same shape:
+
+```ts
+import { defineConnector } from '@vornrun/connector-sdk'
+import postgres from 'postgres'
+
+export default defineConnector({
+  id: 'orders-db',
+  name: 'Orders database',
+  config: [{ key: 'databaseUrl', label: 'Database URL', required: true, secret: true }],
+  triggers: [
+    {
+      type: 'newOrder',
+      label: 'New order',
+      async poll({ config, since, limit }) {
+        const sql = postgres(config.databaseUrl!)
+        try {
+          const rows = await sql`
+            SELECT id, reference, status, updated_at
+            FROM orders
+            WHERE updated_at > ${since ?? '1970-01-01'}
+            ORDER BY updated_at ASC
+            LIMIT ${limit ?? 200}
+          `
+          return {
+            items: rows.map((row) => ({
+              externalId: row.id,
+              title: `Order ${row.reference}`,
+              status: row.status,
+              updatedAt: row.updated_at
+            }))
+          }
+        } finally {
+          await sql.end()
+        }
+      }
+    }
+  ]
+})
+```
+
+Two rules make a pull trigger reliable, and the SDK enforces both:
+
+1. `externalId` must be stable — Vorn dedupes on it, so a changing id means
+   duplicate work items.
+2. `updatedAt` must be monotonic and ISO-comparable — Vorn advances its poll
+   cursor from it. Sort ascending by that column and honor `since`.
+
+## Paging a backlog
+
+Return `hasMore: true` with a `nextCursor`, and Vorn (or `drainPoll` in tests)
+will keep pulling bounded pages until the backlog is drained:
+
+```ts
+async poll({ cursor, config }) {
+  const page = Number(cursor ?? '1')
+  const { items, totalPages } = await fetchPage(config, page)
+  return {
+    items: items.map(toItem),
+    nextCursor: String(page + 1),
+    hasMore: page < totalPages
+  }
+}
+```
+
+A cursor that does not advance is rejected rather than looped on.
+
+## Test it without running the app
+
+```ts
+import { createConnectorHarness } from '@vornrun/connector-sdk'
+import connector from '../src/index'
+
+const harness = createConnectorHarness(connector, {
+  config: { apiToken: 'test' },
+  now: () => '2026-08-05T00:00:00.000Z'
+})
+
+test('emits normalized tickets', async () => {
+  const page = await harness.poll('newTicket')
+  expect(page.items[0]).toMatchObject({ externalId: '1', status: 'open' })
+})
+
+test('does not redeliver the same backlog forever', async () => {
+  // Polls twice, carrying the watermark forward exactly as Vorn does.
+  expect(await harness.pollTwice('newTicket')).toEqual([])
+})
+```
+
+`harness.drain()` walks every page, `harness.execute()` runs an action, and
+`harness.manifest()` returns what Vorn will see.
+
+## Install it in Vorn
+
+Run the CLI to get the exact connection settings:
+
+```bash
+npx vorn-connector setup ./dist/index.js
+```
+
+It prints the values for **Settings → Connectors → MCP → New connection**:
+
+| Field      | Value                                                                                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Command    | `npx`                                                                                                                                    |
+| Arguments  | `["-y", "@your-scope/acme-connector"]`                                                                                                   |
+| Secret env | `{"API_TOKEN": "…"}`                                                                                                                     |
+| Filters    | `pollTool: poll_newTicket`, `itemsPath: items`, `idField: externalId`, `timestampField: updatedAt`, `titleField: title`, `urlField: url` |
+
+Because the connector is a normal npm package, versions are pinned by the
+`npx` argument and upgrades are a version bump — no separate registry.
+
+## CLI
+
+```
+vorn-connector manifest <module>          Print the manifest as JSON
+vorn-connector setup <module> [trigger]   Print the Vorn connection settings
+vorn-connector poll <module> <trigger>    Run one poll against the environment
+vorn-connector serve <module>             Serve on stdio (what Vorn runs)
+```
+
+`poll` accepts `--since <iso>` and `--limit <n>`, and reads the connector's
+declared config from your shell environment — the fastest way to confirm
+credentials and field mapping before wiring anything up.

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@vornrun/connector-sdk",
+  "version": "0.5.1",
+  "description": "Build and share Vorn pull connectors as ordinary npm packages",
+  "type": "module",
+  "license": "MIT",
+  "author": "Javier Canizalez <javier-canizalez@outlook.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vorn-run/vorn.git",
+    "directory": "packages/connector-sdk"
+  },
+  "keywords": [
+    "vorn",
+    "connector",
+    "mcp",
+    "model-context-protocol",
+    "integration"
+  ],
+  "bin": {
+    "vorn-connector": "dist/cli.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",
@@ -23,7 +23,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { resolveConfig } from './define'
+import { runPoll } from './runtime'
+import { connectionSetup, connectorManifest } from './setup'
+import { serveConnector } from './server'
+import type { Connector } from './types'
+
+const USAGE = `vorn-connector <command> <module> [options]
+
+Commands:
+  manifest <module>             Print the connector manifest as JSON
+  setup <module> [trigger]      Print the Vorn connection settings to paste
+  poll <module> <trigger>       Run one poll against the current environment
+  serve <module>                Serve the connector on stdio (what Vorn runs)
+
+Options:
+  --since <iso>                 Lower bound passed to poll
+  --limit <n>                   Maximum items to request`
+
+export interface CliDeps {
+  load(modulePath: string): Promise<unknown>
+  write(line: string): void
+  env?: NodeJS.ProcessEnv
+}
+
+function parseFlags(args: string[]): Record<string, string> {
+  const flags: Record<string, string> = {}
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (!arg.startsWith('--')) continue
+    const value = args[index + 1]
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`)
+    }
+    flags[arg.slice(2)] = value
+    index++
+  }
+  return flags
+}
+
+/** Accept either `export default connector` or `export const connector`. */
+function pickConnector(loaded: unknown, modulePath: string): Connector {
+  const module = loaded as Record<string, unknown> | null
+  const candidate = module?.default ?? module?.connector
+  const connector = candidate as Connector | undefined
+  if (!connector || typeof connector !== 'object' || !Array.isArray(connector.triggers)) {
+    throw new Error(
+      `${modulePath} does not export a connector built with defineConnector() (default or named "connector")`
+    )
+  }
+  return connector
+}
+
+export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
+  const [command, modulePath, ...rest] = argv
+  if (!command || command === 'help' || command === '--help') {
+    deps.write(USAGE)
+    return command ? 0 : 1
+  }
+  if (!modulePath) {
+    deps.write(`Missing <module> argument\n\n${USAGE}`)
+    return 1
+  }
+
+  const connector = pickConnector(await deps.load(modulePath), modulePath)
+  const positional = rest.filter((arg) => !arg.startsWith('--'))
+  const flags = parseFlags(rest)
+
+  switch (command) {
+    case 'manifest':
+      deps.write(JSON.stringify(connectorManifest(connector), null, 2))
+      return 0
+
+    case 'setup': {
+      const triggers = positional[0] ? [positional[0]] : connector.triggers.map((t) => t.type)
+      for (const triggerType of triggers) {
+        const setup = connectionSetup(connector, triggerType)
+        deps.write(`# ${connector.name} — ${triggerType}`)
+        deps.write(`Command: npx`)
+        deps.write(`Arguments: ["-y", "<your-package>"]`)
+        deps.write(`Filters: ${JSON.stringify(setup.filters, null, 2)}`)
+        if (setup.env.length > 0) {
+          deps.write(
+            `Environment: ${setup.env
+              .map((entry) => `${entry.name}${entry.required ? ' (required)' : ''}`)
+              .join(', ')}`
+          )
+        }
+      }
+      return 0
+    }
+
+    case 'poll': {
+      const triggerType = positional[0]
+      if (!triggerType) {
+        deps.write(`Missing <trigger> argument\n\n${USAGE}`)
+        return 1
+      }
+      const page = await runPoll(connector, triggerType, {
+        config: resolveConfig(connector, deps.env ?? process.env),
+        ...(flags.since !== undefined && { since: flags.since }),
+        ...(flags.limit !== undefined && { limit: Number(flags.limit) })
+      })
+      deps.write(JSON.stringify(page, null, 2))
+      return 0
+    }
+
+    case 'serve':
+      await serveConnector(connector)
+      return 0
+
+    default:
+      deps.write(`Unknown command "${command}"\n\n${USAGE}`)
+      return 1
+  }
+}
+
+/* c8 ignore start -- process wiring exercised by the bin, not by unit tests */
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+
+if (invokedDirectly) {
+  runCli(process.argv.slice(2), {
+    load: (modulePath) =>
+      import(
+        modulePath.startsWith('.') || modulePath.startsWith('/')
+          ? pathToFileURL(resolve(modulePath)).href
+          : modulePath
+      ),
+    write: (line) => process.stdout.write(`${line}\n`)
+  })
+    .then((code) => {
+      process.exitCode = code
+    })
+    .catch((error: unknown) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+      process.exitCode = 1
+    })
+}
+/* c8 ignore stop */

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -98,10 +98,15 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
         deps.write(`Missing <trigger> argument\n\n${USAGE}`)
         return 1
       }
+      const limit = flags.limit === undefined ? undefined : Number(flags.limit)
+      if (limit !== undefined && !Number.isFinite(limit)) {
+        deps.write(`Invalid limit "${flags.limit}"`)
+        return 1
+      }
       const page = await runPoll(connector, triggerType, {
         config: resolveConfig(connector, deps.env ?? process.env),
         ...(flags.since !== undefined && { since: flags.since }),
-        ...(flags.limit !== undefined && { limit: Number(flags.limit) })
+        ...(limit !== undefined && { limit })
       })
       deps.write(JSON.stringify(page, null, 2))
       return 0

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -1,0 +1,109 @@
+import type { Connector, ConnectorConfig, ConnectorDefinition } from './types'
+
+const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
+
+function assertUnique(kind: string, keys: string[]): void {
+  const seen = new Set<string>()
+  for (const key of keys) {
+    if (seen.has(key)) throw new Error(`Duplicate ${kind} "${key}"`)
+    seen.add(key)
+  }
+}
+
+/** Environment variable a config field reads from, e.g. `apiToken` → `API_TOKEN`. */
+export function envNameFor(key: string, explicit?: string): string {
+  if (explicit) return explicit
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[-\s]+/g, '_')
+    .toUpperCase()
+}
+
+/**
+ * Validate a connector definition and fill in its defaults.
+ *
+ * Failing here — at import time — is the whole point: a typo in a trigger
+ * type or a duplicate action key otherwise surfaces as a silently missing
+ * MCP tool once the connector is already installed in someone's app.
+ */
+export function defineConnector(definition: ConnectorDefinition): Connector {
+  if (!KEY_PATTERN.test(definition.id ?? '')) {
+    throw new Error(`Connector id "${definition.id}" must start with a letter and be url-safe`)
+  }
+  if (!definition.name?.trim()) {
+    throw new Error(`Connector ${definition.id} is missing a name`)
+  }
+
+  const triggers = definition.triggers ?? []
+  const actions = definition.actions ?? []
+  if (triggers.length === 0 && actions.length === 0) {
+    throw new Error(`Connector ${definition.id} declares no triggers and no actions`)
+  }
+
+  for (const trigger of triggers) {
+    if (!KEY_PATTERN.test(trigger.type ?? '')) {
+      throw new Error(`Trigger type "${trigger.type}" must start with a letter and be url-safe`)
+    }
+    if (typeof trigger.poll !== 'function') {
+      throw new Error(`Trigger ${trigger.type} is missing a poll() implementation`)
+    }
+  }
+  for (const action of actions) {
+    if (!KEY_PATTERN.test(action.type ?? '')) {
+      throw new Error(`Action type "${action.type}" must start with a letter and be url-safe`)
+    }
+    if (typeof action.run !== 'function') {
+      throw new Error(`Action ${action.type} is missing a run() implementation`)
+    }
+  }
+
+  assertUnique(
+    'trigger',
+    triggers.map((trigger) => trigger.type)
+  )
+  assertUnique(
+    'action',
+    actions.map((action) => action.type)
+  )
+  assertUnique(
+    'config field',
+    (definition.config ?? []).map((field) => field.key)
+  )
+
+  return {
+    ...definition,
+    version: definition.version ?? '0.0.0',
+    config: definition.config ?? [],
+    triggers,
+    actions
+  }
+}
+
+/**
+ * Read the connector's declared config out of the environment. Vorn supplies
+ * these through the connection's `env` / `secretEnv` maps, so a missing
+ * required value is a setup mistake worth reporting by name rather than
+ * letting the first API call fail with a confusing 401.
+ */
+export function resolveConfig(
+  connector: Connector,
+  env: NodeJS.ProcessEnv = process.env
+): ConnectorConfig {
+  const config: ConnectorConfig = {}
+  const missing: string[] = []
+  for (const field of connector.config) {
+    const name = envNameFor(field.key, field.env)
+    const value = env[name] ?? field.default
+    if (value === undefined || value === '') {
+      if (field.required) missing.push(`${field.key} (${name})`)
+      continue
+    }
+    config[field.key] = value
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Connector ${connector.id} is missing required configuration: ${missing.join(', ')}`
+    )
+  }
+  return config
+}

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -1,0 +1,65 @@
+import { drainPoll, runAction, runPoll, type PollPage, type RunPollOptions } from './runtime'
+import { connectorManifest, type ConnectorManifest } from './setup'
+import type { Connector, ConnectorConfig, NormalizedItem } from './types'
+
+export interface HarnessOptions {
+  config?: ConnectorConfig
+  /** Fixed clock, so `updatedAt` defaults and cursors are deterministic. */
+  now?: () => string
+}
+
+export interface ConnectorHarness {
+  poll(triggerType: string, options?: RunPollOptions): Promise<PollPage>
+  drain(triggerType: string, options?: RunPollOptions): Promise<NormalizedItem[]>
+  execute(actionType: string, args?: Record<string, unknown>): Promise<Record<string, unknown>>
+  manifest(): ConnectorManifest
+  /**
+   * Poll repeatedly the way Vorn does — carrying the newest `updatedAt`
+   * forward as the watermark — and return only items a real installation
+   * would treat as new. Catches the classic connector bug where a poll
+   * ignores its lower bound and re-delivers the same backlog forever.
+   */
+  pollTwice(triggerType: string, options?: RunPollOptions): Promise<NormalizedItem[]>
+}
+
+/**
+ * Run a connector in-process, exactly as the MCP server would, without
+ * spawning anything. Authors get real assertions in a plain unit test.
+ */
+export function createConnectorHarness(
+  connector: Connector,
+  harnessOptions: HarnessOptions = {}
+): ConnectorHarness {
+  const defaults = (options: RunPollOptions = {}): RunPollOptions => ({
+    ...(harnessOptions.config && { config: harnessOptions.config }),
+    ...(harnessOptions.now && { now: harnessOptions.now }),
+    ...options
+  })
+
+  return {
+    poll: (triggerType, options) => runPoll(connector, triggerType, defaults(options)),
+    drain: (triggerType, options) => drainPoll(connector, triggerType, defaults(options)),
+    execute: (actionType, args = {}) =>
+      runAction(connector, actionType, args, {
+        ...(harnessOptions.config && { config: harnessOptions.config }),
+        ...(harnessOptions.now && { now: harnessOptions.now })
+      }),
+    manifest: () => connectorManifest(connector),
+    async pollTwice(triggerType, options) {
+      const first = await drainPoll(connector, triggerType, defaults(options))
+      const watermark = first.reduce<string | undefined>(
+        (newest, item) =>
+          newest === undefined || item.updatedAt > newest ? item.updatedAt : newest,
+        options?.since
+      )
+      const second = await drainPoll(
+        connector,
+        triggerType,
+        defaults({ ...options, ...(watermark !== undefined && { since: watermark }) })
+      )
+      // Vorn drops anything at or before the watermark, so only strictly
+      // newer items count as redelivered work.
+      return watermark === undefined ? second : second.filter((item) => item.updatedAt > watermark)
+    }
+  }
+}

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,0 +1,24 @@
+export { defineConnector, resolveConfig, envNameFor } from './define'
+export { normalizeItem, normalizeItems } from './normalize'
+export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
+export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
+export { connectionSetup, connectorManifest, pollToolName, MANIFEST_TOOL } from './setup'
+export type { ConnectionSetup, ConnectorManifest } from './setup'
+export { createConnectorServer, serveConnector } from './server'
+export type { ConnectorServerOptions } from './server'
+export { createConnectorHarness } from './harness'
+export type { ConnectorHarness, HarnessOptions } from './harness'
+export type {
+  ActionContext,
+  ActionDefinition,
+  ActionInputField,
+  Connector,
+  ConnectorConfig,
+  ConnectorConfigField,
+  ConnectorDefinition,
+  ConnectorItem,
+  NormalizedItem,
+  PollContext,
+  PollOutcome,
+  TriggerDefinition
+} from './types'

--- a/packages/connector-sdk/src/normalize.ts
+++ b/packages/connector-sdk/src/normalize.ts
@@ -15,6 +15,13 @@ const RESERVED_KEYS = [
   'updatedAt'
 ] as const
 
+/**
+ * Keys that would mutate `Object.prototype` (or look like they do) once a
+ * consumer spreads or merges the normalized item. Dropped rather than thrown
+ * on, so a single odd column in a source system cannot stall a whole poll.
+ */
+const UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype'] as const
+
 function isoTimestamp(value: string | Date | undefined, fallback: string): string {
   if (value === undefined) return fallback
   const date = value instanceof Date ? value : new Date(value)
@@ -43,6 +50,7 @@ export function normalizeItem(item: ConnectorItem, polledAt: string): Normalized
   const extra: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(item.data ?? {})) {
     if ((RESERVED_KEYS as readonly string[]).includes(key)) continue
+    if ((UNSAFE_KEYS as readonly string[]).includes(key)) continue
     extra[key] = value
   }
 

--- a/packages/connector-sdk/src/normalize.ts
+++ b/packages/connector-sdk/src/normalize.ts
@@ -1,0 +1,77 @@
+import type { ConnectorItem, NormalizedItem } from './types'
+
+/**
+ * Reserved keys a connector item always defines. `data` may not overwrite
+ * them, because Vorn reads them by name to build its task/trigger context.
+ */
+const RESERVED_KEYS = [
+  'externalId',
+  'title',
+  'url',
+  'description',
+  'status',
+  'labels',
+  'assignee',
+  'updatedAt'
+] as const
+
+function isoTimestamp(value: string | Date | undefined, fallback: string): string {
+  if (value === undefined) return fallback
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid updatedAt: ${String(value)}`)
+  }
+  return date.toISOString()
+}
+
+/**
+ * Turn an author-supplied item into the flat JSON shape Vorn consumes.
+ *
+ * Normalizing here rather than in each connector is what lets one host-side
+ * poll configuration (`idField: externalId`, `timestampField: updatedAt`, …)
+ * work for every SDK connector.
+ */
+export function normalizeItem(item: ConnectorItem, polledAt: string): NormalizedItem {
+  const externalId = String(item.externalId ?? '').trim()
+  if (!externalId) {
+    throw new Error('Connector item is missing externalId')
+  }
+  if (!item.title || !item.title.trim()) {
+    throw new Error(`Connector item ${externalId} is missing title`)
+  }
+
+  const extra: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(item.data ?? {})) {
+    if ((RESERVED_KEYS as readonly string[]).includes(key)) continue
+    extra[key] = value
+  }
+
+  return {
+    ...extra,
+    externalId,
+    title: item.title,
+    url: item.url ?? '',
+    description: item.description ?? '',
+    status: item.status ?? 'open',
+    labels: item.labels ?? [],
+    ...(item.assignee !== undefined && { assignee: item.assignee }),
+    updatedAt: isoTimestamp(item.updatedAt, polledAt)
+  }
+}
+
+/**
+ * Normalize a page and reject duplicate ids within it. Two items sharing an
+ * id in one page means one of them would be silently dropped by Vorn's
+ * dedupe, which looks like data loss long after the fact.
+ */
+export function normalizeItems(items: ConnectorItem[], polledAt: string): NormalizedItem[] {
+  const seen = new Set<string>()
+  return items.map((item) => {
+    const normalized = normalizeItem(item, polledAt)
+    if (seen.has(normalized.externalId)) {
+      throw new Error(`Duplicate externalId "${normalized.externalId}" in one poll page`)
+    }
+    seen.add(normalized.externalId)
+    return normalized
+  })
+}

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -1,0 +1,141 @@
+import { normalizeItems } from './normalize'
+import type { Connector, ConnectorConfig, NormalizedItem, PollContext } from './types'
+
+export interface PollPage {
+  items: NormalizedItem[]
+  nextCursor?: string
+  hasMore: boolean
+}
+
+export interface RunPollOptions {
+  config?: ConnectorConfig
+  since?: string
+  cursor?: string
+  limit?: number
+  now?: () => string
+}
+
+/** Longest chain of pages `drainPoll` will follow before calling it a bug. */
+export const MAX_POLL_PAGES = 1_000
+
+/**
+ * Run one poll page and normalize it. Shared by the MCP server, the CLI and
+ * the test harness so all three observe exactly what Vorn will observe.
+ */
+export async function runPoll(
+  connector: Connector,
+  triggerType: string,
+  options: RunPollOptions = {}
+): Promise<PollPage> {
+  const trigger = connector.triggers.find((entry) => entry.type === triggerType)
+  if (!trigger) {
+    throw new Error(`Connector ${connector.id} has no trigger "${triggerType}"`)
+  }
+
+  const now = options.now ?? (() => new Date().toISOString())
+  const polledAt = now()
+  const context: PollContext = {
+    config: options.config ?? {},
+    ...(options.since !== undefined && { since: options.since }),
+    ...(options.cursor !== undefined && { cursor: options.cursor }),
+    ...(options.limit !== undefined && { limit: options.limit }),
+    now
+  }
+
+  const outcome = await trigger.poll(context)
+  if (!outcome || !Array.isArray(outcome.items)) {
+    throw new Error(`Trigger ${triggerType} did not return an items array`)
+  }
+  if (outcome.hasMore && !outcome.nextCursor) {
+    throw new Error(`Trigger ${triggerType} reported more pages without a nextCursor`)
+  }
+
+  return {
+    items: normalizeItems(outcome.items, polledAt),
+    ...(outcome.nextCursor !== undefined && { nextCursor: outcome.nextCursor }),
+    hasMore: outcome.hasMore === true
+  }
+}
+
+/**
+ * Follow `hasMore` to the end of a trigger's backlog. Mirrors how Vorn drains
+ * a connector, including its refusal to follow a cursor that does not move —
+ * so an author sees the infinite loop in a unit test instead of in the app.
+ */
+export async function drainPoll(
+  connector: Connector,
+  triggerType: string,
+  options: RunPollOptions = {}
+): Promise<NormalizedItem[]> {
+  const collected: NormalizedItem[] = []
+  let cursor = options.cursor
+  for (let page = 0; page < MAX_POLL_PAGES; page++) {
+    const result = await runPoll(connector, triggerType, { ...options, ...(cursor && { cursor }) })
+    collected.push(...result.items)
+    if (!result.hasMore) return collected
+    if (result.nextCursor === cursor) {
+      throw new Error(`Trigger ${triggerType} did not advance its cursor`)
+    }
+    cursor = result.nextCursor
+  }
+  throw new Error(`Trigger ${triggerType} exceeded ${MAX_POLL_PAGES} pages`)
+}
+
+export interface RunActionOptions {
+  config?: ConnectorConfig
+  now?: () => string
+}
+
+function coerceArg(value: unknown, type: string | undefined): unknown {
+  if (typeof value !== 'string') return value
+  if (type === 'number') {
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) throw new Error(`Expected a number, got "${value}"`)
+    return parsed
+  }
+  if (type === 'boolean') return value === 'true'
+  return value
+}
+
+/**
+ * Run an action with its declared inputs validated and coerced. Vorn renders
+ * every action argument as a template string, so numbers and booleans arrive
+ * as text and have to be converted back here.
+ */
+export async function runAction(
+  connector: Connector,
+  actionType: string,
+  args: Record<string, unknown>,
+  options: RunActionOptions = {}
+): Promise<Record<string, unknown>> {
+  const action = connector.actions.find((entry) => entry.type === actionType)
+  if (!action) {
+    throw new Error(`Connector ${connector.id} has no action "${actionType}"`)
+  }
+
+  const coerced: Record<string, unknown> = { ...args }
+  for (const input of action.inputs ?? []) {
+    const value = coerced[input.key]
+    if (value === undefined || value === '') {
+      if (input.required) throw new Error(`Action ${actionType} requires "${input.key}"`)
+      delete coerced[input.key]
+      continue
+    }
+    try {
+      coerced[input.key] = coerceArg(value, input.type)
+    } catch (error) {
+      throw new Error(
+        `Action ${actionType} argument "${input.key}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error }
+      )
+    }
+  }
+
+  const output = await action.run(coerced, {
+    config: options.config ?? {},
+    now: options.now ?? (() => new Date().toISOString())
+  })
+  return output ?? {}
+}

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -70,7 +70,10 @@ export async function drainPoll(
   const collected: NormalizedItem[] = []
   let cursor = options.cursor
   for (let page = 0; page < MAX_POLL_PAGES; page++) {
-    const result = await runPoll(connector, triggerType, { ...options, ...(cursor && { cursor }) })
+    const result = await runPoll(connector, triggerType, {
+      ...options,
+      ...(cursor !== undefined && { cursor })
+    })
     collected.push(...result.items)
     if (!result.hasMore) return collected
     if (result.nextCursor === cursor) {
@@ -93,7 +96,11 @@ function coerceArg(value: unknown, type: string | undefined): unknown {
     if (Number.isNaN(parsed)) throw new Error(`Expected a number, got "${value}"`)
     return parsed
   }
-  if (type === 'boolean') return value === 'true'
+  if (type === 'boolean') {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    throw new Error(`Expected a boolean, got "${value}"`)
+  }
   return value
 }
 

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -1,0 +1,176 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z, type ZodTypeAny } from 'zod'
+import { resolveConfig } from './define'
+import { runAction, runPoll } from './runtime'
+import { MANIFEST_TOOL, connectorManifest, pollToolName } from './setup'
+import type { ActionInputField, ActionOutputField, Connector, ConnectorConfig } from './types'
+
+function json(value: Record<string, unknown>): {
+  content: Array<{ type: 'text'; text: string }>
+  structuredContent: Record<string, unknown>
+} {
+  return {
+    // Vorn reads `structuredContent` to build step output and to find the
+    // `items` array a poll returned; the text block keeps the result readable
+    // in any generic MCP client.
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value
+  }
+}
+
+function failure(error: unknown): {
+  content: Array<{ type: 'text'; text: string }>
+  isError: true
+} {
+  return {
+    content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+    isError: true
+  }
+}
+
+function inputShape(inputs: ActionInputField[]): Record<string, ZodTypeAny> {
+  const shape: Record<string, ZodTypeAny> = {}
+  for (const input of inputs) {
+    // Vorn renders action arguments from templates, so every value arrives as
+    // a string; the declared type is applied by `runAction` instead.
+    const base = z.string().describe(input.description ?? input.label)
+    shape[input.key] = input.required ? base : base.optional()
+  }
+  return shape
+}
+
+function scalar(type: ActionOutputField['type']): ZodTypeAny {
+  if (type === 'number') return z.number()
+  if (type === 'boolean') return z.boolean()
+  return z.string()
+}
+
+/**
+ * Output schemas are always loose. An action returns whatever the upstream API
+ * gave it, and a strict schema would make the MCP client reject the call for
+ * the crime of returning an extra field.
+ */
+function outputSchema(outputs: ActionOutputField[]): ZodTypeAny {
+  const shape: Record<string, ZodTypeAny> = {}
+  for (const output of outputs) {
+    shape[output.key] = scalar(output.type)
+      .optional()
+      .describe(output.description ?? output.key)
+  }
+  return z.looseObject(shape)
+}
+
+export interface ConnectorServerOptions {
+  /** Resolved connector configuration. Defaults to reading `process.env`. */
+  config?: ConnectorConfig
+  now?: () => string
+}
+
+/**
+ * Expose a connector as an MCP server.
+ *
+ * Each trigger becomes a `poll_<type>` tool returning the normalized page,
+ * each action becomes a tool of the same name, and `vorn_connector_manifest`
+ * reports everything needed to configure the connection. That is the entire
+ * contract — Vorn's generic MCP connector consumes it with no host changes.
+ */
+export function createConnectorServer(
+  connector: Connector,
+  options: ConnectorServerOptions = {}
+): McpServer {
+  const server = new McpServer(
+    { name: connector.id, version: connector.version },
+    { capabilities: { tools: {} } }
+  )
+
+  // Resolved lazily so a missing environment variable surfaces as a tool error
+  // the user can read, rather than killing the process during MCP handshake.
+  let cached: ConnectorConfig | undefined = options.config
+  const config = (): ConnectorConfig => (cached ??= resolveConfig(connector))
+
+  server.registerTool(
+    MANIFEST_TOOL,
+    {
+      description: `Describe the ${connector.name} connector and how to configure it`,
+      inputSchema: {},
+      outputSchema: z.looseObject({})
+    },
+    () => json(connectorManifest(connector) as unknown as Record<string, unknown>)
+  )
+
+  for (const trigger of connector.triggers) {
+    server.registerTool(
+      pollToolName(trigger.type),
+      {
+        description: trigger.description ?? `Poll ${connector.name} for ${trigger.label}`,
+        inputSchema: {
+          since: z
+            .string()
+            .optional()
+            .describe('Only return items changed after this ISO timestamp'),
+          cursor: z.string().optional().describe('Opaque cursor from a previous page'),
+          limit: z.string().optional().describe('Maximum number of items to return')
+        },
+        outputSchema: z.looseObject({
+          items: z.array(z.looseObject({})).describe('Normalized items'),
+          nextCursor: z.string().optional().describe('Cursor for the next page'),
+          hasMore: z.boolean().describe('Whether another page is immediately available')
+        })
+      },
+      async (args) => {
+        try {
+          const limit = args.limit === undefined ? undefined : Number(args.limit)
+          if (limit !== undefined && !Number.isFinite(limit)) {
+            throw new Error(`Invalid limit "${args.limit}"`)
+          }
+          return json(
+            (await runPoll(connector, trigger.type, {
+              config: config(),
+              ...(args.since !== undefined && { since: args.since }),
+              ...(args.cursor !== undefined && { cursor: args.cursor }),
+              ...(limit !== undefined && { limit }),
+              ...(options.now && { now: options.now })
+            })) as unknown as Record<string, unknown>
+          )
+        } catch (error) {
+          return failure(error)
+        }
+      }
+    )
+  }
+
+  for (const action of connector.actions) {
+    server.registerTool(
+      action.type,
+      {
+        description: action.description ?? `${action.label} in ${connector.name}`,
+        inputSchema: inputShape(action.inputs ?? []),
+        outputSchema: outputSchema(action.outputs ?? [])
+      },
+      async (args) => {
+        try {
+          return json(
+            await runAction(connector, action.type, args as Record<string, unknown>, {
+              config: config(),
+              ...(options.now && { now: options.now })
+            })
+          )
+        } catch (error) {
+          return failure(error)
+        }
+      }
+    )
+  }
+
+  return server
+}
+
+/** Serve a connector on stdio. This is the one line a connector's bin needs. */
+export async function serveConnector(
+  connector: Connector,
+  options: ConnectorServerOptions = {}
+): Promise<void> {
+  const server = createConnectorServer(connector, options)
+  await server.connect(new StdioServerTransport())
+}

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -1,0 +1,99 @@
+import { envNameFor } from './define'
+import type { Connector } from './types'
+
+/** MCP tool name a trigger is served under. */
+export function pollToolName(triggerType: string): string {
+  return `poll_${triggerType}`
+}
+
+/** Tool that reports the connector's manifest and setup hints. */
+export const MANIFEST_TOOL = 'vorn_connector_manifest'
+
+export interface ConnectionSetup {
+  connectorId: string
+  triggerType: string
+  /** Values to paste into Vorn's MCP connection form. */
+  filters: {
+    pollTool: string
+    itemsPath: 'items'
+    idField: 'externalId'
+    timestampField: 'updatedAt'
+    titleField: 'title'
+    urlField: 'url'
+  }
+  /** Environment variable names the connector reads. */
+  env: Array<{ name: string; required: boolean; secret: boolean; description?: string }>
+}
+
+/**
+ * Describe how to wire one trigger into a Vorn MCP connection.
+ *
+ * Every SDK connector normalizes to the same field names, so this mapping is
+ * fixed; it is generated rather than documented so a rename in the SDK cannot
+ * drift away from the setup instructions users copy.
+ */
+export function connectionSetup(connector: Connector, triggerType: string): ConnectionSetup {
+  const trigger = connector.triggers.find((entry) => entry.type === triggerType)
+  if (!trigger) {
+    throw new Error(`Connector ${connector.id} has no trigger "${triggerType}"`)
+  }
+  return {
+    connectorId: connector.id,
+    triggerType,
+    filters: {
+      pollTool: pollToolName(triggerType),
+      itemsPath: 'items',
+      idField: 'externalId',
+      timestampField: 'updatedAt',
+      titleField: 'title',
+      urlField: 'url'
+    },
+    env: connector.config.map((field) => ({
+      name: envNameFor(field.key, field.env),
+      required: field.required === true,
+      secret: field.secret === true,
+      ...(field.description !== undefined && { description: field.description })
+    }))
+  }
+}
+
+export interface ConnectorManifest {
+  id: string
+  name: string
+  version: string
+  description?: string
+  triggers: Array<{ type: string; label: string; description?: string; setup: ConnectionSetup }>
+  actions: Array<{
+    type: string
+    label: string
+    description?: string
+    inputs: Array<{ key: string; label: string; type: string; required: boolean }>
+  }>
+}
+
+/** Full machine-readable description of a connector, served over MCP and printed by the CLI. */
+export function connectorManifest(connector: Connector): ConnectorManifest {
+  return {
+    id: connector.id,
+    name: connector.name,
+    version: connector.version,
+    ...(connector.description !== undefined && { description: connector.description }),
+    triggers: connector.triggers.map((trigger) => ({
+      type: trigger.type,
+      label: trigger.label,
+      ...(trigger.description !== undefined && { description: trigger.description }),
+      setup: connectionSetup(connector, trigger.type)
+    })),
+    actions: connector.actions.map((action) => ({
+      type: action.type,
+      label: action.label,
+      ...(action.description !== undefined && { description: action.description }),
+      inputs: (action.inputs ?? []).map((input) => ({
+        key: input.key,
+        label: input.label,
+        type: input.type ?? 'string',
+        required: input.required === true
+      }))
+    }))
+  }
+}

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -1,0 +1,142 @@
+/**
+ * Author-facing types for Vorn connectors.
+ *
+ * A connector written with this SDK runs as an ordinary MCP stdio server, so
+ * it is shared as a normal npm package and installed by pointing a Vorn
+ * connection at `npx -y <package>`. Nothing about the host app has to change
+ * to accept a new connector.
+ */
+
+/** A raw item as the author's code returns it. Only id and title are required. */
+export interface ConnectorItem {
+  /** Stable upstream identity. Vorn dedupes on this, so it must not change. */
+  externalId: string | number
+  title: string
+  url?: string
+  description?: string
+  /** Raw upstream status (`open`, `Active`, `In Progress`, …). */
+  status?: string
+  labels?: string[]
+  assignee?: string
+  /**
+   * When the item last changed. Vorn advances its poll cursor from this field,
+   * so it must be monotonic per item and comparable as an ISO 8601 string.
+   * Defaults to poll time when omitted.
+   */
+  updatedAt?: string | Date
+  /** Extra fields to expose to workflow templates as `{{trigger.item.<key>}}`. */
+  data?: Record<string, unknown>
+}
+
+/** A connector item after normalization. This is the exact JSON Vorn sees. */
+export interface NormalizedItem extends Record<string, unknown> {
+  externalId: string
+  title: string
+  url: string
+  description: string
+  status: string
+  labels: string[]
+  updatedAt: string
+  assignee?: string
+}
+
+/** Declares a value the connector needs at runtime, read from the environment. */
+export interface ConnectorConfigField {
+  key: string
+  label: string
+  /** Environment variable the value is read from. Defaults to CONSTANT_CASE(key). */
+  env?: string
+  required?: boolean
+  /** Secrets are stored encrypted by Vorn and never printed by the CLI. */
+  secret?: boolean
+  description?: string
+  default?: string
+}
+
+export type ConnectorConfig = Record<string, string | undefined>
+
+export interface PollContext {
+  config: ConnectorConfig
+  /**
+   * Lower bound the host asked for, when it was able to supply one. Treat it
+   * as a hint: returning older items is safe because Vorn dedupes, but
+   * returning fewer than everything after `since` loses events.
+   */
+  since?: string
+  /** Opaque cursor previously returned by this trigger, when supplied. */
+  cursor?: string
+  /** Upper bound on items to return in one page. */
+  limit?: number
+  /** Injectable clock so tests are deterministic. */
+  now(): string
+}
+
+export interface PollOutcome {
+  items: ConnectorItem[]
+  nextCursor?: string
+  hasMore?: boolean
+}
+
+export interface TriggerDefinition {
+  /** Event key, e.g. `workItemCreated`. Becomes the `poll_<type>` MCP tool. */
+  type: string
+  label: string
+  description?: string
+  poll(context: PollContext): Promise<PollOutcome> | PollOutcome
+}
+
+export interface ActionInputField {
+  key: string
+  label: string
+  type?: 'string' | 'number' | 'boolean'
+  required?: boolean
+  description?: string
+}
+
+/**
+ * A field the action is known to return. Declaring these is optional — extra
+ * keys always pass through — but declared fields show up in Vorn's variable
+ * autocomplete as `{{steps.<action>.<key>}}`.
+ */
+export interface ActionOutputField {
+  key: string
+  type?: 'string' | 'number' | 'boolean'
+  description?: string
+}
+
+export interface ActionContext {
+  config: ConnectorConfig
+  now(): string
+}
+
+export interface ActionDefinition {
+  /** Action key, e.g. `closeWorkItem`. Becomes an MCP tool of the same name. */
+  type: string
+  label: string
+  description?: string
+  inputs?: ActionInputField[]
+  outputs?: ActionOutputField[]
+  run(
+    args: Record<string, unknown>,
+    context: ActionContext
+  ): Promise<Record<string, unknown> | void> | Record<string, unknown> | void
+}
+
+export interface ConnectorDefinition {
+  /** Stable connector id, e.g. `azure-devops`. */
+  id: string
+  name: string
+  version?: string
+  description?: string
+  config?: ConnectorConfigField[]
+  triggers?: TriggerDefinition[]
+  actions?: ActionDefinition[]
+}
+
+/** A validated definition. Every accessor below is guaranteed non-null. */
+export interface Connector extends ConnectorDefinition {
+  readonly version: string
+  readonly config: ConnectorConfigField[]
+  readonly triggers: TriggerDefinition[]
+  readonly actions: ActionDefinition[]
+}

--- a/packages/connector-sdk/tsconfig.json
+++ b/packages/connector-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/connector-sdk/tsup.config.ts
+++ b/packages/connector-sdk/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli.ts'],
+  format: ['esm'],
+  target: 'node20',
+  dts: true,
+  clean: true,
+  // Connector authors install these themselves; bundling them would ship two
+  // copies of the MCP runtime into every connector package.
+  external: ['@modelcontextprotocol/sdk', 'zod']
+})

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -11,6 +11,7 @@ PACKAGES=(
   "packages/server"
   "packages/shared"
   "packages/mcp"
+  "packages/connector-sdk"
 )
 
 OUT_OF_SYNC=0

--- a/tests/connector-sdk-integration.test.ts
+++ b/tests/connector-sdk-integration.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import type { SourceConnection } from '../packages/shared/src/types'
+import { createConnectorServer, defineConnector } from '../packages/connector-sdk/src/index'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+const getOrStartClient = vi.fn()
+vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  getOrStartClient: (conn: SourceConnection) => getOrStartClient(conn)
+}))
+
+const NOW = '2026-08-05T00:00:00.000Z'
+
+/**
+ * The exact filters `connectionSetup()` tells a user to paste. Hard-coded here
+ * rather than imported so a change to either side of the contract fails this
+ * test instead of silently agreeing with itself.
+ */
+const SETUP_FILTERS = {
+  pollTool: 'poll_newOrder',
+  itemsPath: 'items',
+  idField: 'externalId',
+  timestampField: 'updatedAt',
+  titleField: 'title',
+  urlField: 'url'
+}
+
+const orders = [
+  { id: 'o-1', reference: 'A', updatedAt: '2026-08-04T10:00:00.000Z' },
+  { id: 'o-2', reference: 'B', updatedAt: '2026-08-04T11:00:00.000Z' }
+]
+
+const connector = defineConnector({
+  id: 'orders-db',
+  name: 'Orders database',
+  triggers: [
+    {
+      type: 'newOrder',
+      label: 'New order',
+      poll: ({ since }) => ({
+        items: orders
+          .filter((order) => !since || order.updatedAt > since)
+          .map((order) => ({
+            externalId: order.id,
+            title: `Order ${order.reference}`,
+            url: `https://erp.test/${order.id}`,
+            status: 'pending',
+            updatedAt: order.updatedAt,
+            data: { reference: order.reference }
+          }))
+      })
+    }
+  ],
+  actions: [
+    {
+      type: 'shipOrder',
+      label: 'Ship order',
+      inputs: [{ key: 'id', label: 'Order id', required: true }],
+      outputs: [{ key: 'shipped', description: 'Shipped order id' }],
+      run: ({ id }) => ({ shipped: id, trackingNumber: 'TRACK-1' })
+    }
+  ]
+})
+
+async function connectSdkServer(): Promise<Client> {
+  const server = createConnectorServer(connector, { config: {}, now: () => NOW })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'vorn', version: '1.0.0' })
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+  return client
+}
+
+async function connection(): Promise<SourceConnection> {
+  const client = await connectSdkServer()
+  getOrStartClient.mockResolvedValue(client)
+  const { discoverTools } = await import('../packages/server/src/connectors/mcp')
+  const base: SourceConnection = {
+    id: 'conn-sdk',
+    connectorId: 'mcp',
+    name: 'Orders database',
+    filters: { ...SETUP_FILTERS },
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: NOW
+  }
+  return { ...base, filters: { ...base.filters, discoveredTools: await discoverTools(base) } }
+}
+
+describe('an SDK connector behind Vorn’s MCP connector', () => {
+  it('polls into trigger events using only the generated setup filters', async () => {
+    const conn = await connection()
+    const { pollMcpConnection } = await import('../packages/server/src/connectors/mcp')
+
+    const result = await pollMcpConnection(conn)
+
+    expect(result.events.map((event) => event.id)).toEqual(['o-1', 'o-2'])
+    expect(result.nextCursor).toBe('2026-08-04T11:00:00.000Z')
+    expect(result.events[0].data).toMatchObject({
+      externalId: 'o-1',
+      title: 'Order A',
+      url: 'https://erp.test/o-1',
+      status: 'pending',
+      reference: 'A'
+    })
+  })
+
+  it('delivers nothing new once its cursor has caught up', async () => {
+    const conn = await connection()
+    const { pollMcpConnection } = await import('../packages/server/src/connectors/mcp')
+
+    const first = await pollMcpConnection(conn)
+    const second = await pollMcpConnection(conn, first.nextCursor)
+
+    expect(second.events).toEqual([])
+    expect(second.nextCursor).toBe(first.nextCursor)
+  })
+
+  it('exposes SDK actions as invocable MCP tools with typed output', async () => {
+    const conn = await connection()
+    const { invokeMcpTool } = await import('../packages/server/src/connectors/mcp')
+
+    const result = await invokeMcpTool(conn, 'shipOrder', { id: 'o-1' })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toMatchObject({ shipped: 'o-1', trackingNumber: 'TRACK-1' })
+  })
+
+  it('reports a connector-side failure as a failed action rather than a crash', async () => {
+    const conn = await connection()
+    const { invokeMcpTool } = await import('../packages/server/src/connectors/mcp')
+
+    const result = await invokeMcpTool(conn, 'shipOrder', {})
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('id')
+  })
+
+  it('renders SDK action inputs as connector action fields for the editor', async () => {
+    const conn = await connection()
+    const { mcpConnectionActions } = await import('../packages/server/src/connectors/mcp')
+
+    const ship = mcpConnectionActions(conn).find((action) => action.type === 'shipOrder')
+
+    expect(ship?.configFields.map((field) => field.key)).toEqual(['id'])
+    expect(ship?.configFields[0].required).toBe(true)
+    // Declared outputs reach the editor's variable autocomplete, while
+    // undeclared ones (trackingNumber) still pass through at runtime.
+    expect(Object.keys((ship?.outputSchema?.properties ?? {}) as Record<string, unknown>)).toEqual([
+      'shipped'
+    ])
+  })
+})

--- a/tests/connector-sdk-server.test.ts
+++ b/tests/connector-sdk-server.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import {
+  createConnectorServer,
+  defineConnector,
+  connectionSetup,
+  connectorManifest,
+  pollToolName,
+  MANIFEST_TOOL
+} from '../packages/connector-sdk/src/index'
+import { runCli } from '../packages/connector-sdk/src/cli'
+import type { Connector } from '../packages/connector-sdk/src/types'
+
+const NOW = '2026-08-05T00:00:00.000Z'
+
+const connector: Connector = defineConnector({
+  id: 'acme',
+  name: 'Acme',
+  version: '1.2.3',
+  description: 'Acme tickets',
+  config: [
+    { key: 'apiToken', label: 'API token', required: true, secret: true },
+    { key: 'orgUrl', label: 'Org URL', description: 'Base URL' }
+  ],
+  triggers: [
+    {
+      type: 'newTicket',
+      label: 'New ticket',
+      description: 'Tickets opened since the last poll',
+      poll: (context) => ({
+        items: [
+          {
+            externalId: '1',
+            title: 'Ticket 1',
+            updatedAt: NOW,
+            data: { since: context.since ?? null, limit: context.limit ?? null }
+          }
+        ]
+      })
+    },
+    {
+      type: 'brokenTrigger',
+      label: 'Broken',
+      poll: () => {
+        throw new Error('upstream exploded')
+      }
+    }
+  ],
+  actions: [
+    {
+      type: 'closeTicket',
+      label: 'Close ticket',
+      inputs: [
+        { key: 'id', label: 'Id', required: true },
+        { key: 'reason', label: 'Reason' }
+      ],
+      run: (args, context) => ({ closed: args.id, token: context.config.apiToken })
+    }
+  ]
+})
+
+type TextBlock = { type: string; text: string }
+type ToolCallResult = { content: TextBlock[]; isError?: boolean }
+
+async function connect(): Promise<Client> {
+  const server = createConnectorServer(connector, {
+    config: { apiToken: 'tok' },
+    now: () => NOW
+  })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+  return client
+}
+
+function payload(result: unknown): unknown {
+  return JSON.parse((result as ToolCallResult).content[0].text)
+}
+
+describe('connector MCP server', () => {
+  it('serves one poll tool per trigger, one tool per action, and a manifest', async () => {
+    const client = await connect()
+    const names = (await client.listTools()).tools.map((tool) => tool.name).sort()
+    expect(names).toEqual(['closeTicket', 'poll_brokenTrigger', 'poll_newTicket', MANIFEST_TOOL])
+    await client.close()
+  })
+
+  it('returns a normalized page and forwards since/limit to the trigger', async () => {
+    const client = await connect()
+    const result = await client.callTool({
+      name: pollToolName('newTicket'),
+      arguments: { since: '2026-08-01T00:00:00.000Z', limit: '25' }
+    })
+
+    expect(payload(result)).toEqual({
+      items: [
+        {
+          since: '2026-08-01T00:00:00.000Z',
+          limit: 25,
+          externalId: '1',
+          title: 'Ticket 1',
+          url: '',
+          description: '',
+          status: 'open',
+          labels: [],
+          updatedAt: NOW
+        }
+      ],
+      hasMore: false
+    })
+    await client.close()
+  })
+
+  it('reports a failing poll as a tool error instead of killing the server', async () => {
+    const client = await connect()
+    const result = (await client.callTool({
+      name: pollToolName('brokenTrigger'),
+      arguments: {}
+    })) as ToolCallResult
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('upstream exploded')
+
+    const badLimit = (await client.callTool({
+      name: pollToolName('newTicket'),
+      arguments: { limit: 'many' }
+    })) as ToolCallResult
+    expect(badLimit.isError).toBe(true)
+    expect(badLimit.content[0].text).toContain('Invalid limit')
+    await client.close()
+  })
+
+  it('runs actions with resolved config and reports argument errors', async () => {
+    const client = await connect()
+    expect(payload(await client.callTool({ name: 'closeTicket', arguments: { id: '7' } }))).toEqual(
+      {
+        closed: '7',
+        token: 'tok'
+      }
+    )
+
+    const missing = (await client.callTool({
+      name: 'closeTicket',
+      arguments: { reason: 'done' }
+    })) as ToolCallResult
+    expect(missing.isError).toBe(true)
+    await client.close()
+  })
+
+  it('advertises action inputs so the workflow editor can render a form', async () => {
+    const client = await connect()
+    const tool = (await client.listTools()).tools.find((entry) => entry.name === 'closeTicket')
+    expect(Object.keys(tool?.inputSchema.properties ?? {})).toEqual(['id', 'reason'])
+    expect(tool?.inputSchema.required).toEqual(['id'])
+    await client.close()
+  })
+
+  it('serves the manifest a user needs to configure the connection', async () => {
+    const client = await connect()
+    expect(payload(await client.callTool({ name: MANIFEST_TOOL, arguments: {} }))).toEqual(
+      connectorManifest(connector)
+    )
+    await client.close()
+  })
+})
+
+describe('connectionSetup', () => {
+  it('generates the exact filters a Vorn MCP connection needs', () => {
+    expect(connectionSetup(connector, 'newTicket')).toEqual({
+      connectorId: 'acme',
+      triggerType: 'newTicket',
+      filters: {
+        pollTool: 'poll_newTicket',
+        itemsPath: 'items',
+        idField: 'externalId',
+        timestampField: 'updatedAt',
+        titleField: 'title',
+        urlField: 'url'
+      },
+      env: [
+        { name: 'API_TOKEN', required: true, secret: true },
+        { name: 'ORG_URL', required: false, secret: false, description: 'Base URL' }
+      ]
+    })
+  })
+
+  it('rejects a trigger the connector does not have', () => {
+    expect(() => connectionSetup(connector, 'nope')).toThrow(/has no trigger "nope"/)
+  })
+})
+
+describe('vorn-connector CLI', () => {
+  const capture = (): { lines: string[]; write: (line: string) => void } => {
+    const lines: string[] = []
+    return { lines, write: (line) => lines.push(line) }
+  }
+  const load = async (): Promise<unknown> => ({ default: connector })
+
+  it('prints the manifest as JSON', async () => {
+    const out = capture()
+    expect(await runCli(['manifest', 'pkg'], { load, write: out.write })).toBe(0)
+    expect(JSON.parse(out.lines.join('\n')).id).toBe('acme')
+  })
+
+  it('prints setup for one trigger or for all of them', async () => {
+    const one = capture()
+    await runCli(['setup', 'pkg', 'newTicket'], { load, write: one.write })
+    expect(one.lines.join('\n')).toContain('"pollTool": "poll_newTicket"')
+    expect(one.lines.join('\n')).toContain('API_TOKEN (required)')
+
+    const all = capture()
+    await runCli(['setup', 'pkg'], { load, write: all.write })
+    expect(all.lines.join('\n')).toContain('poll_brokenTrigger')
+  })
+
+  it('polls against the supplied environment', async () => {
+    const out = capture()
+    const code = await runCli(['poll', 'pkg', 'newTicket', '--since', '2026-08-01T00:00:00.000Z'], {
+      load,
+      write: out.write,
+      env: { API_TOKEN: 'tok' }
+    })
+    expect(code).toBe(0)
+    expect(JSON.parse(out.lines.join('\n')).items[0].since).toBe('2026-08-01T00:00:00.000Z')
+  })
+
+  it('surfaces missing configuration rather than polling with none', async () => {
+    const out = capture()
+    await expect(
+      runCli(['poll', 'pkg', 'newTicket'], { load, write: out.write, env: {} })
+    ).rejects.toThrow(/missing required configuration/)
+  })
+
+  it('explains usage errors', async () => {
+    const usage = capture()
+    expect(await runCli([], { load, write: usage.write })).toBe(1)
+    expect(usage.lines.join('\n')).toContain('vorn-connector <command>')
+
+    const help = capture()
+    expect(await runCli(['help'], { load, write: help.write })).toBe(0)
+
+    const noModule = capture()
+    expect(await runCli(['manifest'], { load, write: noModule.write })).toBe(1)
+    expect(noModule.lines.join('\n')).toContain('Missing <module>')
+
+    const noTrigger = capture()
+    expect(await runCli(['poll', 'pkg'], { load, write: noTrigger.write })).toBe(1)
+    expect(noTrigger.lines.join('\n')).toContain('Missing <trigger>')
+
+    const unknown = capture()
+    expect(await runCli(['frobnicate', 'pkg'], { load, write: unknown.write })).toBe(1)
+    expect(unknown.lines.join('\n')).toContain('Unknown command')
+  })
+
+  it('rejects a module that does not export a connector', async () => {
+    const out = capture()
+    await expect(
+      runCli(['manifest', 'pkg'], { load: async () => ({}), write: out.write })
+    ).rejects.toThrow(/does not export a connector/)
+  })
+
+  it('rejects a flag with no value', async () => {
+    const out = capture()
+    await expect(
+      runCli(['poll', 'pkg', 'newTicket', '--since'], { load, write: out.write, env: {} })
+    ).rejects.toThrow(/Missing value for --since/)
+  })
+})

--- a/tests/connector-sdk-server.test.ts
+++ b/tests/connector-sdk-server.test.ts
@@ -247,6 +247,16 @@ describe('vorn-connector CLI', () => {
     expect(await runCli(['poll', 'pkg'], { load, write: noTrigger.write })).toBe(1)
     expect(noTrigger.lines.join('\n')).toContain('Missing <trigger>')
 
+    const badLimit = capture()
+    expect(
+      await runCli(['poll', 'pkg', 'newTicket', '--limit', 'lots'], {
+        load,
+        write: badLimit.write,
+        env: { API_TOKEN: 'tok' }
+      })
+    ).toBe(1)
+    expect(badLimit.lines.join('\n')).toContain('Invalid limit "lots"')
+
     const unknown = capture()
     expect(await runCli(['frobnicate', 'pkg'], { load, write: unknown.write })).toBe(1)
     expect(unknown.lines.join('\n')).toContain('Unknown command')

--- a/tests/connector-sdk.test.ts
+++ b/tests/connector-sdk.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createConnectorHarness,
+  defineConnector,
+  drainPoll,
+  normalizeItem,
+  resolveConfig,
+  runAction,
+  runPoll,
+  envNameFor
+} from '../packages/connector-sdk/src/index'
+import type { ConnectorItem, PollContext } from '../packages/connector-sdk/src/types'
+
+const NOW = '2026-08-05T00:00:00.000Z'
+
+const ticket = (id: string, updatedAt?: string): ConnectorItem => ({
+  externalId: id,
+  title: `Ticket ${id}`,
+  url: `https://example.test/${id}`,
+  ...(updatedAt && { updatedAt })
+})
+
+const simple = (poll: (context: PollContext) => unknown) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    triggers: [{ type: 'newTicket', label: 'New ticket', poll: poll as never }]
+  })
+
+describe('defineConnector', () => {
+  it('fills in defaults for an otherwise minimal definition', () => {
+    const connector = simple(() => ({ items: [] }))
+    expect(connector.version).toBe('0.0.0')
+    expect(connector.actions).toEqual([])
+    expect(connector.config).toEqual([])
+  })
+
+  it('rejects definitions that could never be served', () => {
+    expect(() => defineConnector({ id: '1bad', name: 'X' })).toThrow(/url-safe/)
+    expect(() => defineConnector({ id: 'acme', name: '' })).toThrow(/missing a name/)
+    expect(() => defineConnector({ id: 'acme', name: 'Acme' })).toThrow(
+      /no triggers and no actions/
+    )
+  })
+
+  it('rejects duplicate or malformed trigger and action keys', () => {
+    const trigger = { type: 'a', label: 'A', poll: () => ({ items: [] }) }
+    expect(() =>
+      defineConnector({ id: 'acme', name: 'Acme', triggers: [trigger, { ...trigger }] })
+    ).toThrow(/Duplicate trigger "a"/)
+    expect(() =>
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        triggers: [{ type: 'has space', label: 'A', poll: () => ({ items: [] }) }]
+      })
+    ).toThrow(/url-safe/)
+    expect(() =>
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        actions: [{ type: 'close', label: 'Close' } as never]
+      })
+    ).toThrow(/missing a run\(\)/)
+    expect(() =>
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        triggers: [{ type: 'a', label: 'A' } as never]
+      })
+    ).toThrow(/missing a poll\(\)/)
+  })
+
+  it('rejects duplicate config keys', () => {
+    expect(() =>
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        config: [
+          { key: 'token', label: 'Token' },
+          { key: 'token', label: 'Token again' }
+        ],
+        triggers: [{ type: 'a', label: 'A', poll: () => ({ items: [] }) }]
+      })
+    ).toThrow(/Duplicate config field "token"/)
+  })
+})
+
+describe('resolveConfig', () => {
+  const connector = defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    config: [
+      { key: 'apiToken', label: 'API token', required: true, secret: true },
+      { key: 'organizationUrl', label: 'Org URL', env: 'ACME_ORG_URL' },
+      { key: 'pageSize', label: 'Page size', default: '50' }
+    ],
+    triggers: [{ type: 'a', label: 'A', poll: () => ({ items: [] }) }]
+  })
+
+  it('derives env names and applies defaults', () => {
+    expect(envNameFor('apiToken')).toBe('API_TOKEN')
+    expect(envNameFor('organizationUrl', 'ACME_ORG_URL')).toBe('ACME_ORG_URL')
+
+    expect(resolveConfig(connector, { API_TOKEN: 't', ACME_ORG_URL: 'https://x' })).toEqual({
+      apiToken: 't',
+      organizationUrl: 'https://x',
+      pageSize: '50'
+    })
+  })
+
+  it('names every missing required value instead of failing at the first API call', () => {
+    expect(() => resolveConfig(connector, {})).toThrow(/apiToken \(API_TOKEN\)/)
+    expect(() => resolveConfig(connector, { API_TOKEN: '' })).toThrow(/missing required/)
+  })
+})
+
+describe('normalizeItem', () => {
+  it('fills every field Vorn reads by name', () => {
+    expect(normalizeItem({ externalId: 7, title: 'Seven' }, NOW)).toEqual({
+      externalId: '7',
+      title: 'Seven',
+      url: '',
+      description: '',
+      status: 'open',
+      labels: [],
+      updatedAt: NOW
+    })
+  })
+
+  it('keeps extra data but never lets it shadow a reserved field', () => {
+    const normalized = normalizeItem(
+      {
+        externalId: '1',
+        title: 'Real title',
+        assignee: 'dev',
+        data: { title: 'spoofed', severity: 'high' }
+      },
+      NOW
+    )
+    expect(normalized.title).toBe('Real title')
+    expect(normalized.severity).toBe('high')
+    expect(normalized.assignee).toBe('dev')
+  })
+
+  it('normalizes Date timestamps and rejects unusable ones', () => {
+    expect(
+      normalizeItem({ externalId: '1', title: 't', updatedAt: new Date(NOW) }, NOW).updatedAt
+    ).toBe(NOW)
+    expect(() => normalizeItem({ externalId: '1', title: 't', updatedAt: 'soon' }, NOW)).toThrow(
+      /Invalid updatedAt/
+    )
+  })
+
+  it('rejects items that would be undeliverable', () => {
+    expect(() => normalizeItem({ externalId: '  ', title: 't' }, NOW)).toThrow(/missing externalId/)
+    expect(() => normalizeItem({ externalId: '1', title: ' ' }, NOW)).toThrow(/missing title/)
+  })
+})
+
+describe('runPoll', () => {
+  it('normalizes a page and defaults timestamps to poll time', async () => {
+    const connector = simple(() => ({ items: [ticket('1')] }))
+    const page = await runPoll(connector, 'newTicket', { now: () => NOW })
+    expect(page).toEqual({
+      items: [
+        {
+          externalId: '1',
+          title: 'Ticket 1',
+          url: 'https://example.test/1',
+          description: '',
+          status: 'open',
+          labels: [],
+          updatedAt: NOW
+        }
+      ],
+      hasMore: false
+    })
+  })
+
+  it('passes config, since, cursor and limit through to the author', async () => {
+    let seen: PollContext | undefined
+    const connector = simple((context) => {
+      seen = context
+      return { items: [] }
+    })
+    await runPoll(connector, 'newTicket', {
+      config: { apiToken: 't' },
+      since: NOW,
+      cursor: 'c1',
+      limit: 5,
+      now: () => NOW
+    })
+    expect(seen).toMatchObject({ config: { apiToken: 't' }, since: NOW, cursor: 'c1', limit: 5 })
+    expect(seen?.now()).toBe(NOW)
+  })
+
+  it('rejects a trigger that claims more pages without a cursor', async () => {
+    const connector = simple(() => ({ items: [], hasMore: true }))
+    await expect(runPoll(connector, 'newTicket', {})).rejects.toThrow(/without a nextCursor/)
+  })
+
+  it('rejects a malformed poll result or an unknown trigger', async () => {
+    await expect(
+      runPoll(
+        simple(() => ({})),
+        'newTicket',
+        {}
+      )
+    ).rejects.toThrow(/items array/)
+    await expect(
+      runPoll(
+        simple(() => ({ items: [] })),
+        'nope',
+        {}
+      )
+    ).rejects.toThrow(/has no trigger "nope"/)
+  })
+
+  it('rejects duplicate ids inside one page', async () => {
+    const connector = simple(() => ({ items: [ticket('1'), ticket('1')] }))
+    await expect(runPoll(connector, 'newTicket', { now: () => NOW })).rejects.toThrow(
+      /Duplicate externalId "1"/
+    )
+  })
+})
+
+describe('drainPoll', () => {
+  it('follows advancing cursors to the end of the backlog', async () => {
+    const pages: Record<
+      string,
+      { items: ConnectorItem[]; nextCursor?: string; hasMore?: boolean }
+    > = {
+      start: { items: [ticket('1')], nextCursor: 'p2', hasMore: true },
+      p2: { items: [ticket('2')] }
+    }
+    const connector = simple((context) => pages[context.cursor ?? 'start'])
+
+    const items = await drainPoll(connector, 'newTicket', { now: () => NOW })
+    expect(items.map((item) => item.externalId)).toEqual(['1', '2'])
+  })
+
+  it('stops a trigger whose cursor never moves', async () => {
+    const connector = simple(() => ({ items: [], nextCursor: 'same', hasMore: true }))
+    await expect(
+      drainPoll(connector, 'newTicket', { cursor: 'same', now: () => NOW })
+    ).rejects.toThrow(/did not advance its cursor/)
+  })
+
+  it('stops a trigger that pages forever', async () => {
+    let page = 0
+    const connector = simple(() => ({ items: [], nextCursor: `p${++page}`, hasMore: true }))
+    await expect(drainPoll(connector, 'newTicket', { now: () => NOW })).rejects.toThrow(
+      /exceeded 1000 pages/
+    )
+  })
+})
+
+describe('runAction', () => {
+  const connector = defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    actions: [
+      {
+        type: 'closeTicket',
+        label: 'Close ticket',
+        inputs: [
+          { key: 'id', label: 'Id', required: true },
+          { key: 'number', label: 'Number', type: 'number' },
+          { key: 'notify', label: 'Notify', type: 'boolean' }
+        ],
+        run: (args) => ({ received: args })
+      },
+      { type: 'ping', label: 'Ping', run: () => undefined }
+    ]
+  })
+
+  it('coerces templated string arguments back to their declared types', async () => {
+    expect(
+      await runAction(connector, 'closeTicket', { id: '7', number: '42', notify: 'true' })
+    ).toEqual({ received: { id: '7', number: 42, notify: true } })
+  })
+
+  it('drops blank optional arguments rather than passing empty strings upstream', async () => {
+    expect(await runAction(connector, 'closeTicket', { id: '7', number: '' })).toEqual({
+      received: { id: '7' }
+    })
+  })
+
+  it('reports missing required and uncoercible arguments by name', async () => {
+    await expect(runAction(connector, 'closeTicket', {})).rejects.toThrow(/requires "id"/)
+    await expect(runAction(connector, 'closeTicket', { id: '1', number: 'x' })).rejects.toThrow(
+      /argument "number": Expected a number/
+    )
+  })
+
+  it('returns an empty object for an action with no output, and rejects unknown actions', async () => {
+    expect(await runAction(connector, 'ping', {})).toEqual({})
+    await expect(runAction(connector, 'nope', {})).rejects.toThrow(/has no action "nope"/)
+  })
+})
+
+describe('createConnectorHarness', () => {
+  it('exposes poll, drain, execute and manifest with shared defaults', async () => {
+    const connector = defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      config: [{ key: 'apiToken', label: 'Token' }],
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          poll: (context) => ({ items: [ticket(String(context.config.apiToken))] })
+        }
+      ],
+      actions: [{ type: 'ping', label: 'Ping', run: (_args, ctx) => ({ at: ctx.now() }) }]
+    })
+    const harness = createConnectorHarness(connector, {
+      config: { apiToken: 'tok' },
+      now: () => NOW
+    })
+
+    expect((await harness.poll('newTicket')).items[0].externalId).toBe('tok')
+    expect((await harness.drain('newTicket')).map((item) => item.title)).toEqual(['Ticket tok'])
+    expect(await harness.execute('ping')).toEqual({ at: NOW })
+    expect(harness.manifest().triggers[0].setup.filters.pollTool).toBe('poll_newTicket')
+  })
+
+  it('detects a trigger that ignores its lower bound and redelivers forever', async () => {
+    const connector = simple(() => ({ items: [ticket('1', '2026-08-01T00:00:00.000Z')] }))
+    const harness = createConnectorHarness(connector, { now: () => NOW })
+    expect(await harness.pollTwice('newTicket')).toEqual([])
+  })
+
+  it('reports genuinely new items on the second poll', async () => {
+    const later = '2026-08-02T00:00:00.000Z'
+    let call = 0
+    const connector = simple(() => ({
+      items: call++ === 0 ? [ticket('1', '2026-08-01T00:00:00.000Z')] : [ticket('2', later)]
+    }))
+    const harness = createConnectorHarness(connector, { now: () => NOW })
+    expect((await harness.pollTwice('newTicket')).map((item) => item.externalId)).toEqual(['2'])
+  })
+})

--- a/tests/connector-sdk.test.ts
+++ b/tests/connector-sdk.test.ts
@@ -152,6 +152,20 @@ describe('normalizeItem', () => {
     )
   })
 
+  it('drops prototype-polluting keys from extra data', () => {
+    const normalized = normalizeItem(
+      {
+        externalId: '1',
+        title: 't',
+        data: JSON.parse('{"__proto__":{"polluted":true},"constructor":1,"safe":"yes"}')
+      },
+      NOW
+    )
+    expect(normalized.safe).toBe('yes')
+    expect(normalized.constructor).toBe(Object)
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
   it('rejects items that would be undeliverable', () => {
     expect(() => normalizeItem({ externalId: '  ', title: 't' }, NOW)).toThrow(/missing externalId/)
     expect(() => normalizeItem({ externalId: '1', title: ' ' }, NOW)).toThrow(/missing title/)
@@ -247,6 +261,17 @@ describe('drainPoll', () => {
     ).rejects.toThrow(/did not advance its cursor/)
   })
 
+  it('forwards an empty-string cursor instead of treating it as absent', async () => {
+    const seen: (string | undefined)[] = []
+    const connector = simple((context) => {
+      seen.push(context.cursor)
+      return { items: [ticket('1')] }
+    })
+
+    await drainPoll(connector, 'newTicket', { cursor: '', now: () => NOW })
+    expect(seen).toEqual([''])
+  })
+
   it('stops a trigger that pages forever', async () => {
     let page = 0
     const connector = simple(() => ({ items: [], nextCursor: `p${++page}`, hasMore: true }))
@@ -291,6 +316,9 @@ describe('runAction', () => {
     await expect(runAction(connector, 'closeTicket', {})).rejects.toThrow(/requires "id"/)
     await expect(runAction(connector, 'closeTicket', { id: '1', number: 'x' })).rejects.toThrow(
       /argument "number": Expected a number/
+    )
+    await expect(runAction(connector, 'closeTicket', { id: '1', notify: 'treu' })).rejects.toThrow(
+      /argument "notify": Expected a boolean/
     )
   })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'text-summary', 'lcov'],
       include: [
+        'packages/connector-sdk/src/**/*.ts',
         'packages/server/src/**/*.ts',
         'packages/shared/src/**/*.ts',
         'src/renderer/lib/**/*.ts',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4552,6 +4552,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vornrun/connector-sdk@workspace:packages/connector-sdk":
+  version: 0.0.0-use.local
+  resolution: "@vornrun/connector-sdk@workspace:packages/connector-sdk"
+  dependencies:
+    "@modelcontextprotocol/sdk": "npm:^1.29.0"
+    tsup: "npm:^8.5.1"
+    typescript: "npm:^6.0.3"
+    zod: "npm:^4.4.3"
+  bin:
+    vorn-connector: dist/cli.js
+  languageName: unknown
+  linkType: soft
+
 "@vornrun/desktop@workspace:packages/desktop":
   version: 0.0.0-use.local
   resolution: "@vornrun/desktop@workspace:packages/desktop"


### PR DESCRIPTION
Phase 2 of the connector plan. Lets anyone write a Vorn pull connector in TypeScript and share it as an ordinary npm package — no marketplace, no plugin host, and **no changes to the app**.

## How it works

A connector built with the SDK runs as an MCP stdio server, which Vorn's existing generic MCP connector already knows how to drive. Installing a third-party connector is just pointing a connection at `npx -y <package>`, so versions are pinned by the npx argument and the connector runs out-of-process.

```ts
export default defineConnector({
  id: 'orders-db',
  name: 'Orders database',
  config: [{ key: 'databaseUrl', label: 'Database URL', required: true, secret: true }],
  triggers: [
    {
      type: 'newOrder',
      label: 'New order',
      async poll({ config, since, limit }) {
        const rows = await sql`SELECT ... WHERE updated_at > ${since} ORDER BY updated_at LIMIT ${limit}`
        return { items: rows.map(toItem) }
      }
    }
  ]
})
```

## What's in it

- **`defineConnector()`** — validates the definition at import time (duplicate keys, unusable ids, missing `poll`/`run`) instead of surfacing as a silently missing MCP tool after install.
- **Normalization** — every item is coerced to the exact field names Vorn reads (`externalId`, `title`, `url`, `status`, `updatedAt`, …), with reserved keys protected from `data` and duplicate ids within a page rejected.
- **MCP server** — one `poll_<trigger>` tool per trigger, one tool per action, plus `vorn_connector_manifest`. All results carry `structuredContent`, which is what Vorn actually reads.
- **`connectionSetup()`** — generates the exact connection filters to paste, so setup docs cannot drift from the code.
- **`createConnectorHarness()`** — runs a connector in-process for unit tests. `pollTwice()` reproduces Vorn's watermark behavior and catches the classic bug of a trigger that ignores its lower bound and redelivers the same backlog forever.
- **`vorn-connector` CLI** — `manifest`, `setup`, `poll`, `serve`. `poll` runs against your real environment, so credentials and field mapping can be confirmed before wiring anything up.
- **README** — authoring guide with API, SQL-database, and paging examples.

## Testing

45 new tests, 94% patch coverage, ~96% statements on the package.

`tests/connector-sdk-integration.test.ts` drives a real SDK connector through Vorn's own `pollMcpConnection` / `invokeMcpTool` / `mcpConnectionActions` using only the generated setup filters. That test already earned its keep: it caught that actions with a strict output schema were rejected client-side for returning an undeclared field, which no unit test saw.

## Next

Phase 3 (`@vornrun/connector-azure-devops`) is now a package built on this SDK rather than app work.
