### PR TITLE
Offer connectors by name, and expose them to agents

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,6 +5,7 @@ import { registerSessionTools } from './tools/sessions'
 import { registerWorkflowTools } from './tools/workflows'
 import { registerConfigTools } from './tools/config'
 import { registerWorkspaceTools } from './tools/workspaces'
+import { registerConnectorTools } from './tools/connectors'
 
 export function createMcpServer(version: string): McpServer {
   const server = new McpServer({ name: 'vorn', version }, { capabilities: { tools: {} } })
@@ -15,6 +16,7 @@ export function createMcpServer(version: string): McpServer {
   registerSessionTools(server)
   registerWorkflowTools(server)
   registerWorkspaceTools(server)
+  registerConnectorTools(server)
 
   return server
 }

--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -1,0 +1,363 @@
+/**
+ * Connector tools.
+ *
+ * Vorn's own connectors were invisible to agents: an agent could create a
+ * workflow that calls a connector action but could not see which connectors
+ * existed, which were set up, or why one was failing. These tools close that
+ * gap — discovery, installation and invocation — so an agent can work on a
+ * connector-backed workflow without a person reading the settings screen out
+ * to it.
+ *
+ * Every tool is a thin call into the same server methods the UI uses, so
+ * behaviour cannot drift between what an agent does and what a person does.
+ */
+import { z } from 'zod'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { V } from '../validation'
+import type {
+  ActionResult,
+  ConnectorActionDef,
+  ConnectorCatalogItem,
+  ConnectorManifest,
+  SdkProbeResult,
+  SourceConnection
+} from '@vornrun/shared/types'
+import { rpcCall } from '../ws-client'
+
+/**
+ * Starting a connector package downloads it first, so the probe is allowed
+ * far longer than an ordinary call. The server caps its own attempt below
+ * this, so it reports a real error rather than being cut off here.
+ */
+const PROBE_TIMEOUT_MS = 120_000
+
+interface ConnectorListEntry {
+  id: string
+  name: string
+  capabilities: string[]
+  manifest: ConnectorManifest
+}
+
+interface ConnectorStatus {
+  connectorId: string
+  authed: boolean
+  message?: string
+}
+
+const json = (value: unknown) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }]
+})
+
+const failure = (message: string) => ({
+  content: [{ type: 'text' as const, text: `Error: ${message}` }],
+  isError: true
+})
+
+/** The connector a connection belongs to, which for a package is not `mcp`. */
+function connectionConnectorId(conn: SourceConnection): string {
+  const packaged = conn.filters?.sdkConnectorId
+  return typeof packaged === 'string' && packaged !== '' ? packaged : conn.connectorId
+}
+
+export function registerConnectorTools(server: McpServer): void {
+  server.tool(
+    'list_connectors',
+    'List every connector: the ones built into Vorn, the ones installable from a package, ' +
+      'and how many connections each already has. Use this before creating a workflow that ' +
+      'calls a connector action, or to find the id of a connector to install.',
+    {
+      installable_only: z.boolean().optional().describe('Only connectors that are not set up yet')
+    },
+    async (args) => {
+      const [builtIns, catalog, connections, statuses] = await Promise.all([
+        rpcCall<ConnectorListEntry[]>('connector:list'),
+        rpcCall<ConnectorCatalogItem[]>('connector:catalog'),
+        rpcCall<SourceConnection[]>('connection:list', { connectorId: undefined }),
+        rpcCall<ConnectorStatus[]>('connector:status')
+      ])
+
+      const countFor = (id: string) =>
+        connections.filter((conn) => connectionConnectorId(conn) === id).length
+      const statusFor = (id: string) => statuses.find((s) => s.connectorId === id)
+
+      const entries = [
+        ...builtIns.map((c) => ({
+          id: c.id,
+          name: c.name,
+          source: 'built-in' as const,
+          capabilities: c.capabilities,
+          connections: countFor(c.id),
+          // Only meaningful for connectors that authenticate up front; the
+          // rest report nothing rather than a misleading "not authed".
+          ...(statusFor(c.id) && {
+            authenticated: statusFor(c.id)!.authed,
+            ...(statusFor(c.id)!.message && { authMessage: statusFor(c.id)!.message })
+          })
+        })),
+        ...catalog.map((entry) => ({
+          id: entry.id,
+          name: entry.name,
+          source: 'package' as const,
+          description: entry.description,
+          package: entry.packageName,
+          capabilities: entry.capabilities,
+          connections: countFor(entry.id),
+          ...(entry.auth && { auth: entry.auth })
+        }))
+      ]
+
+      return json(args.installable_only ? entries.filter((e) => e.connections === 0) : entries)
+    }
+  )
+
+  server.tool(
+    'list_connections',
+    'List configured connector connections, including when each last synced and the error ' +
+      'from its last failure. Use this to diagnose a connector that is not producing tasks.',
+    {
+      connector_id: V.id.optional().describe('Only connections for this connector'),
+      failing_only: z.boolean().optional().describe('Only connections whose last sync failed')
+    },
+    async (args) => {
+      const connections = await rpcCall<SourceConnection[]>('connection:list', {
+        connectorId: undefined
+      })
+
+      const visible = connections
+        .filter((conn) => !args.connector_id || connectionConnectorId(conn) === args.connector_id)
+        .filter((conn) => !args.failing_only || !!conn.lastSyncError)
+
+      return json(
+        visible.map((conn) => ({
+          id: conn.id,
+          name: conn.name,
+          connectorId: connectionConnectorId(conn),
+          project: conn.executionProject,
+          syncIntervalMinutes: conn.syncIntervalMinutes,
+          lastSyncAt: conn.lastSyncAt,
+          lastSyncError: conn.lastSyncError,
+          // Deliberately not the whole `filters` blob: it holds encrypted
+          // credentials, and an agent has no use for ciphertext.
+          config: publicFilters(conn)
+        }))
+      )
+    }
+  )
+
+  server.tool(
+    'list_connector_actions',
+    'List the actions a connection can execute, with their input schemas. Call this before ' +
+      'run_connector_action or before adding a callConnectorAction node to a workflow.',
+    { connection_id: V.id.describe('Connection ID') },
+    async (args) => {
+      const actions = await rpcCall<ConnectorActionDef[]>(
+        'connection:listActions',
+        args.connection_id
+      )
+      if (actions.length === 0) {
+        return failure(
+          `No actions for connection "${args.connection_id}". Either the connection does not ` +
+            'exist, or its connector exposes no actions yet — for an MCP connection, tool ' +
+            'discovery may still be running.'
+        )
+      }
+      return json(actions)
+    }
+  )
+
+  server.tool(
+    'inspect_connector_package',
+    'Start a connector package and read what it offers — its triggers, actions and required ' +
+      'environment variables — without installing it. Use this to review a connector before ' +
+      'install_connector, or to check a local build.',
+    {
+      package: V.shortText.describe(
+        'npm package name, or a command to run a local build (e.g. "node /path/to/dist/index.js")'
+      )
+    },
+    async (args) => {
+      const result = await probe(args.package)
+      if (!result.ok) return failure(result.error)
+      return json(result.manifest)
+    }
+  )
+
+  server.tool(
+    'install_connector',
+    'Install a connector from the catalog or from an npm package, creating a connection ready ' +
+      'to poll. Call list_connectors for catalog ids and inspect_connector_package to see which ' +
+      'environment variables are needed. Secrets cannot be set this way — see the error it ' +
+      'returns if the connector requires one.',
+    {
+      connector_id: V.id
+        .optional()
+        .describe('Catalog connector id (from list_connectors). Use this or package.'),
+      package: V.shortText.optional().describe('npm package name or launch command'),
+      name: V.title.optional().describe('Connection name (defaults to the connector name)'),
+      project: V.name.optional().describe('Vorn project tasks should be created in'),
+      trigger: V.shortText
+        .optional()
+        .describe('Trigger type to configure (defaults to the first the connector offers)'),
+      env: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe('Non-secret environment variables the connector needs'),
+      sync_interval_minutes: z.number().int().min(1).max(1440).optional()
+    },
+    async (args) => {
+      const catalog = await rpcCall<ConnectorCatalogItem[]>('connector:catalog')
+      const entry = args.connector_id ? catalog.find((c) => c.id === args.connector_id) : undefined
+
+      if (args.connector_id && !entry) {
+        return failure(
+          `No connector "${args.connector_id}" in the catalog. Known: ` +
+            `${catalog.map((c) => c.id).join(', ') || '(none)'}. ` +
+            'To install something not in the catalog, pass `package` instead.'
+        )
+      }
+      const target = entry ? entry.launch : args.package
+      if (!target) return failure('Provide either connector_id or package.')
+
+      const result = await probe(target)
+      if (!result.ok) return failure(result.error)
+      const manifest = result.manifest
+
+      // Refused rather than stored in the clear: encryption runs in the
+      // desktop process, which this one cannot reach, so the only way to
+      // accept a secret here would be to write a credential to the database
+      // unprotected.
+      const missingSecret = manifest.env.filter((e) => e.required && e.secret)
+      if (missingSecret.length > 0) {
+        return failure(
+          `${manifest.name} requires the secret ${plural(missingSecret.length, 'value')} ` +
+            `${missingSecret.map((e) => e.name).join(', ')}, which must be entered by a person ` +
+            'in Settings > Connectors so it can be stored in the OS keychain. ' +
+            'Everything else about the connector is ready to install.'
+        )
+      }
+
+      const supplied = args.env ?? {}
+      const unknown = Object.keys(supplied).filter(
+        (name) => !manifest.env.some((e) => e.name === name)
+      )
+      if (unknown.length > 0) {
+        return failure(
+          `${manifest.name} does not use ${unknown.join(', ')}. It accepts: ` +
+            `${manifest.env.map((e) => e.name).join(', ') || '(none)'}.`
+        )
+      }
+
+      const missing = manifest.env.filter((e) => e.required && !supplied[e.name]?.trim())
+      if (missing.length > 0) {
+        return failure(
+          `${manifest.name} needs ${missing.map((e) => describeEnv(e)).join(', ')}. ` +
+            'Pass them in `env`.'
+        )
+      }
+
+      const trigger = args.trigger
+        ? manifest.triggers.find((t) => t.type === args.trigger)
+        : manifest.triggers[0]
+      if (args.trigger && !trigger) {
+        return failure(
+          `${manifest.name} has no trigger "${args.trigger}". It offers: ` +
+            `${manifest.triggers.map((t) => t.type).join(', ') || '(none)'}.`
+        )
+      }
+
+      const launch = typeof target === 'string' ? parseLaunch(target) : target
+      const connection = await rpcCall<SourceConnection>('connection:create', {
+        connectorId: 'mcp',
+        name: args.name ?? (trigger ? `${manifest.name}: ${trigger.label}` : manifest.name),
+        filters: {
+          command: launch.command,
+          args: JSON.stringify(launch.args),
+          env: JSON.stringify(supplied),
+          sdkConnectorId: manifest.id,
+          sdkVersion: manifest.version,
+          ...(manifest.icon && { sdkIcon: JSON.stringify(manifest.icon) }),
+          ...(trigger?.filters ?? {})
+        },
+        syncIntervalMinutes: args.sync_interval_minutes ?? 5,
+        statusMapping: {},
+        ...(args.project && { executionProject: args.project })
+      })
+
+      return json({
+        installed: manifest.name,
+        connectionId: connection.id,
+        trigger: trigger?.type,
+        note: 'Poll it now with backfill_connection, or reference it from a workflow.'
+      })
+    }
+  )
+
+  server.tool(
+    'run_connector_action',
+    'Execute one action on a connection — create an issue, run a query, close a work item. ' +
+      'Call list_connector_actions first for the action name and its arguments.',
+    {
+      connection_id: V.id.describe('Connection ID'),
+      action: V.shortText.describe('Action name from list_connector_actions'),
+      args: z.record(z.string(), z.unknown()).optional().describe('Action arguments')
+    },
+    async (args) => {
+      const result = await rpcCall<ActionResult>('connection:executeAction', {
+        connectionId: args.connection_id,
+        action: args.action,
+        args: args.args ?? {}
+      })
+      // Returned as a tool error so a failure is not mistaken for a result.
+      if (!result.success) return failure(result.error ?? 'Action failed')
+      return json(result)
+    }
+  )
+
+  server.tool(
+    'backfill_connection',
+    'Pull items from a connection now and turn them into tasks, without waiting for its poll ' +
+      'interval. Use this to verify a connection works after installing it.',
+    { connection_id: V.id.describe('Connection ID') },
+    async (args) => {
+      const result = await rpcCall<{ imported: number; updated: number; error?: string }>(
+        'connection:backfill',
+        { connectionId: args.connection_id },
+        PROBE_TIMEOUT_MS
+      )
+      if (result.error) return failure(result.error)
+      return json(result)
+    }
+  )
+}
+
+/** Read a connector by starting it, given a package name, command, or spec. */
+async function probe(
+  target: string | { command: string; args: string[] }
+): Promise<SdkProbeResult> {
+  const launch = typeof target === 'string' ? parseLaunch(target) : target
+  return rpcCall<SdkProbeResult>('connector:probeSdk', launch, PROBE_TIMEOUT_MS)
+}
+
+/**
+ * A bare package name runs through `npx`; anything with spaces is already a
+ * command, which is how a local build is loaded.
+ */
+function parseLaunch(spec: string): { command: string; args: string[] } {
+  const parts = spec.trim().split(/\s+/)
+  if (parts.length === 1) return { command: 'npx', args: ['-y', parts[0]] }
+  return { command: parts[0], args: parts.slice(1) }
+}
+
+/** Connection config minus anything holding a credential. */
+function publicFilters(conn: SourceConnection): Record<string, unknown> {
+  const hidden = new Set(['secretEnv', 'discoveredTools'])
+  return Object.fromEntries(Object.entries(conn.filters ?? {}).filter(([key]) => !hidden.has(key)))
+}
+
+function describeEnv(entry: { name: string; description?: string }): string {
+  return entry.description ? `${entry.name} (${entry.description})` : entry.name
+}
+
+function plural(count: number, word: string): string {
+  return count === 1 ? word : `${word}s`
+}

--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -23,6 +23,7 @@ import type {
   SourceConnection
 } from '@vornrun/shared/types'
 import { rpcCall } from '../ws-client'
+import { SDK_FILTER_KEYS, connectionConnectorId } from '@vornrun/shared/types'
 
 /**
  * Starting a connector package downloads it first, so the probe is allowed
@@ -52,12 +53,6 @@ const failure = (message: string) => ({
   content: [{ type: 'text' as const, text: `Error: ${message}` }],
   isError: true
 })
-
-/** The connector a connection belongs to, which for a package is not `mcp`. */
-function connectionConnectorId(conn: SourceConnection): string {
-  const packaged = conn.filters?.sdkConnectorId
-  return typeof packaged === 'string' && packaged !== '' ? packaged : conn.connectorId
-}
 
 export function registerConnectorTools(server: McpServer): void {
   server.tool(
@@ -222,20 +217,6 @@ export function registerConnectorTools(server: McpServer): void {
       if (!result.ok) return failure(result.error)
       const manifest = result.manifest
 
-      // Refused rather than stored in the clear: encryption runs in the
-      // desktop process, which this one cannot reach, so the only way to
-      // accept a secret here would be to write a credential to the database
-      // unprotected.
-      const missingSecret = manifest.env.filter((e) => e.required && e.secret)
-      if (missingSecret.length > 0) {
-        return failure(
-          `${manifest.name} requires the secret ${plural(missingSecret.length, 'value')} ` +
-            `${missingSecret.map((e) => e.name).join(', ')}, which must be entered by a person ` +
-            'in Settings > Connectors so it can be stored in the OS keychain. ' +
-            'Everything else about the connector is ready to install.'
-        )
-      }
-
       const supplied = args.env ?? {}
       const unknown = Object.keys(supplied).filter(
         (name) => !manifest.env.some((e) => e.name === name)
@@ -244,6 +225,22 @@ export function registerConnectorTools(server: McpServer): void {
         return failure(
           `${manifest.name} does not use ${unknown.join(', ')}. It accepts: ` +
             `${manifest.env.map((e) => e.name).join(', ') || '(none)'}.`
+        )
+      }
+
+      // Refused rather than stored in the clear: encryption runs in the
+      // desktop process, which this one cannot reach, so the only way to
+      // accept a secret here would be to write a credential to the database
+      // unprotected. This covers a secret the connector demands and one the
+      // caller offered unasked — an optional secret is no less a credential.
+      const secrets = manifest.env.filter((e) => e.secret && (e.required || supplied[e.name]))
+      if (secrets.length > 0) {
+        return failure(
+          `${manifest.name} uses the secret ${plural(secrets.length, 'value')} ` +
+            `${secrets.map((e) => e.name).join(', ')}, which this tool cannot accept: it runs ` +
+            'outside the desktop process, where encryption lives, so it could only store them ' +
+            'unprotected. They must be entered by a person in Settings > Connectors to reach ' +
+            'the OS keychain. Everything else about the connector is ready to install.'
         )
       }
 
@@ -273,9 +270,9 @@ export function registerConnectorTools(server: McpServer): void {
           command: launch.command,
           args: JSON.stringify(launch.args),
           env: JSON.stringify(supplied),
-          sdkConnectorId: manifest.id,
-          sdkVersion: manifest.version,
-          ...(manifest.icon && { sdkIcon: JSON.stringify(manifest.icon) }),
+          [SDK_FILTER_KEYS.connectorId]: manifest.id,
+          [SDK_FILTER_KEYS.version]: manifest.version,
+          ...(manifest.icon && { [SDK_FILTER_KEYS.icon]: JSON.stringify(manifest.icon) }),
           ...(trigger?.filters ?? {})
         },
         syncIntervalMinutes: args.sync_interval_minutes ?? 5,

--- a/packages/mcp/src/ws-client.ts
+++ b/packages/mcp/src/ws-client.ts
@@ -156,7 +156,16 @@ function readPort(): { port: number } | { port: null; reason: 'missing' | 'inval
  * Send a single JSON-RPC request to the running Vorn server over WebSocket.
  * Opens a connection, sends, waits for the response, then closes.
  */
-export async function rpcCall<T = unknown>(method: string, params?: unknown): Promise<T> {
+export async function rpcCall<T = unknown>(
+  method: string,
+  params?: unknown,
+  /**
+   * Overrides the default ceiling for the few calls that legitimately take
+   * longer — starting a connector package downloads it first, which the
+   * default would abort while it was still working.
+   */
+  timeoutMs: number = TIMEOUT_MS
+): Promise<T> {
   const result = readPort()
   if (!result.port) {
     throw new Error(result.reason === 'invalid' ? PORT_FILE_INVALID_MSG : PORT_FILE_MISSING_MSG)
@@ -168,8 +177,8 @@ export async function rpcCall<T = unknown>(method: string, params?: unknown): Pr
 
     const timer = setTimeout(() => {
       ws.close()
-      reject(new Error(`RPC call "${method}" timed out after ${TIMEOUT_MS}ms`))
-    }, TIMEOUT_MS)
+      reject(new Error(`RPC call "${method}" timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
 
     ws.on('open', () => {
       ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -1,0 +1,83 @@
+/**
+ * Connector packages Vorn knows about by name.
+ *
+ * A packaged connector is only discoverable if you already know its package
+ * name, which makes a first-party connector harder to add than a third-party
+ * MCP server. The catalog is what lets one be presented like any other
+ * connector: a name, an icon and an Add button, with the package name an
+ * implementation detail rather than something to memorize.
+ *
+ * Entries carry their own icon and blurb so the list renders without starting
+ * anything. Everything a *connection* needs — triggers, config, poll filters —
+ * still comes from probing the package itself, so this stays a pointer and
+ * cannot drift into a second, stale copy of a connector's definition.
+ */
+import { existsSync } from 'fs'
+import { join } from 'path'
+import type { ConnectorCatalogEntry, ConnectorCatalogItem } from '@vornrun/shared/types'
+
+export const CONNECTOR_CATALOG: ConnectorCatalogEntry[] = [
+  {
+    id: 'kusto',
+    name: 'Azure Data Explorer',
+    description: 'Trigger workflows from the rows a KQL query returns.',
+    packageName: '@vornrun/connector-kusto',
+    capabilities: ['triggers', 'actions'],
+    category: 'Data & observability',
+    keywords: ['kusto', 'adx', 'azure', 'kql', 'query', 'logs', 'telemetry'],
+    auth: 'Signs in with your Azure identity — `az login` is usually all it needs.',
+    icon: {
+      viewBox: '0 0 24 24',
+      paths: [
+        'M12 2C7.6 2 4 3.6 4 5.5S7.6 9 12 9s8-1.6 8-3.5S16.4 2 12 2zm0 5.5c-3.6 0-6-1.2-6-2s2.4-2 6-2 6 1.2 6 2-2.4 2-6 2z',
+        'M4 9.4v2.1c0 1.9 3.6 3.5 8 3.5.5 0 1 0 1.4-.1a5.6 5.6 0 01.8-1.9c-.7.1-1.5.2-2.2.2-3.6 0-6-1.2-6-2V9.4z',
+        'M4 15.4v2.1C4 19.4 7.6 21 12 21c.3 0 .6 0 .9-.1a5.6 5.6 0 01-1-1.9H12c-3.6 0-6-1.2-6-2v-1.6z',
+        'M17.5 13a4.5 4.5 0 103.1 7.7l1.6 1.6a1 1 0 001.4-1.4l-1.6-1.6A4.5 4.5 0 0017.5 13zm0 2a2.5 2.5 0 110 5 2.5 2.5 0 010-5z'
+      ]
+    }
+  }
+]
+
+/**
+ * Where a catalog entry is launched from.
+ *
+ * Normally `npx -y`, which resolves the package at run time so a connector is
+ * never bundled into the app and an upgrade is a version bump rather than a
+ * release.
+ *
+ * A local build wins only when the launcher says a checkout is being run,
+ * because otherwise working on a connector would mean testing whatever is
+ * published rather than the code just changed — and a connector that has not
+ * shipped yet could not be run at all. Sniffing the working directory instead
+ * would make a released app pick up a stray `packages/` folder it happened to
+ * be started next to, so the repo root is passed in rather than guessed.
+ */
+export function catalogLaunchSpec(
+  entry: ConnectorCatalogEntry,
+  repoRoot: string | undefined = process.env.VORN_REPO_ROOT
+): { command: string; args: string[] } {
+  if (repoRoot) {
+    const local = join(repoRoot, 'packages', localPackageDir(entry.packageName), 'dist', 'index.js')
+    if (existsSync(local)) return { command: 'node', args: [local] }
+  }
+  return { command: 'npx', args: ['-y', entry.packageName] }
+}
+
+/** `@vornrun/connector-kusto` lives in `packages/connector-kusto`. */
+function localPackageDir(packageName: string): string {
+  return packageName.replace(/^@[^/]+\//, '')
+}
+
+/**
+ * The catalog as the UI consumes it, resolved once.
+ *
+ * Neither the catalog nor the repo root changes while the process runs, so
+ * resolving per request would re-stat the filesystem for every entry on every
+ * settings page load.
+ */
+export function catalogItems(): ConnectorCatalogItem[] {
+  resolved ??= CONNECTOR_CATALOG.map((entry) => ({ ...entry, launch: catalogLaunchSpec(entry) }))
+  return resolved
+}
+
+let resolved: ConnectorCatalogItem[] | undefined

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -85,6 +85,7 @@ import {
 } from './connectors'
 import { MCP_CONNECTOR_ID } from './connectors/mcp'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
+import { catalogItems } from './connectors/catalog'
 import { detectRepoSlug } from './connectors/github'
 import { forEachConnectorItem } from './connectors/paging'
 import { buildConnectorSeededWorkflow } from './default-workflows'
@@ -780,6 +781,12 @@ export function registerAllMethods(): void {
   registerMethod('connector:probeSdk', async (request: SdkProbeRequest) => {
     return probeSdkConnector(request)
   })
+
+  /**
+   * Connector packages Vorn knows by name, so a first-party connector can be
+   * offered in the connector list rather than requiring its package name.
+   */
+  registerMethod('connector:catalog', () => catalogItems())
 
   /**
    * One-shot backfill for a connection. Calls listItems() (not poll()) so it

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1157,7 +1157,8 @@ export const IPC = {
   CONNECTION_LIST_ACTIONS: 'connection:listActions',
   CONNECTION_LIST_MCP_TOOLS: 'connection:listMcpTools',
   CONNECTION_REFRESH_MCP_TOOLS: 'connection:refreshMcpTools',
-  CONNECTOR_PROBE_SDK: 'connector:probeSdk'
+  CONNECTOR_PROBE_SDK: 'connector:probeSdk',
+  CONNECTOR_CATALOG: 'connector:catalog'
 } as const
 
 /**
@@ -1201,6 +1202,38 @@ export interface SdkTrigger {
 export interface SdkConnectorIcon {
   viewBox: string
   paths: string[]
+}
+
+/**
+ * A connector package Vorn ships knowledge of, so it can be offered by name
+ * instead of requiring one.
+ *
+ * Metadata only. What a connection actually needs is read from the package at
+ * install time, so this cannot become a stale second copy of the connector's
+ * own definition.
+ */
+export interface ConnectorCatalogEntry {
+  id: string
+  name: string
+  description: string
+  /** npm package the connector is published as. */
+  packageName: string
+  capabilities: Array<'tasks' | 'triggers' | 'actions'>
+  /** One line on how it authenticates, shown before anyone commits to install. */
+  auth?: string
+  icon?: SdkConnectorIcon
+  /** Groups the connector in the list once there are too many to scan. */
+  category?: string
+  /** Extra search terms, so it is findable by what it talks to. */
+  keywords?: string[]
+}
+
+/**
+ * A catalog entry plus where to actually launch it, resolved in the main
+ * process because that resolution depends on the filesystem.
+ */
+export interface ConnectorCatalogItem extends ConnectorCatalogEntry {
+  launch: { command: string; args: string[] }
 }
 
 export interface SdkConnectorManifest {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -372,6 +372,32 @@ export interface SourceConnection {
   createdAt: string
 }
 
+/**
+ * Where a packaged connector records itself on the connection that runs it.
+ *
+ * A connector installed from a package is stored as an `mcp` connection, so
+ * `connectorId` is `mcp` for every one of them and its real identity, version
+ * and icon have to travel in `filters` instead. Both the desktop app and the
+ * MCP server create these connections, so the key names live here rather than
+ * being spelled out at each site — a disagreement between a writer and a
+ * reader is invisible until a connection shows the wrong icon or is counted
+ * against the wrong connector.
+ */
+export const SDK_FILTER_KEYS = {
+  connectorId: 'sdkConnectorId',
+  version: 'sdkVersion',
+  icon: 'sdkIcon'
+} as const
+
+/** The connector a connection belongs to, which for a package is not `mcp`. */
+export function connectionConnectorId(connection: {
+  connectorId: string
+  filters: SourceConnection['filters']
+}): string {
+  const packaged = connection.filters?.[SDK_FILTER_KEYS.connectorId]
+  return typeof packaged === 'string' && packaged !== '' ? packaged : connection.connectorId
+}
+
 // -- Task source link (sync metadata, separate from TaskConfig) --
 
 export interface TaskSourceLink {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -228,6 +228,7 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONNECTOR_PROBE_SDK, (_, request) =>
     requireBridge().request(IPC.CONNECTOR_PROBE_SDK, request)
   )
+  safeHandle(IPC.CONNECTOR_CATALOG, () => requireBridge().request(IPC.CONNECTOR_CATALOG))
   safeHandle(IPC.CONNECTION_GET_SOURCE_LINK, (_, taskId) =>
     requireBridge().request(IPC.CONNECTION_GET_SOURCE_LINK, taskId)
   )

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -33,13 +33,19 @@ export async function launchServer(): Promise<ServerBridge> {
 
   if (isDev) {
     // Dev mode: use npx tsx to run TypeScript directly
+    const repoRoot = path.join(__dirname, '../..')
+
     const child = spawn('npx', ['tsx', serverEntryPoint, `--data-dir=${dataDir}`], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,
-        NODE_ENV: process.env.NODE_ENV ?? 'development'
+        NODE_ENV: process.env.NODE_ENV ?? 'development',
+        // Told, not guessed: this is the one place that knows a checkout is
+        // being run, so connector packages built locally can be preferred
+        // over published ones without the server sniffing its own cwd.
+        VORN_REPO_ROOT: repoRoot
       },
-      cwd: path.join(__dirname, '../..')
+      cwd: repoRoot
     })
 
     child.stdin?.end()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -537,6 +537,10 @@ const api = {
   ): Promise<import('../../packages/shared/src/types').SdkProbeResult> =>
     ipcRenderer.invoke(IPC.CONNECTOR_PROBE_SDK, request),
 
+  listConnectorCatalog: (): Promise<
+    Array<import('../../packages/shared/src/types').ConnectorCatalogItem>
+  > => ipcRenderer.invoke(IPC.CONNECTOR_CATALOG),
+
   upsertTaskFromItem: (params: {
     connectionId: string
     item: import('../../packages/shared/src/types').ConnectorItemContext

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -132,6 +132,10 @@ export function ConnectorSettings() {
   )
   const visible = useMemo(() => filterConnectorListings(listings, search), [listings, search])
   const groups = useMemo(() => groupConnectorListings(visible), [visible])
+  // Resolved up front so the built-in form is only rendered once there is a
+  // connector to hand it.
+  const addingBuiltIn =
+    adding?.source === 'builtin' ? connectors.find((c) => c.id === adding.id) : undefined
 
   const findSeededWorkflows = (conn: SourceConnection): WorkflowDefinition[] => {
     const prefix = `connector:${conn.id}:`
@@ -265,16 +269,20 @@ export function ConnectorSettings() {
                         <Check size={12} /> {listing.connectedCount} connected
                       </span>
                     )}
-                    <Tooltip
-                      label={listing.catalogItem?.auth ?? `Add a ${listing.name} connection`}
-                    >
-                      <button
-                        onClick={() => setAdding(listing)}
-                        className="text-xs text-gray-400 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+                    {/* An installed row has no manifest and no package spec,
+                        so there is no form to open against it. */}
+                    {listing.source !== 'installed' && (
+                      <Tooltip
+                        label={listing.catalogItem?.auth ?? `Add a ${listing.name} connection`}
                       >
-                        <Plus size={12} /> Add
-                      </button>
-                    </Tooltip>
+                        <button
+                          onClick={() => setAdding(listing)}
+                          className="text-xs text-gray-400 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+                        >
+                          <Plus size={12} /> Add
+                        </button>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
               ))}
@@ -302,9 +310,9 @@ export function ConnectorSettings() {
         </div>
       )}
 
-      {adding && !adding.catalogItem && (
+      {adding && addingBuiltIn && (
         <AddConnectionForm
-          connector={connectors.find((c) => c.id === adding.id)!}
+          connector={addingBuiltIn}
           onDone={() => {
             setAdding(null)
             load()

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -1,11 +1,18 @@
-import { useState, useEffect, useCallback, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { useAppStore } from '../../stores'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectionIcon } from '../../lib/connection-icon'
 import {
+  buildConnectorListings,
+  filterConnectorListings,
+  groupConnectorListings,
+  type ConnectorListing
+} from '../../lib/connector-browse'
+import {
   Plus,
   Play,
+  Search,
   Trash2,
   Check,
   AlertCircle,
@@ -19,6 +26,7 @@ import {
 } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import type {
+  ConnectorCatalogItem,
   SourceConnection,
   ConnectorManifest,
   ConnectorConfigField,
@@ -85,7 +93,10 @@ export function ConnectorSettings() {
   const [connectors, setConnectors] = useState<ConnectorInfo[]>([])
   const [connections, setConnections] = useState<SourceConnection[]>([])
   const [statuses, setStatuses] = useState<ConnectorStatus[]>([])
-  const [adding, setAdding] = useState<string | null>(null)
+  // One selection, so "both open at once" is not a representable state.
+  const [adding, setAdding] = useState<ConnectorListing | null>(null)
+  const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([])
+  const [search, setSearch] = useState('')
   const [runningId, setRunningId] = useState<string | null>(null)
   const [backfillingId, setBackfillingId] = useState<string | null>(null)
   const [backfillResult, setBackfillResult] = useState<
@@ -107,6 +118,20 @@ export function ConnectorSettings() {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: loads connectors from the main process on mount
     void load()
   }, [load])
+
+  // Fetched once rather than with every refresh: the catalog is fixed for the
+  // life of the process, so re-reading it after each run, delete or install
+  // would be a round trip that always returns the same answer.
+  useEffect(() => {
+    void window.api.listConnectorCatalog().then(setCatalog)
+  }, [])
+
+  const listings = useMemo(
+    () => buildConnectorListings(connectors, catalog, connections),
+    [connectors, catalog, connections]
+  )
+  const visible = useMemo(() => filterConnectorListings(listings, search), [listings, search])
+  const groups = useMemo(() => groupConnectorListings(visible), [visible])
 
   const findSeededWorkflows = (conn: SourceConnection): WorkflowDefinition[] => {
     const prefix = `connector:${conn.id}:`
@@ -180,53 +205,106 @@ export function ConnectorSettings() {
 
       {/* Available connectors */}
       <div className="mb-6">
-        <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-          Available Connectors
-        </h3>
-        <div className="space-y-1">
-          {connectors.map((c) => {
-            const existingConns = connections.filter((conn) => conn.connectorId === c.id)
-            return (
-              <div
-                key={c.id}
-                className="flex items-center justify-between px-4 py-2.5 bg-white/[0.03] border border-white/[0.06] rounded-sm"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-7 h-7 shrink-0 flex items-center justify-center bg-white/[0.04] rounded-sm">
-                    <ConnectorIcon connectorId={c.id} size={16} className="text-gray-200" />
-                  </span>
-                  <div>
-                    <span className="text-sm text-gray-200 font-medium">{c.name}</span>
-                    <span className="text-xs text-gray-500 ml-2">{c.capabilities.join(' · ')}</span>
+        <div className="flex items-center justify-between gap-3 mb-3">
+          <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Available Connectors
+          </h3>
+          <div className="relative w-56">
+            <Search
+              size={12}
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-600"
+            />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search connectors"
+              className="w-full pl-7 pr-2 py-1 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-200 focus:border-white/[0.2] outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <div key={group.category} className="space-y-1">
+              {/* Headings only earn their place once there is more than one group. */}
+              {groups.length > 1 && (
+                <p className="text-[10px] text-gray-600 uppercase tracking-wider">
+                  {group.category}
+                </p>
+              )}
+              {group.listings.map((listing) => (
+                <div
+                  key={listing.key}
+                  className="flex items-center justify-between px-4 py-2.5 bg-white/[0.03] border border-white/[0.06] rounded-sm"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="w-7 h-7 shrink-0 flex items-center justify-center bg-white/[0.04] rounded-sm">
+                      <ConnectorIcon
+                        connectorId={listing.id}
+                        icon={listing.catalogItem?.icon ?? listing.icon}
+                        size={16}
+                        className="text-gray-200"
+                      />
+                    </span>
+                    <div>
+                      <div>
+                        <span className="text-sm text-gray-200 font-medium">{listing.name}</span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          {listing.capabilities.join(' · ')}
+                        </span>
+                      </div>
+                      {listing.description && (
+                        <p className="text-[11px] text-gray-500">{listing.description}</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {listing.connectedCount > 0 && (
+                      <span className="text-xs text-green-500 flex items-center gap-1">
+                        <Check size={12} /> {listing.connectedCount} connected
+                      </span>
+                    )}
+                    <Tooltip
+                      label={listing.catalogItem?.auth ?? `Add a ${listing.name} connection`}
+                    >
+                      <button
+                        onClick={() => setAdding(listing)}
+                        className="text-xs text-gray-400 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+                      >
+                        <Plus size={12} /> Add
+                      </button>
+                    </Tooltip>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  {existingConns.length > 0 && (
-                    <span className="text-xs text-green-500 flex items-center gap-1">
-                      <Check size={12} /> {existingConns.length} connected
-                    </span>
-                  )}
-                  <Tooltip label={`Add a ${c.name} connection`}>
-                    <button
-                      onClick={() => setAdding(c.id)}
-                      className="text-xs text-gray-400 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
-                    >
-                      <Plus size={12} /> Add
-                    </button>
-                  </Tooltip>
-                </div>
-              </div>
-            )
-          })}
-          {connectors.length === 0 && (
-            <p className="text-sm text-gray-500">No connectors available.</p>
+              ))}
+            </div>
+          ))}
+          {visible.length === 0 && (
+            <p className="text-sm text-gray-500">
+              {search ? `No connectors match "${search}".` : 'No connectors available.'}
+            </p>
           )}
         </div>
       </div>
 
-      {adding && (
+      {adding?.catalogItem && (
+        <div className="mb-6 p-4 bg-white/[0.03] border border-white/[0.08] rounded-sm">
+          <h4 className="text-sm text-gray-200 font-medium mb-3">Add {adding.name} connection</h4>
+          <SdkConnectorForm
+            catalogEntry={adding.catalogItem}
+            onDone={() => {
+              setAdding(null)
+              load()
+            }}
+            onCancel={() => setAdding(null)}
+          />
+        </div>
+      )}
+
+      {adding && !adding.catalogItem && (
         <AddConnectionForm
-          connector={connectors.find((c) => c.id === adding)!}
+          connector={connectors.find((c) => c.id === adding.id)!}
           onDone={() => {
             setAdding(null)
             load()

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { AlertCircle, Check, Loader2, Search } from 'lucide-react'
-import type { SdkConnectorManifest, TaskStatus } from '../../../shared/types'
+import type { ConnectorCatalogItem, SdkConnectorManifest, TaskStatus } from '../../../shared/types'
 import { useAppStore } from '../../stores'
 import { parseLaunchSpec } from './parse-launch-spec'
 import { ConnectorIcon } from '../ConnectorIcon'
+import { SDK_FILTER_KEYS } from '../../lib/connection-icon'
 
 const INPUT_CLASS =
   'w-full px-3 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-sm text-sm text-gray-200 focus:border-white/[0.2] outline-none'
@@ -18,10 +19,18 @@ const INPUT_CLASS =
  */
 export function SdkConnectorForm({
   onDone,
-  onCancel
+  onCancel,
+  catalogEntry
 }: {
   onDone: () => void
   onCancel: () => void
+  /**
+   * Set when the install started from a connector Vorn already knows about.
+   * The package name is then a detail of the catalog rather than something to
+   * type, so the lookup step disappears and the form opens on the questions
+   * only the person can answer.
+   */
+  catalogEntry?: ConnectorCatalogItem
 }) {
   const projects = useAppStore((s) => s.config?.projects || [])
 
@@ -35,19 +44,24 @@ export function SdkConnectorForm({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleProbe = async () => {
+  /**
+   * Read a connector by starting it.
+   *
+   * Takes the target rather than reading `spec`, so it closes over no state
+   * and is safe to call from an effect.
+   */
+  const probe = useCallback(async (target: { command: string; args: string[] }) => {
     setError(null)
     setManifest(null)
     setProbing(true)
     try {
-      const parsed = parseLaunchSpec(spec)
-      const result = await window.api.probeSdkConnector(parsed)
+      const result = await window.api.probeSdkConnector(target)
       if (!result.ok) {
         setError(result.error)
         return
       }
       setManifest(result.manifest)
-      setLaunch(parsed)
+      setLaunch(target)
       setTriggerType(result.manifest.triggers[0]?.type ?? '')
       // Seed defaults so a field the user never touches still round-trips.
       setValues(Object.fromEntries(result.manifest.env.map((entry) => [entry.name, ''])))
@@ -56,7 +70,20 @@ export function SdkConnectorForm({
     } finally {
       setProbing(false)
     }
-  }
+  }, [])
+
+  // A catalog entry names its own package, so there is nothing to look up by
+  // hand — go straight to reading it.
+  //
+  // Guarded because a probe spawns a child process that downloads a package:
+  // React runs effects twice on mount in development, and two `npx` cold
+  // installs race to fill the same form.
+  const probedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!catalogEntry || probedRef.current === catalogEntry.packageName) return
+    probedRef.current = catalogEntry.packageName
+    void probe(catalogEntry.launch)
+  }, [catalogEntry, probe])
 
   const trigger = manifest?.triggers.find((entry) => entry.type === triggerType)
   const missing = (manifest?.env ?? []).filter(
@@ -82,11 +109,11 @@ export function SdkConnectorForm({
         env: JSON.stringify(plain),
         // Recorded so the connection can be re-probed later without the user
         // retyping what they installed.
-        sdkConnectorId: manifest.id,
-        sdkVersion: manifest.version,
+        [SDK_FILTER_KEYS.connectorId]: manifest.id,
+        [SDK_FILTER_KEYS.version]: manifest.version,
         // Carried on the connection because a packaged connector is stored as
         // an `mcp` connection, so there is no connector id to key a glyph by.
-        ...(manifest.icon && { sdkIcon: JSON.stringify(manifest.icon) })
+        ...(manifest.icon && { [SDK_FILTER_KEYS.icon]: JSON.stringify(manifest.icon) })
       }
 
       if (Object.keys(secret).length > 0) {
@@ -118,32 +145,34 @@ export function SdkConnectorForm({
 
   return (
     <div className="space-y-3">
-      <div>
-        <label className="block text-xs text-gray-500 mb-1">Connector package</label>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={spec}
-            onChange={(e) => setSpec(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && spec.trim() && !probing) void handleProbe()
-            }}
-            placeholder="@vornrun/connector-kusto"
-            className={INPUT_CLASS}
-          />
-          <button
-            onClick={() => void handleProbe()}
-            disabled={probing || !spec.trim()}
-            className="px-3 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 flex items-center gap-1.5 shrink-0"
-          >
-            {probing ? <Loader2 size={12} className="animate-spin" /> : <Search size={12} />}
-            {probing ? 'Reading…' : 'Look up'}
-          </button>
+      {!catalogEntry && (
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Connector package</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={spec}
+              onChange={(e) => setSpec(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && spec.trim() && !probing) void probe(parseLaunchSpec(spec))
+              }}
+              placeholder="@vornrun/connector-kusto"
+              className={INPUT_CLASS}
+            />
+            <button
+              onClick={() => void probe(parseLaunchSpec(spec))}
+              disabled={probing || !spec.trim()}
+              className="px-3 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 flex items-center gap-1.5 shrink-0"
+            >
+              {probing ? <Loader2 size={12} className="animate-spin" /> : <Search size={12} />}
+              {probing ? 'Reading…' : 'Look up'}
+            </button>
+          </div>
+          <p className="text-[11px] text-gray-600 mt-1">
+            An npm package name, or a command to run a connector from a local checkout.
+          </p>
         </div>
-        <p className="text-[11px] text-gray-600 mt-1">
-          An npm package name, or a command to run a connector from a local checkout.
-        </p>
-      </div>
+      )}
 
       {probing && (
         <p className="text-[11px] text-gray-500">

--- a/src/renderer/lib/connection-icon.ts
+++ b/src/renderer/lib/connection-icon.ts
@@ -1,34 +1,7 @@
 import type { SdkConnectorIcon, SourceConnection } from '../../shared/types'
+import { SDK_FILTER_KEYS } from '../../shared/types'
 
-/**
- * The `filters` keys a packaged connector writes about itself.
- *
- * A packaged connector is stored as an `mcp` connection, so everything that
- * distinguishes it from any other MCP server lives in `filters`. Naming the
- * keys once keeps the writer and the several readers from drifting apart,
- * where a mismatch shows up as a silently wrong icon or count rather than an
- * error.
- */
-export const SDK_FILTER_KEYS = {
-  connectorId: 'sdkConnectorId',
-  version: 'sdkVersion',
-  icon: 'sdkIcon'
-} as const
-
-/**
- * Which connector a connection belongs to.
- *
- * For a packaged connector this is not `connectorId` — that is `mcp` for all
- * of them, so counting by it would credit every packaged connector to every
- * other.
- */
-export function connectionConnectorId(connection: {
-  connectorId: string
-  filters: SourceConnection['filters']
-}): string {
-  const packaged = connection.filters?.[SDK_FILTER_KEYS.connectorId]
-  return typeof packaged === 'string' && packaged !== '' ? packaged : connection.connectorId
-}
+export { SDK_FILTER_KEYS, connectionConnectorId } from '../../shared/types'
 
 /**
  * The glyph a connection should show.

--- a/src/renderer/lib/connection-icon.ts
+++ b/src/renderer/lib/connection-icon.ts
@@ -1,6 +1,36 @@
 import type { SdkConnectorIcon, SourceConnection } from '../../shared/types'
 
 /**
+ * The `filters` keys a packaged connector writes about itself.
+ *
+ * A packaged connector is stored as an `mcp` connection, so everything that
+ * distinguishes it from any other MCP server lives in `filters`. Naming the
+ * keys once keeps the writer and the several readers from drifting apart,
+ * where a mismatch shows up as a silently wrong icon or count rather than an
+ * error.
+ */
+export const SDK_FILTER_KEYS = {
+  connectorId: 'sdkConnectorId',
+  version: 'sdkVersion',
+  icon: 'sdkIcon'
+} as const
+
+/**
+ * Which connector a connection belongs to.
+ *
+ * For a packaged connector this is not `connectorId` — that is `mcp` for all
+ * of them, so counting by it would credit every packaged connector to every
+ * other.
+ */
+export function connectionConnectorId(connection: {
+  connectorId: string
+  filters: SourceConnection['filters']
+}): string {
+  const packaged = connection.filters?.[SDK_FILTER_KEYS.connectorId]
+  return typeof packaged === 'string' && packaged !== '' ? packaged : connection.connectorId
+}
+
+/**
  * The glyph a connection should show.
  *
  * A connector installed from a package is stored as an `mcp` connection, so
@@ -13,7 +43,7 @@ import type { SdkConnectorIcon, SourceConnection } from '../../shared/types'
 export function connectionIcon(
   connection: { filters: SourceConnection['filters'] } | null | undefined
 ): SdkConnectorIcon | undefined {
-  const raw = connection?.filters?.sdkIcon
+  const raw = connection?.filters?.[SDK_FILTER_KEYS.icon]
   if (typeof raw !== 'string' || raw === '') return undefined
   try {
     const parsed: unknown = JSON.parse(raw)

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -17,6 +17,13 @@ export interface ConnectorListing {
   description?: string
   capabilities: string[]
   category: string
+  /**
+   * Where the row came from, which decides what "Add" can do.
+   *
+   * An `installed` row is a connector we can see connections for but hold no
+   * manifest or package spec for, so there is nothing to open a form against.
+   */
+  source: 'builtin' | 'catalog' | 'installed'
   /** Extra search terms, so a connector is findable by what it talks to. */
   keywords: string[]
   connectedCount: number
@@ -57,6 +64,7 @@ export function buildConnectorListings(
       name: c.name,
       capabilities: c.capabilities,
       category: 'Built in',
+      source: 'builtin' as const,
       keywords: [],
       connectedCount: countFor(c.id)
     })),
@@ -64,6 +72,7 @@ export function buildConnectorListings(
       ...entry,
       key: `catalog:${entry.id}`,
       category: entry.category ?? UNCATEGORIZED,
+      source: 'catalog' as const,
       keywords: entry.keywords ?? [],
       connectedCount: countFor(entry.id),
       catalogItem: entry
@@ -102,6 +111,7 @@ function installedListings(
       name: id,
       capabilities: [],
       category: 'Installed',
+      source: 'installed' as const,
       keywords: [],
       connectedCount: 1,
       icon: connectionIcon(conn)

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -1,0 +1,154 @@
+import type { ConnectorCatalogItem, SdkConnectorIcon, SourceConnection } from '../../shared/types'
+import { connectionConnectorId, connectionIcon } from './connection-icon'
+
+/**
+ * One row in the connector list, whether it came from a built-in connector, a
+ * package in the catalog, or a package someone installed by name.
+ *
+ * All three are presented identically on purpose: a person picking a connector
+ * has no reason to care which of them runs in-process and which is installed
+ * from a package, and asking them to look in two places is how a first-party
+ * connector ends up harder to find than a third-party one.
+ */
+export interface ConnectorListing {
+  key: string
+  id: string
+  name: string
+  description?: string
+  capabilities: string[]
+  category: string
+  /** Extra search terms, so a connector is findable by what it talks to. */
+  keywords: string[]
+  connectedCount: number
+  /** Set when adding this one means installing a package. */
+  catalogItem?: ConnectorCatalogItem
+  /** Set for a packaged connector that is installed but not in the catalog. */
+  icon?: SdkConnectorIcon
+}
+
+export interface BuiltInConnector {
+  id: string
+  name: string
+  capabilities: string[]
+}
+
+const UNCATEGORIZED = 'Other'
+
+/**
+ * Merge the built-in connectors, the catalog and anything already installed
+ * into a single list.
+ *
+ * Connected connectors sort first — the list is also how you find something
+ * already set up — and the rest sort by name so position is stable as the
+ * catalog grows rather than depending on registration order.
+ */
+export function buildConnectorListings(
+  builtIns: BuiltInConnector[],
+  catalog: ConnectorCatalogItem[],
+  connections: SourceConnection[]
+): ConnectorListing[] {
+  const countFor = (id: string) =>
+    connections.filter((conn) => connectionConnectorId(conn) === id).length
+
+  const listings: ConnectorListing[] = [
+    ...builtIns.map((c) => ({
+      key: c.id,
+      id: c.id,
+      name: c.name,
+      capabilities: c.capabilities,
+      category: 'Built in',
+      keywords: [],
+      connectedCount: countFor(c.id)
+    })),
+    ...catalog.map((entry) => ({
+      ...entry,
+      key: `catalog:${entry.id}`,
+      category: entry.category ?? UNCATEGORIZED,
+      keywords: entry.keywords ?? [],
+      connectedCount: countFor(entry.id),
+      catalogItem: entry
+    })),
+    // A connector installed by package name, or one dropped from the catalog,
+    // still has working connections. Without a row of its own it would be
+    // missing from the list that is meant to show what is set up.
+    ...installedListings(builtIns, catalog, connections)
+  ]
+
+  return listings.sort((a, b) => {
+    if (a.connectedCount > 0 !== b.connectedCount > 0) return a.connectedCount > 0 ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+}
+
+function installedListings(
+  builtIns: BuiltInConnector[],
+  catalog: ConnectorCatalogItem[],
+  connections: SourceConnection[]
+): ConnectorListing[] {
+  const known = new Set([...builtIns.map((c) => c.id), ...catalog.map((c) => c.id)])
+  const seen = new Map<string, ConnectorListing>()
+
+  for (const conn of connections) {
+    const id = connectionConnectorId(conn)
+    if (known.has(id)) continue
+    const existing = seen.get(id)
+    if (existing) {
+      existing.connectedCount += 1
+      continue
+    }
+    seen.set(id, {
+      key: `installed:${id}`,
+      id,
+      name: id,
+      capabilities: [],
+      category: 'Installed',
+      keywords: [],
+      connectedCount: 1,
+      icon: connectionIcon(conn)
+    })
+  }
+
+  return [...seen.values()]
+}
+
+/**
+ * Narrow the list to what someone typed.
+ *
+ * Matches name, description, capabilities and keywords, so a connector is
+ * reachable by what it does ("query", "logs") and not only by a product name
+ * you would have to already know.
+ */
+export function filterConnectorListings(
+  listings: ConnectorListing[],
+  query: string
+): ConnectorListing[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (terms.length === 0) return listings
+
+  return listings.filter((listing) => {
+    const haystack = [
+      listing.name,
+      listing.description ?? '',
+      listing.category,
+      ...listing.capabilities,
+      ...listing.keywords
+    ]
+      .join(' ')
+      .toLowerCase()
+    // Every term must match, so typing more narrows rather than widens.
+    return terms.every((term) => haystack.includes(term))
+  })
+}
+
+/** Listings grouped under their category, in the order the listings arrive. */
+export function groupConnectorListings(
+  listings: ConnectorListing[]
+): Array<{ category: string; listings: ConnectorListing[] }> {
+  const groups = new Map<string, ConnectorListing[]>()
+  for (const listing of listings) {
+    const existing = groups.get(listing.category)
+    if (existing) existing.push(listing)
+    else groups.set(listing.category, [listing])
+  }
+  return [...groups].map(([category, entries]) => ({ category, listings: entries }))
+}

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -185,6 +185,20 @@ describe('connectors that are installed but not in the catalog', () => {
     expect(jira?.connectedCount).toBe(1)
   })
 
+  it('is marked so the UI does not offer to add one', () => {
+    // There is no manifest and no package spec behind such a row, so there is
+    // nothing for an add form to open against.
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [catalogItem('kusto', 'Azure Data Explorer')],
+      [connection({ filters: { sdkConnectorId: 'jira' } })]
+    )
+
+    expect(listings.find((l) => l.id === 'jira')?.source).toBe('installed')
+    expect(listings.find((l) => l.id === 'github')?.source).toBe('builtin')
+    expect(listings.find((l) => l.id === 'kusto')?.source).toBe('catalog')
+  })
+
   it('keeps one row per connector rather than one per connection', () => {
     const listings = buildConnectorListings(
       [],

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildConnectorListings,
+  filterConnectorListings,
+  groupConnectorListings,
+  type BuiltInConnector
+} from '../src/renderer/lib/connector-browse'
+import type { ConnectorCatalogItem, SourceConnection } from '../src/shared/types'
+
+const builtIn = (id: string, name: string): BuiltInConnector => ({
+  id,
+  name,
+  capabilities: ['triggers']
+})
+
+const catalogItem = (
+  id: string,
+  name: string,
+  extra: Partial<ConnectorCatalogItem> = {}
+): ConnectorCatalogItem => ({
+  id,
+  name,
+  description: `${name} connector`,
+  packageName: `@vornrun/connector-${id}`,
+  capabilities: ['triggers'],
+  launch: { command: 'npx', args: ['-y', `@vornrun/connector-${id}`] },
+  ...extra
+})
+
+const connection = (overrides: Partial<SourceConnection>): SourceConnection =>
+  ({
+    id: 'c1',
+    connectorId: 'mcp',
+    name: 'conn',
+    filters: {},
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    ...overrides
+  }) as SourceConnection
+
+describe('buildConnectorListings', () => {
+  it('presents built-ins and packaged connectors as one list', () => {
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [catalogItem('kusto', 'Azure Data Explorer')],
+      []
+    )
+
+    expect(listings.map((l) => l.name)).toEqual(['Azure Data Explorer', 'GitHub'])
+  })
+
+  it('carries the launch spec only for packaged ones, which is what Add branches on', () => {
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [catalogItem('kusto', 'Kusto')],
+      []
+    )
+
+    expect(listings.find((l) => l.id === 'github')?.catalogItem).toBeUndefined()
+    expect(listings.find((l) => l.id === 'kusto')?.catalogItem?.launch).toEqual({
+      command: 'npx',
+      args: ['-y', '@vornrun/connector-kusto']
+    })
+  })
+
+  it('counts a packaged connection by the connector it installed, not its connector id', () => {
+    // Packaged connectors are all stored as `mcp`, so counting by connectorId
+    // would credit every one of them to every other.
+    const listings = buildConnectorListings(
+      [],
+      [catalogItem('kusto', 'Kusto'), catalogItem('other', 'Other')],
+      [
+        connection({ id: 'a', filters: { sdkConnectorId: 'kusto' } }),
+        connection({ id: 'b', filters: { sdkConnectorId: 'kusto' } })
+      ]
+    )
+
+    expect(listings.find((l) => l.id === 'kusto')?.connectedCount).toBe(2)
+    expect(listings.find((l) => l.id === 'other')?.connectedCount).toBe(0)
+  })
+
+  it('floats connected connectors up, so the list also serves finding one already set up', () => {
+    const listings = buildConnectorListings(
+      [builtIn('alpha', 'Alpha'), builtIn('zulu', 'Zulu')],
+      [],
+      [connection({ connectorId: 'zulu' })]
+    )
+
+    expect(listings.map((l) => l.id)).toEqual(['zulu', 'alpha'])
+  })
+
+  it('orders by name rather than registration, so positions stay put as the catalog grows', () => {
+    const listings = buildConnectorListings(
+      [builtIn('c', 'Charlie'), builtIn('a', 'Alpha')],
+      [catalogItem('b', 'Bravo')],
+      []
+    )
+
+    expect(listings.map((l) => l.name)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+  })
+})
+
+describe('filterConnectorListings', () => {
+  const listings = buildConnectorListings(
+    [builtIn('github', 'GitHub')],
+    [
+      catalogItem('kusto', 'Azure Data Explorer', {
+        description: 'Trigger from a KQL query',
+        keywords: ['kusto', 'adx', 'logs'],
+        capabilities: ['triggers', 'actions']
+      })
+    ],
+    []
+  )
+
+  it('returns everything for an empty or blank query', () => {
+    expect(filterConnectorListings(listings, '')).toHaveLength(2)
+    expect(filterConnectorListings(listings, '   ')).toHaveLength(2)
+  })
+
+  it('finds a connector by a name nobody would guess from the product name', () => {
+    expect(filterConnectorListings(listings, 'kusto').map((l) => l.id)).toEqual(['kusto'])
+  })
+
+  it('finds a connector by what it does, not only by what it is called', () => {
+    expect(filterConnectorListings(listings, 'kql').map((l) => l.id)).toEqual(['kusto'])
+    expect(filterConnectorListings(listings, 'logs').map((l) => l.id)).toEqual(['kusto'])
+  })
+
+  it('ignores case, since nobody types product capitalisation', () => {
+    expect(filterConnectorListings(listings, 'GITHUB').map((l) => l.id)).toEqual(['github'])
+  })
+
+  it('narrows on each extra word rather than widening', () => {
+    expect(filterConnectorListings(listings, 'azure explorer')).toHaveLength(1)
+    expect(filterConnectorListings(listings, 'azure github')).toHaveLength(0)
+  })
+
+  it('returns nothing rather than everything when there is no match', () => {
+    expect(filterConnectorListings(listings, 'nonexistent')).toEqual([])
+  })
+})
+
+describe('groupConnectorListings', () => {
+  it('groups by category and keeps each group in list order', () => {
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [
+        catalogItem('kusto', 'Kusto', { category: 'Data' }),
+        catalogItem('grafana', 'Grafana', { category: 'Data' })
+      ],
+      []
+    )
+
+    const groups = groupConnectorListings(listings)
+    // Group order follows the name-sorted listings: GitHub precedes Grafana.
+    expect(groups.map((g) => g.category)).toEqual(['Built in', 'Data'])
+    expect(groups[1].listings.map((l) => l.name)).toEqual(['Grafana', 'Kusto'])
+  })
+
+  it('files an uncategorised package rather than dropping it from the list', () => {
+    const groups = groupConnectorListings(
+      buildConnectorListings([], [catalogItem('kusto', 'Kusto')], [])
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].listings.map((l) => l.id)).toEqual(['kusto'])
+  })
+
+  it('produces nothing to render when a search matched nothing', () => {
+    expect(groupConnectorListings([])).toEqual([])
+  })
+})
+
+describe('connectors that are installed but not in the catalog', () => {
+  it('still gets a row, so a package installed by name is not invisible', () => {
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [],
+      [connection({ filters: { sdkConnectorId: 'jira' } })]
+    )
+
+    const jira = listings.find((l) => l.id === 'jira')
+    expect(jira?.category).toBe('Installed')
+    expect(jira?.connectedCount).toBe(1)
+  })
+
+  it('keeps one row per connector rather than one per connection', () => {
+    const listings = buildConnectorListings(
+      [],
+      [],
+      [
+        connection({ id: 'a', filters: { sdkConnectorId: 'jira' } }),
+        connection({ id: 'b', filters: { sdkConnectorId: 'jira' } })
+      ]
+    )
+
+    expect(listings).toHaveLength(1)
+    expect(listings[0].connectedCount).toBe(2)
+  })
+
+  it('does not duplicate a connector the catalog already lists', () => {
+    const listings = buildConnectorListings(
+      [],
+      [catalogItem('kusto', 'Kusto')],
+      [connection({ filters: { sdkConnectorId: 'kusto' } })]
+    )
+
+    expect(listings).toHaveLength(1)
+    expect(listings[0].catalogItem).toBeDefined()
+  })
+
+  it('carries the icon the connection stored, so the row is not blank', () => {
+    const listings = buildConnectorListings(
+      [],
+      [],
+      [
+        connection({
+          filters: {
+            sdkConnectorId: 'jira',
+            sdkIcon: JSON.stringify({ viewBox: '0 0 24 24', paths: ['M0 0h24v24H0z'] })
+          }
+        })
+      ]
+    )
+
+    expect(listings[0].icon).toEqual({ viewBox: '0 0 24 24', paths: ['M0 0h24v24H0z'] })
+  })
+
+  it('leaves a plain MCP connection under mcp rather than inventing a row', () => {
+    const listings = buildConnectorListings(
+      [builtIn('mcp', 'MCP')],
+      [],
+      [connection({ connectorId: 'mcp', filters: {} })]
+    )
+
+    expect(listings).toHaveLength(1)
+    expect(listings[0].id).toBe('mcp')
+    expect(listings[0].connectedCount).toBe(1)
+  })
+})

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { defineConnector } from '../packages/connector-sdk/src'
+import {
+  CONNECTOR_CATALOG,
+  catalogItems,
+  catalogLaunchSpec
+} from '../packages/server/src/connectors/catalog'
+
+const ENTRY = CONNECTOR_CATALOG[0]
+
+describe('connector catalog', () => {
+  it('names a package for every entry so nothing has to be typed to install it', () => {
+    expect(CONNECTOR_CATALOG.length).toBeGreaterThan(0)
+    for (const entry of CONNECTOR_CATALOG) {
+      expect(entry.packageName).toMatch(/\S/)
+      expect(entry.name).toMatch(/\S/)
+      expect(entry.description).toMatch(/\S/)
+      expect(entry.capabilities.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps entry ids unique so a card cannot shadow another', () => {
+    const ids = CONNECTOR_CATALOG.map((e) => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('ships icons the connector SDK itself accepts, so a card is never blank', () => {
+    // Validated with the real validator rather than a copy of its rules: a
+    // copy keeps passing after the rules tighten, while the icon it approved
+    // renders as nothing.
+    for (const entry of CONNECTOR_CATALOG) {
+      if (!entry.icon) continue
+      expect(() =>
+        defineConnector({
+          id: entry.id,
+          name: entry.name,
+          version: '0.0.0',
+          icon: entry.icon,
+          triggers: [],
+          actions: [{ type: 'noop', label: 'No-op', run: () => undefined }]
+        })
+      ).not.toThrow()
+    }
+  })
+})
+
+describe('catalogLaunchSpec', () => {
+  it('resolves the published package when not running from a checkout', () => {
+    expect(catalogLaunchSpec(ENTRY, undefined)).toEqual({
+      command: 'npx',
+      args: ['-y', ENTRY.packageName]
+    })
+  })
+
+  it('prefers the local build in a checkout, so an unpublished connector still runs', () => {
+    const root = mkdtempSync(join(tmpdir(), 'catalog-'))
+    const dist = join(root, 'packages', ENTRY.packageName.replace(/^@[^/]+\//, ''), 'dist')
+    mkdirSync(dist, { recursive: true })
+    writeFileSync(join(dist, 'index.js'), '')
+
+    expect(catalogLaunchSpec(ENTRY, root)).toEqual({
+      command: 'node',
+      args: [join(dist, 'index.js')]
+    })
+  })
+
+  it('falls back to the package when a checkout has not built the connector', () => {
+    const root = mkdtempSync(join(tmpdir(), 'catalog-'))
+
+    expect(catalogLaunchSpec(ENTRY, root)).toEqual({
+      command: 'npx',
+      args: ['-y', ENTRY.packageName]
+    })
+  })
+
+  it('never treats a stray directory as a checkout unless the root was given', () => {
+    // A released app must not run whatever `packages/` folder it happened to
+    // be started next to, so the repo root is passed in, never sniffed.
+    expect(catalogLaunchSpec(ENTRY, undefined).command).toBe('npx')
+  })
+})
+
+describe('catalogItems', () => {
+  it('gives every entry a launch spec, which is what Add needs', () => {
+    for (const item of catalogItems()) {
+      expect(item.launch.command).toMatch(/\S/)
+      expect(item.launch.args.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('resolves once, since neither the catalog nor the checkout moves at run time', () => {
+    expect(catalogItems()).toBe(catalogItems())
+  })
+})

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -320,6 +320,46 @@ describe('install_connector', () => {
     expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
   })
 
+  it('refuses an optional secret the caller offered unasked', async () => {
+    // An optional secret is no less a credential; only checking `required`
+    // would let it through to the database unencrypted.
+    server({
+      'connector:probeSdk': {
+        ok: true,
+        manifest: {
+          ...MANIFEST,
+          env: [...MANIFEST.env, { name: 'KUSTO_APP_KEY', required: false, secret: true }]
+        }
+      }
+    })
+
+    const result = await tools.get('install_connector')!({
+      connector_id: 'kusto',
+      env: { ...ENV, KUSTO_APP_KEY: 'super-secret' }
+    })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('KUSTO_APP_KEY')
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+
+  it('installs when an optional secret is simply left out', async () => {
+    server({
+      'connector:probeSdk': {
+        ok: true,
+        manifest: {
+          ...MANIFEST,
+          env: [...MANIFEST.env, { name: 'KUSTO_APP_KEY', required: false, secret: true }]
+        }
+      }
+    })
+
+    const result = await tools.get('install_connector')!({ connector_id: 'kusto', env: ENV })
+
+    expect(result.isError).toBeFalsy()
+    expect(rpcCall).toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+
   it('names the triggers on offer when asked for one that does not exist', async () => {
     const result = await tools.get('install_connector')!({
       connector_id: 'kusto',

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+const rpcCall = vi.fn()
+vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
+
+const { registerConnectorTools } = await import('../packages/mcp/src/tools/connectors')
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>
+  isError?: boolean
+}>
+
+/** Collects the tools the module registers so they can be invoked directly. */
+function collect(): Map<string, Handler> {
+  const tools = new Map<string, Handler>()
+  const server = {
+    tool: (name: string, _desc: string, schemaOrHandler: unknown, maybeHandler?: unknown) => {
+      tools.set(name, (maybeHandler ?? schemaOrHandler) as Handler)
+    }
+  } as unknown as McpServer
+  registerConnectorTools(server)
+  return tools
+}
+
+const MANIFEST = {
+  id: 'kusto',
+  name: 'Azure Data Explorer',
+  version: '0.5.2',
+  triggers: [
+    { type: 'queryResult', label: 'Query result', filters: { pollTool: 'poll_queryResult' } }
+  ],
+  actions: [],
+  env: [
+    { name: 'KUSTO_CLUSTER', required: true, secret: false, description: 'Cluster URL' },
+    { name: 'KUSTO_LOOKBACK', required: false, secret: false }
+  ]
+}
+
+const CATALOG = [
+  {
+    id: 'kusto',
+    name: 'Azure Data Explorer',
+    description: 'Trigger from a KQL query',
+    packageName: '@vornrun/connector-kusto',
+    capabilities: ['triggers'],
+    launch: { command: 'npx', args: ['-y', '@vornrun/connector-kusto'] }
+  }
+]
+
+/** Route each RPC method to a canned answer, so a tool can be driven end to end. */
+function server(overrides: Record<string, unknown> = {}) {
+  const defaults: Record<string, unknown> = {
+    'connector:list': [
+      { id: 'github', name: 'GitHub', capabilities: ['tasks'], manifest: {} },
+      { id: 'mcp', name: 'MCP', capabilities: ['actions'], manifest: {} }
+    ],
+    'connector:catalog': CATALOG,
+    'connection:list': [],
+    'connector:status': [{ connectorId: 'github', authed: true }],
+    'connector:probeSdk': { ok: true, manifest: MANIFEST },
+    'connection:create': { id: 'new-conn' },
+    'connection:listActions': [],
+    'connection:executeAction': { success: true, data: {} },
+    'connection:backfill': { imported: 0, updated: 0 }
+  }
+  const table = { ...defaults, ...overrides }
+  rpcCall.mockImplementation((method: string) => Promise.resolve(table[method]))
+}
+
+const text = (r: { content: Array<{ text: string }> }) => r.content.map((c) => c.text).join('\n')
+const parsed = (r: { content: Array<{ text: string }> }) => JSON.parse(text(r))
+
+let tools: Map<string, Handler>
+
+beforeEach(() => {
+  rpcCall.mockReset()
+  server()
+  tools = collect()
+})
+
+describe('connector tools', () => {
+  it('registers discovery, install and invocation tools', () => {
+    expect([...tools.keys()]).toEqual([
+      'list_connectors',
+      'list_connections',
+      'list_connector_actions',
+      'inspect_connector_package',
+      'install_connector',
+      'run_connector_action',
+      'backfill_connection'
+    ])
+  })
+})
+
+describe('list_connectors', () => {
+  it('shows built-in and installable connectors in one list', async () => {
+    const result = parsed(await tools.get('list_connectors')!({}))
+
+    expect(result.map((c: { id: string }) => c.id)).toEqual(['github', 'mcp', 'kusto'])
+    expect(result[2]).toMatchObject({ source: 'package', package: '@vornrun/connector-kusto' })
+  })
+
+  it('reports auth state, so an agent can explain why a connector fails', async () => {
+    server({
+      'connector:status': [{ connectorId: 'github', authed: false, message: 'run gh auth login' }]
+    })
+
+    const result = parsed(await tools.get('list_connectors')!({}))
+
+    expect(result[0]).toMatchObject({ authenticated: false, authMessage: 'run gh auth login' })
+  })
+
+  it('counts a packaged connection against its own connector, not mcp', async () => {
+    // Every packaged connector is stored as `mcp`, so counting by connectorId
+    // would credit all of them to MCP and none to themselves.
+    server({
+      'connection:list': [{ id: 'c1', connectorId: 'mcp', filters: { sdkConnectorId: 'kusto' } }]
+    })
+
+    const result = parsed(await tools.get('list_connectors')!({}))
+
+    expect(result.find((c: { id: string }) => c.id === 'kusto').connections).toBe(1)
+    expect(result.find((c: { id: string }) => c.id === 'mcp').connections).toBe(0)
+  })
+
+  it('narrows to what is not set up yet when asked', async () => {
+    server({
+      'connection:list': [{ id: 'c1', connectorId: 'mcp', filters: { sdkConnectorId: 'kusto' } }]
+    })
+
+    const result = parsed(await tools.get('list_connectors')!({ installable_only: true }))
+
+    expect(result.map((c: { id: string }) => c.id)).not.toContain('kusto')
+  })
+})
+
+describe('list_connections', () => {
+  const CONNECTIONS = [
+    {
+      id: 'c1',
+      name: 'repo',
+      connectorId: 'github',
+      filters: { owner: 'me' },
+      lastSyncError: 'Validation Failed (HTTP 422)'
+    },
+    { id: 'c2', name: 'other', connectorId: 'linear', filters: {} }
+  ]
+
+  it('surfaces the last sync error, which is the point of asking', async () => {
+    server({ 'connection:list': CONNECTIONS })
+
+    const result = parsed(await tools.get('list_connections')!({}))
+
+    expect(result[0].lastSyncError).toBe('Validation Failed (HTTP 422)')
+  })
+
+  it('narrows to failing connections', async () => {
+    server({ 'connection:list': CONNECTIONS })
+
+    const result = parsed(await tools.get('list_connections')!({ failing_only: true }))
+
+    expect(result.map((c: { id: string }) => c.id)).toEqual(['c1'])
+  })
+
+  it('filters by connector using the packaged id, not the stored mcp id', async () => {
+    server({
+      'connection:list': [
+        { id: 'c1', name: 'k', connectorId: 'mcp', filters: { sdkConnectorId: 'kusto' } }
+      ]
+    })
+
+    const result = parsed(await tools.get('list_connections')!({ connector_id: 'kusto' }))
+
+    expect(result).toHaveLength(1)
+  })
+
+  it('never returns stored credentials', async () => {
+    server({
+      'connection:list': [
+        {
+          id: 'c1',
+          name: 'k',
+          connectorId: 'mcp',
+          filters: { env: '{}', secretEnv: 'ENCRYPTED-BLOB', discoveredTools: [{ name: 'x' }] }
+        }
+      ]
+    })
+
+    const out = text(await tools.get('list_connections')!({}))
+
+    expect(out).not.toContain('ENCRYPTED-BLOB')
+    expect(out).not.toContain('secretEnv')
+  })
+})
+
+describe('inspect_connector_package', () => {
+  it('reads a package without creating anything', async () => {
+    const result = parsed(await tools.get('inspect_connector_package')!({ package: 'pkg' }))
+
+    expect(result.name).toBe('Azure Data Explorer')
+    expect(rpcCall).not.toHaveBeenCalledWith(
+      'connection:create',
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('runs a bare package name through npx and a command as given', async () => {
+    await tools.get('inspect_connector_package')!({ package: '@vornrun/connector-kusto' })
+    expect(rpcCall).toHaveBeenCalledWith(
+      'connector:probeSdk',
+      { command: 'npx', args: ['-y', '@vornrun/connector-kusto'] },
+      expect.any(Number)
+    )
+
+    await tools.get('inspect_connector_package')!({ package: 'node /tmp/dist/index.js' })
+    expect(rpcCall).toHaveBeenCalledWith(
+      'connector:probeSdk',
+      { command: 'node', args: ['/tmp/dist/index.js'] },
+      expect.any(Number)
+    )
+  })
+
+  it('allows longer than a normal call, since the package downloads first', async () => {
+    await tools.get('inspect_connector_package')!({ package: 'pkg' })
+
+    const [, , timeout] = rpcCall.mock.calls.find((c) => c[0] === 'connector:probeSdk')!
+    expect(timeout).toBeGreaterThan(10_000)
+  })
+
+  it('reports why a package could not be read', async () => {
+    server({ 'connector:probeSdk': { ok: false, error: 'package not found' } })
+
+    const result = await tools.get('inspect_connector_package')!({ package: 'nope' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('package not found')
+  })
+})
+
+describe('install_connector', () => {
+  const ENV = { KUSTO_CLUSTER: 'https://help.kusto.windows.net' }
+
+  it('installs a catalog connector and reports the connection', async () => {
+    const result = parsed(
+      await tools.get('install_connector')!({ connector_id: 'kusto', env: ENV })
+    )
+
+    expect(result.connectionId).toBe('new-conn')
+    expect(result.trigger).toBe('queryResult')
+  })
+
+  it('records what it installed so the connection can be identified later', async () => {
+    await tools.get('install_connector')!({ connector_id: 'kusto', env: ENV })
+
+    const [, params] = rpcCall.mock.calls.find((c) => c[0] === 'connection:create')!
+    expect(params.filters).toMatchObject({
+      sdkConnectorId: 'kusto',
+      sdkVersion: '0.5.2',
+      env: JSON.stringify(ENV),
+      pollTool: 'poll_queryResult'
+    })
+  })
+
+  it('names the catalog ids it knows when given one it does not', async () => {
+    const result = await tools.get('install_connector')!({ connector_id: 'nope' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('kusto')
+  })
+
+  it('refuses without a connector to install rather than guessing', async () => {
+    const result = await tools.get('install_connector')!({})
+
+    expect(result.isError).toBe(true)
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+
+  it('lists the missing values instead of creating a connection that cannot run', async () => {
+    const result = await tools.get('install_connector')!({ connector_id: 'kusto' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('KUSTO_CLUSTER')
+    expect(text(result)).toContain('Cluster URL')
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+
+  it('rejects an env var the connector does not use, which is usually a typo', async () => {
+    const result = await tools.get('install_connector')!({
+      connector_id: 'kusto',
+      env: { ...ENV, KUSTO_CLUSTR: 'x' }
+    })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('KUSTO_CLUSTR')
+  })
+
+  it('refuses to store a secret, which it cannot encrypt from here', async () => {
+    // Encryption runs in the desktop process; accepting the value here would
+    // mean writing a credential to the database in the clear.
+    server({
+      'connector:probeSdk': {
+        ok: true,
+        manifest: {
+          ...MANIFEST,
+          env: [{ name: 'API_TOKEN', required: true, secret: true }]
+        }
+      }
+    })
+
+    const result = await tools.get('install_connector')!({
+      connector_id: 'kusto',
+      env: { API_TOKEN: 'super-secret' }
+    })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('API_TOKEN')
+    expect(text(result)).toMatch(/keychain|person/i)
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+
+  it('names the triggers on offer when asked for one that does not exist', async () => {
+    const result = await tools.get('install_connector')!({
+      connector_id: 'kusto',
+      env: ENV,
+      trigger: 'nope'
+    })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('queryResult')
+  })
+
+  it('installs a package that is not in the catalog', async () => {
+    const result = parsed(
+      await tools.get('install_connector')!({ package: '@scope/other', env: ENV })
+    )
+
+    expect(result.connectionId).toBe('new-conn')
+    const [, params] = rpcCall.mock.calls.find((c) => c[0] === 'connection:create')!
+    expect(params.filters.command).toBe('npx')
+  })
+
+  it('reports a package that could not be started rather than saving it', async () => {
+    server({ 'connector:probeSdk': { ok: false, error: 'no such package' } })
+
+    const result = await tools.get('install_connector')!({ package: 'nope' })
+
+    expect(result.isError).toBe(true)
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+  })
+})
+
+describe('run_connector_action', () => {
+  it('returns what the action produced', async () => {
+    server({ 'connection:executeAction': { success: true, data: { rows: 2 } } })
+
+    const result = parsed(
+      await tools.get('run_connector_action')!({
+        connection_id: 'c1',
+        action: 'runQuery'
+      })
+    )
+
+    expect(result.data.rows).toBe(2)
+  })
+
+  it('reports a failed action as an error, not as a result', async () => {
+    server({ 'connection:executeAction': { success: false, error: 'query is invalid' } })
+
+    const result = await tools.get('run_connector_action')!({ connection_id: 'c1', action: 'x' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('query is invalid')
+  })
+})
+
+describe('backfill_connection', () => {
+  it('reports what it imported', async () => {
+    server({ 'connection:backfill': { imported: 3, updated: 1 } })
+
+    const result = parsed(await tools.get('backfill_connection')!({ connection_id: 'c1' }))
+
+    expect(result).toMatchObject({ imported: 3, updated: 1 })
+  })
+
+  it('surfaces a backfill error rather than reporting zero imported', async () => {
+    server({ 'connection:backfill': { imported: 0, updated: 0, error: 'Connection not found' } })
+
+    const result = await tools.get('backfill_connection')!({ connection_id: 'nope' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('Connection not found')
+  })
+})
+
+describe('list_connector_actions', () => {
+  it('returns the actions with their inputs', async () => {
+    server({
+      'connection:listActions': [{ type: 'runQuery', label: 'Run query', configFields: [] }]
+    })
+
+    const result = parsed(await tools.get('list_connector_actions')!({ connection_id: 'c1' }))
+
+    expect(result[0].type).toBe('runQuery')
+  })
+
+  it('explains an empty list rather than returning a bare []', async () => {
+    const result = await tools.get('list_connector_actions')!({ connection_id: 'c1' })
+
+    expect(result.isError).toBe(true)
+    expect(text(result)).toMatch(/discovery/i)
+  })
+})

--- a/tests/sdk-connector-form-ui.test.tsx
+++ b/tests/sdk-connector-form-ui.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { SdkConnectorForm } from '../src/renderer/components/settings/SdkConnectorForm'
-import type { SdkConnectorManifest } from '../src/shared/types'
+import type { ConnectorCatalogItem, SdkConnectorManifest } from '../src/shared/types'
 
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
@@ -54,10 +54,21 @@ beforeEach(() => {
   }
 })
 
-const setup = () => {
+const setup = (catalogEntry?: ConnectorCatalogItem) => {
   const onDone = vi.fn()
-  const utils = render(<SdkConnectorForm onDone={onDone} onCancel={vi.fn()} />)
+  const utils = render(
+    <SdkConnectorForm onDone={onDone} onCancel={vi.fn()} catalogEntry={catalogEntry} />
+  )
   return { ...utils, onDone }
+}
+
+const CATALOG_ENTRY: ConnectorCatalogItem = {
+  id: 'kusto',
+  name: 'Azure Data Explorer',
+  description: 'Trigger workflows from the rows a KQL query returns.',
+  packageName: '@vornrun/connector-kusto',
+  capabilities: ['triggers', 'actions'],
+  launch: { command: 'npx', args: ['-y', '@vornrun/connector-kusto'] }
 }
 
 /** Type a package name and run the lookup, leaving the manifest on screen. */
@@ -264,5 +275,45 @@ describe('SdkConnectorForm', () => {
 
     await waitFor(() => expect(utils.getByText('database is locked')).toBeInTheDocument())
     expect(utils.onDone).not.toHaveBeenCalled()
+  })
+})
+
+describe('installing from a catalog entry', () => {
+  it('reads the connector on open instead of asking for its package name', async () => {
+    const utils = setup(CATALOG_ENTRY)
+
+    await waitFor(() => expect(probeSdkConnector).toHaveBeenCalledWith(CATALOG_ENTRY.launch))
+    expect(await utils.findByText('Azure Data Explorer')).toBeInTheDocument()
+  })
+
+  it('hides the package lookup, which is the step the catalog exists to remove', async () => {
+    const utils = setup(CATALOG_ENTRY)
+
+    await waitFor(() => expect(probeSdkConnector).toHaveBeenCalled())
+    expect(utils.queryByText('Connector package')).not.toBeInTheDocument()
+    expect(utils.queryByPlaceholderText('@vornrun/connector-kusto')).not.toBeInTheDocument()
+  })
+
+  it('starts the connector once, not once per effect run', async () => {
+    // A probe spawns a child process that downloads a package, so a second
+    // run is a duplicate cold install racing the first.
+    setup(CATALOG_ENTRY)
+
+    await waitFor(() => expect(probeSdkConnector).toHaveBeenCalled())
+    expect(probeSdkConnector).toHaveBeenCalledTimes(1)
+  })
+
+  it('still offers the lookup with no entry, so a local build can be loaded', () => {
+    const utils = setup()
+
+    expect(utils.getByText('Connector package')).toBeInTheDocument()
+    expect(probeSdkConnector).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed read rather than leaving an empty form', async () => {
+    probeSdkConnector.mockResolvedValue({ ok: false, error: 'package not found' })
+    const utils = setup(CATALOG_ENTRY)
+
+    expect(await utils.findByText('package not found')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Adding a first-party connector meant clicking a generic "MCP" row, hitting
"+ Add", and typing an npm package name from memory. The escape hatch was the
front door, and there was no way to discover what we ship.

## A catalog

`CONNECTOR_CATALOG` lists connectors we publish, and they now render as
first-class rows next to the built-ins. Picking one opens a form that already
knows its package and probes it for you, so nothing has to be typed from
memory.

The built-in list and the catalog list started out as two near-identical copies
of the same row markup. They are now one searchable, grouped list built by
`connector-browse.ts`, which merges both sources plus anything already
installed that isn't catalogued. Grouping and search matter as soon as this
list is longer than a screen.

A few things fell out of the cleanup:

- The auto-probe fired twice under StrictMode, launching two cold `npx -y`
  installs racing to fill one form. Guarded by a ref keyed on package name.
- `adding` and `addingCatalog` were two states for one selection, which made
  "both forms open at once" representable. Now one nullable value.
- Locating a local build sniffed `process.cwd()` for `packages/*/dist`, so a
  released app sitting next to such a folder would have spawned it. The
  launcher now passes `VORN_REPO_ROOT` in its dev branch only — the server is
  told rather than guessing, matching how `VORN_NATIVE_MODULES_PATH` already
  works.
- Three files independently knew the packaged-connection `filters` vocabulary.
  That now has one owner in `connection-icon.ts`.

## Connectors over MCP

Agents could read tasks, projects, sessions and workflows but had no visibility
into connectors, so they couldn't answer which integrations exist or exercise
one. Seven tools close that: `list_connectors`, `list_connections`,
`list_connector_actions`, `inspect_connector_package`, `install_connector`,
`run_connector_action`, `backfill_connection`.

Each is a thin wrapper over a server method that already existed, so agent
behaviour can't drift from what the UI does.

`install_connector` refuses when a required env var is marked `secret`.
Encryption lives in the Electron main process and there's no channel back from
the server, so accepting one would mean writing a credential to the database in
the clear — the tool points the caller at Settings instead. Connectors that
authenticate ambiently (Kusto uses `DefaultAzureCredential`) install fully.

`rpcCall` takes an optional timeout because probing a package can take up to
90s, well past the 10s default.

## Testing

213 files / 2413 tests pass; typecheck and lint clean. The seven tools were also
driven end to end against a running dev server over real stdio MCP — installing
a Kusto connection, listing its actions, and checking each error path produces
something actionable.
