### PR TITLE
chore(release): v0.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,12 +261,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Serialised, in order: a dependent must not reach the registry before
+      # the package it depends on, or installing it fails until the other
+      # lands. The matrix runs top to bottom at max-parallel 1.
+      max-parallel: 1
       matrix:
         include:
-          - name: '@vornrun/mcp'
-            directory: packages/mcp
           - name: '@vornrun/connector-sdk'
             directory: packages/connector-sdk
+          - name: '@vornrun/mcp'
+            directory: packages/mcp
           - name: '@vornrun/connector-kusto'
             directory: packages/connector-kusto
     steps:
@@ -289,10 +293,16 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      # Every publishable package, not just the one being published: a
+      # `workspace:^` dependency is rewritten at pack time using the version
+      # found in the workspace, so bumping only the matrix package would ship
+      # a dependency range pointing at the version we are replacing.
       - name: Sync version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          cd "${{ matrix.directory }}" && npm pkg set version="$VERSION"
+          for dir in packages/connector-sdk packages/mcp packages/connector-kusto; do
+            (cd "$dir" && npm pkg set version="$VERSION")
+          done
 
       - name: Build package
         run: yarn workspace ${{ matrix.name }} build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-kusto/package.json
+++ b/packages/connector-kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-kusto",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Trigger Vorn workflows from an Azure Data Explorer (Kusto) query",
   "type": "module",
   "license": "MIT",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps every workspace package to 0.5.3.

This release is the first time `@vornrun/connector-sdk` and
`@vornrun/connector-kusto` reach npm, which surfaced two problems in the
publish job that would have shipped a broken package.

**The dependency range would have pointed at the wrong version.** The job
bumped only the package it was publishing, but yarn rewrites a `workspace:^`
dependency at pack time using the version it finds in the workspace. So
`connector-kusto@0.5.3` would have depended on `connector-sdk@^0.5.2` while
the sdk actually published as 0.5.3. It resolves this time only because a
caret on a 0.5.x version spans 0.5.3, and it breaks outright at the next
minor bump. Every publishable package is now synced from the tag, and a local
`yarn pack` confirms the packed manifest carries `^0.5.3`.

**They published in parallel.** Nothing stopped kusto reaching the registry
before the sdk it depends on, leaving `npx -y @vornrun/connector-kusto`
failing until the other job caught up. They now publish one at a time with the
sdk first.

Tagging `v0.5.3` after this merges builds the desktop apps and publishes the
three packages.