### PR TITLE
feat(connector-sdk): declarative triggers, cursor round-trip and conformance checks

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -1,9 +1,8 @@
 # @vornrun/connector-sdk
 
 Build a Vorn pull connector in TypeScript and share it as an ordinary npm
-package. No marketplace, no plugin host, no changes to Vorn itself: a connector
-built with this SDK runs as an MCP stdio server, and Vorn's generic MCP
-connector already knows how to talk to one.
+package. A connector built with this SDK runs as an MCP stdio server, and
+Vorn's generic MCP connector already knows how to talk to one.
 
 ```bash
 npm install @vornrun/connector-sdk

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -27,7 +27,10 @@ export default defineConnector({
     {
       type: 'newTicket',
       label: 'New ticket',
-      async poll({ config, since, limit }) {
+      description: 'Tickets created or updated since the last poll',
+      // Say how new items are recognized and the SDK owns the cursor for you.
+      dedupe: 'timestamp',
+      async fetch({ config, since, limit }) {
         const url = new URL('/tickets', config.baseUrl)
         if (since) url.searchParams.set('updated_after', since)
         url.searchParams.set('per_page', String(limit ?? 100))
@@ -38,17 +41,15 @@ export default defineConnector({
         if (!response.ok) throw new Error(`Acme returned ${response.status}`)
         const tickets = (await response.json()) as AcmeTicket[]
 
-        return {
-          items: tickets.map((ticket) => ({
-            externalId: ticket.id,
-            title: ticket.subject,
-            url: ticket.html_url,
-            description: ticket.body,
-            status: ticket.state,
-            updatedAt: ticket.updated_at,
-            data: { priority: ticket.priority }
-          }))
-        }
+        return tickets.map((ticket) => ({
+          externalId: ticket.id,
+          title: ticket.subject,
+          url: ticket.html_url,
+          description: ticket.body,
+          status: ticket.state,
+          updatedAt: ticket.updated_at,
+          data: { priority: ticket.priority }
+        }))
       }
     }
   ],
@@ -101,24 +102,23 @@ export default defineConnector({
     {
       type: 'newOrder',
       label: 'New order',
-      async poll({ config, since, limit }) {
+      dedupe: 'timestamp',
+      async fetch({ config, since, limit }) {
         const sql = postgres(config.databaseUrl!)
         try {
           const rows = await sql`
             SELECT id, reference, status, updated_at
             FROM orders
-            WHERE updated_at > ${since ?? '1970-01-01'}
+            WHERE updated_at >= ${since ?? '1970-01-01'}
             ORDER BY updated_at ASC
             LIMIT ${limit ?? 200}
           `
-          return {
-            items: rows.map((row) => ({
-              externalId: row.id,
-              title: `Order ${row.reference}`,
-              status: row.status,
-              updatedAt: row.updated_at
-            }))
-          }
+          return rows.map((row) => ({
+            externalId: row.id,
+            title: `Order ${row.reference}`,
+            status: row.status,
+            updatedAt: row.updated_at
+          }))
         } finally {
           await sql.end()
         }
@@ -132,13 +132,39 @@ Two rules make a pull trigger reliable, and the SDK enforces both:
 
 1. `externalId` must be stable — Vorn dedupes on it, so a changing id means
    duplicate work items.
-2. `updatedAt` must be monotonic and ISO-comparable — Vorn advances its poll
-   cursor from it. Sort ascending by that column and honor `since`.
+2. `updatedAt` must be monotonic and ISO-comparable — the cursor advances from
+   it. Use `>=` when filtering on `since` and sort ascending; returning a few
+   items again is free, because the SDK drops anything already delivered.
 
-## Paging a backlog
+## Dedupe strategies
 
-Return `hasMore: true` with a `nextCursor`, and Vorn (or `drainPoll` in tests)
-will keep pulling bounded pages until the backlog is drained:
+`dedupe` tells the SDK how to recognize new items, and it then owns the cursor
+— including the case that quietly breaks hand-written connectors, where several
+items share the newest timestamp and are either dropped forever (`>`) or
+redelivered on every poll (`>=`).
+
+| strategy    | your `fetch` receives | use it when                                      |
+| ----------- | --------------------- | ------------------------------------------------ |
+| `timestamp` | `since`               | the source has a reliable "last changed" field   |
+| `lastItem`  | `lastItemId`          | a newest-first feed with no dependable timestamp |
+
+```ts
+{
+  type: 'newPost',
+  label: 'New post',
+  dedupe: 'lastItem',
+  // Return the feed newest-first; the SDK stops at the last id it delivered.
+  fetch: ({ config }) => fetchFeed(config)
+}
+```
+
+A first poll never drains the whole history — it delivers one page and starts
+tracking from there.
+
+## Paging a backlog by hand
+
+When a source's paging cannot be expressed as "everything since X", implement
+`poll` instead of `fetch` and own the cursor yourself:
 
 ```ts
 async poll({ cursor, config }) {
@@ -153,6 +179,35 @@ async poll({ cursor, config }) {
 ```
 
 A cursor that does not advance is rejected rather than looped on.
+
+## Check it before shipping
+
+`vorn-connector check` verifies a connector against the contract Vorn relies
+on — most importantly that re-polling with its own cursor does not redeliver
+items it already handed over:
+
+```console
+$ npx vorn-connector check ./dist/index.js
+error  trigger newTicket: re-polling with its own nextCursor returned 3 already-delivered item(s), starting with "1042" [redelivers-items]
+warn   action closeTicket: does not declare `idempotent`, so an agent cannot tell whether retrying is safe [missing-idempotent]
+
+1 error(s), 1 warning(s)
+```
+
+It exits non-zero on errors, so it works as a CI gate. Add `sample` items to a
+trigger and they are replayed through the real dedupe pipeline, so a connector
+can be checked before anyone has credentials for it; pass `--live` to poll the
+real source instead.
+
+```ts
+{
+  type: 'newTicket',
+  label: 'New ticket',
+  dedupe: 'timestamp',
+  sample: [{ externalId: '1', title: 'Example ticket', updatedAt: '2026-01-01T00:00:00.000Z' }],
+  fetch: ({ config, since }) => fetchTickets(config, since)
+}
+```
 
 ## Test it without running the app
 
@@ -189,12 +244,16 @@ npx vorn-connector setup ./dist/index.js
 
 It prints the values for **Settings → Connectors → MCP → New connection**:
 
-| Field      | Value                                                                                                                                    |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Command    | `npx`                                                                                                                                    |
-| Arguments  | `["-y", "@your-scope/acme-connector"]`                                                                                                   |
-| Secret env | `{"API_TOKEN": "…"}`                                                                                                                     |
-| Filters    | `pollTool: poll_newTicket`, `itemsPath: items`, `idField: externalId`, `timestampField: updatedAt`, `titleField: title`, `urlField: url` |
+| Field      | Value                                                                                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command    | `npx`                                                                                                                                                                                   |
+| Arguments  | `["-y", "@your-scope/acme-connector"]`                                                                                                                                                  |
+| Secret env | `{"API_TOKEN": "…"}`                                                                                                                                                                    |
+| Filters    | `pollTool: poll_newTicket`, `itemsPath: items`, `idField: externalId`, `timestampField: updatedAt`, `titleField: title`, `urlField: url`, `cursorArg: cursor`, `cursorPath: nextCursor` |
+
+`cursorArg` is what makes the dedupe strategy load-bearing: Vorn hands the
+connector back its own cursor on every poll and fires for whatever it returns,
+rather than re-filtering the results by timestamp itself.
 
 Because the connector is a normal npm package, versions are pinned by the
 `npx` argument and upgrades are a version bump — no separate registry.
@@ -205,9 +264,13 @@ Because the connector is a normal npm package, versions are pinned by the
 vorn-connector manifest <module>          Print the manifest as JSON
 vorn-connector setup <module> [trigger]   Print the Vorn connection settings
 vorn-connector poll <module> <trigger>    Run one poll against the environment
+vorn-connector check <module>             Verify the connector against the contract
 vorn-connector serve <module>             Serve on stdio (what Vorn runs)
 ```
 
 `poll` accepts `--since <iso>` and `--limit <n>`, and reads the connector's
 declared config from your shell environment — the fastest way to confirm
 credentials and field mapping before wiring anything up.
+
+`check` runs against declared `sample` data by default and takes `--live` to
+poll the real source instead.

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -144,8 +144,8 @@ export async function checkConnector(
     )
   }
 
-  // Triggers share no state, so a live check of a multi-trigger connector pays
-  // one round-trip rather than one per trigger.
+  // Triggers share no state, so their checks run concurrently rather than
+  // waiting on each other's polls.
   const perTrigger = await Promise.all(
     connector.triggers.map(async (trigger) => {
       const target = `trigger ${trigger.type}`

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -32,8 +32,10 @@ function finding(
 
 /**
  * Replay a trigger's declared `sample` through the real dedupe pipeline by
- * swapping in a fetch that serves the sample once. Everything else — cursor
- * encoding, ordering, normalization — is the production code path.
+ * swapping in a fetch that serves the whole sample on every call. Serving it
+ * again on the second poll is the point: a correct trigger recognizes its own
+ * cursor and delivers nothing, while one that redelivers is caught. Everything
+ * else — cursor encoding, ordering, normalization — is the production path.
  */
 function sampleTrigger(trigger: TriggerDefinition & { dedupe: DedupeStrategy }): TriggerDefinition {
   return { ...trigger, poll: undefined, fetch: () => trigger.sample ?? [] }

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -1,0 +1,224 @@
+import { runPoll, type PollPage } from './runtime'
+import type { Connector, ConnectorConfig, DedupeStrategy, TriggerDefinition } from './types'
+
+export interface CheckFinding {
+  /** `error` means the connector will misbehave in Vorn; `warn` is advisory. */
+  level: 'error' | 'warn'
+  code: string
+  /** Which part of the connector the finding is about. */
+  target: string
+  message: string
+}
+
+export interface CheckOptions {
+  /**
+   * Poll every trigger against the real source. Off by default, so a check
+   * runs on declared `sample` items and the definition alone.
+   */
+  live?: boolean
+  /** Credentials, required by `live`. */
+  config?: ConnectorConfig
+  now?: () => string
+}
+
+function finding(
+  level: CheckFinding['level'],
+  code: string,
+  target: string,
+  message: string
+): CheckFinding {
+  return { level, code, target, message }
+}
+
+/**
+ * Replay a trigger's declared `sample` through the real dedupe pipeline by
+ * swapping in a fetch that serves the sample once. Everything else — cursor
+ * encoding, ordering, normalization — is the production code path.
+ */
+function sampleTrigger(trigger: TriggerDefinition & { dedupe: DedupeStrategy }): TriggerDefinition {
+  return { ...trigger, poll: undefined, fetch: () => trigger.sample ?? [] }
+}
+
+async function checkPollBehaviour(
+  connector: Connector,
+  trigger: TriggerDefinition,
+  options: CheckOptions
+): Promise<CheckFinding[]> {
+  const found: CheckFinding[] = []
+  const probe: Connector = { ...connector, triggers: [trigger] }
+  const target = `trigger ${trigger.type}`
+  const now = options.now ?? (() => new Date().toISOString())
+
+  const attempt = async (
+    cursor: string | undefined,
+    code: string,
+    what: string
+  ): Promise<PollPage | CheckFinding> => {
+    try {
+      return await runPoll(probe, trigger.type, {
+        config: options.config ?? {},
+        ...(cursor !== undefined && { cursor }),
+        now
+      })
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      return finding('error', code, target, `${what} threw: ${reason}`)
+    }
+  }
+
+  const first = await attempt(undefined, 'poll-failed', 'first poll')
+  if ('level' in first) return [first]
+
+  if (first.items.length === 0) {
+    found.push(
+      finding('warn', 'no-items', target, 'returned nothing, so delivery could not be verified')
+    )
+    return found
+  }
+  if (first.nextCursor === undefined) {
+    found.push(
+      finding(
+        'error',
+        'no-cursor',
+        target,
+        'returned items but no nextCursor, so every poll will redeliver them'
+      )
+    )
+    return found
+  }
+
+  // The check that matters: a second poll carrying the returned cursor must
+  // not hand back anything it already delivered.
+  const second = await attempt(
+    first.nextCursor,
+    'cursor-rejected',
+    're-polling with its own nextCursor'
+  )
+  if ('level' in second) return [...found, second]
+
+  const delivered = new Set(first.items.map((item) => item.externalId))
+  const repeated = second.items.filter((item) => delivered.has(item.externalId))
+  if (repeated.length > 0) {
+    found.push(
+      finding(
+        'error',
+        'redelivers-items',
+        target,
+        `re-polling with its own nextCursor returned ${repeated.length} already-delivered item(s), starting with "${repeated[0]!.externalId}"`
+      )
+    )
+  }
+  if (second.hasMore && second.nextCursor === first.nextCursor) {
+    found.push(
+      finding('error', 'stuck-cursor', target, 'reports more pages but its cursor never advances')
+    )
+  }
+
+  return found
+}
+
+/**
+ * Check a connector against the contract Vorn relies on.
+ *
+ * The point is a feedback loop: a connector — hand-written or generated — can
+ * be verified before it is ever installed, catching the failures that are
+ * otherwise invisible until duplicate tasks show up in someone's inbox days
+ * later.
+ */
+export async function checkConnector(
+  connector: Connector,
+  options: CheckOptions = {}
+): Promise<CheckFinding[]> {
+  const found: CheckFinding[] = []
+
+  if (!connector.description?.trim()) {
+    found.push(
+      finding(
+        'warn',
+        'missing-description',
+        connector.id,
+        'has no description; agents use it to decide when the connector applies'
+      )
+    )
+  }
+
+  // Triggers share no state, so a live check of a multi-trigger connector pays
+  // one round-trip rather than one per trigger.
+  const perTrigger = await Promise.all(
+    connector.triggers.map(async (trigger) => {
+      const target = `trigger ${trigger.type}`
+      const triggerFindings: CheckFinding[] = []
+      if (!trigger.description?.trim()) {
+        triggerFindings.push(finding('warn', 'missing-description', target, 'has no description'))
+      }
+
+      if (options.live) {
+        triggerFindings.push(...(await checkPollBehaviour(connector, trigger, options)))
+      } else if (!trigger.sample?.length) {
+        triggerFindings.push(
+          finding(
+            'warn',
+            'unverifiable',
+            target,
+            'has no sample items and no credentials were supplied, so nothing could be verified'
+          )
+        )
+      } else if (!trigger.dedupe) {
+        triggerFindings.push(
+          finding(
+            'warn',
+            'sample-unusable',
+            target,
+            'declares sample items but implements poll() directly, so they cannot be replayed; re-run with --live'
+          )
+        )
+      } else {
+        triggerFindings.push(
+          ...(await checkPollBehaviour(connector, sampleTrigger(trigger), options))
+        )
+      }
+      return triggerFindings
+    })
+  )
+  found.push(...perTrigger.flat())
+
+  for (const action of connector.actions) {
+    const target = `action ${action.type}`
+    if (!action.description?.trim()) {
+      found.push(
+        finding('warn', 'missing-description', target, 'has no description for the agent to read')
+      )
+    }
+    if (action.idempotent === undefined) {
+      found.push(
+        finding(
+          'warn',
+          'missing-idempotent',
+          target,
+          'does not declare `idempotent`, so an agent cannot tell whether retrying is safe'
+        )
+      )
+    }
+    for (const input of action.inputs ?? []) {
+      if (!input.description?.trim()) {
+        found.push(
+          finding(
+            'warn',
+            'missing-description',
+            `${target} input ${input.key}`,
+            'has no description'
+          )
+        )
+      }
+    }
+  }
+
+  return found
+}
+
+/** Render findings for a terminal. Returns an empty string when all clear. */
+export function formatFindings(findings: CheckFinding[]): string {
+  return findings
+    .map((item) => `${item.level.padEnd(5)}  ${item.target}: ${item.message} [${item.code}]`)
+    .join('\n')
+}

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
+import { checkConnector, formatFindings } from './check'
 import { resolveConfig } from './define'
 import { runPoll } from './runtime'
 import { connectionSetup, connectorManifest } from './setup'
@@ -12,12 +13,14 @@ const USAGE = `vorn-connector <command> <module> [options]
 Commands:
   manifest <module>             Print the connector manifest as JSON
   setup <module> [trigger]      Print the Vorn connection settings to paste
+  check <module>                Verify the connector against Vorn's contract
   poll <module> <trigger>       Run one poll against the current environment
   serve <module>                Serve the connector on stdio (what Vorn runs)
 
 Options:
   --since <iso>                 Lower bound passed to poll
-  --limit <n>                   Maximum items to request`
+  --limit <n>                   Maximum items to request
+  --live                        Let check poll for real using the environment`
 
 export interface CliDeps {
   load(modulePath: string): Promise<unknown>
@@ -25,16 +28,24 @@ export interface CliDeps {
   env?: NodeJS.ProcessEnv
 }
 
+/** Flags that stand alone; everything else must be followed by a value. */
+const BOOLEAN_FLAGS = new Set(['live'])
+
 function parseFlags(args: string[]): Record<string, string> {
   const flags: Record<string, string> = {}
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
     if (!arg.startsWith('--')) continue
+    const name = arg.slice(2)
+    if (BOOLEAN_FLAGS.has(name)) {
+      flags[name] = 'true'
+      continue
+    }
     const value = args[index + 1]
     if (value === undefined || value.startsWith('--')) {
       throw new Error(`Missing value for ${arg}`)
     }
-    flags[arg.slice(2)] = value
+    flags[name] = value
     index++
   }
   return flags
@@ -90,6 +101,23 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
         }
       }
       return 0
+    }
+
+    case 'check': {
+      const findings = await checkConnector(connector, {
+        ...(flags.live === 'true' && {
+          live: true,
+          config: resolveConfig(connector, deps.env ?? process.env)
+        })
+      })
+      const errors = findings.filter((item) => item.level === 'error')
+      if (findings.length > 0) deps.write(formatFindings(findings))
+      deps.write(
+        errors.length > 0
+          ? `\n${errors.length} error(s), ${findings.length - errors.length} warning(s)`
+          : `\n${connector.id} passed with ${findings.length} warning(s)`
+      )
+      return errors.length > 0 ? 1 : 0
     }
 
     case 'poll': {

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -31,11 +31,22 @@ export interface CliDeps {
 /** Flags that stand alone; everything else must be followed by a value. */
 const BOOLEAN_FLAGS = new Set(['live'])
 
-function parseFlags(args: string[]): Record<string, string> {
+/**
+ * Split arguments into flags and positionals in one pass, so a flag's value is
+ * never also read as a positional argument.
+ */
+function parseArgs(args: string[]): {
+  flags: Record<string, string>
+  positional: string[]
+} {
   const flags: Record<string, string> = {}
+  const positional: string[] = []
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
-    if (!arg.startsWith('--')) continue
+    if (!arg.startsWith('--')) {
+      positional.push(arg)
+      continue
+    }
     const name = arg.slice(2)
     if (BOOLEAN_FLAGS.has(name)) {
       flags[name] = 'true'
@@ -48,7 +59,7 @@ function parseFlags(args: string[]): Record<string, string> {
     flags[name] = value
     index++
   }
-  return flags
+  return { flags, positional }
 }
 
 /** Accept either `export default connector` or `export const connector`. */
@@ -76,8 +87,7 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
   }
 
   const connector = pickConnector(await deps.load(modulePath), modulePath)
-  const positional = rest.filter((arg) => !arg.startsWith('--'))
-  const flags = parseFlags(rest)
+  const { flags, positional } = parseArgs(rest)
 
   switch (command) {
     case 'manifest':

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -43,6 +43,15 @@ function decodeCursor<S extends DedupeStrategy>(
   if (!state || typeof state !== 'object' || state.v !== 1 || state.s !== strategy) {
     throw new Error(`Cursor does not belong to the "${strategy}" strategy: ${cursor}`)
   }
+  // Check the payload too, so a hand-edited or truncated cursor fails here
+  // rather than somewhere further in with an unrelated error.
+  const wellFormed =
+    state.s === 'timestamp'
+      ? typeof state.t === 'string' && Array.isArray(state.ids)
+      : typeof state.id === 'string'
+  if (!wellFormed) {
+    throw new Error(`Cursor is missing the fields the "${strategy}" strategy needs: ${cursor}`)
+  }
   return state as CursorFor<S>
 }
 

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -46,6 +46,11 @@ function decodeCursor<S extends DedupeStrategy>(
   return state as CursorFor<S>
 }
 
+function compare(left: string, right: string): number {
+  if (left === right) return 0
+  return left < right ? -1 : 1
+}
+
 /** An item with its dedupe keys resolved once, rather than per comparison. */
 interface Keyed {
   item: ConnectorItem
@@ -100,9 +105,7 @@ function timestampPoll(
       (at === boundary && !seen.has(itemExternalId(item)))
     if (isNew) fresh.push({ item, at, id: itemExternalId(item) })
   }
-  fresh.sort((left, right) =>
-    left.at === right.at ? (left.id < right.id ? -1 : 1) : left.at < right.at ? -1 : 1
-  )
+  fresh.sort((left, right) => compare(left.at, right.at) || compare(left.id, right.id))
 
   return page(fresh, context, state !== undefined, (delivered) => {
     const newest = delivered[delivered.length - 1]!.at

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -1,0 +1,196 @@
+import { itemExternalId, itemTimestamp } from './normalize'
+import type {
+  ConnectorItem,
+  DedupeStrategy,
+  FetchContext,
+  PollContext,
+  PollOutcome,
+  TriggerDefinition
+} from './types'
+
+/**
+ * Cursor state the SDK owns on the author's behalf. It travels through Vorn as
+ * an opaque string, so the shape is versioned and never inspected by the host.
+ */
+type DedupeCursor =
+  | { v: 1; s: 'timestamp'; t: string; ids: string[] }
+  | { v: 1; s: 'lastItem'; id: string }
+
+type CursorFor<S extends DedupeStrategy> = Extract<DedupeCursor, { s: S }>
+
+/**
+ * How many ids are remembered at the newest timestamp. Items sharing one
+ * instant are the only ones the timestamp window cannot separate, so the list
+ * is normally tiny; the cap stops a source that stamps thousands of rows
+ * identically from growing the cursor without bound. Which ids are dropped is
+ * arbitrary — exceeding the cap can redeliver an item, which Vorn's inbox
+ * de-duplicates on `externalId` anyway.
+ */
+const MAX_BOUNDARY_IDS = 500
+
+function decodeCursor<S extends DedupeStrategy>(
+  cursor: string | undefined,
+  strategy: S
+): CursorFor<S> | undefined {
+  if (!cursor) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cursor)
+  } catch (error) {
+    throw new Error(`Cursor is not valid SDK cursor JSON: ${cursor}`, { cause: error })
+  }
+  const state = parsed as DedupeCursor
+  if (!state || typeof state !== 'object' || state.v !== 1 || state.s !== strategy) {
+    throw new Error(`Cursor does not belong to the "${strategy}" strategy: ${cursor}`)
+  }
+  return state as CursorFor<S>
+}
+
+/** An item with its dedupe keys resolved once, rather than per comparison. */
+interface Keyed {
+  item: ConnectorItem
+  at: string
+  id: string
+}
+
+/**
+ * Turn one page into the shape the strategies share. Delivering `items` in
+ * oldest-first order means Vorn creates runs in the order things actually
+ * happened, and truncating to `limit` always leaves the *newest* items for the
+ * next poll rather than stranding the oldest behind an advanced cursor.
+ */
+function page(
+  chronological: Keyed[],
+  context: PollContext,
+  hadCursor: boolean,
+  nextCursor: (delivered: Keyed[]) => DedupeCursor
+): PollOutcome {
+  const delivered =
+    context.limit === undefined ? chronological : chronological.slice(0, context.limit)
+  if (delivered.length === 0) {
+    return { items: [], ...(context.cursor !== undefined && { nextCursor: context.cursor }) }
+  }
+  return {
+    items: delivered.map((entry) => entry.item),
+    nextCursor: JSON.stringify(nextCursor(delivered)),
+    // Only drain a backlog we know we truncated, and only once a cursor
+    // exists — a first poll should not pull the source's entire history.
+    hasMore: chronological.length > delivered.length && hadCursor
+  }
+}
+
+function timestampPoll(
+  fetched: ConnectorItem[],
+  state: CursorFor<'timestamp'> | undefined,
+  context: PollContext,
+  polledAt: string
+): PollOutcome {
+  const boundary = state?.t ?? context.since
+  const seen = new Set(state?.ids ?? [])
+
+  const fresh: Keyed[] = []
+  for (const item of fetched) {
+    const at = itemTimestamp(item, polledAt)
+    // Items sharing the boundary instant are new only if this cursor has not
+    // already delivered them. Without this, `>` drops them forever and `>=`
+    // redelivers them on every single poll.
+    const isNew =
+      boundary === undefined ||
+      at > boundary ||
+      (at === boundary && !seen.has(itemExternalId(item)))
+    if (isNew) fresh.push({ item, at, id: itemExternalId(item) })
+  }
+  fresh.sort((left, right) =>
+    left.at === right.at ? (left.id < right.id ? -1 : 1) : left.at < right.at ? -1 : 1
+  )
+
+  return page(fresh, context, state !== undefined, (delivered) => {
+    const newest = delivered[delivered.length - 1]!.at
+    const atNewest: string[] = []
+    for (let i = delivered.length - 1; i >= 0 && delivered[i]!.at === newest; i -= 1) {
+      atNewest.push(delivered[i]!.id)
+    }
+    // Carry the previous boundary ids forward only while the boundary itself
+    // has not moved; once it does they can never match again.
+    const ids = (newest === boundary ? [...seen, ...atNewest] : atNewest).slice(-MAX_BOUNDARY_IDS)
+    return { v: 1, s: 'timestamp', t: newest, ids }
+  })
+}
+
+function lastItemPoll(
+  fetched: ConnectorItem[],
+  state: CursorFor<'lastItem'> | undefined,
+  context: PollContext,
+  polledAt: string
+): PollOutcome {
+  // `fetch` is documented to return newest-first for this strategy.
+  const keyed = fetched.map((item) => ({
+    item,
+    at: itemTimestamp(item, polledAt),
+    id: itemExternalId(item)
+  }))
+  const stopAt = state ? keyed.findIndex((entry) => entry.id === state.id) : -1
+  const chronological = (stopAt === -1 ? keyed : keyed.slice(0, stopAt)).reverse()
+
+  return page(chronological, context, state !== undefined, (delivered) => ({
+    v: 1,
+    s: 'lastItem',
+    id: delivered[delivered.length - 1]!.id
+  }))
+}
+
+/**
+ * Run a declarative trigger: call the author's `fetch`, then apply the chosen
+ * dedupe strategy.
+ *
+ * This exists because cursor bookkeeping is where hand-written pull connectors
+ * go wrong — duplicate deliveries, items lost at the timestamp boundary, and
+ * cursors that never advance. Solving it once here means every connector, and
+ * every connector an agent generates, inherits the fix.
+ */
+export async function pollWithDedupe(
+  trigger: TriggerDefinition,
+  context: PollContext
+): Promise<PollOutcome> {
+  const strategy = trigger.dedupe
+  const fetchItems = trigger.fetch
+  if (!strategy || !fetchItems) {
+    throw new Error(`Trigger ${trigger.type} is not a declarative trigger`)
+  }
+  const polledAt = context.now()
+
+  if (strategy === 'lastItem') {
+    const state = decodeCursor(context.cursor, 'lastItem')
+    const fetched = await runFetch(trigger.type, fetchItems, {
+      config: context.config,
+      ...(state && { lastItemId: state.id }),
+      ...(context.limit !== undefined && { limit: context.limit }),
+      now: context.now
+    })
+    return lastItemPoll(fetched, state, context, polledAt)
+  }
+
+  const state = decodeCursor(context.cursor, 'timestamp')
+  // The cursor is the authority on what has been delivered; the host's `since`
+  // only seeds the very first poll.
+  const since = state?.t ?? context.since
+  const fetched = await runFetch(trigger.type, fetchItems, {
+    config: context.config,
+    ...(since !== undefined && { since }),
+    ...(context.limit !== undefined && { limit: context.limit }),
+    now: context.now
+  })
+  return timestampPoll(fetched, state, context, polledAt)
+}
+
+async function runFetch(
+  type: string,
+  fetchItems: NonNullable<TriggerDefinition['fetch']>,
+  context: FetchContext
+): Promise<ConnectorItem[]> {
+  const fetched = await fetchItems(context)
+  if (!Array.isArray(fetched)) {
+    throw new Error(`Trigger ${type} fetch() did not return an array`)
+  }
+  return fetched
+}

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -47,7 +47,9 @@ function decodeCursor<S extends DedupeStrategy>(
   // rather than somewhere further in with an unrelated error.
   const wellFormed =
     state.s === 'timestamp'
-      ? typeof state.t === 'string' && Array.isArray(state.ids)
+      ? typeof state.t === 'string' &&
+        Array.isArray(state.ids) &&
+        state.ids.every((id) => typeof id === 'string')
       : typeof state.id === 'string'
   if (!wellFormed) {
     throw new Error(`Cursor is missing the fields the "${strategy}" strategy needs: ${cursor}`)

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -56,6 +56,8 @@ interface Keyed {
   item: ConnectorItem
   at: string
   id: string
+  /** True when `at` was borrowed from the boundary because the item has none. */
+  pinned?: boolean
 }
 
 /**
@@ -94,16 +96,24 @@ function timestampPoll(
   const seen = new Set(state?.ids ?? [])
 
   const fresh: Keyed[] = []
+  // Ids of timestamp-less items this cursor has already delivered. They have to
+  // survive into the next cursor even when the boundary moves past them,
+  // because the id set is the only thing that can recognize them.
+  const pinnedAlreadySeen: string[] = []
+
   for (const item of fetched) {
-    const at = itemTimestamp(item, polledAt)
+    const id = itemExternalId(item)
+    // An item with no `updatedAt` cannot be placed against the boundary. Give
+    // it the boundary itself rather than poll time, which would make it look
+    // newer on every single poll and redeliver it forever.
+    const pinned = item.updatedAt === undefined && boundary !== undefined
+    const at = pinned ? boundary : itemTimestamp(item, polledAt)
     // Items sharing the boundary instant are new only if this cursor has not
     // already delivered them. Without this, `>` drops them forever and `>=`
     // redelivers them on every single poll.
-    const isNew =
-      boundary === undefined ||
-      at > boundary ||
-      (at === boundary && !seen.has(itemExternalId(item)))
-    if (isNew) fresh.push({ item, at, id: itemExternalId(item) })
+    const isNew = boundary === undefined || at > boundary || (at === boundary && !seen.has(id))
+    if (isNew) fresh.push({ item, at, id, ...(pinned && { pinned: true }) })
+    else if (pinned) pinnedAlreadySeen.push(id)
   }
   fresh.sort((left, right) => compare(left.at, right.at) || compare(left.id, right.id))
 
@@ -114,9 +124,17 @@ function timestampPoll(
       atNewest.push(delivered[i]!.id)
     }
     // Carry the previous boundary ids forward only while the boundary itself
-    // has not moved; once it does they can never match again.
-    const ids = (newest === boundary ? [...seen, ...atNewest] : atNewest).slice(-MAX_BOUNDARY_IDS)
-    return { v: 1, s: 'timestamp', t: newest, ids }
+    // has not moved; once it does they can never match again — except for
+    // pinned items, which re-pin to wherever the boundary lands next.
+    const carried =
+      newest === boundary
+        ? [...seen, ...atNewest]
+        : [
+            ...pinnedAlreadySeen,
+            ...delivered.filter((entry) => entry.pinned).map((entry) => entry.id),
+            ...atNewest
+          ]
+    return { v: 1, s: 'timestamp', t: newest, ids: carried.slice(-MAX_BOUNDARY_IDS) }
   })
 }
 

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -1,6 +1,7 @@
-import type { Connector, ConnectorConfig, ConnectorDefinition } from './types'
+import type { Connector, ConnectorConfig, ConnectorDefinition, DedupeStrategy } from './types'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
+const DEDUPE_STRATEGIES: DedupeStrategy[] = ['timestamp', 'lastItem']
 
 function assertUnique(kind: string, keys: string[]): void {
   const seen = new Set<string>()
@@ -55,6 +56,14 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
     if (declarative !== (loose.dedupe !== undefined)) {
       throw new Error(
         `Trigger ${trigger.type} needs fetch() and a dedupe strategy together, not one alone`
+      )
+    }
+    if (loose.dedupe !== undefined && !DEDUPE_STRATEGIES.includes(loose.dedupe as DedupeStrategy)) {
+      // Without this a typo runs a strategy the author did not ask for, which
+      // shows up as mis-delivered items rather than as an error.
+      throw new Error(
+        `Trigger ${trigger.type} has unknown dedupe strategy ${JSON.stringify(loose.dedupe)}; ` +
+          `expected ${DEDUPE_STRATEGIES.join(' or ')}`
       )
     }
     if (!declarative && !imperative) {

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -44,8 +44,21 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
     if (!KEY_PATTERN.test(trigger.type ?? '')) {
       throw new Error(`Trigger type "${trigger.type}" must start with a letter and be url-safe`)
     }
-    if (typeof trigger.poll !== 'function') {
-      throw new Error(`Trigger ${trigger.type} is missing a poll() implementation`)
+    // `TriggerDefinition` already rules these out for TypeScript authors; the
+    // checks stay for plain-JS connectors, where the union buys nothing.
+    const loose = trigger as { dedupe?: unknown; fetch?: unknown; poll?: unknown }
+    const declarative = typeof loose.fetch === 'function'
+    const imperative = typeof loose.poll === 'function'
+    if (declarative && imperative) {
+      throw new Error(`Trigger ${trigger.type} declares both fetch() and poll(); pick one`)
+    }
+    if (declarative !== (loose.dedupe !== undefined)) {
+      throw new Error(
+        `Trigger ${trigger.type} needs fetch() and a dedupe strategy together, not one alone`
+      )
+    }
+    if (!declarative && !imperative) {
+      throw new Error(`Trigger ${trigger.type} is missing a fetch() or poll() implementation`)
     }
   }
   for (const action of actions) {

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -66,6 +66,9 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
           `expected ${DEDUPE_STRATEGIES.join(' or ')}`
       )
     }
+    if (loose.poll !== undefined && !imperative) {
+      throw new Error(`Trigger ${trigger.type} declares poll but it is not a function`)
+    }
     if (!declarative && !imperative) {
       throw new Error(`Trigger ${trigger.type} is missing a fetch() or poll() implementation`)
     }

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,4 +1,7 @@
 export { defineConnector, resolveConfig, envNameFor } from './define'
+export { checkConnector, formatFindings } from './check'
+export type { CheckFinding, CheckOptions } from './check'
+export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
 export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
@@ -17,6 +20,8 @@ export type {
   ConnectorConfigField,
   ConnectorDefinition,
   ConnectorItem,
+  DedupeStrategy,
+  FetchContext,
   NormalizedItem,
   PollContext,
   PollOutcome,

--- a/packages/connector-sdk/src/normalize.ts
+++ b/packages/connector-sdk/src/normalize.ts
@@ -22,6 +22,25 @@ const RESERVED_KEYS = [
  */
 const UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype'] as const
 
+/**
+ * Resolve an item's `externalId` to the string Vorn dedupes on. Exported for
+ * the same reason as `itemTimestamp`: the ids the dedupe strategies remember
+ * have to be the ones normalization emits, or a boundary id stops matching and
+ * items are silently redelivered.
+ */
+export function itemExternalId(item: ConnectorItem): string {
+  return String(item.externalId ?? '').trim()
+}
+
+/**
+ * Resolve an item's `updatedAt` to a comparable ISO string, falling back to
+ * poll time. Exported so the dedupe strategies order and window items by the
+ * exact value normalization will later emit.
+ */
+export function itemTimestamp(item: ConnectorItem, fallback: string): string {
+  return isoTimestamp(item.updatedAt, fallback)
+}
+
 function isoTimestamp(value: string | Date | undefined, fallback: string): string {
   if (value === undefined) return fallback
   const date = value instanceof Date ? value : new Date(value)
@@ -39,7 +58,7 @@ function isoTimestamp(value: string | Date | undefined, fallback: string): strin
  * work for every SDK connector.
  */
 export function normalizeItem(item: ConnectorItem, polledAt: string): NormalizedItem {
-  const externalId = String(item.externalId ?? '').trim()
+  const externalId = itemExternalId(item)
   if (!externalId) {
     throw new Error('Connector item is missing externalId')
   }

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -43,9 +43,10 @@ export async function runPoll(
     now
   }
 
-  const outcome = trigger.poll
-    ? await trigger.poll(context)
-    : await pollWithDedupe(trigger, context)
+  const outcome =
+    typeof trigger.poll === 'function'
+      ? await trigger.poll(context)
+      : await pollWithDedupe(trigger, context)
   if (!outcome || !Array.isArray(outcome.items)) {
     throw new Error(`Trigger ${triggerType} did not return an items array`)
   }

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -1,3 +1,4 @@
+import { pollWithDedupe } from './dedupe'
 import { normalizeItems } from './normalize'
 import type { Connector, ConnectorConfig, NormalizedItem, PollContext } from './types'
 
@@ -42,7 +43,9 @@ export async function runPoll(
     now
   }
 
-  const outcome = await trigger.poll(context)
+  const outcome = trigger.poll
+    ? await trigger.poll(context)
+    : await pollWithDedupe(trigger, context)
   if (!outcome || !Array.isArray(outcome.items)) {
     throw new Error(`Trigger ${triggerType} did not return an items array`)
   }

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -141,10 +141,19 @@ export function createConnectorServer(
   }
 
   for (const action of connector.actions) {
+    const base = action.description ?? `${action.label} in ${connector.name}`
+    // An agent retrying a failed step has no other way to know whether it is
+    // about to create a second issue.
+    const retryHint =
+      action.idempotent === undefined
+        ? ''
+        : action.idempotent
+          ? ' Safe to retry: repeating this call with the same arguments has no additional effect.'
+          : ' Not idempotent: repeating this call performs the operation again.'
     server.registerTool(
       action.type,
       {
-        description: action.description ?? `${action.label} in ${connector.name}`,
+        description: `${base}${retryHint}`,
         inputSchema: inputShape(action.inputs ?? []),
         outputSchema: outputSchema(action.outputs ?? [])
       },

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -20,6 +20,8 @@ export interface ConnectionSetup {
     timestampField: 'updatedAt'
     titleField: 'title'
     urlField: 'url'
+    cursorArg: 'cursor'
+    cursorPath: 'nextCursor'
   }
   /** Environment variable names the connector reads. */
   env: Array<{ name: string; required: boolean; secret: boolean; description?: string }>
@@ -30,7 +32,9 @@ export interface ConnectionSetup {
  *
  * Every SDK connector normalizes to the same field names, so this mapping is
  * fixed; it is generated rather than documented so a rename in the SDK cannot
- * drift away from the setup instructions users copy.
+ * drift away from the setup instructions users copy. `cursorArg` hands the
+ * connector back its own cursor each poll, which is what lets its dedupe
+ * strategy — rather than Vorn's timestamp comparison — decide what is new.
  */
 export function connectionSetup(connector: Connector, triggerType: string): ConnectionSetup {
   const trigger = connector.triggers.find((entry) => entry.type === triggerType)
@@ -46,7 +50,9 @@ export function connectionSetup(connector: Connector, triggerType: string): Conn
       idField: 'externalId',
       timestampField: 'updatedAt',
       titleField: 'title',
-      urlField: 'url'
+      urlField: 'url',
+      cursorArg: 'cursor',
+      cursorPath: 'nextCursor'
     },
     env: connector.config.map((field) => ({
       name: envNameFor(field.key, field.env),

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -77,13 +77,81 @@ export interface PollOutcome {
   hasMore?: boolean
 }
 
-export interface TriggerDefinition {
+/**
+ * How the SDK decides which fetched items are new.
+ *
+ * - `timestamp` — for sources that expose a reliable "last changed" field and
+ *   can filter on it. Handles the boundary case where several items share the
+ *   newest timestamp, which is the classic source of both duplicates and
+ *   silently dropped items.
+ * - `lastItem` — for feeds that return newest-first with no dependable
+ *   timestamp. The cursor is the newest id already delivered.
+ */
+export type DedupeStrategy = 'timestamp' | 'lastItem'
+
+/**
+ * What a declarative trigger's `fetch` receives. Deliberately smaller than
+ * {@link PollContext}: cursor encoding, ordering, windowing and de-duplication
+ * are the SDK's job, so the author only has to answer "what is there now?".
+ */
+export interface FetchContext {
+  config: ConnectorConfig
+  /**
+   * With `dedupe: 'timestamp'`, everything changed at or after this instant is
+   * worth returning. Absent on the very first poll. Returning a little too
+   * much is safe — the SDK drops what was already delivered.
+   */
+  since?: string
+  /**
+   * With `dedupe: 'lastItem'`, the newest id already delivered. Absent on the
+   * very first poll. Return the feed newest-first and the SDK will stop there.
+   */
+  lastItemId?: string
+  /** Upper bound on items worth returning in one call. */
+  limit?: number
+  /** Injectable clock so tests are deterministic. */
+  now(): string
+}
+
+interface TriggerBase {
   /** Event key, e.g. `workItemCreated`. Becomes the `poll_<type>` MCP tool. */
   type: string
   label: string
   description?: string
-  poll(context: PollContext): Promise<PollOutcome> | PollOutcome
+  /**
+   * Representative items. `vorn-connector check` replays these through the
+   * real dedupe pipeline, so a connector can be verified before anyone has
+   * credentials for it.
+   */
+  sample?: ConnectorItem[]
 }
+
+/**
+ * A trigger is either declarative or hand-written, never both — expressed as a
+ * union so the invalid combinations are a type error at authoring time rather
+ * than a throw when the connector is first loaded.
+ */
+export type TriggerDefinition = TriggerBase &
+  (
+    | {
+        /**
+         * Declarative polling: return what the source has and let the SDK
+         * handle cursors and de-duplication.
+         */
+        dedupe: DedupeStrategy
+        fetch(context: FetchContext): Promise<ConnectorItem[]> | ConnectorItem[]
+        poll?: never
+      }
+    | {
+        /**
+         * Full control over cursors and paging. Use only when the source's
+         * paging cannot be expressed as "give me everything since X".
+         */
+        poll(context: PollContext): Promise<PollOutcome> | PollOutcome
+        dedupe?: never
+        fetch?: never
+      }
+  )
 
 export interface ActionInputField {
   key: string
@@ -114,6 +182,12 @@ export interface ActionDefinition {
   type: string
   label: string
   description?: string
+  /**
+   * Whether repeating the call with the same arguments is safe. Surfaced in
+   * the MCP tool description, because an agent retrying a failed step has no
+   * other way to know whether it is about to create a second issue.
+   */
+  idempotent?: boolean
   inputs?: ActionInputField[]
   outputs?: ActionOutputField[]
   run(

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -322,6 +322,8 @@ export async function pollMcpConnection(
     if (UNSAFE_ARG_KEYS.includes(cfg.cursorArg)) {
       throw new Error(`Cursor argument "${cfg.cursorArg}" is not a usable argument name`)
     }
+    // Only overwrite once a cursor is stored, so any value already in
+    // `pollArgs` under this key acts as the seed for the very first poll.
     if (cursor !== undefined) pollArgs = { ...pollArgs, [cfg.cursorArg]: cursor }
   }
 

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -223,6 +223,19 @@ interface McpPollConfig {
 
 const UNSAFE_ARG_KEYS: string[] = ['__proto__', 'constructor', 'prototype']
 
+/**
+ * Tool arguments come from user-supplied JSON and are later re-keyed onto a
+ * fresh object by `coerceMcpArgs`. Keys that address the prototype chain are
+ * dropped here so that re-keying cannot mutate anything but the payload.
+ */
+function withoutUnsafeKeys(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(args)) {
+    if (!UNSAFE_ARG_KEYS.includes(key)) out[key] = value
+  }
+  return out
+}
+
 function readPollConfig(conn: SourceConnection): McpPollConfig {
   const f = conn.filters
   const str = (v: unknown): string | undefined => {
@@ -300,7 +313,7 @@ export async function pollMcpConnection(
     try {
       const parsed = JSON.parse(cfg.pollArgs)
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        pollArgs = parsed as Record<string, unknown>
+        pollArgs = withoutUnsafeKeys(parsed as Record<string, unknown>)
       } else {
         throw new Error('pollArgs must be a JSON object')
       }

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -249,6 +249,9 @@ function walkPath(root: unknown, path: string | undefined): unknown {
   let current: unknown = root
   for (const segment of path.split('.')) {
     if (current == null || typeof current !== 'object') return undefined
+    // Own properties only: a path like `constructor.name` would otherwise
+    // resolve against Object.prototype and quietly yield a real-looking value.
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined
     current = (current as Record<string, unknown>)[segment]
   }
   return current

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -217,6 +217,8 @@ interface McpPollConfig {
   timestampField?: string
   titleField?: string
   urlField?: string
+  cursorArg?: string
+  cursorPath?: string
 }
 
 function readPollConfig(conn: SourceConnection): McpPollConfig {
@@ -232,7 +234,9 @@ function readPollConfig(conn: SourceConnection): McpPollConfig {
     idField: str(f.idField),
     timestampField: str(f.timestampField),
     titleField: str(f.titleField),
-    urlField: str(f.urlField)
+    urlField: str(f.urlField),
+    cursorArg: str(f.cursorArg),
+    cursorPath: str(f.cursorPath)
   }
 }
 
@@ -264,11 +268,20 @@ function fieldString(item: Record<string, unknown>, field: string | undefined): 
  * flattened filters object) can't provide. The scheduler special-cases MCP to
  * call this directly.
  *
- * Cursor semantics mirror the GitHub connector: when a `timestampField` is
- * configured, only items with `timestampField > cursor` are emitted and the
- * cursor advances to the newest timestamp seen. Without a `timestampField`
- * every item is emitted each poll; that stays at-most-once because
- * `createTaskFromItem` upserts by `externalId` (from `idField`).
+ * Cursor semantics come in two flavours. When `cursorArg` is configured the
+ * tool owns dedup: the stored cursor is passed through as that argument, every
+ * returned item is emitted, and the next cursor is read back from the result
+ * (`cursorPath`, default `nextCursor`). Connectors built with
+ * `@vornrun/connector-sdk` are wired this way, so their dedupe strategy — not
+ * this function — decides what is new.
+ *
+ * Otherwise Vorn dedupes client-side, mirroring the GitHub connector: with a
+ * `timestampField` configured, only items with `timestampField >= cursor` are
+ * emitted and the cursor advances to the newest timestamp seen. Items exactly
+ * at the cursor are re-emitted so none are lost at the boundary; that stays
+ * at-most-once because the inbox ignores event ids it already holds. Without a
+ * `timestampField` every item is emitted each poll; that stays at-most-once
+ * because `createTaskFromItem` upserts by `externalId` (from `idField`).
  */
 export async function pollMcpConnection(
   conn: SourceConnection,
@@ -296,6 +309,10 @@ export async function pollMcpConnection(
     }
   }
 
+  if (cfg.cursorArg && cursor !== undefined) {
+    pollArgs = { ...pollArgs, [cfg.cursorArg]: cursor }
+  }
+
   const result = await invokeMcpTool(conn, cfg.pollTool, pollArgs)
   if (!result.success) {
     throw new Error(result.error || `MCP poll tool ${cfg.pollTool} failed`)
@@ -315,13 +332,21 @@ export async function pollMcpConnection(
   let newest = cursor
   for (const item of items) {
     const ts = fieldString(item, cfg.timestampField)
-    if (cfg.timestampField) {
+    // When the tool takes the cursor it has already dropped what we have seen,
+    // so filtering again here would only re-apply a weaker rule to its output.
+    if (cfg.timestampField && !cfg.cursorArg) {
       // With ordering configured, an item that lacks the timestamp field can't
       // be placed relative to the cursor — emit it and it would re-fire every
       // poll. Skip it rather than churn.
       if (ts === undefined) continue
-      // Skip items at or before the cursor.
-      if (cursor && ts <= cursor) continue
+      // Skip items strictly before the cursor. Items *at* the cursor are
+      // re-emitted on purpose: the newest timestamp is usually shared by
+      // several items, and skipping them would drop the ones that arrived
+      // after this cursor was recorded — permanently, since nothing re-reads
+      // that window. Re-emission is free because the inbox insert ignores an
+      // event id it has already stored. The GitHub connector rewinds its
+      // cursor by a second for the same reason.
+      if (cursor && ts < cursor) continue
     }
     if (ts !== undefined && (newest === undefined || ts > newest)) newest = ts
 
@@ -347,6 +372,11 @@ export async function pollMcpConnection(
 
   // Advance the cursor only when we can order by timestamp; otherwise leave it
   // unset and rely on upsert dedup.
+  if (cfg.cursorArg) {
+    const next = walkPath(result.output, cfg.cursorPath ?? 'nextCursor')
+    const nextCursor = typeof next === 'string' && next ? next : cursor
+    return nextCursor === undefined ? { events } : { events, nextCursor }
+  }
   return cfg.timestampField ? { events, nextCursor: newest ?? cursor } : { events }
 }
 
@@ -460,6 +490,25 @@ export const mcpConnector: VornConnector = {
           type: 'text',
           placeholder: 'url',
           description: 'Field mapped into the created task URL.'
+        },
+        {
+          key: 'cursorArg',
+          label: 'Cursor argument',
+          type: 'text',
+          placeholder: 'cursor',
+          description:
+            'Tool argument that receives the previous cursor. Set this when the tool tracks ' +
+            'what it has already returned; Vorn then fires for every item it hands back ' +
+            'instead of filtering by timestamp field.'
+        },
+        {
+          key: 'cursorPath',
+          label: 'Cursor path',
+          type: 'text',
+          placeholder: 'nextCursor',
+          description:
+            'Dotted path to the next cursor in the tool result. Only used with a cursor ' +
+            'argument. Blank = `nextCursor`.'
         }
       ],
       triggers: [

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -311,13 +311,15 @@ export async function pollMcpConnection(
     }
   }
 
-  if (cfg.cursorArg && cursor !== undefined) {
+  if (cfg.cursorArg) {
     // `cursorArg` is user-supplied and becomes an object key, so a name that
-    // walks the prototype chain must not get that far.
+    // walks the prototype chain must not get that far. Checked whenever it is
+    // configured, not just once a cursor exists, so a misconfigured connection
+    // fails on its first poll rather than days later.
     if (UNSAFE_ARG_KEYS.includes(cfg.cursorArg)) {
       throw new Error(`Cursor argument "${cfg.cursorArg}" is not a usable argument name`)
     }
-    pollArgs = { ...pollArgs, [cfg.cursorArg]: cursor }
+    if (cursor !== undefined) pollArgs = { ...pollArgs, [cfg.cursorArg]: cursor }
   }
 
   const result = await invokeMcpTool(conn, cfg.pollTool, pollArgs)

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -221,6 +221,8 @@ interface McpPollConfig {
   cursorPath?: string
 }
 
+const UNSAFE_ARG_KEYS: string[] = ['__proto__', 'constructor', 'prototype']
+
 function readPollConfig(conn: SourceConnection): McpPollConfig {
   const f = conn.filters
   const str = (v: unknown): string | undefined => {
@@ -310,6 +312,11 @@ export async function pollMcpConnection(
   }
 
   if (cfg.cursorArg && cursor !== undefined) {
+    // `cursorArg` is user-supplied and becomes an object key, so a name that
+    // walks the prototype chain must not get that far.
+    if (UNSAFE_ARG_KEYS.includes(cfg.cursorArg)) {
+      throw new Error(`Cursor argument "${cfg.cursorArg}" is not a usable argument name`)
+    }
     pollArgs = { ...pollArgs, [cfg.cursorArg]: cursor }
   }
 

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -56,6 +56,24 @@ describe('declarative triggers', () => {
     ).toThrow(/fetch\(\) and a dedupe strategy together/)
   })
 
+  it('rejects a misspelled dedupe strategy instead of guessing one', () => {
+    expect(() =>
+      defineConnector({
+        id: 'x',
+        name: 'X',
+        triggers: [
+          {
+            type: 'a',
+            label: 'A',
+            // A plain-JS author gets no type error here.
+            dedupe: 'timeStamp' as 'timestamp',
+            fetch: () => []
+          }
+        ]
+      })
+    ).toThrow(/unknown dedupe strategy "timeStamp"; expected timestamp or lastItem/)
+  })
+
   it('hands the author a since derived from its own cursor', async () => {
     const seen: (string | undefined)[] = []
     const connector = timestampConnector((context) => {

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -56,6 +56,25 @@ describe('declarative triggers', () => {
     ).toThrow(/fetch\(\) and a dedupe strategy together/)
   })
 
+  it('rejects a poll that is not callable rather than crashing at poll time', () => {
+    expect(() =>
+      defineConnector({
+        id: 'x',
+        name: 'X',
+        triggers: [
+          {
+            type: 'a',
+            label: 'A',
+            dedupe: 'timestamp',
+            fetch: () => [],
+            // A plain-JS author gets no type error here.
+            poll: 'later' as unknown as undefined
+          }
+        ]
+      })
+    ).toThrow(/declares poll but it is not a function/)
+  })
+
   it('rejects a misspelled dedupe strategy instead of guessing one', () => {
     expect(() =>
       defineConnector({
@@ -223,6 +242,13 @@ describe('timestamp dedupe', () => {
     await expect(
       runPoll(connector, 'newTicket', {
         cursor: '{"v":1,"s":"timestamp","t":"2026-01-01T00:00:00.000Z","ids":5}',
+        now: () => NOW
+      })
+    ).rejects.toThrow(/missing the fields the "timestamp" strategy needs/)
+
+    await expect(
+      runPoll(connector, 'newTicket', {
+        cursor: '{"v":1,"s":"timestamp","t":"2026-01-01T00:00:00.000Z","ids":[1]}',
         now: () => NOW
       })
     ).rejects.toThrow(/missing the fields the "timestamp" strategy needs/)

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkConnector,
+  defineConnector,
+  drainPoll,
+  formatFindings,
+  runPoll,
+  type ConnectorItem,
+  type FetchContext
+} from '../packages/connector-sdk/src'
+
+const NOW = '2026-08-05T12:00:00.000Z'
+
+function ticket(id: string, updatedAt: string): ConnectorItem {
+  return { externalId: id, title: `Ticket ${id}`, updatedAt }
+}
+
+/** A connector whose fetch records what the SDK asked for. */
+function timestampConnector(
+  fetch: (context: FetchContext) => ConnectorItem[] | Promise<ConnectorItem[]>
+) {
+  return defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    triggers: [{ type: 'newTicket', label: 'New ticket', dedupe: 'timestamp', fetch }]
+  })
+}
+
+function lastItemConnector(
+  fetch: (context: FetchContext) => ConnectorItem[] | Promise<ConnectorItem[]>
+) {
+  return defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    triggers: [{ type: 'newPost', label: 'New post', dedupe: 'lastItem', fetch }]
+  })
+}
+
+describe('declarative triggers', () => {
+  it('rejects a trigger that mixes or omits the two polling styles', () => {
+    const base = { type: 'a', label: 'A' }
+    expect(() =>
+      defineConnector({
+        id: 'x',
+        name: 'X',
+        triggers: [{ ...base, dedupe: 'timestamp', fetch: () => [], poll: () => ({ items: [] }) }]
+      })
+    ).toThrow(/declares both fetch\(\) and poll\(\)/)
+
+    expect(() =>
+      defineConnector({ id: 'x', name: 'X', triggers: [{ ...base, fetch: () => [] }] })
+    ).toThrow(/fetch\(\) and a dedupe strategy together/)
+
+    expect(() =>
+      defineConnector({ id: 'x', name: 'X', triggers: [{ ...base, dedupe: 'timestamp' }] })
+    ).toThrow(/fetch\(\) and a dedupe strategy together/)
+  })
+
+  it('hands the author a since derived from its own cursor', async () => {
+    const seen: (string | undefined)[] = []
+    const connector = timestampConnector((context) => {
+      seen.push(context.since)
+      return [ticket('1', '2026-08-05T10:00:00.000Z')]
+    })
+
+    const first = await runPoll(connector, 'newTicket', { since: '2026-08-01T00:00:00.000Z' })
+    await runPoll(connector, 'newTicket', { cursor: first.nextCursor!, now: () => NOW })
+
+    expect(seen).toEqual(['2026-08-01T00:00:00.000Z', '2026-08-05T10:00:00.000Z'])
+  })
+})
+
+describe('timestamp dedupe', () => {
+  it('never redelivers items that share the newest timestamp', async () => {
+    const shared = '2026-08-05T10:00:00.000Z'
+    const items = [ticket('1', shared), ticket('2', shared), ticket('3', shared)]
+    const connector = timestampConnector(() => items)
+
+    const first = await runPoll(connector, 'newTicket', { now: () => NOW })
+    expect(first.items.map((item) => item.externalId)).toEqual(['1', '2', '3'])
+
+    // The source still returns all three; none of them may come back.
+    const second = await runPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      now: () => NOW
+    })
+    expect(second.items).toEqual([])
+  })
+
+  it('still delivers a late item stamped at the boundary instant', async () => {
+    const shared = '2026-08-05T10:00:00.000Z'
+    let items = [ticket('1', shared)]
+    const connector = timestampConnector(() => items)
+
+    const first = await runPoll(connector, 'newTicket', { now: () => NOW })
+    // A second item appears with the exact same timestamp after the first poll.
+    items = [ticket('1', shared), ticket('2', shared)]
+
+    const second = await runPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      now: () => NOW
+    })
+    expect(second.items.map((item) => item.externalId)).toEqual(['2'])
+  })
+
+  it('emits oldest first and leaves the newest behind when truncating', async () => {
+    const connector = timestampConnector(() => [
+      ticket('3', '2026-08-05T12:00:00.000Z'),
+      ticket('1', '2026-08-05T10:00:00.000Z'),
+      ticket('2', '2026-08-05T11:00:00.000Z')
+    ])
+
+    const first = await runPoll(connector, 'newTicket', { limit: 2, now: () => NOW })
+    expect(first.items.map((item) => item.externalId)).toEqual(['1', '2'])
+    // A first poll must not drain the source's whole history.
+    expect(first.hasMore).toBe(false)
+
+    const second = await runPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      limit: 2,
+      now: () => NOW
+    })
+    expect(second.items.map((item) => item.externalId)).toEqual(['3'])
+  })
+
+  it('drains a truncated backlog once a cursor exists', async () => {
+    const all = Array.from({ length: 5 }, (_, index) =>
+      ticket(String(index), `2026-08-05T1${index}:00:00.000Z`)
+    )
+    const connector = timestampConnector(() => all)
+
+    const first = await runPoll(connector, 'newTicket', { limit: 2, now: () => NOW })
+    expect(first.hasMore).toBe(false)
+
+    const rest = await drainPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      limit: 2,
+      now: () => NOW
+    })
+    expect(rest.map((item) => item.externalId)).toEqual(['2', '3', '4'])
+  })
+
+  it('holds its cursor when a poll finds nothing', async () => {
+    const connector = timestampConnector(() => [])
+    const cursor = '{"v":1,"s":"timestamp","t":"2026-08-05T10:00:00.000Z","ids":["1"]}'
+    const page = await runPoll(connector, 'newTicket', { cursor, now: () => NOW })
+    expect(page).toEqual({ items: [], nextCursor: cursor, hasMore: false })
+  })
+
+  it('falls back to poll time for items with no timestamp', async () => {
+    const connector = timestampConnector(() => [{ externalId: '1', title: 'No timestamp' }])
+    const first = await runPoll(connector, 'newTicket', { now: () => NOW })
+    expect(first.items[0]!.updatedAt).toBe(NOW)
+    expect(JSON.parse(first.nextCursor!).t).toBe(NOW)
+  })
+
+  it('rejects a cursor belonging to another strategy', async () => {
+    const connector = timestampConnector(() => [])
+    await expect(
+      runPoll(connector, 'newTicket', { cursor: '{"v":1,"s":"lastItem","id":"9"}', now: () => NOW })
+    ).rejects.toThrow(/does not belong to the "timestamp" strategy/)
+    await expect(
+      runPoll(connector, 'newTicket', { cursor: 'not json', now: () => NOW })
+    ).rejects.toThrow(/not valid SDK cursor JSON/)
+  })
+
+  it('rejects a fetch that does not return an array', async () => {
+    const connector = timestampConnector(() => undefined as never)
+    await expect(runPoll(connector, 'newTicket', { now: () => NOW })).rejects.toThrow(
+      /fetch\(\) did not return an array/
+    )
+  })
+})
+
+describe('lastItem dedupe', () => {
+  const post = (id: string): ConnectorItem => ({ externalId: id, title: `Post ${id}` })
+
+  it('stops at the newest id it already delivered and emits chronologically', async () => {
+    let feed = [post('3'), post('2'), post('1')]
+    const connector = lastItemConnector(() => feed)
+
+    const first = await runPoll(connector, 'newPost', { now: () => NOW })
+    expect(first.items.map((item) => item.externalId)).toEqual(['1', '2', '3'])
+
+    feed = [post('5'), post('4'), post('3'), post('2'), post('1')]
+    const second = await runPoll(connector, 'newPost', {
+      cursor: first.nextCursor!,
+      now: () => NOW
+    })
+    expect(second.items.map((item) => item.externalId)).toEqual(['4', '5'])
+  })
+
+  it('tells the author which id it already has', async () => {
+    const seen: (string | undefined)[] = []
+    const connector = lastItemConnector((context) => {
+      seen.push(context.lastItemId)
+      return [post('2'), post('1')]
+    })
+
+    const first = await runPoll(connector, 'newPost', { now: () => NOW })
+    await runPoll(connector, 'newPost', { cursor: first.nextCursor!, now: () => NOW })
+    expect(seen).toEqual([undefined, '2'])
+  })
+
+  it('advances only over what it delivered when truncating', async () => {
+    const connector = lastItemConnector(() => [post('4'), post('3'), post('2'), post('1')])
+    const first = await runPoll(connector, 'newPost', { limit: 2, now: () => NOW })
+    expect(first.items.map((item) => item.externalId)).toEqual(['1', '2'])
+
+    const second = await runPoll(connector, 'newPost', {
+      cursor: first.nextCursor!,
+      limit: 2,
+      now: () => NOW
+    })
+    expect(second.items.map((item) => item.externalId)).toEqual(['3', '4'])
+  })
+
+  it('delivers everything when it has fallen off the end of the feed', async () => {
+    const connector = lastItemConnector(() => [post('9'), post('8')])
+    const page = await runPoll(connector, 'newPost', {
+      cursor: '{"v":1,"s":"lastItem","id":"1"}',
+      now: () => NOW
+    })
+    expect(page.items.map((item) => item.externalId)).toEqual(['8', '9'])
+  })
+
+  it('holds its cursor when the feed has nothing new', async () => {
+    const connector = lastItemConnector(() => [post('1')])
+    const cursor = '{"v":1,"s":"lastItem","id":"1"}'
+    const page = await runPoll(connector, 'newPost', { cursor, now: () => NOW })
+    expect(page).toEqual({ items: [], nextCursor: cursor, hasMore: false })
+  })
+})
+
+describe('checkConnector', () => {
+  const clean = defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    description: 'Acme tickets',
+    triggers: [
+      {
+        type: 'newTicket',
+        label: 'New ticket',
+        description: 'Tickets opened since the last poll',
+        dedupe: 'timestamp',
+        fetch: () => [],
+        sample: [ticket('1', '2026-08-05T10:00:00.000Z')]
+      }
+    ],
+    actions: [
+      {
+        type: 'closeTicket',
+        label: 'Close ticket',
+        description: 'Close a ticket',
+        idempotent: true,
+        inputs: [{ key: 'id', label: 'Id', description: 'Ticket id' }],
+        run: () => ({})
+      }
+    ]
+  })
+
+  it('passes a well-formed connector using only its samples', async () => {
+    expect(await checkConnector(clean)).toEqual([])
+  })
+
+  it('catches a connector that redelivers its own items', async () => {
+    const broken = defineConnector({
+      id: 'broken',
+      name: 'Broken',
+      description: 'Broken',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'Never advances',
+          // A hand-rolled poll that ignores the cursor: the classic bug.
+          poll: () => ({ items: [ticket('1', '2026-08-05T10:00:00.000Z')], nextCursor: 'same' })
+        }
+      ]
+    })
+
+    const findings = await checkConnector(broken, { live: true, config: {}, now: () => NOW })
+    expect(findings.map((item) => item.code)).toContain('redelivers-items')
+    expect(findings.find((item) => item.code === 'redelivers-items')!.level).toBe('error')
+  })
+
+  it('reports a trigger that returns items with no cursor', async () => {
+    const broken = defineConnector({
+      id: 'broken',
+      name: 'Broken',
+      description: 'Broken',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'No cursor',
+          poll: () => ({ items: [ticket('1', '2026-08-05T10:00:00.000Z')] })
+        }
+      ]
+    })
+    const findings = await checkConnector(broken, { live: true, config: {}, now: () => NOW })
+    expect(findings.map((item) => item.code)).toEqual(['no-cursor'])
+  })
+
+  it('reports a trigger whose first poll throws', async () => {
+    const broken = defineConnector({
+      id: 'broken',
+      name: 'Broken',
+      description: 'Broken',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'Throws',
+          poll: () => {
+            throw new Error('boom')
+          }
+        }
+      ]
+    })
+    const findings = await checkConnector(broken, { live: true, config: {}, now: () => NOW })
+    expect(findings[0]!.code).toBe('poll-failed')
+    expect(findings[0]!.message).toContain('boom')
+  })
+
+  it('warns when nothing could be verified', async () => {
+    const bare = defineConnector({
+      id: 'bare',
+      name: 'Bare',
+      triggers: [{ type: 'newTicket', label: 'New ticket', poll: () => ({ items: [] }) }],
+      actions: [{ type: 'ping', label: 'Ping', run: () => ({}) }]
+    })
+
+    const codes = (await checkConnector(bare)).map((item) => item.code)
+    expect(codes).toContain('missing-description')
+    expect(codes).toContain('unverifiable')
+    expect(codes).toContain('missing-idempotent')
+    expect((await checkConnector(bare)).every((item) => item.level === 'warn')).toBe(true)
+  })
+
+  it('warns that samples cannot be replayed through a hand-written poll', async () => {
+    const manual = defineConnector({
+      id: 'manual',
+      name: 'Manual',
+      description: 'Manual',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'Manual',
+          poll: () => ({ items: [] }),
+          sample: [ticket('1', '2026-08-05T10:00:00.000Z')]
+        }
+      ]
+    })
+    expect((await checkConnector(manual)).map((item) => item.code)).toEqual(['sample-unusable'])
+  })
+
+  it('warns when a live poll returns nothing to check', async () => {
+    const empty = defineConnector({
+      id: 'empty',
+      name: 'Empty',
+      description: 'Empty',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'Empty',
+          dedupe: 'timestamp',
+          fetch: () => []
+        }
+      ]
+    })
+    expect(
+      (await checkConnector(empty, { live: true, config: {} })).map((item) => item.code)
+    ).toEqual(['no-items'])
+  })
+
+  it('renders findings for a terminal', () => {
+    expect(
+      formatFindings([{ level: 'error', code: 'x', target: 'trigger a', message: 'broke' }])
+    ).toBe('error  trigger a: broke [x]')
+    expect(formatFindings([])).toBe('')
+  })
+})

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -218,6 +218,27 @@ describe('timestamp dedupe', () => {
     ).rejects.toThrow(/not valid SDK cursor JSON/)
   })
 
+  it('rejects a cursor whose payload is malformed', async () => {
+    const connector = timestampConnector(() => [])
+    await expect(
+      runPoll(connector, 'newTicket', {
+        cursor: '{"v":1,"s":"timestamp","t":"2026-01-01T00:00:00.000Z","ids":5}',
+        now: () => NOW
+      })
+    ).rejects.toThrow(/missing the fields the "timestamp" strategy needs/)
+
+    await expect(
+      runPoll(
+        lastItemConnector(() => []),
+        'newPost',
+        {
+          cursor: '{"v":1,"s":"lastItem"}',
+          now: () => NOW
+        }
+      )
+    ).rejects.toThrow(/missing the fields the "lastItem" strategy needs/)
+  })
+
   it('rejects a fetch that does not return an array', async () => {
     const connector = timestampConnector(() => undefined as never)
     await expect(runPoll(connector, 'newTicket', { now: () => NOW })).rejects.toThrow(

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -154,6 +154,42 @@ describe('timestamp dedupe', () => {
     expect(JSON.parse(first.nextCursor!).t).toBe(NOW)
   })
 
+  it('does not redeliver a timestamp-less item as poll time moves on', async () => {
+    const connector = timestampConnector(() => [{ externalId: '1', title: 'No timestamp' }])
+    const first = await runPoll(connector, 'newTicket', { now: () => NOW })
+
+    // Poll time has advanced, but the item is the same one — giving it the new
+    // poll time would make it look newer than the cursor on every single poll.
+    const later = '2026-08-05T13:00:00.000Z'
+    const second = await runPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      now: () => later
+    })
+    expect(second.items).toEqual([])
+  })
+
+  it('still recognizes a timestamp-less item after the boundary has moved past it', async () => {
+    let rows: ConnectorItem[] = [{ externalId: 'x', title: 'No timestamp' }]
+    const connector = timestampConnector(() => rows)
+    const first = await runPoll(connector, 'newTicket', { now: () => NOW })
+    expect(first.items.map((item) => item.externalId)).toEqual(['x'])
+
+    // A properly stamped item arrives and drags the boundary forward. The
+    // timestamp-less one must not come back with it.
+    rows = [...rows, ticket('2', '2026-08-05T14:00:00.000Z')]
+    const second = await runPoll(connector, 'newTicket', {
+      cursor: first.nextCursor!,
+      now: () => '2026-08-05T13:00:00.000Z'
+    })
+    expect(second.items.map((item) => item.externalId)).toEqual(['2'])
+
+    const third = await runPoll(connector, 'newTicket', {
+      cursor: second.nextCursor!,
+      now: () => '2026-08-05T15:00:00.000Z'
+    })
+    expect(third.items).toEqual([])
+  })
+
   it('rejects a cursor belonging to another strategy', async () => {
     const connector = timestampConnector(() => [])
     await expect(

--- a/tests/connector-sdk-integration.test.ts
+++ b/tests/connector-sdk-integration.test.ts
@@ -26,7 +26,9 @@ const SETUP_FILTERS = {
   idField: 'externalId',
   timestampField: 'updatedAt',
   titleField: 'title',
-  urlField: 'url'
+  urlField: 'url',
+  cursorArg: 'cursor',
+  cursorPath: 'nextCursor'
 }
 
 const orders = [
@@ -41,9 +43,10 @@ const connector = defineConnector({
     {
       type: 'newOrder',
       label: 'New order',
-      poll: ({ since }) => ({
-        items: orders
-          .filter((order) => !since || order.updatedAt > since)
+      dedupe: 'timestamp',
+      fetch: ({ since }) =>
+        orders
+          .filter((order) => !since || order.updatedAt >= since)
           .map((order) => ({
             externalId: order.id,
             title: `Order ${order.reference}`,
@@ -52,7 +55,6 @@ const connector = defineConnector({
             updatedAt: order.updatedAt,
             data: { reference: order.reference }
           }))
-      })
     }
   ],
   actions: [
@@ -98,7 +100,9 @@ describe('an SDK connector behind Vorn’s MCP connector', () => {
     const result = await pollMcpConnection(conn)
 
     expect(result.events.map((event) => event.id)).toEqual(['o-1', 'o-2'])
-    expect(result.nextCursor).toBe('2026-08-04T11:00:00.000Z')
+    // The cursor Vorn stores is the connector's own opaque one, handed straight
+    // back on the next poll rather than re-derived from timestamps here.
+    expect(JSON.parse(result.nextCursor!)).toMatchObject({ s: 'timestamp' })
     expect(result.events[0].data).toMatchObject({
       externalId: 'o-1',
       title: 'Order A',
@@ -108,13 +112,15 @@ describe('an SDK connector behind Vorn’s MCP connector', () => {
     })
   })
 
-  it('delivers nothing new once its cursor has caught up', async () => {
+  it('delivers nothing once its cursor has caught up', async () => {
     const conn = await connection()
     const { pollMcpConnection } = await import('../packages/server/src/connectors/mcp')
 
     const first = await pollMcpConnection(conn)
     const second = await pollMcpConnection(conn, first.nextCursor)
 
+    // The connector recognizes its own cursor, so nothing is re-delivered —
+    // not even the items sharing the newest instant.
     expect(second.events).toEqual([])
     expect(second.nextCursor).toBe(first.nextCursor)
   })
@@ -152,5 +158,61 @@ describe('an SDK connector behind Vorn’s MCP connector', () => {
     expect(Object.keys((ship?.outputSchema?.properties ?? {}) as Record<string, unknown>)).toEqual([
       'shipped'
     ])
+  })
+
+  it('drives a declarative dedupe trigger without the author writing cursor code', async () => {
+    const shared = '2026-08-04T12:00:00.000Z'
+    let rows = [{ id: 'r-1', updatedAt: shared }]
+    const declarative = defineConnector({
+      id: 'orders-db',
+      name: 'Orders database',
+      triggers: [
+        {
+          type: 'newOrder',
+          label: 'New order',
+          dedupe: 'timestamp',
+          // The author only answers "what is there now?" — no cursor handling.
+          fetch: () =>
+            rows.map((row) => ({
+              externalId: row.id,
+              title: `Order ${row.id}`,
+              updatedAt: row.updatedAt
+            }))
+        }
+      ]
+    })
+
+    const server = createConnectorServer(declarative, { config: {}, now: () => NOW })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'vorn', version: '1.0.0' })
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+    getOrStartClient.mockResolvedValue(client)
+
+    const { discoverTools, pollMcpConnection } =
+      await import('../packages/server/src/connectors/mcp')
+    const base: SourceConnection = {
+      id: 'conn-declarative',
+      connectorId: 'mcp',
+      name: 'Orders database',
+      filters: { ...SETUP_FILTERS },
+      syncIntervalMinutes: 5,
+      statusMapping: {},
+      createdAt: NOW
+    }
+    const conn = {
+      ...base,
+      filters: { ...base.filters, discoveredTools: await discoverTools(base) }
+    }
+
+    const first = await pollMcpConnection(conn)
+    expect(first.events.map((event) => event.id)).toEqual(['r-1'])
+
+    // A second row lands at the exact same instant — the case that silently
+    // loses items when a connector windows on `updatedAt > cursor`.
+    rows = [...rows, { id: 'r-2', updatedAt: shared }]
+    const second = await pollMcpConnection(conn, first.nextCursor)
+    expect(second.events.map((event) => event.id)).toEqual(['r-2'])
+
+    await client.close()
   })
 })

--- a/tests/connector-sdk-server.test.ts
+++ b/tests/connector-sdk-server.test.ts
@@ -51,6 +51,7 @@ const connector: Connector = defineConnector({
     {
       type: 'closeTicket',
       label: 'Close ticket',
+      idempotent: true,
       inputs: [
         { key: 'id', label: 'Id', required: true },
         { key: 'reason', label: 'Reason' }
@@ -155,6 +156,33 @@ describe('connector MCP server', () => {
     await client.close()
   })
 
+  it('tells an agent whether an action is safe to retry', async () => {
+    const client = await connect()
+    const tools = (await client.listTools()).tools
+    expect(tools.find((entry) => entry.name === 'closeTicket')?.description).toContain(
+      'Safe to retry'
+    )
+
+    const risky = createConnectorServer(
+      defineConnector({
+        id: 'risky',
+        name: 'Risky',
+        actions: [
+          { type: 'createTicket', label: 'Create ticket', idempotent: false, run: () => ({}) }
+        ]
+      }),
+      { config: {} }
+    )
+    const [riskyClient, riskyServer] = InMemoryTransport.createLinkedPair()
+    const probe = new Client({ name: 'probe', version: '1.0.0' })
+    await Promise.all([risky.connect(riskyServer), probe.connect(riskyClient)])
+    expect(
+      (await probe.listTools()).tools.find((entry) => entry.name === 'createTicket')?.description
+    ).toContain('Not idempotent')
+    await probe.close()
+    await client.close()
+  })
+
   it('serves the manifest a user needs to configure the connection', async () => {
     const client = await connect()
     expect(payload(await client.callTool({ name: MANIFEST_TOOL, arguments: {} }))).toEqual(
@@ -175,7 +203,9 @@ describe('connectionSetup', () => {
         idField: 'externalId',
         timestampField: 'updatedAt',
         titleField: 'title',
-        urlField: 'url'
+        urlField: 'url',
+        cursorArg: 'cursor',
+        cursorPath: 'nextCursor'
       },
       env: [
         { name: 'API_TOKEN', required: true, secret: true },
@@ -211,6 +241,36 @@ describe('vorn-connector CLI', () => {
     const all = capture()
     await runCli(['setup', 'pkg'], { load, write: all.write })
     expect(all.lines.join('\n')).toContain('poll_brokenTrigger')
+  })
+
+  it('checks a connector and fails only on errors', async () => {
+    const warnings = capture()
+    expect(await runCli(['check', 'pkg'], { load, write: warnings.write })).toBe(0)
+    expect(warnings.lines.join('\n')).toContain('passed with')
+
+    const broken = defineConnector({
+      id: 'broken',
+      name: 'Broken',
+      description: 'Broken',
+      triggers: [
+        {
+          type: 'stuck',
+          label: 'Stuck',
+          description: 'Ignores its cursor',
+          poll: () => ({ items: [{ externalId: '1', title: 'One' }], nextCursor: 'same' })
+        }
+      ]
+    })
+    const errors = capture()
+    expect(
+      await runCli(['check', 'pkg', '--live'], {
+        load: async () => ({ default: broken }),
+        write: errors.write,
+        env: {}
+      })
+    ).toBe(1)
+    expect(errors.lines.join('\n')).toContain('redelivers-items')
+    expect(errors.lines.join('\n')).toContain('1 error(s)')
   })
 
   it('polls against the supplied environment', async () => {

--- a/tests/connector-sdk.test.ts
+++ b/tests/connector-sdk.test.ts
@@ -68,7 +68,7 @@ describe('defineConnector', () => {
         name: 'Acme',
         triggers: [{ type: 'a', label: 'A' } as never]
       })
-    ).toThrow(/missing a poll\(\)/)
+    ).toThrow(/missing a fetch\(\) or poll\(\)/)
   })
 
   it('rejects duplicate config keys', () => {

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -234,6 +234,19 @@ describe('pollMcpConnection', () => {
       expect(result.nextCursor).toBe('c1')
     })
 
+    it('drops prototype-chain keys from user-supplied pollArgs', async () => {
+      toolReturns({ items: [] })
+      await pollMcpConnection(
+        cursorConn({ pollArgs: '{"__proto__":{"polluted":true},"limit":5}' }),
+        undefined
+      )
+      expect(callTool).toHaveBeenCalledWith({
+        name: 'poll_newOrder',
+        arguments: { limit: 5 }
+      })
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    })
+
     it('refuses a cursor argument that would reach the prototype chain', async () => {
       toolReturns({ items: [], nextCursor: 'c2' })
       await expect(pollMcpConnection(cursorConn({ cursorArg: '__proto__' }), 'c1')).rejects.toThrow(

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -215,6 +215,13 @@ describe('pollMcpConnection', () => {
       expect(result.nextCursor).toBe('c2')
     })
 
+    it('ignores a cursor path that only resolves through the prototype chain', async () => {
+      toolReturns({ items: [] })
+      const result = await pollMcpConnection(cursorConn({ cursorPath: 'constructor.name' }), 'c1')
+      // Without an own-property check this would store "Object" as the cursor.
+      expect(result.nextCursor).toBe('c1')
+    })
+
     it('reads the next cursor from a configured cursorPath', async () => {
       toolReturns({ items: [], paging: { next: 'c9' } })
       const result = await pollMcpConnection(cursorConn({ cursorPath: 'paging.next' }))

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -227,6 +227,13 @@ describe('pollMcpConnection', () => {
       expect(result.nextCursor).toBe('c1')
     })
 
+    it('refuses a cursor argument that would reach the prototype chain', async () => {
+      toolReturns({ items: [], nextCursor: 'c2' })
+      await expect(pollMcpConnection(cursorConn({ cursorArg: '__proto__' }), 'c1')).rejects.toThrow(
+        /not a usable argument name/
+      )
+    })
+
     it('emits every item the tool returned instead of filtering by timestamp', async () => {
       // The tool already dropped what Vorn has seen; re-filtering here against
       // an opaque cursor would only throw away items it deliberately sent.

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -67,7 +67,7 @@ describe('pollMcpConnection', () => {
     expect(result.nextCursor).toBe('2026-07-02')
   })
 
-  it('filters out items at or before the cursor when a timestampField is set', async () => {
+  it('filters out items strictly before the cursor when a timestampField is set', async () => {
     toolReturns({
       items: [
         { id: 'a', ts: '2026-07-01' },
@@ -82,6 +82,25 @@ describe('pollMcpConnection', () => {
     expect(result.nextCursor).toBe('2026-07-03')
   })
 
+  it('re-emits items sharing the cursor timestamp so none are lost at the boundary', async () => {
+    // 'known' was delivered by the poll that set this cursor; 'late' has the
+    // same timestamp but showed up afterwards. Skipping the whole instant
+    // would drop 'late' permanently, so both are re-emitted and the inbox
+    // ignores the one it already stored.
+    toolReturns({
+      items: [
+        { id: 'known', ts: '2026-07-02' },
+        { id: 'late', ts: '2026-07-02' }
+      ]
+    })
+    const result = await pollMcpConnection(
+      makeConn({ pollTool: 'list', itemsPath: 'items', idField: 'id', timestampField: 'ts' }),
+      '2026-07-02'
+    )
+    expect(result.events.map((e) => e.id)).toEqual(['known', 'late'])
+    expect(result.nextCursor).toBe('2026-07-02')
+  })
+
   it('skips items missing the timestampField when ordering is configured', async () => {
     toolReturns({
       items: [
@@ -94,7 +113,7 @@ describe('pollMcpConnection', () => {
       makeConn({ pollTool: 'list', itemsPath: 'items', idField: 'id', timestampField: 'ts' }),
       '2026-07-02'
     )
-    // Only 'a' (ts > cursor) fires; 'b' (no ts) and 'c' (<= cursor) are skipped.
+    // Only 'a' (ts > cursor) fires; 'b' (no ts) and 'c' (before cursor) are skipped.
     expect(result.events.map((e) => e.id)).toEqual(['a'])
     expect(result.nextCursor).toBe('2026-07-03')
   })
@@ -164,5 +183,62 @@ describe('pollMcpConnection', () => {
       pollMcpConnection(makeConn({ pollTool: 'list', pollArgs: '[1, 2, 3]' }))
     ).rejects.toThrow(/must be a JSON object/)
     expect(callTool).not.toHaveBeenCalled()
+  })
+
+  describe('when the tool tracks its own cursor (cursorArg)', () => {
+    const cursorConn = (extra: Record<string, unknown> = {}) =>
+      makeConn({
+        pollTool: 'poll_newOrder',
+        itemsPath: 'items',
+        idField: 'externalId',
+        timestampField: 'updatedAt',
+        cursorArg: 'cursor',
+        pollArgs: '{"project": "acme"}',
+        ...extra
+      })
+
+    it('hands the stored cursor back to the tool alongside the static args', async () => {
+      toolReturns({ items: [], nextCursor: 'c2' })
+      await pollMcpConnection(cursorConn(), 'c1')
+      expect(callTool).toHaveBeenCalledWith({
+        name: 'poll_newOrder',
+        arguments: { project: 'acme', cursor: 'c1' }
+      })
+    })
+
+    it('stores the cursor the tool returned rather than the newest timestamp', async () => {
+      toolReturns({
+        items: [{ externalId: 'a', updatedAt: '2026-07-02' }],
+        nextCursor: 'c2'
+      })
+      const result = await pollMcpConnection(cursorConn(), 'c1')
+      expect(result.nextCursor).toBe('c2')
+    })
+
+    it('reads the next cursor from a configured cursorPath', async () => {
+      toolReturns({ items: [], paging: { next: 'c9' } })
+      const result = await pollMcpConnection(cursorConn({ cursorPath: 'paging.next' }))
+      expect(result.nextCursor).toBe('c9')
+    })
+
+    it('keeps the previous cursor when the tool returns none', async () => {
+      toolReturns({ items: [] })
+      const result = await pollMcpConnection(cursorConn(), 'c1')
+      expect(result.nextCursor).toBe('c1')
+    })
+
+    it('emits every item the tool returned instead of filtering by timestamp', async () => {
+      // The tool already dropped what Vorn has seen; re-filtering here against
+      // an opaque cursor would only throw away items it deliberately sent.
+      toolReturns({
+        items: [
+          { externalId: 'a', updatedAt: '2026-07-01' },
+          { externalId: 'b', updatedAt: '2026-07-02' }
+        ],
+        nextCursor: 'c2'
+      })
+      const result = await pollMcpConnection(cursorConn(), 'c1')
+      expect(result.events.map((event) => event.id)).toEqual(['a', 'b'])
+    })
   })
 })

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -234,6 +234,13 @@ describe('pollMcpConnection', () => {
       )
     })
 
+    it('refuses it on the very first poll, before any cursor exists', async () => {
+      await expect(pollMcpConnection(cursorConn({ cursorArg: 'constructor' }))).rejects.toThrow(
+        /not a usable argument name/
+      )
+      expect(callTool).not.toHaveBeenCalled()
+    })
+
     it('emits every item the tool returned instead of filtering by timestamp', async () => {
       // The tool already dropped what Vorn has seen; re-filtering here against
       // an opaque cursor would only throw away items it deliberately sent.


### PR DESCRIPTION
Makes the parts of a pull connector that authors reliably get wrong impossible to get wrong, and gives them a way to verify the result before shipping.

## Declarative triggers

Cursor bookkeeping is where hand-written pull connectors fail: duplicate deliveries, items lost at the timestamp boundary, cursors that never advance. A trigger can now declare *how* items are recognized and let the SDK own the rest:

```ts
{
  type: 'newOrder',
  label: 'New order',
  dedupe: 'timestamp',
  fetch: ({ since }) => queryOrders(since)   // "what is there now?" — no cursor code
}
```

`timestamp` handles the case that quietly breaks hand-written connectors — several items sharing the newest instant, where `>` drops them forever and `>=` redelivers them on every poll — by remembering the ids at the boundary instant in the cursor. `lastItem` covers newest-first feeds with no dependable timestamp. `TriggerDefinition` is now a union, so mixing the declarative and hand-written styles is a compile error rather than a throw at load time.

## The host actually round-trips the cursor now

`pollMcpConnection` never forwarded `since`/`cursor` to the poll tool — it passed static args, got everything back, and re-filtered client-side. So an SDK connector's `nextCursor` was computed and then discarded, and correctness was hostage to Vorn's own timestamp comparison.

The MCP connection gains `cursorArg` (which tool argument receives the stored cursor) and `cursorPath` (where the next one is read back from). When set, the tool owns dedup and Vorn fires for everything it returns. `connectionSetup()` emits both, so SDK connectors are wired this way automatically; connections without `cursorArg` behave exactly as before.

## Host bug fix (observable behavior change)

The timestamp path skipped items with `ts <= cursor`. Because nothing ever re-reads that window, every item sharing the newest timestamp was **dropped permanently**. Now `ts < cursor`, so boundary items are re-emitted; that is safe because `connector_inbox` inserts with `INSERT OR IGNORE` on a unique key, and it matches the GitHub connector, which already rewinds its cursor by a second for this exact reason.

Reviewers should look at this one explicitly: connections *without* `cursorArg` will re-emit items at the cursor instant that they previously skipped.

## A feedback loop for authored connectors

```console
$ npx vorn-connector check ./dist/index.js
error  trigger newTicket: re-polling with its own nextCursor returned 3 already-delivered item(s), starting with "1042" [redelivers-items]
warn   action closeTicket: does not declare `idempotent`, so an agent cannot tell whether retrying is safe [missing-idempotent]
```

It polls, re-polls with the returned cursor, and reports redelivery, stuck cursors and missing agent-facing metadata. Exits non-zero on errors, so it works as a CI gate. Triggers can declare `sample` items, which are replayed through the *real* dedupe pipeline — so a connector can be verified before anyone has credentials for it. `--live` polls the real source instead.

Actions can also declare `idempotent`, which is appended to the MCP tool description; an agent retrying a failed step otherwise has no way to know whether it is about to create a second issue.

## Verification

- Full suite: 2225 tests across 203 files, all passing
- New: 23 dedupe/check tests, 5 host cursor tests, 1 end-to-end declarative-trigger test through the real MCP connector
- `dedupe.ts` 98% / `check.ts` 97% line coverage
- Typecheck, eslint `--max-warnings 0`, prettier clean
