### PR TITLE
feat(worktrees): a manager that measures what worktrees cost, and reclaims it

### DIFF
--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -185,6 +185,18 @@ function generateName(): string {
   return `${adj}-${noun}`
 }
 
+/**
+ * True when a branch name came from `generateName()` — an adjective-noun pair,
+ * optionally suffixed with the 8-hex worktree id. Used to tell branches vorn
+ * created for a worktree apart from branches the user named themselves, so
+ * cleanup only ever proposes deleting its own leftovers.
+ */
+export function isGeneratedWorktreeBranch(branch: string): boolean {
+  const match = branch.match(/^([a-z]+)-([a-z]+)(?:-[0-9a-f]{8})?$/)
+  if (!match) return false
+  return ADJECTIVES.includes(match[1]) && NOUNS.includes(match[2])
+}
+
 export function createWorktree(
   projectPath: string,
   branch: string,
@@ -316,16 +328,176 @@ export function removeWorktree(
   projectPath: string,
   worktreePath: string,
   force = false,
-  remote?: RemoteHost
+  remote?: RemoteHost,
+  deleteBranch = false
 ): boolean {
+  // Read the branch before removal — afterwards git no longer associates it
+  // with a path, and we would have nothing left to delete.
+  const branch = deleteBranch ? getGitBranch(worktreePath, remote) : null
   try {
     const args = ['worktree', 'remove', worktreePath]
     if (force) args.push('--force')
     gitExec(args, projectPath, { timeout: 10000, remote })
+  } catch {
+    return false
+  }
+  // Best-effort, and never forced: `force` here means "discard uncommitted
+  // changes", which is not permission to drop unmerged commits. A branch git
+  // refuses to delete is left alone rather than failing a removal that
+  // already succeeded.
+  if (branch) deleteBranches(projectPath, [branch], false, remote)
+  return true
+}
+
+/**
+ * The branch a project's work is measured against. Prefers the remote HEAD
+ * symref, then the usual local names, then whatever HEAD points at.
+ */
+export function getDefaultBranch(projectPath: string, remote?: RemoteHost): string | null {
+  try {
+    const symref = gitExec(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], projectPath, {
+      timeout: 5000,
+      remote
+    }).trim()
+    if (symref) return symref.replace(/^origin\//, '')
+  } catch {
+    // No origin/HEAD — fall through to local names.
+  }
+  const locals = listBranches(projectPath, remote)
+  for (const candidate of ['main', 'master', 'trunk', 'develop']) {
+    if (locals.includes(candidate)) return candidate
+  }
+  return getGitBranch(projectPath, remote)
+}
+
+/** True when `branch` is already contained in `base` — nothing would be lost. */
+export function isBranchMerged(
+  projectPath: string,
+  branch: string,
+  base: string,
+  remote?: RemoteHost
+): boolean {
+  if (branch === base) return true
+  try {
+    gitExec(['merge-base', '--is-ancestor', branch, base], projectPath, { timeout: 5000, remote })
     return true
   } catch {
     return false
   }
+}
+
+/** The upstream ref for a branch, or null when it was never pushed. */
+export function getBranchUpstream(
+  projectPath: string,
+  branch: string,
+  remote?: RemoteHost
+): string | null {
+  try {
+    const upstream = gitExec(
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', `${branch}@{upstream}`],
+      projectPath,
+      { timeout: 5000, remote }
+    ).trim()
+    return upstream || null
+  } catch {
+    return null
+  }
+}
+
+/** ISO timestamp of a ref's last commit, or null if the ref is unreadable. */
+export function getLastCommitDate(cwd: string, ref = 'HEAD', remote?: RemoteHost): string | null {
+  try {
+    const raw = gitExec(['log', '-1', '--format=%cI', ref], cwd, { timeout: 5000, remote }).trim()
+    return raw || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Branches already contained in `base` — one call instead of a `merge-base`
+ * per branch, which matters when a repo has dozens of them.
+ */
+export function listMergedBranches(
+  projectPath: string,
+  base: string,
+  remote?: RemoteHost
+): string[] {
+  try {
+    const output = gitExec(['branch', '--merged', base, '--format=%(refname:short)'], projectPath, {
+      timeout: 10000,
+      remote
+    }).trim()
+    return output
+      ? output
+          .split('\n')
+          .map((b: string) => b.trim())
+          .filter(Boolean)
+      : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Every local branch with its upstream and last commit date, tab-separated —
+ * enough to classify a whole repo's branches in a single git invocation.
+ */
+export function gitForEachRef(projectPath: string, remote?: RemoteHost): string[] {
+  try {
+    const output = gitExec(
+      [
+        'for-each-ref',
+        '--format=%(refname:short)%09%(upstream:short)%09%(committerdate:iso-strict)',
+        'refs/heads'
+      ],
+      projectPath,
+      { timeout: 10000, remote }
+    ).trim()
+    return output ? output.split('\n').filter(Boolean) : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The real git directory backing a path. For a linked worktree this is
+ * `<repo>/.git/worktrees/<name>`, whose `index` mtime tracks activity in that
+ * worktree alone. Returns null when the path isn't inside a repository.
+ */
+export function getAbsoluteGitDir(anyPath: string, remote?: RemoteHost): string | null {
+  try {
+    const dir = gitExec(['rev-parse', '--absolute-git-dir'], anyPath, {
+      timeout: 5000,
+      remote
+    }).trim()
+    return dir || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Delete local branches. Uses `-d` so git refuses anything unmerged; `force`
+ * escalates to `-D` and must be an explicit choice by the user.
+ */
+export function deleteBranches(
+  projectPath: string,
+  branches: string[],
+  force = false,
+  remote?: RemoteHost
+): { deleted: string[]; failed: { branch: string; error: string }[] } {
+  const deleted: string[] = []
+  const failed: { branch: string; error: string }[] = []
+  for (const branch of branches) {
+    try {
+      gitExec(['branch', force ? '-D' : '-d', branch], projectPath, { timeout: 10000, remote })
+      deleted.push(branch)
+    } catch (err) {
+      failed.push({ branch, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+  return { deleted, failed }
 }
 
 export interface WorktreeEntry {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -27,8 +27,23 @@ import {
   RemoteHost,
   getProjectRemoteHostId
 } from '@vornrun/shared/types'
-import type { SourceConnection, TaskStatus } from '@vornrun/shared/types'
+import type {
+  SourceConnection,
+  TaskStatus,
+  ProjectConfig,
+  WorktreeRetentionConfig
+} from '@vornrun/shared/types'
+import { DEFAULT_ARTIFACT_DIRS } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
+import {
+  scanWorktreeInventory,
+  reclaimArtifacts,
+  removeWorktrees,
+  pruneOrphanDirs,
+  deleteStaleBranches,
+  measureWorktree,
+  invalidateSizeCache
+} from './worktree-inventory'
 import { listDir, readFileContent, writeFileContent } from './file-utils'
 import { listShellExecutables } from './shell-integration'
 import { listInstalledShells } from './shell-integration/installed'
@@ -348,9 +363,10 @@ export function registerAllMethods(): void {
     const remote = resolveRemoteHost(projectPath)
     return gitUtils.createWorktree(projectPath, branch, worktreeName, remote)
   })
-  registerMethod('git:removeWorktree', ({ projectPath, worktreePath, force }) => {
+  registerMethod('git:removeWorktree', ({ projectPath, worktreePath, force, deleteBranch }) => {
     const remote = resolveRemoteHost(projectPath)
-    return gitUtils.removeWorktree(projectPath, worktreePath, force, remote)
+    invalidateSizeCache(worktreePath)
+    return gitUtils.removeWorktree(projectPath, worktreePath, force, remote, deleteBranch)
   })
   registerMethod('git:checkoutBranch', ({ cwd, branch }) => {
     const remote = resolveRemoteHostByPath(cwd)
@@ -405,6 +421,87 @@ export function registerAllMethods(): void {
       count: pty.count + headless.count,
       sessionIds: [...pty.sessionIds, ...headless.sessionIds]
     }
+  })
+
+  // ─── Worktree manager ──────────────────────────────────────────
+
+  function activeSessionIds(worktreePath: string): string[] {
+    return [
+      ...ptyManager.getActiveSessionsForWorktree(worktreePath).sessionIds,
+      ...headlessManager.getActiveSessionsForWorktree(worktreePath).sessionIds
+    ]
+  }
+
+  function retentionConfig(): WorktreeRetentionConfig {
+    return configManager.loadConfig().defaults.worktreeRetention ?? {}
+  }
+
+  function artifactDirNames(): string[] {
+    const configured = retentionConfig().artifactDirs
+    return configured?.length ? configured : DEFAULT_ARTIFACT_DIRS
+  }
+
+  /** Cached size for a path — measured during the scan that preceded the action. */
+  function cachedSizeOf(worktreePath: string): number {
+    const remote = resolveRemoteHostByPath(worktreePath)
+    return measureWorktree(worktreePath, artifactDirNames(), remote).sizeBytes
+  }
+
+  /**
+   * Refuse to act on a worktree that has a live session. Checked immediately
+   * before the action rather than read off the scan, because a session can
+   * start while the panel is open.
+   */
+  function assertNoActiveSessions(paths: string[]): void {
+    for (const p of paths) {
+      const count = activeSessionIds(p).length
+      if (count > 0) {
+        throw new Error(
+          `${p} has ${count} active session${count > 1 ? 's' : ''} — close them first`
+        )
+      }
+    }
+  }
+
+  /** Resolve a project to its remote host, or undefined when it is local. */
+  function remoteForProject(project: ProjectConfig): RemoteHost | undefined {
+    const remoteId = getProjectRemoteHostId(project)
+    if (!remoteId) return undefined
+    return configManager.loadConfig().remoteHosts?.find((h) => h.id === remoteId)
+  }
+
+  registerMethod('worktree:inventory', (params) => {
+    const cfg = configManager.loadConfig()
+    return scanWorktreeInventory({
+      projects: cfg.projects,
+      projectPaths: params?.projectPaths,
+      refresh: params?.refresh,
+      retention: cfg.defaults.worktreeRetention,
+      resolveRemote: remoteForProject,
+      getActiveSessions: activeSessionIds
+    })
+  })
+
+  registerMethod('worktree:reclaimArtifacts', ({ paths }) => {
+    assertNoActiveSessions(paths)
+    const cfg = configManager.loadConfig()
+    return reclaimArtifacts(paths, artifactDirNames(), cfg.projects, remoteForProject)
+  })
+
+  registerMethod('worktree:removeMany', ({ items }) => {
+    assertNoActiveSessions(items.map((i) => i.worktreePath))
+    const cfg = configManager.loadConfig()
+    return removeWorktrees(items, cachedSizeOf, cfg.projects, remoteForProject)
+  })
+
+  registerMethod('worktree:pruneOrphans', ({ paths }) => {
+    assertNoActiveSessions(paths)
+    return pruneOrphanDirs(paths, cachedSizeOf, resolveRemoteHostByPath)
+  })
+
+  registerMethod('git:deleteBranches', ({ projectPath, branches, force }) => {
+    const remote = resolveRemoteHost(projectPath)
+    return deleteStaleBranches(projectPath, branches, force ?? false, remote)
   })
   registerMethod('git:getBranch', (cwd) => {
     const remote = resolveRemoteHostByPath(cwd)

--- a/packages/server/src/worktree-inventory.ts
+++ b/packages/server/src/worktree-inventory.ts
@@ -1,0 +1,974 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import type {
+  BranchDeleteResult,
+  ProjectConfig,
+  RemoteHost,
+  StaleBranch,
+  WorktreeActionResult,
+  WorktreeInventory,
+  WorktreeInventoryEntry,
+  WorktreeProjectInventory,
+  WorktreeRetentionConfig,
+  WorktreeVerdict
+} from '@vornrun/shared/types'
+import {
+  DEFAULT_ARTIFACT_DIRS,
+  DEFAULT_IDLE_DAYS_THRESHOLD,
+  getProjectHostIds
+} from '@vornrun/shared/types'
+import { getSafeEnv, shellEscape, sshExecSync } from './process-utils'
+import * as gitUtils from './git-utils'
+import log from './logger'
+
+/** The directory vorn parks every worktree under, relative to a project's parent. */
+export const WORKTREE_ROOT_SEGMENT = '.vorn-worktrees'
+
+/** Sizes are stable enough that re-measuring on every panel open is waste. */
+const SIZE_CACHE_TTL_MS = 5 * 60 * 1000
+const DU_TIMEOUT_MS = 45_000
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+interface SizeSample {
+  sizeBytes: number
+  artifactBytes: number
+  measuredAt: number
+}
+
+const sizeCache = new Map<string, SizeSample>()
+
+/** Drop cached sizes for a path (and anything under it) after it changes on disk. */
+export function invalidateSizeCache(prefix?: string): void {
+  if (!prefix) {
+    sizeCache.clear()
+    return
+  }
+  for (const key of sizeCache.keys()) {
+    if (key === prefix || key.startsWith(prefix + path.sep) || key.startsWith(prefix + '/')) {
+      sizeCache.delete(key)
+    }
+  }
+}
+
+// ─── Shell helpers ──────────────────────────────────────────────
+
+/**
+ * Whether this host can run the POSIX `du`/`find` fast path. Windows without a
+ * remote falls back to walking the tree in Node, which is slower but correct.
+ */
+function hasPosixTools(remote?: RemoteHost): boolean {
+  return !!remote || process.platform !== 'win32'
+}
+
+function runShell(cmd: string, remote: RemoteHost | undefined, timeout: number): string {
+  if (remote) return sshExecSync(remote, cmd, { timeout })
+  return execFileSync('/bin/sh', ['-c', cmd], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: getSafeEnv(),
+    timeout,
+    maxBuffer: 8 * 1024 * 1024
+  }).trim()
+}
+
+function joinPath(base: string, child: string, remote?: RemoteHost): string {
+  return remote ? `${base}/${child}` : path.join(base, child)
+}
+
+function baseName(p: string, remote?: RemoteHost): string {
+  if (remote) return p.split('/').filter(Boolean).pop() ?? p
+  return path.basename(p)
+}
+
+function parentDir(p: string, remote?: RemoteHost): string {
+  if (remote) return p.split('/').slice(0, -1).join('/')
+  return path.dirname(p)
+}
+
+/** Where a project's worktrees live: `<parent>/.vorn-worktrees/<project>`. */
+export function worktreeBaseDir(projectPath: string, remote?: RemoteHost): string {
+  const parent = parentDir(projectPath, remote)
+  const name = baseName(projectPath, remote)
+  return joinPath(joinPath(parent, WORKTREE_ROOT_SEGMENT, remote), name, remote)
+}
+
+// ─── Deletion guards ────────────────────────────────────────────
+//
+// Two different questions, two different authorities.
+//
+// `git worktree remove` only ever touches a path git already claims as a
+// worktree of the repo, and refuses to drop uncommitted work unless forced.
+// For that, git's own answer is the authority — a worktree created by hand
+// outside `.vorn-worktrees/` is still perfectly safe to remove, and refusing
+// it would mean showing a row the button can't act on.
+//
+// A raw `fs.rm` has no such backstop, so it carries the strict checks: the
+// target must sit inside a worktree vorn resolved from git, or — for orphan
+// directories, which by definition no longer have a git record — inside
+// `.vorn-worktrees/<project>/`.
+
+/**
+ * Refuse to delete anything that isn't inside a `.vorn-worktrees/<project>/`
+ * directory. Symlinks are resolved first so a link planted inside the worktree
+ * root can't be used to reach the rest of the filesystem.
+ *
+ * Used for orphan directories only — the one case with no git record to check
+ * against. Throws with a readable reason; callers surface it per path.
+ */
+export function assertRemovablePath(target: string, remote?: RemoteHost): void {
+  if (!target || target.trim() === '') {
+    throw new Error('Refusing to delete an empty path')
+  }
+
+  let resolved = remote ? target : path.resolve(target)
+  if (!remote) {
+    try {
+      resolved = fs.realpathSync(resolved)
+    } catch {
+      // Missing paths keep their resolved form — nothing to delete, and the
+      // segment check below still applies.
+    }
+  }
+
+  const sep = remote ? '/' : path.sep
+  const segments = resolved.split(sep).filter(Boolean)
+  const rootIndex = segments.lastIndexOf(WORKTREE_ROOT_SEGMENT)
+  if (rootIndex === -1) {
+    throw new Error(`Refusing to delete a path outside ${WORKTREE_ROOT_SEGMENT}: ${target}`)
+  }
+  // Must be at least `.vorn-worktrees/<project>/<worktree>` — never the root
+  // itself and never a whole project's worktree folder in one go.
+  if (segments.length < rootIndex + 3) {
+    throw new Error(`Refusing to delete ${target}: not a worktree directory`)
+  }
+}
+
+/** Resolve symlinks so two spellings of the same directory compare equal. */
+function canonical(p: string, remote?: RemoteHost): string {
+  if (remote) return p.replace(/\/+$/, '')
+  const resolved = path.resolve(p)
+  try {
+    return fs.realpathSync(resolved)
+  } catch {
+    return resolved
+  }
+}
+
+/**
+ * Refuse any delete target that isn't the worktree itself or something beneath
+ * it. Both sides are canonicalised, so a symlink inside the worktree can't be
+ * used to reach out of it.
+ */
+export function assertInsideWorktree(
+  target: string,
+  worktreePath: string,
+  remote?: RemoteHost
+): void {
+  if (!target || target.trim() === '') throw new Error('Refusing to delete an empty path')
+  const sep = remote ? '/' : path.sep
+  const root = canonical(worktreePath, remote)
+  const resolved = canonical(target, remote)
+  if (resolved !== root && !resolved.startsWith(root + sep)) {
+    throw new Error(`Refusing to delete ${target}: outside the worktree at ${worktreePath}`)
+  }
+}
+
+/**
+ * The worktree git says owns this path, across all known projects — or null.
+ * The main worktree is deliberately never returned: it is the project itself,
+ * and neither removal nor a build-output sweep belongs there.
+ */
+export function findOwningWorktree(
+  target: string,
+  projects: ProjectConfig[],
+  resolveRemote: (project: ProjectConfig) => RemoteHost | undefined,
+  cache = new Map<string, { path: string; isMain: boolean }[]>()
+): { projectPath: string; worktreePath: string; remote?: RemoteHost } | null {
+  for (const project of projects) {
+    const remote = resolveRemote(project)
+    let listed = cache.get(project.path)
+    if (!listed) {
+      listed = gitUtils
+        .listWorktrees(project.path, remote)
+        .map((wt) => ({ path: wt.path, isMain: wt.isMain }))
+      cache.set(project.path, listed)
+    }
+    const wanted = canonical(target, remote)
+    for (const wt of listed) {
+      if (wt.isMain) continue
+      if (canonical(wt.path, remote) === wanted) {
+        return { projectPath: project.path, worktreePath: wt.path, remote }
+      }
+    }
+  }
+  return null
+}
+
+function removeDir(target: string, remote?: RemoteHost): void {
+  if (remote) {
+    runShell(`rm -rf ${shellEscape(target, 'posix')}`, remote, 60_000)
+    return
+  }
+  fs.rmSync(target, { recursive: true, force: true })
+}
+
+// ─── Sizing ─────────────────────────────────────────────────────
+
+/**
+ * Locate build-output directories inside a worktree. `-prune` stops the search
+ * descending into them, so a nested `node_modules/.../node_modules` is counted
+ * once by its outermost parent.
+ */
+export function findArtifactDirs(
+  root: string,
+  artifactDirs: string[],
+  remote?: RemoteHost
+): string[] {
+  if (artifactDirs.length === 0) return []
+
+  if (hasPosixTools(remote)) {
+    const nameTests = artifactDirs.map((name) => `-name ${shellEscape(name, 'posix')}`).join(' -o ')
+    const cmd = `find ${shellEscape(root, 'posix')} -type d \\( ${nameTests} \\) -prune -print`
+    try {
+      const out = runShell(cmd, remote, 30_000)
+      return out
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+    } catch (err) {
+      log.warn({ err, root }, '[worktree-inventory] find failed, falling back to walk')
+    }
+  }
+
+  const found: string[] = []
+  const names = new Set(artifactDirs)
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue
+      const full = path.join(dir, entry.name)
+      if (names.has(entry.name)) {
+        found.push(full)
+        continue // prune — don't descend into build output
+      }
+      if (entry.name === '.git') continue
+      walk(full)
+    }
+  }
+  walk(root)
+  return found
+}
+
+/** Sum `du -sk` over a set of paths, in chunks so the arg list stays sane. */
+function duBytes(paths: string[], remote: RemoteHost | undefined, timeout: number): number {
+  let totalKb = 0
+  for (let i = 0; i < paths.length; i += 50) {
+    const chunk = paths.slice(i, i + 50)
+    const cmd = `du -sk ${chunk.map((p) => shellEscape(p, 'posix')).join(' ')}`
+    // `du` exits non-zero if any single path is unreadable but still reports
+    // the rest on stdout, so a throw here means we genuinely got nothing.
+    const out = runShell(cmd, remote, timeout)
+    for (const line of out.split('\n')) {
+      const kb = parseInt(line.trim().split(/\s+/)[0], 10)
+      if (!Number.isNaN(kb)) totalKb += kb
+    }
+  }
+  return totalKb * 1024
+}
+
+function walkBytes(root: string, prune: Set<string>): number {
+  let total = 0
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name)
+      if (entry.isSymbolicLink()) continue
+      if (entry.isDirectory()) {
+        if (prune.has(full)) continue
+        walk(full)
+      } else if (entry.isFile()) {
+        try {
+          total += fs.statSync(full).size
+        } catch {
+          // Vanished mid-walk — skip it.
+        }
+      }
+    }
+  }
+  walk(root)
+  return total
+}
+
+/**
+ * Total bytes on disk for a worktree and, separately, the part that lives in
+ * build-output directories — the part a reinstall rebuilds for free.
+ */
+export function measureWorktree(
+  root: string,
+  artifactDirs: string[],
+  remote?: RemoteHost,
+  refresh = false
+): SizeSample & { measured: boolean } {
+  const cached = sizeCache.get(root)
+  if (!refresh && cached && Date.now() - cached.measuredAt < SIZE_CACHE_TTL_MS) {
+    return { ...cached, measured: true }
+  }
+
+  try {
+    const artifacts = findArtifactDirs(root, artifactDirs, remote)
+    let sizeBytes: number
+    let artifactBytes: number
+
+    if (hasPosixTools(remote)) {
+      sizeBytes = duBytes([root], remote, DU_TIMEOUT_MS)
+      artifactBytes = artifacts.length ? duBytes(artifacts, remote, DU_TIMEOUT_MS) : 0
+    } else {
+      const pruneSet = new Set(artifacts)
+      const sourceBytes = walkBytes(root, pruneSet)
+      artifactBytes = artifacts.reduce((sum, dir) => sum + walkBytes(dir, new Set()), 0)
+      sizeBytes = sourceBytes + artifactBytes
+    }
+
+    // `du` reports allocated blocks, so a pathological rounding could put the
+    // artifact total above the tree total. Keep the pair coherent.
+    artifactBytes = Math.min(artifactBytes, sizeBytes)
+
+    const sample: SizeSample = { sizeBytes, artifactBytes, measuredAt: Date.now() }
+    sizeCache.set(root, sample)
+    return { ...sample, measured: true }
+  } catch (err) {
+    log.warn({ err, root }, '[worktree-inventory] sizing failed')
+    // A stale number beats no number; only fall back to zero if we never had one.
+    if (cached) return { ...cached, measured: true }
+    return { sizeBytes: 0, artifactBytes: 0, measuredAt: Date.now(), measured: false }
+  }
+}
+
+// ─── Activity ───────────────────────────────────────────────────
+
+/**
+ * Newest git activity in a worktree, taken from the mtime of its index. The
+ * index is rewritten by any git operation an agent performs, and unlike a file
+ * walk it doesn't get reset to "now" by an unrelated `yarn install`.
+ */
+function readIndexMtime(worktreePath: string, remote?: RemoteHost): string | null {
+  try {
+    const gitDir = gitUtils.getAbsoluteGitDir(worktreePath, remote)
+    if (!gitDir) return null
+    const indexPath = joinPath(gitDir, 'index', remote)
+    if (remote) {
+      const epoch = parseInt(
+        runShell(`stat -c %Y ${shellEscape(indexPath, 'posix')}`, remote, 10_000).trim(),
+        10
+      )
+      return Number.isNaN(epoch) ? null : new Date(epoch * 1000).toISOString()
+    }
+    return fs.statSync(indexPath).mtime.toISOString()
+  } catch {
+    return null
+  }
+}
+
+function daysSince(iso: string | null): number | null {
+  if (!iso) return null
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return null
+  return Math.max(0, Math.floor((Date.now() - then) / MS_PER_DAY))
+}
+
+function newest(a: string | null, b: string | null): string | null {
+  if (!a) return b
+  if (!b) return a
+  return Date.parse(a) >= Date.parse(b) ? a : b
+}
+
+// ─── Verdict ────────────────────────────────────────────────────
+
+export interface VerdictInput {
+  isMain: boolean
+  kind: 'registered' | 'orphan-dir'
+  isDirty: boolean
+  isMerged: boolean
+  hasUpstream: boolean
+  activeSessionCount: number
+  isPinned: boolean
+  sizeBytes: number
+  artifactBytes: number
+  idleDays: number | null
+}
+
+/**
+ * The safest action available for one worktree. Ordered most-protective first:
+ * anything that could lose work stops at `review`, and only a merged, clean,
+ * idle worktree is ever pre-selected.
+ */
+export function computeVerdict(input: VerdictInput, idleDaysThreshold: number): WorktreeVerdict {
+  const {
+    isMain,
+    kind,
+    isDirty,
+    isMerged,
+    hasUpstream,
+    activeSessionCount,
+    isPinned,
+    sizeBytes,
+    artifactBytes,
+    idleDays
+  } = input
+
+  if (isMain) {
+    return { level: 'keep', freesBytes: 0, reasons: ['main worktree'], autoSelect: false }
+  }
+  if (activeSessionCount > 0) {
+    return {
+      level: 'keep',
+      freesBytes: 0,
+      reasons: [`${activeSessionCount} active session${activeSessionCount > 1 ? 's' : ''}`],
+      autoSelect: false
+    }
+  }
+  if (isPinned) {
+    return { level: 'keep', freesBytes: 0, reasons: ['pinned'], autoSelect: false }
+  }
+  if (kind === 'orphan-dir') {
+    return {
+      level: 'orphan',
+      freesBytes: sizeBytes,
+      reasons: ['not registered with git'],
+      autoSelect: false
+    }
+  }
+  if (isDirty) {
+    return {
+      level: 'review',
+      freesBytes: 0,
+      reasons: ['uncommitted changes'],
+      autoSelect: false
+    }
+  }
+  if (!isMerged && !hasUpstream) {
+    return {
+      level: 'review',
+      freesBytes: 0,
+      reasons: ['unmerged and never pushed'],
+      autoSelect: false
+    }
+  }
+  if (!isMerged) {
+    return {
+      level: 'reclaim',
+      freesBytes: artifactBytes,
+      reasons: ['unmerged but pushed', 'build output can go'],
+      autoSelect: false
+    }
+  }
+
+  const reasons = ['merged']
+  if (idleDays !== null) reasons.push(`idle ${idleDays} day${idleDays === 1 ? '' : 's'}`)
+  return {
+    level: 'remove',
+    freesBytes: sizeBytes,
+    reasons,
+    autoSelect: idleDays === null ? false : idleDays >= idleDaysThreshold
+  }
+}
+
+// ─── Scan ───────────────────────────────────────────────────────
+
+export interface ScanOptions {
+  projects: ProjectConfig[]
+  /** Limit the scan to these project paths; omit to scan all of them. */
+  projectPaths?: string[]
+  refresh?: boolean
+  retention?: WorktreeRetentionConfig
+  /** Resolves a project to its remote host, or undefined when it is local. */
+  resolveRemote: (project: ProjectConfig) => RemoteHost | undefined
+  /** Live PTY + headless session ids running in a worktree. */
+  getActiveSessions: (worktreePath: string) => string[]
+}
+
+/** Branch metadata for a whole repo in one `for-each-ref` call. */
+function readBranchInfo(
+  projectPath: string,
+  remote?: RemoteHost
+): Map<string, { upstream: string | null; committerDate: string | null }> {
+  const info = new Map<string, { upstream: string | null; committerDate: string | null }>()
+  try {
+    const out = gitUtils.gitForEachRef(projectPath, remote)
+    for (const line of out) {
+      const [name, upstream, date] = line.split('\t')
+      if (!name) continue
+      info.set(name, { upstream: upstream || null, committerDate: date || null })
+    }
+  } catch {
+    // Leave the map empty — callers treat a miss as "unknown", not "absent".
+  }
+  return info
+}
+
+function scanProject(
+  project: ProjectConfig,
+  opts: ScanOptions,
+  artifactDirs: string[],
+  idleDaysThreshold: number,
+  pinned: Set<string>
+): WorktreeProjectInventory {
+  const remote = opts.resolveRemote(project)
+  const remoteHostId = remote ? remote.id : null
+  const base: WorktreeProjectInventory = {
+    projectPath: project.path,
+    projectName: project.name,
+    defaultBranch: null,
+    remoteHostId,
+    entries: [],
+    staleBranches: []
+  }
+
+  if (!remote && !gitUtils.isGitRepo(project.path)) {
+    return { ...base, error: 'not a git repository' }
+  }
+
+  const worktrees = gitUtils.listWorktrees(project.path, remote)
+  if (worktrees.length === 0) {
+    return { ...base, error: 'could not read worktrees' }
+  }
+
+  const defaultBranch = gitUtils.getDefaultBranch(project.path, remote)
+  const branchInfo = readBranchInfo(project.path, remote)
+  const mergedBranches = defaultBranch
+    ? new Set(gitUtils.listMergedBranches(project.path, defaultBranch, remote))
+    : new Set<string>()
+
+  const entries: WorktreeInventoryEntry[] = []
+  const registeredPaths = new Set<string>()
+  const branchesInUse = new Set<string>()
+
+  for (const wt of worktrees) {
+    registeredPaths.add(wt.path)
+    if (wt.branch && wt.branch !== 'detached') branchesInUse.add(wt.branch)
+
+    // The main worktree is the project itself — report it so the totals are
+    // honest, but never measure or offer to touch it.
+    if (wt.isMain) {
+      entries.push({
+        path: wt.path,
+        name: wt.name,
+        projectPath: project.path,
+        projectName: project.name,
+        kind: 'registered',
+        branch: wt.branch,
+        isMain: true,
+        sizeBytes: 0,
+        artifactBytes: 0,
+        sizeMeasured: false,
+        lastCommitAt: null,
+        lastTouchedAt: null,
+        idleDays: null,
+        isDirty: false,
+        isMerged: false,
+        hasUpstream: false,
+        activeSessionIds: [],
+        verdict: computeVerdict(
+          {
+            isMain: true,
+            kind: 'registered',
+            isDirty: false,
+            isMerged: false,
+            hasUpstream: false,
+            activeSessionCount: 0,
+            isPinned: false,
+            sizeBytes: 0,
+            artifactBytes: 0,
+            idleDays: null
+          },
+          idleDaysThreshold
+        )
+      })
+      continue
+    }
+
+    const size = measureWorktree(wt.path, artifactDirs, remote, opts.refresh)
+    const branch = wt.branch && wt.branch !== 'detached' ? wt.branch : null
+    const info = branch ? branchInfo.get(branch) : undefined
+    const lastCommitAt = info?.committerDate ?? gitUtils.getLastCommitDate(wt.path, 'HEAD', remote)
+    const lastTouchedAt = readIndexMtime(wt.path, remote)
+    const activeSessionIds = opts.getActiveSessions(wt.path)
+    const isDirty = gitUtils.isWorktreeDirty(wt.path, remote)
+    const isMerged = branch ? mergedBranches.has(branch) : false
+    const hasUpstream = !!info?.upstream
+    const idleDays = daysSince(newest(lastCommitAt, lastTouchedAt))
+
+    entries.push({
+      path: wt.path,
+      name: wt.name,
+      projectPath: project.path,
+      projectName: project.name,
+      kind: 'registered',
+      branch,
+      isMain: false,
+      sizeBytes: size.sizeBytes,
+      artifactBytes: size.artifactBytes,
+      sizeMeasured: size.measured,
+      lastCommitAt,
+      lastTouchedAt,
+      idleDays,
+      isDirty,
+      isMerged,
+      hasUpstream,
+      activeSessionIds,
+      verdict: computeVerdict(
+        {
+          isMain: false,
+          kind: 'registered',
+          isDirty,
+          isMerged,
+          hasUpstream,
+          activeSessionCount: activeSessionIds.length,
+          isPinned: pinned.has(wt.path),
+          sizeBytes: size.sizeBytes,
+          artifactBytes: size.artifactBytes,
+          idleDays
+        },
+        idleDaysThreshold
+      )
+    })
+  }
+
+  // Directories git has forgotten. `git worktree prune` won't report these —
+  // once the administrative entry is gone, only the filesystem knows.
+  for (const orphanPath of listOrphanDirs(project.path, registeredPaths, remote)) {
+    const size = measureWorktree(orphanPath, artifactDirs, remote, opts.refresh)
+    const activeSessionIds = opts.getActiveSessions(orphanPath)
+    entries.push({
+      path: orphanPath,
+      name: baseName(orphanPath, remote),
+      projectPath: project.path,
+      projectName: project.name,
+      kind: 'orphan-dir',
+      branch: null,
+      isMain: false,
+      sizeBytes: size.sizeBytes,
+      artifactBytes: size.artifactBytes,
+      sizeMeasured: size.measured,
+      lastCommitAt: null,
+      lastTouchedAt: null,
+      idleDays: null,
+      isDirty: false,
+      isMerged: false,
+      hasUpstream: false,
+      activeSessionIds,
+      verdict: computeVerdict(
+        {
+          isMain: false,
+          kind: 'orphan-dir',
+          isDirty: false,
+          isMerged: false,
+          hasUpstream: false,
+          activeSessionCount: activeSessionIds.length,
+          isPinned: pinned.has(orphanPath),
+          sizeBytes: size.sizeBytes,
+          artifactBytes: size.artifactBytes,
+          idleDays: null
+        },
+        idleDaysThreshold
+      )
+    })
+  }
+
+  return {
+    ...base,
+    defaultBranch,
+    entries,
+    staleBranches: collectStaleBranches(branchInfo, branchesInUse, mergedBranches, defaultBranch)
+  }
+}
+
+/** Directories under `.vorn-worktrees/<project>` that git no longer tracks. */
+export function listOrphanDirs(
+  projectPath: string,
+  registeredPaths: Set<string>,
+  remote?: RemoteHost
+): string[] {
+  const baseDir = worktreeBaseDir(projectPath, remote)
+  let names: string[]
+  try {
+    if (remote) {
+      const out = runShell(
+        `ls -1 ${shellEscape(baseDir, 'posix')} 2>/dev/null || true`,
+        remote,
+        10_000
+      )
+      names = out
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+    } else {
+      names = fs
+        .readdirSync(baseDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+    }
+  } catch {
+    return []
+  }
+
+  const orphans: string[] = []
+  for (const name of names) {
+    if (name.startsWith('.')) continue
+    const full = joinPath(baseDir, name, remote)
+    if (registeredPaths.has(full)) continue
+    // `git worktree list` reports resolved paths; on macOS `/tmp` and other
+    // symlinked parents make the string comparison above miss.
+    if (!remote) {
+      try {
+        if (registeredPaths.has(fs.realpathSync(full))) continue
+      } catch {
+        // Unreadable — fall through and report it; removal is still guarded.
+      }
+    }
+    orphans.push(full)
+  }
+  return orphans
+}
+
+/**
+ * Branches left behind by removed worktrees. Restricted to vorn's own
+ * generated adjective-noun names so cleanup never proposes deleting a branch
+ * the user named themselves.
+ */
+export function collectStaleBranches(
+  branchInfo: Map<string, { upstream: string | null; committerDate: string | null }>,
+  branchesInUse: Set<string>,
+  mergedBranches: Set<string>,
+  defaultBranch: string | null
+): StaleBranch[] {
+  const stale: StaleBranch[] = []
+  for (const [name, info] of branchInfo) {
+    if (name === defaultBranch) continue
+    if (branchesInUse.has(name)) continue
+    if (!gitUtils.isGeneratedWorktreeBranch(name)) continue
+    stale.push({
+      name,
+      isMerged: mergedBranches.has(name),
+      hasUpstream: !!info.upstream,
+      lastCommitAt: info.committerDate
+    })
+  }
+  return stale.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function scanWorktreeInventory(opts: ScanOptions): WorktreeInventory {
+  const artifactDirs = opts.retention?.artifactDirs?.length
+    ? opts.retention.artifactDirs
+    : DEFAULT_ARTIFACT_DIRS
+  const idleDaysThreshold = opts.retention?.idleDaysThreshold ?? DEFAULT_IDLE_DAYS_THRESHOLD
+  const pinned = new Set(opts.retention?.pinnedPaths ?? [])
+
+  const wanted = opts.projectPaths?.length ? new Set(opts.projectPaths) : null
+  const projects = opts.projects.filter((p) => !wanted || wanted.has(p.path))
+
+  // Deduplicate: a project configured on several hosts appears once per host in
+  // the sidebar, but its worktrees live in one place per host path.
+  const seen = new Set<string>()
+  const results: WorktreeProjectInventory[] = []
+  for (const project of projects) {
+    const key = `${getProjectHostIds(project).join(',')}:${project.path}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    try {
+      results.push(scanProject(project, opts, artifactDirs, idleDaysThreshold, pinned))
+    } catch (err) {
+      log.error({ err, project: project.name }, '[worktree-inventory] project scan failed')
+      results.push({
+        projectPath: project.path,
+        projectName: project.name,
+        defaultBranch: null,
+        remoteHostId: null,
+        entries: [],
+        staleBranches: [],
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+  }
+
+  return { projects: results, scannedAt: new Date().toISOString() }
+}
+
+// ─── Actions ────────────────────────────────────────────────────
+
+const EMPTY_RESULT = (): WorktreeActionResult => ({
+  succeeded: [],
+  failed: [],
+  freedBytes: 0,
+  deletedBranches: []
+})
+
+/**
+ * Delete build output inside worktrees without touching git state. The highest
+ * value action in the manager and the only one that cannot lose work.
+ */
+export function reclaimArtifacts(
+  paths: string[],
+  artifactDirs: string[],
+  projects: ProjectConfig[],
+  resolveRemote: (project: ProjectConfig) => RemoteHost | undefined
+): WorktreeActionResult {
+  const result = EMPTY_RESULT()
+  const listCache = new Map<string, { path: string; isMain: boolean }[]>()
+
+  for (const worktreePath of paths) {
+    try {
+      // Git decides what counts as a worktree — including ones created by hand
+      // outside `.vorn-worktrees/`, which hold build output like any other.
+      const owner = findOwningWorktree(worktreePath, projects, resolveRemote, listCache)
+      if (!owner) {
+        throw new Error('not a worktree of any known project')
+      }
+      const remote = owner.remote
+      const dirs = findArtifactDirs(worktreePath, artifactDirs, remote)
+      if (dirs.length === 0) {
+        result.succeeded.push(worktreePath)
+        continue
+      }
+      const before = hasPosixTools(remote)
+        ? duBytes(dirs, remote, DU_TIMEOUT_MS)
+        : dirs.reduce((sum, d) => sum + walkBytes(d, new Set()), 0)
+
+      for (const dir of dirs) {
+        // Each artifact directory is re-checked on its own: `find` follows the
+        // worktree's real layout, and a symlinked build dir must not become a
+        // way out of the worktree root.
+        assertInsideWorktree(dir, owner.worktreePath, remote)
+        removeDir(dir, remote)
+      }
+      invalidateSizeCache(worktreePath)
+      result.freedBytes += before
+      result.succeeded.push(worktreePath)
+    } catch (err) {
+      result.failed.push({
+        path: worktreePath,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+  }
+  return result
+}
+
+export interface RemoveItem {
+  projectPath: string
+  worktreePath: string
+  force?: boolean
+  deleteBranch?: boolean
+}
+
+/**
+ * Remove registered worktrees, optionally taking their branches with them.
+ *
+ * The guard here is git's own record rather than a path prefix: `git worktree
+ * remove` refuses anything it doesn't own and won't drop uncommitted work
+ * unless forced, so a worktree created by hand outside `.vorn-worktrees/` is
+ * as safe to remove as one vorn made.
+ */
+export function removeWorktrees(
+  items: RemoveItem[],
+  sizeOf: (worktreePath: string) => number,
+  projects: ProjectConfig[],
+  resolveRemote: (project: ProjectConfig) => RemoteHost | undefined
+): WorktreeActionResult {
+  const result = EMPTY_RESULT()
+  const listCache = new Map<string, { path: string; isMain: boolean }[]>()
+
+  for (const item of items) {
+    try {
+      const owner = findOwningWorktree(item.worktreePath, projects, resolveRemote, listCache)
+      if (!owner) {
+        throw new Error('not a worktree of any known project')
+      }
+      const remote = owner.remote
+      const bytes = sizeOf(item.worktreePath)
+      const branch = item.deleteBranch ? gitUtils.getGitBranch(item.worktreePath, remote) : null
+
+      // Use the project git resolved, not the one the client claimed.
+      const ok = gitUtils.removeWorktree(
+        owner.projectPath,
+        item.worktreePath,
+        item.force ?? false,
+        remote,
+        item.deleteBranch ?? false
+      )
+      if (!ok) throw new Error('git worktree remove failed')
+
+      invalidateSizeCache(item.worktreePath)
+      result.freedBytes += bytes
+      result.succeeded.push(item.worktreePath)
+      // removeWorktree deletes the branch best-effort; report only what is
+      // actually gone so the summary can't overstate what happened.
+      if (branch && !gitUtils.listBranches(owner.projectPath, remote).includes(branch)) {
+        result.deletedBranches.push(branch)
+      }
+    } catch (err) {
+      result.failed.push({
+        path: item.worktreePath,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+  }
+  return result
+}
+
+/** Delete directories git has forgotten. `git worktree remove` can't reach these. */
+export function pruneOrphanDirs(
+  paths: string[],
+  sizeOf: (p: string) => number,
+  resolveRemoteByPath: (p: string) => RemoteHost | undefined
+): WorktreeActionResult {
+  const result = EMPTY_RESULT()
+
+  for (const target of paths) {
+    const remote = resolveRemoteByPath(target)
+    try {
+      assertRemovablePath(target, remote)
+      // Last line of defence: if git still claims this path, it is a real
+      // worktree and must go through `git worktree remove` instead.
+      if (isRegisteredWorktree(target, remote)) {
+        throw new Error('still registered with git — remove it as a worktree instead')
+      }
+      const bytes = sizeOf(target)
+      removeDir(target, remote)
+      invalidateSizeCache(target)
+      result.freedBytes += bytes
+      result.succeeded.push(target)
+    } catch (err) {
+      result.failed.push({ path: target, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+  return result
+}
+
+function isRegisteredWorktree(target: string, remote?: RemoteHost): boolean {
+  try {
+    return gitUtils.getAbsoluteGitDir(target, remote) !== null
+  } catch {
+    return false
+  }
+}
+
+export function deleteStaleBranches(
+  projectPath: string,
+  branches: string[],
+  force: boolean,
+  remote?: RemoteHost
+): BranchDeleteResult {
+  return gitUtils.deleteBranches(projectPath, branches, force, remote)
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -21,7 +21,10 @@ import type {
   TaskSourceLink,
   ConnectorManifest,
   ConnectorItemContext,
-  TaskStatus
+  TaskStatus,
+  WorktreeInventory,
+  WorktreeActionResult,
+  BranchDeleteResult
 } from './types'
 
 // ─── JSON-RPC 2.0 Envelope Types ────────────────────────────────
@@ -78,8 +81,42 @@ export interface RequestMethods {
     result: string
   }
   'git:removeWorktree': {
-    params: { projectPath: string; worktreePath: string; force?: boolean }
-    result: void
+    params: {
+      projectPath: string
+      worktreePath: string
+      force?: boolean
+      /** Delete the worktree's branch too, when it is safe to (merged, or forced). */
+      deleteBranch?: boolean
+    }
+    /** False when `git worktree remove` refused — callers surface it as an error. */
+    result: boolean
+  }
+  'worktree:inventory': {
+    params: { projectPaths?: string[]; refresh?: boolean } | undefined
+    result: WorktreeInventory
+  }
+  'worktree:reclaimArtifacts': {
+    params: { paths: string[] }
+    result: WorktreeActionResult
+  }
+  'worktree:removeMany': {
+    params: {
+      items: Array<{
+        projectPath: string
+        worktreePath: string
+        force?: boolean
+        deleteBranch?: boolean
+      }>
+    }
+    result: WorktreeActionResult
+  }
+  'worktree:pruneOrphans': {
+    params: { paths: string[] }
+    result: WorktreeActionResult
+  }
+  'git:deleteBranches': {
+    params: { projectPath: string; branches: string[]; force?: boolean }
+    result: BranchDeleteResult
   }
   'git:renameWorktreeBranch': {
     params: { worktreePath: string; newBranch: string }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -920,6 +920,8 @@ export interface AppConfig {
      * the next launch.
      */
     hasSeededDefaultTaskWorkflow?: boolean
+    /** Which worktrees the manager treats as stale, and what counts as build output. */
+    worktreeRetention?: WorktreeRetentionConfig
   }
   projects: ProjectConfig[]
   agentCommands?: Partial<Record<AiAgentType, AgentCommandConfig>>
@@ -1060,6 +1062,133 @@ export interface InstalledShell {
   }
 }
 
+/**
+ * The safest action available for a worktree, computed server-side so the
+ * settings panel, the command palette and any future nudge all agree on what
+ * can be touched.
+ *
+ *  keep    — do nothing; the main worktree, or sessions are running in it
+ *  review  — needs a human decision; uncommitted changes, or work that was
+ *            never pushed and so cannot be recovered after removal
+ *  reclaim — the build artifacts can go but the worktree should stay
+ *  remove  — the whole worktree can go; merged and clean
+ *  orphan  — a directory git no longer knows about; only `fs.rm` can clear it
+ */
+export type WorktreeVerdictLevel = 'keep' | 'review' | 'reclaim' | 'remove' | 'orphan'
+
+export interface WorktreeVerdict {
+  level: WorktreeVerdictLevel
+  /** Bytes recovered by taking the action this level names. */
+  freesBytes: number
+  /** Short phrases explaining the level, e.g. ['merged into main', 'idle 92 days']. */
+  reasons: string[]
+  /**
+   * Whether "Select suggested" ticks this row. A merged, clean worktree is
+   * always removable, but one touched yesterday shouldn't be pre-selected.
+   */
+  autoSelect: boolean
+}
+
+export interface WorktreeInventoryEntry {
+  path: string
+  name: string
+  projectPath: string
+  projectName: string
+  /** registered — git knows it; orphan-dir — on disk only. */
+  kind: 'registered' | 'orphan-dir'
+  branch: string | null
+  isMain: boolean
+
+  sizeBytes: number
+  /** node_modules, dist, out and friends — the part that a reinstall rebuilds. */
+  artifactBytes: number
+  /** False when sizing timed out or the platform has no fast path; sizes read 0. */
+  sizeMeasured: boolean
+
+  lastCommitAt: string | null
+  /** Newest git activity in the worktree, from the index mtime. */
+  lastTouchedAt: string | null
+  idleDays: number | null
+
+  isDirty: boolean
+  isMerged: boolean
+  hasUpstream: boolean
+  activeSessionIds: string[]
+
+  verdict: WorktreeVerdict
+}
+
+/** A branch left behind by a removed worktree. */
+export interface StaleBranch {
+  name: string
+  isMerged: boolean
+  hasUpstream: boolean
+  lastCommitAt: string | null
+}
+
+export interface WorktreeProjectInventory {
+  projectPath: string
+  projectName: string
+  defaultBranch: string | null
+  /** Set when the project lives on a remote host — sizes come over SSH. */
+  remoteHostId: string | null
+  entries: WorktreeInventoryEntry[]
+  staleBranches: StaleBranch[]
+  /** Populated when the project could not be scanned at all. */
+  error?: string
+}
+
+export interface WorktreeInventory {
+  projects: WorktreeProjectInventory[]
+  scannedAt: string
+}
+
+export interface WorktreeActionFailure {
+  path: string
+  error: string
+}
+
+export interface WorktreeActionResult {
+  succeeded: string[]
+  failed: WorktreeActionFailure[]
+  freedBytes: number
+  /** Branches deleted alongside removed worktrees. */
+  deletedBranches: string[]
+}
+
+export interface BranchDeleteResult {
+  deleted: string[]
+  failed: { branch: string; error: string }[]
+}
+
+/** Retention preferences for the worktree manager. */
+export interface WorktreeRetentionConfig {
+  /**
+   * A merged, clean worktree idle for at least this many days is pre-selected
+   * by "Select suggested". 0 pre-selects every removable worktree.
+   */
+  idleDaysThreshold?: number
+  /** Directory names treated as rebuildable build output. */
+  artifactDirs?: string[]
+  /** Worktree paths the scanner always reports as `keep`. */
+  pinnedPaths?: string[]
+}
+
+export const DEFAULT_ARTIFACT_DIRS = [
+  'node_modules',
+  'dist',
+  'out',
+  '.next',
+  '.turbo',
+  '.nuxt',
+  'target',
+  'coverage',
+  '.venv',
+  '__pycache__'
+]
+
+export const DEFAULT_IDLE_DAYS_THRESHOLD = 14
+
 export const IPC = {
   TERMINAL_CREATE: 'terminal:create',
   TERMINAL_WRITE: 'terminal:write',
@@ -1094,6 +1223,11 @@ export const IPC = {
   GIT_GET_WORKTREE_BRANCH: 'git:getWorktreeBranch',
   WORKTREE_CONFIRM_CLEANUP: 'worktree:confirmCleanup',
   WORKTREE_ACTIVE_SESSIONS: 'worktree:activeSessions',
+  WORKTREE_INVENTORY: 'worktree:inventory',
+  WORKTREE_RECLAIM_ARTIFACTS: 'worktree:reclaimArtifacts',
+  WORKTREE_REMOVE_MANY: 'worktree:removeMany',
+  WORKTREE_PRUNE_ORPHANS: 'worktree:pruneOrphans',
+  GIT_DELETE_BRANCHES: 'git:deleteBranches',
   GIT_GET_BRANCH: 'git:getBranch',
   GIT_DIFF_STAT: 'git:diffStat',
   GIT_DIFF_FULL: 'git:diffFull',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -292,14 +292,33 @@ export function createApiShim(wsUrl: string) {
     listRemoteBranches: (projectPath: string) => rpc.invoke('git:listRemoteBranches', projectPath),
     createWorktree: (projectPath: string, branch: string) =>
       rpc.invoke('git:createWorktree', { projectPath, branch }),
-    removeWorktree: (projectPath: string, worktreePath: string, force?: boolean) =>
-      rpc.invoke('git:removeWorktree', { projectPath, worktreePath, force }),
+    removeWorktree: (
+      projectPath: string,
+      worktreePath: string,
+      force?: boolean,
+      deleteBranch?: boolean
+    ) => rpc.invoke('git:removeWorktree', { projectPath, worktreePath, force, deleteBranch }),
     renameWorktreeBranch: (worktreePath: string, newBranch: string) =>
       rpc.invoke('git:renameWorktreeBranch', { worktreePath, newBranch }),
     isWorktreeDirty: (worktreePath: string) => rpc.invoke('git:worktreeDirty', worktreePath),
     listWorktrees: (projectPath: string) => rpc.invoke('git:listWorktrees', projectPath),
     getWorktreeActiveSessions: (worktreePath: string) =>
       rpc.invoke('worktree:activeSessions', worktreePath),
+    getWorktreeInventory: (params?: { projectPaths?: string[]; refresh?: boolean }) =>
+      rpc.invoke('worktree:inventory', params),
+    reclaimWorktreeArtifacts: (paths: string[]) =>
+      rpc.invoke('worktree:reclaimArtifacts', { paths }),
+    removeWorktrees: (
+      items: {
+        projectPath: string
+        worktreePath: string
+        force?: boolean
+        deleteBranch?: boolean
+      }[]
+    ) => rpc.invoke('worktree:removeMany', { items }),
+    pruneOrphanWorktrees: (paths: string[]) => rpc.invoke('worktree:pruneOrphans', { paths }),
+    deleteBranches: (projectPath: string, branches: string[], force?: boolean) =>
+      rpc.invoke('git:deleteBranches', { projectPath, branches, force }),
     getGitDiffStat: (cwd: string) => rpc.invoke('git:diffStat', cwd),
     getGitDiffFull: (cwd: string) => rpc.invoke('git:diffFull', cwd),
     gitCommit: (payload: unknown) => rpc.invoke('git:commit', payload),

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -77,6 +77,21 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.WORKTREE_ACTIVE_SESSIONS, (_, worktreePath) =>
     requireBridge().request(IPC.WORKTREE_ACTIVE_SESSIONS, worktreePath)
   )
+  safeHandle(IPC.WORKTREE_INVENTORY, (_, params) =>
+    requireBridge().request(IPC.WORKTREE_INVENTORY, params)
+  )
+  safeHandle(IPC.WORKTREE_RECLAIM_ARTIFACTS, (_, params) =>
+    requireBridge().request(IPC.WORKTREE_RECLAIM_ARTIFACTS, params)
+  )
+  safeHandle(IPC.WORKTREE_REMOVE_MANY, (_, params) =>
+    requireBridge().request(IPC.WORKTREE_REMOVE_MANY, params)
+  )
+  safeHandle(IPC.WORKTREE_PRUNE_ORPHANS, (_, params) =>
+    requireBridge().request(IPC.WORKTREE_PRUNE_ORPHANS, params)
+  )
+  safeHandle(IPC.GIT_DELETE_BRANCHES, (_, params) =>
+    requireBridge().request(IPC.GIT_DELETE_BRANCHES, params)
+  )
   safeHandle(IPC.GIT_GET_BRANCH, (_, cwd) => requireBridge().request(IPC.GIT_GET_BRANCH, cwd))
   safeHandle(IPC.GIT_DIFF_STAT, (_, cwd) => requireBridge().request(IPC.GIT_DIFF_STAT, cwd))
   safeHandle(IPC.GIT_DIFF_FULL, (_, cwd) => requireBridge().request(IPC.GIT_DIFF_FULL, cwd))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,7 +23,10 @@ import {
   TaskSourceLink,
   ConnectorManifest,
   ConnectorActionDef,
-  InstalledShell
+  InstalledShell,
+  WorktreeInventory,
+  WorktreeActionResult,
+  BranchDeleteResult
 } from '../shared/types'
 
 const api = {
@@ -131,8 +134,13 @@ const api = {
   ): Promise<{ worktreePath: string; branch: string; name: string }> =>
     ipcRenderer.invoke(IPC.GIT_CREATE_WORKTREE, { projectPath, branch, worktreeName }),
 
-  removeWorktree: (projectPath: string, worktreePath: string, force?: boolean): Promise<boolean> =>
-    ipcRenderer.invoke(IPC.GIT_REMOVE_WORKTREE, { projectPath, worktreePath, force }),
+  removeWorktree: (
+    projectPath: string,
+    worktreePath: string,
+    force?: boolean,
+    deleteBranch?: boolean
+  ): Promise<boolean> =>
+    ipcRenderer.invoke(IPC.GIT_REMOVE_WORKTREE, { projectPath, worktreePath, force, deleteBranch }),
 
   renameWorktreeBranch: (worktreePath: string, newBranch: string): Promise<boolean> =>
     ipcRenderer.invoke(IPC.GIT_RENAME_WORKTREE_BRANCH, { worktreePath, newBranch }),
@@ -161,6 +169,33 @@ const api = {
     worktreePath: string
   ): Promise<{ count: number; sessionIds: string[] }> =>
     ipcRenderer.invoke(IPC.WORKTREE_ACTIVE_SESSIONS, worktreePath),
+
+  getWorktreeInventory: (params?: {
+    projectPaths?: string[]
+    refresh?: boolean
+  }): Promise<WorktreeInventory> => ipcRenderer.invoke(IPC.WORKTREE_INVENTORY, params),
+
+  reclaimWorktreeArtifacts: (paths: string[]): Promise<WorktreeActionResult> =>
+    ipcRenderer.invoke(IPC.WORKTREE_RECLAIM_ARTIFACTS, { paths }),
+
+  removeWorktrees: (
+    items: {
+      projectPath: string
+      worktreePath: string
+      force?: boolean
+      deleteBranch?: boolean
+    }[]
+  ): Promise<WorktreeActionResult> => ipcRenderer.invoke(IPC.WORKTREE_REMOVE_MANY, { items }),
+
+  pruneOrphanWorktrees: (paths: string[]): Promise<WorktreeActionResult> =>
+    ipcRenderer.invoke(IPC.WORKTREE_PRUNE_ORPHANS, { paths }),
+
+  deleteBranches: (
+    projectPath: string,
+    branches: string[],
+    force?: boolean
+  ): Promise<BranchDeleteResult> =>
+    ipcRenderer.invoke(IPC.GIT_DELETE_BRANCHES, { projectPath, branches, force }),
 
   getGitBranch: (cwd: string): Promise<string | null> =>
     ipcRenderer.invoke(IPC.GIT_GET_BRANCH, cwd),

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -31,6 +31,7 @@ import {
   BookOpen,
   Terminal,
   Plug,
+  HardDrive,
   LayoutDashboard
 } from 'lucide-react'
 
@@ -247,6 +248,17 @@ function useCommands(
       icon: <Plug size={14} strokeWidth={1.5} />,
       keywords: ['mcp', 'api', 'integration', 'claude', 'cursor', 'server', 'url'],
       onExecute: () => navigator.clipboard.writeText('http://localhost:56433/mcp')
+    })
+    commands.push({
+      id: 'action:manage-worktrees',
+      label: 'Manage Worktrees',
+      category: 'actions',
+      icon: <HardDrive size={14} strokeWidth={1.5} />,
+      keywords: ['worktree', 'disk', 'space', 'cleanup', 'clean', 'prune', 'size', 'node_modules'],
+      onExecute: () => {
+        setSettingsOpen(true)
+        useAppStore.getState().setSettingsCategory('worktrees')
+      }
     })
     commands.push({
       id: 'action:manage-ssh',

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { SectionHeader } from './settings/SectionHeader'
 import { AppearanceSettings } from './settings/AppearanceSettings'
 import { GeneralSettings } from './settings/GeneralSettings'
 import { NotificationSettings } from './settings/NotificationSettings'
+import { WorktreeSettings } from './settings/WorktreeSettings'
 import { AgentSettings } from './settings/AgentSettings'
 import { SSHSettings } from './settings/SSHSettings'
 import { McpSettings } from './settings/McpSettings'
@@ -70,6 +71,25 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
           >
             <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9" />
             <path d="M13.73 21a2 2 0 01-3.46 0" />
+          </svg>
+        )
+      },
+      {
+        key: 'worktrees',
+        label: 'Worktrees',
+        icon: (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <circle cx="6" cy="5" r="2.5" />
+            <circle cx="18" cy="5" r="2.5" />
+            <circle cx="12" cy="19" r="2.5" />
+            <path d="M6 7.5v3a2 2 0 002 2h8a2 2 0 002-2v-3M12 12.5v4" />
           </svg>
         )
       }
@@ -276,6 +296,7 @@ export function SettingsPage() {
           {settingsCategory === 'appearance' && <AppearanceSettings />}
           {settingsCategory === 'general' && <GeneralSettings />}
           {settingsCategory === 'notifications' && <NotificationSettings />}
+          {settingsCategory === 'worktrees' && <WorktreeSettings />}
           {settingsCategory === 'agents' && <AgentSettings />}
           {settingsCategory === 'ssh' && <SSHSettings />}
           {settingsCategory === 'mcp' && <McpSettings />}

--- a/src/renderer/components/settings/WorktreeSettings.tsx
+++ b/src/renderer/components/settings/WorktreeSettings.tsx
@@ -1,0 +1,746 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import {
+  AlertTriangle,
+  FolderGit2,
+  GitBranch,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Trash2
+} from 'lucide-react'
+import type {
+  StaleBranch,
+  WorktreeActionResult,
+  WorktreeInventory,
+  WorktreeInventoryEntry,
+  WorktreeProjectInventory,
+  WorktreeVerdictLevel
+} from '../../../shared/types'
+import { formatBytes } from '../../lib/format-bytes'
+import { toast } from '../Toast'
+import { withProgressToast } from '../../lib/progress-toast'
+import { SettingsPageHeader } from './SettingsPageHeader'
+
+/**
+ * Separator for the `<projectPath> <branch>` keys that identify a stale branch
+ * across projects. NUL can appear in neither a path nor a branch name.
+ */
+const KEY_SEP = '\u0000'
+
+/** Which destructive action is showing its second, spelled-out confirm step. */
+type Pending = 'reclaim' | 'remove' | null
+
+const VERDICT_STYLES: Record<WorktreeVerdictLevel, { label: string; className: string }> = {
+  keep: { label: 'Keep', className: 'text-gray-400 bg-white/[0.05]' },
+  review: { label: 'Review', className: 'text-amber-300 bg-amber-500/[0.12]' },
+  reclaim: { label: 'Build output only', className: 'text-teal-300 bg-teal-500/[0.12]' },
+  remove: { label: 'Removable', className: 'text-teal-300 bg-teal-500/[0.12]' },
+  orphan: { label: 'Orphan directory', className: 'text-red-300 bg-red-500/[0.12]' }
+}
+
+function isSelectable(entry: WorktreeInventoryEntry): boolean {
+  return !entry.isMain && entry.activeSessionIds.length === 0
+}
+
+function idleLabel(entry: WorktreeInventoryEntry): string {
+  if (entry.idleDays === null) return '—'
+  if (entry.idleDays === 0) return 'today'
+  return `${entry.idleDays}d idle`
+}
+
+/** Reports what a batch actually did, including the parts that failed. */
+function reportResult(result: WorktreeActionResult | undefined, verb: string): void {
+  if (!result) return
+  const freed = result.freedBytes > 0 ? ` · freed ${formatBytes(result.freedBytes)}` : ''
+  if (result.succeeded.length > 0) {
+    toast(`${verb} ${result.succeeded.length}${freed}`, 'success')
+  }
+  for (const failure of result.failed) {
+    toast(`${failure.path.split('/').pop()}: ${failure.error}`, 'error')
+  }
+}
+
+export function WorktreeSettings() {
+  const [inventory, setInventory] = useState<WorktreeInventory | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [selectedBranches, setSelectedBranches] = useState<Set<string>>(new Set())
+  const [confirming, setConfirming] = useState<Pending>(null)
+  const [busy, setBusy] = useState(false)
+  const inFlight = useRef(false)
+
+  // Nothing is set synchronously here: `loading` starts true for the first
+  // scan, and the Rescan button flips it before calling in.
+  const load = useCallback(async (refresh: boolean): Promise<void> => {
+    if (inFlight.current) return
+    inFlight.current = true
+    try {
+      const next = await window.api.getWorktreeInventory({ refresh })
+      setInventory(next)
+      // Drop selections for anything the rescan no longer reports.
+      const live = new Set(next.projects.flatMap((p) => p.entries.map((e) => e.path)))
+      setSelected((prev) => new Set([...prev].filter((p) => live.has(p))))
+      const liveBranches = new Set(
+        next.projects.flatMap((p) =>
+          p.staleBranches.map((b) => `${p.projectPath}${KEY_SEP}${b.name}`)
+        )
+      )
+      setSelectedBranches((prev) => new Set([...prev].filter((b) => liveBranches.has(b))))
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Could not read worktrees', 'error')
+    } finally {
+      inFlight.current = false
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: scans worktrees via the main process on mount
+    void load(false)
+  }, [load])
+
+  const allEntries = useMemo(() => inventory?.projects.flatMap((p) => p.entries) ?? [], [inventory])
+
+  const totals = useMemo(() => {
+    let onDisk = 0
+    let artifacts = 0
+    let removable = 0
+    for (const entry of allEntries) {
+      onDisk += entry.sizeBytes
+      if (isSelectable(entry)) {
+        artifacts += entry.artifactBytes
+        if (entry.verdict.level === 'remove' || entry.verdict.level === 'orphan') {
+          removable += entry.sizeBytes
+        }
+      }
+    }
+    return { onDisk, artifacts, removable }
+  }, [allEntries])
+
+  const selectedEntries = useMemo(
+    () => allEntries.filter((e) => selected.has(e.path)),
+    [allEntries, selected]
+  )
+
+  const selection = useMemo(() => {
+    const orphans = selectedEntries.filter((e) => e.kind === 'orphan-dir')
+    const worktrees = selectedEntries.filter((e) => e.kind === 'registered')
+    return {
+      orphans,
+      worktrees,
+      dirty: selectedEntries.filter((e) => e.isDirty),
+      unmerged: worktrees.filter((e) => !e.isMerged),
+      bytes: selectedEntries.reduce((sum, e) => sum + e.sizeBytes, 0),
+      artifactBytes: selectedEntries.reduce((sum, e) => sum + e.artifactBytes, 0)
+    }
+  }, [selectedEntries])
+
+  const reclaimTargets = useMemo(
+    () => allEntries.filter((e) => isSelectable(e) && e.artifactBytes > 0),
+    [allEntries]
+  )
+
+  const toggle = (path: string): void => {
+    setConfirming(null)
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  const selectSuggested = (): void => {
+    setConfirming(null)
+    setSelected(
+      new Set(allEntries.filter((e) => isSelectable(e) && e.verdict.autoSelect).map((e) => e.path))
+    )
+  }
+
+  const rescan = (): void => {
+    setLoading(true)
+    void load(true)
+  }
+
+  const run = async (
+    labels: { loading: string; success: string },
+    fn: () => Promise<WorktreeActionResult | undefined>
+  ): Promise<void> => {
+    if (busy) return
+    setBusy(true)
+    setConfirming(null)
+    const result = await withProgressToast(labels, async () => {
+      const res = await fn()
+      // A batch where every item failed is a failure, not a quiet success.
+      if (res && res.succeeded.length === 0 && res.failed.length > 0) {
+        throw new Error(res.failed[0].error)
+      }
+      return res
+    })
+    reportResult(result, labels.success)
+    setBusy(false)
+    rescan()
+  }
+
+  const handleReclaim = (): void =>
+    void run({ loading: 'Deleting build output…', success: 'Reclaimed' }, () =>
+      window.api.reclaimWorktreeArtifacts(reclaimTargets.map((e) => e.path))
+    )
+
+  const handleRemoveSelected = (): void =>
+    void run({ loading: 'Removing worktrees…', success: 'Removed' }, async () => {
+      const combined: WorktreeActionResult = {
+        succeeded: [],
+        failed: [],
+        freedBytes: 0,
+        deletedBranches: []
+      }
+      if (selection.worktrees.length > 0) {
+        const res = await window.api.removeWorktrees(
+          selection.worktrees.map((e) => ({
+            projectPath: e.projectPath,
+            worktreePath: e.path,
+            force: e.isDirty,
+            // Only vorn's own merged branches — an unmerged branch survives the
+            // worktree so the commits stay reachable.
+            deleteBranch: e.isMerged
+          }))
+        )
+        combined.succeeded.push(...res.succeeded)
+        combined.failed.push(...res.failed)
+        combined.freedBytes += res.freedBytes
+        combined.deletedBranches.push(...res.deletedBranches)
+      }
+      if (selection.orphans.length > 0) {
+        const res = await window.api.pruneOrphanWorktrees(selection.orphans.map((e) => e.path))
+        combined.succeeded.push(...res.succeeded)
+        combined.failed.push(...res.failed)
+        combined.freedBytes += res.freedBytes
+      }
+      return combined
+    })
+
+  const handleDeleteBranches = (project: WorktreeProjectInventory): void => {
+    const branches = project.staleBranches
+      .filter((b) => selectedBranches.has(`${project.projectPath}${KEY_SEP}${b.name}`))
+      .map((b) => b.name)
+    if (branches.length === 0) return
+    void run({ loading: 'Deleting branches…', success: 'Deleted' }, async () => {
+      const res = await window.api.deleteBranches(project.projectPath, branches, false)
+      return {
+        succeeded: res.deleted,
+        failed: res.failed.map((f) => ({ path: f.branch, error: f.error })),
+        freedBytes: 0,
+        deletedBranches: res.deleted
+      }
+    })
+  }
+
+  const projects = inventory?.projects ?? []
+  const hasAnything = projects.some((p) => p.entries.length > 0 || p.staleBranches.length > 0)
+
+  return (
+    <div className="pb-24">
+      <SettingsPageHeader
+        title="Worktrees"
+        description="What every worktree costs on disk, and what can safely go"
+        actions={
+          <button
+            onClick={rescan}
+            disabled={loading || busy}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-300 bg-white/[0.04]
+                       hover:bg-white/[0.08] rounded-lg transition-colors disabled:opacity-50"
+          >
+            {loading ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
+            Rescan
+          </button>
+        }
+      />
+
+      <SummaryCard
+        onDisk={totals.onDisk}
+        artifacts={totals.artifacts}
+        removable={totals.removable}
+        loading={loading}
+        busy={busy}
+        confirming={confirming === 'reclaim'}
+        targetCount={reclaimTargets.length}
+        onAsk={() => setConfirming(confirming === 'reclaim' ? null : 'reclaim')}
+        onConfirm={handleReclaim}
+      />
+
+      {loading && !inventory && (
+        <div className="flex items-center gap-2 py-10 text-sm text-gray-500 justify-center">
+          <Loader2 size={15} className="animate-spin" />
+          Measuring worktrees…
+        </div>
+      )}
+
+      {!loading && !hasAnything && (
+        <div className="py-10 text-center text-sm text-gray-500">
+          No worktrees yet. They appear here as soon as you create one.
+        </div>
+      )}
+
+      {projects.map((project) => (
+        <ProjectGroup
+          key={`${project.projectPath}:${project.remoteHostId ?? 'local'}`}
+          project={project}
+          selected={selected}
+          onToggle={toggle}
+          selectedBranches={selectedBranches}
+          onToggleBranch={(name) =>
+            setSelectedBranches((prev) => {
+              const key = `${project.projectPath}${KEY_SEP}${name}`
+              const next = new Set(prev)
+              if (next.has(key)) next.delete(key)
+              else next.add(key)
+              return next
+            })
+          }
+          onDeleteBranches={() => handleDeleteBranches(project)}
+          busy={busy}
+        />
+      ))}
+
+      {allEntries.some((e) => isSelectable(e) && e.verdict.autoSelect) && (
+        <button
+          onClick={selectSuggested}
+          className="mt-4 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          Select everything merged and idle
+        </button>
+      )}
+
+      <AnimatePresence>
+        {selectedEntries.length > 0 && (
+          <SelectionBar
+            count={selectedEntries.length}
+            bytes={selection.bytes}
+            dirtyCount={selection.dirty.length}
+            unmergedCount={selection.unmerged.length}
+            orphanCount={selection.orphans.length}
+            confirming={confirming === 'remove'}
+            busy={busy}
+            onClear={() => {
+              setSelected(new Set())
+              setConfirming(null)
+            }}
+            onAsk={() => setConfirming(confirming === 'remove' ? null : 'remove')}
+            onConfirm={handleRemoveSelected}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+// ─── Summary ────────────────────────────────────────────────────
+
+function SummaryCard({
+  onDisk,
+  artifacts,
+  removable,
+  loading,
+  busy,
+  confirming,
+  targetCount,
+  onAsk,
+  onConfirm
+}: {
+  onDisk: number
+  artifacts: number
+  removable: number
+  loading: boolean
+  busy: boolean
+  confirming: boolean
+  targetCount: number
+  onAsk: () => void
+  onConfirm: () => void
+}) {
+  const artifactPct = onDisk > 0 ? Math.min(100, (artifacts / onDisk) * 100) : 0
+  const removablePct = onDisk > 0 ? Math.min(100 - artifactPct, (removable / onDisk) * 100) : 0
+
+  return (
+    <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 mb-6">
+      <div className="flex items-end justify-between gap-6 flex-wrap">
+        <div>
+          <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-gray-500">
+            <HardDrive size={12} />
+            On disk
+          </div>
+          <div className="text-3xl font-semibold text-white tabular-nums mt-1">
+            {formatBytes(onDisk)}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[11px] uppercase tracking-wider text-gray-500">
+            Build output — rebuilt by a reinstall
+          </div>
+          <div className="text-xl font-semibold text-teal-300 tabular-nums mt-1">
+            {formatBytes(artifacts)}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 h-2 rounded-full bg-white/[0.06] overflow-hidden flex">
+        <div className="h-full bg-teal-400/70" style={{ width: `${artifactPct}%` }} />
+        <div className="h-full bg-teal-400/25" style={{ width: `${removablePct}%` }} />
+      </div>
+      <div className="mt-2 flex gap-4 text-[11px] text-gray-500">
+        <span>Build output</span>
+        <span>Removable worktrees</span>
+        <span className="ml-auto tabular-nums">{formatBytes(removable)} in merged worktrees</span>
+      </div>
+
+      {artifacts > 0 && (
+        <div className="mt-4 flex items-center gap-2">
+          <button
+            onClick={confirming ? onConfirm : onAsk}
+            disabled={loading || busy}
+            className={`flex items-center gap-2 px-3 py-2 text-xs rounded-lg transition-colors
+                        disabled:opacity-50 ${
+                          confirming
+                            ? 'text-white bg-teal-500/25 hover:bg-teal-500/35 border border-teal-400/40'
+                            : 'text-teal-200 bg-teal-500/[0.12] hover:bg-teal-500/20'
+                        }`}
+          >
+            <Trash2 size={13} />
+            {confirming
+              ? `Delete build output in ${targetCount} worktree${targetCount === 1 ? '' : 's'} — frees ${formatBytes(artifacts)}`
+              : `Reclaim ${formatBytes(artifacts)} of build output`}
+          </button>
+          {confirming && (
+            <button
+              onClick={onAsk}
+              className="px-3 py-2 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Project group ──────────────────────────────────────────────
+
+function ProjectGroup({
+  project,
+  selected,
+  onToggle,
+  selectedBranches,
+  onToggleBranch,
+  onDeleteBranches,
+  busy
+}: {
+  project: WorktreeProjectInventory
+  selected: Set<string>
+  onToggle: (path: string) => void
+  selectedBranches: Set<string>
+  onToggleBranch: (name: string) => void
+  onDeleteBranches: () => void
+  busy: boolean
+}) {
+  const entries = [...project.entries]
+    .filter((e) => !e.isMain)
+    .sort((a, b) => b.sizeBytes - a.sizeBytes)
+  const total = project.entries.reduce((sum, e) => sum + e.sizeBytes, 0)
+
+  if (entries.length === 0 && project.staleBranches.length === 0 && !project.error) return null
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-baseline justify-between gap-3 pb-2 border-b border-white/[0.06]">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-sm font-medium text-gray-200 truncate">{project.projectName}</span>
+          {project.defaultBranch && (
+            <span className="text-[11px] text-gray-600 font-mono shrink-0">
+              vs {project.defaultBranch}
+            </span>
+          )}
+          {project.remoteHostId && (
+            <span className="text-[11px] text-gray-600 shrink-0">remote</span>
+          )}
+        </div>
+        <span className="text-xs text-gray-500 tabular-nums shrink-0">{formatBytes(total)}</span>
+      </div>
+
+      {project.error && (
+        <div className="py-3 text-xs text-gray-500">Could not scan — {project.error}</div>
+      )}
+
+      <div className="divide-y divide-white/[0.04]">
+        {entries.map((entry) => (
+          <WorktreeRow
+            key={entry.path}
+            entry={entry}
+            checked={selected.has(entry.path)}
+            onToggle={() => onToggle(entry.path)}
+          />
+        ))}
+      </div>
+
+      {project.staleBranches.length > 0 && (
+        <StaleBranchStrip
+          projectPath={project.projectPath}
+          branches={project.staleBranches}
+          selected={selectedBranches}
+          onToggle={onToggleBranch}
+          onDelete={onDeleteBranches}
+          busy={busy}
+        />
+      )}
+    </div>
+  )
+}
+
+function WorktreeRow({
+  entry,
+  checked,
+  onToggle
+}: {
+  entry: WorktreeInventoryEntry
+  checked: boolean
+  onToggle: () => void
+}) {
+  const selectable = isSelectable(entry)
+  const style = VERDICT_STYLES[entry.verdict.level]
+  const artifactPct = entry.sizeBytes > 0 ? (entry.artifactBytes / entry.sizeBytes) * 100 : 0
+
+  return (
+    <div className={`flex items-center gap-3 py-2.5 ${selectable ? '' : 'opacity-50'}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={!selectable}
+        onChange={onToggle}
+        aria-label={`Select ${entry.name}`}
+        className="shrink-0 accent-teal-400 disabled:cursor-not-allowed"
+      />
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 min-w-0">
+          <FolderGit2 size={13} className="text-gray-600 shrink-0" />
+          <span className="text-[13px] text-gray-200 truncate">{entry.name}</span>
+          <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${style.className}`}>
+            {style.label}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 mt-1 text-[11px] text-gray-600 min-w-0">
+          <span className="font-mono truncate">{entry.branch ?? 'no branch'}</span>
+          <span className="shrink-0">·</span>
+          <span className="shrink-0">{idleLabel(entry)}</span>
+          {entry.verdict.reasons.length > 0 && (
+            <>
+              <span className="shrink-0">·</span>
+              <span className="truncate">{entry.verdict.reasons.join(', ')}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="shrink-0 w-[86px] text-right">
+        <div className="text-xs text-gray-300 tabular-nums">
+          {entry.sizeMeasured ? formatBytes(entry.sizeBytes) : '—'}
+        </div>
+        {entry.artifactBytes > 0 && (
+          <div className="mt-1 h-1 rounded-full bg-white/[0.06] overflow-hidden">
+            <div className="h-full bg-teal-400/60" style={{ width: `${artifactPct}%` }} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Stale branches ─────────────────────────────────────────────
+
+function StaleBranchStrip({
+  projectPath,
+  branches,
+  selected,
+  onToggle,
+  onDelete,
+  busy
+}: {
+  projectPath: string
+  branches: StaleBranch[]
+  selected: Set<string>
+  onToggle: (name: string) => void
+  onDelete: () => void
+  busy: boolean
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const merged = branches.filter((b) => b.isMerged)
+  const chosen = branches.filter((b) => selected.has(`${projectPath}${KEY_SEP}${b.name}`))
+
+  return (
+    <div className="mt-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
+      <div className="flex items-center gap-2 flex-wrap">
+        <GitBranch size={13} className="text-gray-600 shrink-0" />
+        <span className="text-xs text-gray-400">
+          {branches.length} branch{branches.length === 1 ? '' : 'es'} left behind by removed
+          worktrees
+          {merged.length > 0 && ` — ${merged.length} already merged`}
+        </span>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="ml-auto text-[11px] text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          {expanded ? 'Hide' : 'Show'}
+        </button>
+      </div>
+
+      {expanded && (
+        <>
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            {branches.map((branch) => {
+              const key = `${projectPath}${KEY_SEP}${branch.name}`
+              const isSelected = selected.has(key)
+              return (
+                <button
+                  key={branch.name}
+                  onClick={() => onToggle(branch.name)}
+                  title={
+                    branch.isMerged
+                      ? 'Merged — deleting loses nothing'
+                      : 'Not merged — git will refuse to delete it'
+                  }
+                  className={`font-mono text-[11px] px-2 py-1 rounded border transition-colors ${
+                    isSelected
+                      ? 'border-red-400/40 bg-red-500/[0.15] text-red-200'
+                      : branch.isMerged
+                        ? 'border-white/[0.08] bg-white/[0.03] text-gray-400 hover:text-white'
+                        : 'border-amber-500/25 bg-amber-500/[0.06] text-amber-300/80 hover:text-amber-200'
+                  }`}
+                >
+                  {branch.name}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              onClick={() =>
+                merged.forEach((b) => {
+                  if (!selected.has(`${projectPath}${KEY_SEP}${b.name}`)) onToggle(b.name)
+                })
+              }
+              disabled={merged.length === 0}
+              className="text-[11px] text-gray-500 hover:text-gray-300 transition-colors disabled:opacity-40"
+            >
+              Select {merged.length} merged
+            </button>
+            <button
+              onClick={onDelete}
+              disabled={chosen.length === 0 || busy}
+              className="ml-auto flex items-center gap-1.5 px-2.5 py-1 text-[11px] text-red-300
+                         bg-red-500/[0.1] hover:bg-red-500/20 rounded-md transition-colors
+                         disabled:opacity-40"
+            >
+              <Trash2 size={11} />
+              Delete {chosen.length || ''} branch{chosen.length === 1 ? '' : 'es'}
+            </button>
+          </div>
+          <p className="mt-2 text-[10px] text-gray-600">
+            Deletion uses <span className="font-mono">git branch -d</span>, so git refuses anything
+            that isn&apos;t merged.
+          </p>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─── Selection bar ──────────────────────────────────────────────
+
+function SelectionBar({
+  count,
+  bytes,
+  dirtyCount,
+  unmergedCount,
+  orphanCount,
+  confirming,
+  busy,
+  onClear,
+  onAsk,
+  onConfirm
+}: {
+  count: number
+  bytes: number
+  dirtyCount: number
+  unmergedCount: number
+  orphanCount: number
+  confirming: boolean
+  busy: boolean
+  onClear: () => void
+  onAsk: () => void
+  onConfirm: () => void
+}) {
+  const warnings: string[] = []
+  if (dirtyCount > 0) {
+    warnings.push(
+      `${dirtyCount} ${dirtyCount === 1 ? 'has' : 'have'} uncommitted changes that will be lost`
+    )
+  }
+  if (unmergedCount > 0) {
+    warnings.push(`${unmergedCount} not merged — the branch is kept`)
+  }
+  if (orphanCount > 0) {
+    warnings.push(`${orphanCount} deleted from disk directly`)
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 12 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-10 w-[min(560px,calc(100vw-4rem))]
+                 rounded-xl border border-white/[0.1] shadow-2xl px-4 py-3"
+      style={{ background: '#26262b' }}
+    >
+      <div className="flex items-center gap-3">
+        <div className="min-w-0">
+          <div className="text-[13px] text-white">
+            {count} selected ·{' '}
+            <span className="tabular-nums text-gray-300">frees {formatBytes(bytes)}</span>
+          </div>
+          {warnings.length > 0 && (
+            <div className="flex items-start gap-1.5 mt-1">
+              <AlertTriangle size={11} className="text-amber-400 shrink-0 mt-0.5" />
+              <span className="text-[11px] text-amber-300/85">{warnings.join(' · ')}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          <button
+            onClick={onClear}
+            className="px-2.5 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            Clear
+          </button>
+          <button
+            onClick={confirming ? onConfirm : onAsk}
+            disabled={busy}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors
+                        disabled:opacity-50 ${
+                          confirming
+                            ? 'text-white bg-red-500/30 hover:bg-red-500/45 border border-red-400/40'
+                            : 'text-red-300 bg-red-500/[0.12] hover:bg-red-500/20'
+                        }`}
+          >
+            <Trash2 size={12} />
+            {confirming ? `Yes — remove ${count} and free ${formatBytes(bytes)}` : 'Remove'}
+          </button>
+        </div>
+      </div>
+      {confirming && <p className="mt-2 text-[11px] text-gray-500">This cannot be undone.</p>}
+    </motion.div>
+  )
+}

--- a/src/renderer/lib/format-bytes.ts
+++ b/src/renderer/lib/format-bytes.ts
@@ -1,0 +1,21 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB']
+
+/**
+ * Human-readable byte count in binary units, matching what `du -h` prints —
+ * the command someone will reach for to check these numbers by hand.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024
+    unit++
+  }
+
+  // Bytes and KB never need a decimal; larger units keep one significant
+  // decimal below 10 so "1.9 GB" doesn't collapse to "2 GB".
+  const decimals = unit <= 1 ? 0 : value < 10 ? 1 : 0
+  return `${value.toFixed(decimals)} ${UNITS[unit]}`
+}

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -110,6 +110,7 @@ export type SettingsCategory =
   | 'general'
   | 'notifications'
   | 'agents'
+  | 'worktrees'
   | 'ssh'
   | 'mcp'
   | 'connectors'

--- a/tests/format-bytes.test.ts
+++ b/tests/format-bytes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { formatBytes } from '../src/renderer/lib/format-bytes'
+
+describe('formatBytes', () => {
+  it('reports nothing and negatives as zero', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(-1)).toBe('0 B')
+    expect(formatBytes(NaN)).toBe('0 B')
+  })
+
+  it('keeps bytes and kilobytes whole', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1 KB')
+    expect(formatBytes(1536)).toBe('2 KB')
+  })
+
+  it('keeps one decimal below ten so 1.9 GB does not read as 2 GB', () => {
+    expect(formatBytes(1.9 * 1024 ** 3)).toBe('1.9 GB')
+    expect(formatBytes(983 * 1024 ** 2)).toBe('983 MB')
+  })
+
+  it('drops the decimal at ten and above', () => {
+    expect(formatBytes(15 * 1024 ** 2)).toBe('15 MB')
+    expect(formatBytes(12 * 1024 ** 3)).toBe('12 GB')
+  })
+
+  it('uses binary units, matching what du -h prints', () => {
+    // 1_000_000 bytes is "1 MB" only in decimal units; du calls it 976K.
+    expect(formatBytes(1_000_000)).toBe('977 KB')
+  })
+})

--- a/tests/git-utils-branch-cleanup.test.ts
+++ b/tests/git-utils-branch-cleanup.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn()
+}))
+
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn(() => true)
+  }
+}))
+
+import { execFileSync } from 'node:child_process'
+import {
+  deleteBranches,
+  getDefaultBranch,
+  isBranchMerged,
+  isGeneratedWorktreeBranch,
+  removeWorktree
+} from '../packages/server/src/git-utils'
+
+const mockExecFileSync = vi.mocked(execFileSync)
+
+/** git args of every call, ignoring which binary path was resolved. */
+function callArgs(): string[][] {
+  return mockExecFileSync.mock.calls.map((c) => c[1] as string[])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockExecFileSync.mockReturnValue('' as never)
+})
+
+describe('isGeneratedWorktreeBranch', () => {
+  it('recognises vorn adjective-noun names, with or without the id suffix', () => {
+    expect(isGeneratedWorktreeBranch('royal-stanza')).toBe(true)
+    expect(isGeneratedWorktreeBranch('gilded-sketch-2a9c9f51')).toBe(true)
+    expect(isGeneratedWorktreeBranch('obsidian-study')).toBe(true)
+  })
+
+  it('leaves branches the user named alone', () => {
+    expect(isGeneratedWorktreeBranch('main')).toBe(false)
+    expect(isGeneratedWorktreeBranch('feat/headless-run-diagnostics')).toBe(false)
+    expect(isGeneratedWorktreeBranch('chore/release-0.5.3')).toBe(false)
+    // Right shape, words that are not in the generator's lists.
+    expect(isGeneratedWorktreeBranch('quick-fix')).toBe(false)
+    expect(isGeneratedWorktreeBranch('royal-widget')).toBe(false)
+  })
+
+  it('does not match a suffix that is not the 8-hex worktree id', () => {
+    expect(isGeneratedWorktreeBranch('royal-stanza-v2')).toBe(false)
+    expect(isGeneratedWorktreeBranch('royal-stanza-2a9c9f5')).toBe(false)
+  })
+})
+
+describe('deleteBranches', () => {
+  it('uses -d so git refuses anything unmerged', () => {
+    deleteBranches('/repo', ['royal-stanza'])
+    expect(callArgs()).toContainEqual(['branch', '-d', 'royal-stanza'])
+  })
+
+  it('escalates to -D only when forced', () => {
+    deleteBranches('/repo', ['royal-stanza'], true)
+    expect(callArgs()).toContainEqual(['branch', '-D', 'royal-stanza'])
+  })
+
+  it('keeps going after one branch fails and reports both sides', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('not fully merged')
+      })
+      .mockReturnValueOnce('' as never)
+
+    const result = deleteBranches('/repo', ['ivory-relic', 'royal-stanza'])
+    expect(result.deleted).toEqual(['royal-stanza'])
+    expect(result.failed).toEqual([{ branch: 'ivory-relic', error: 'not fully merged' }])
+  })
+})
+
+describe('removeWorktree', () => {
+  it('leaves the branch alone by default', () => {
+    removeWorktree('/repo', '/repo/.vorn-worktrees/p/wt')
+    expect(callArgs()).toEqual([['worktree', 'remove', '/repo/.vorn-worktrees/p/wt']])
+  })
+
+  it('reads the branch before removal, then deletes it when asked', () => {
+    mockExecFileSync.mockReturnValueOnce('royal-stanza\n' as never)
+
+    removeWorktree('/repo', '/repo/.vorn-worktrees/p/wt', false, undefined, true)
+
+    expect(callArgs()).toEqual([
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      ['worktree', 'remove', '/repo/.vorn-worktrees/p/wt'],
+      ['branch', '-d', 'royal-stanza']
+    ])
+  })
+
+  it('never force-deletes the branch just because the removal was forced', () => {
+    mockExecFileSync.mockReturnValueOnce('royal-stanza\n' as never)
+
+    removeWorktree('/repo', '/repo/.vorn-worktrees/p/wt', true, undefined, true)
+
+    expect(callArgs()).toContainEqual([
+      'worktree',
+      'remove',
+      '/repo/.vorn-worktrees/p/wt',
+      '--force'
+    ])
+    expect(callArgs()).toContainEqual(['branch', '-d', 'royal-stanza'])
+    expect(callArgs()).not.toContainEqual(['branch', '-D', 'royal-stanza'])
+  })
+
+  it('does not try to delete a branch when the worktree is detached', () => {
+    mockExecFileSync.mockReturnValueOnce('HEAD\n' as never)
+
+    removeWorktree('/repo', '/repo/.vorn-worktrees/p/wt', false, undefined, true)
+
+    expect(callArgs().some((a) => a[0] === 'branch')).toBe(false)
+  })
+
+  it('reports failure and skips the branch when the removal itself fails', () => {
+    mockExecFileSync.mockReturnValueOnce('royal-stanza\n' as never).mockImplementationOnce(() => {
+      throw new Error('worktree is dirty')
+    })
+
+    expect(removeWorktree('/repo', '/repo/.vorn-worktrees/p/wt', false, undefined, true)).toBe(
+      false
+    )
+    expect(callArgs().some((a) => a[0] === 'branch')).toBe(false)
+  })
+})
+
+describe('getDefaultBranch', () => {
+  it('prefers the remote HEAD symref', () => {
+    mockExecFileSync.mockReturnValueOnce('origin/main\n' as never)
+    expect(getDefaultBranch('/repo')).toBe('main')
+  })
+
+  it('falls back to a conventional local name when there is no origin/HEAD', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('no symref')
+      })
+      .mockReturnValueOnce('feature-x\nmaster\ntopic\n' as never)
+    expect(getDefaultBranch('/repo')).toBe('master')
+  })
+})
+
+describe('isBranchMerged', () => {
+  it('treats a branch as merged into itself without asking git', () => {
+    expect(isBranchMerged('/repo', 'main', 'main')).toBe(true)
+    expect(mockExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('reads a non-zero exit from merge-base as not merged', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('exit 1')
+    })
+    expect(isBranchMerged('/repo', 'ivory-relic', 'main')).toBe(false)
+  })
+})

--- a/tests/worktree-inventory-scan.test.ts
+++ b/tests/worktree-inventory-scan.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }))
+
+vi.mock('node:fs', () => ({
+  default: {
+    realpathSync: vi.fn((p: string) => p),
+    readdirSync: vi.fn(() => []),
+    rmSync: vi.fn(),
+    statSync: vi.fn(() => ({ size: 0, mtime: new Date('2026-08-01T00:00:00Z') })),
+    accessSync: vi.fn(() => {
+      throw new Error('not executable')
+    }),
+    constants: { X_OK: 1 },
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn(() => true)
+  }
+}))
+
+import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import {
+  invalidateSizeCache,
+  listOrphanDirs,
+  measureWorktree,
+  pruneOrphanDirs,
+  reclaimArtifacts,
+  removeWorktrees,
+  scanWorktreeInventory
+} from '../packages/server/src/worktree-inventory'
+import type { ProjectConfig } from '../packages/shared/src/types'
+
+const mockFs = vi.mocked(fs)
+const mockExec = vi.mocked(execFileSync)
+
+const PROJECT = '/dev/repo'
+const WT_A = '/dev/.vorn-worktrees/repo/royal-stanza-a0494142'
+const WT_B = '/dev/.vorn-worktrees/repo/ivory-relic-b1111111'
+const ORPHAN = '/dev/.vorn-worktrees/repo/swift-spark-0f339ef6'
+
+const projects: ProjectConfig[] = [{ name: 'repo', path: PROJECT, preferredAgents: [] }]
+
+/** Per-worktree git answers the router serves. */
+interface Fake {
+  branch: string
+  dirty?: boolean
+}
+
+let worktrees: Record<string, Fake>
+let mergedBranches: string[]
+let refs: string[]
+/** Shell commands the code ran, in order — asserted on for the du/find path. */
+let shellCalls: string[]
+let removedDirs: string[]
+let failCommand: ((cmd: string) => boolean) | null
+
+function porcelain(): string {
+  const blocks = [`worktree ${PROJECT}\nHEAD aaa\nbranch refs/heads/main`]
+  for (const [p, f] of Object.entries(worktrees)) {
+    blocks.push(`worktree ${p}\nHEAD bbb\nbranch refs/heads/${f.branch}`)
+  }
+  return blocks.join('\n\n')
+}
+
+/** Routes a mocked execFileSync call to a canned git or shell answer. */
+function route(bin: string, args: string[]): string {
+  if (args[0] === '-c') {
+    const cmd = args[1]
+    shellCalls.push(cmd)
+    if (failCommand?.(cmd)) throw new Error('command failed')
+    if (cmd.startsWith('find ')) {
+      const root = cmd.split(' ')[1]
+      return root === WT_A ? `${WT_A}/node_modules\n${WT_A}/packages/web/dist` : ''
+    }
+    if (cmd.startsWith('du -sk')) {
+      // 1 MB per path, so totals are easy to reason about in assertions.
+      return cmd
+        .slice('du -sk '.length)
+        .split(' ')
+        .map((p) => `1024\t${p}`)
+        .join('\n')
+    }
+    return ''
+  }
+  if (args[0] === '-ilc') return '' // login-shell env probe at import time
+
+  const key = args.join(' ')
+  if (key === 'rev-parse --is-inside-work-tree') return 'true'
+  if (key === 'worktree list --porcelain') return porcelain()
+  if (key === 'symbolic-ref --short refs/remotes/origin/HEAD') return 'origin/main'
+  if (key.startsWith('branch --merged')) return mergedBranches.join('\n')
+  if (key.startsWith('for-each-ref')) return refs.join('\n')
+  if (key === 'rev-parse --absolute-git-dir') return '/dev/repo/.git/worktrees/x'
+  if (key === 'rev-parse --abbrev-ref HEAD') return worktrees[currentCwd]?.branch ?? 'HEAD'
+  if (key === 'status --porcelain') {
+    const cwd = currentCwd
+    return worktrees[cwd]?.dirty ? ' M src/index.ts' : ''
+  }
+  if (key.startsWith('log -1')) return '2026-05-07T18:22:48-06:00'
+  if (key.startsWith('worktree remove')) return ''
+  if (key.startsWith('branch -d') || key.startsWith('branch -D')) return ''
+  if (key === 'branch --format=%(refname:short)')
+    return ['main', ...refs.map((r) => r.split('\t')[0])].join('\n')
+  return ''
+}
+
+let currentCwd = ''
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  invalidateSizeCache()
+  shellCalls = []
+  removedDirs = []
+  failCommand = null
+  currentCwd = ''
+  worktrees = { [WT_A]: { branch: 'royal-stanza' }, [WT_B]: { branch: 'ivory-relic' } }
+  mergedBranches = ['main', 'royal-stanza', 'gilded-sketch']
+  refs = [
+    'main\torigin/main\t2026-08-07T16:18:15-06:00',
+    'royal-stanza\t\t2026-05-07T18:22:48-06:00',
+    'ivory-relic\torigin/ivory-relic\t2026-07-29T09:09:32-06:00',
+    'gilded-sketch\t\t2026-05-01T10:00:00-06:00'
+  ]
+
+  mockFs.realpathSync.mockImplementation(((p: string) => p) as never)
+  mockFs.readdirSync.mockImplementation((() => []) as never)
+  mockFs.rmSync.mockImplementation(((p: string) => {
+    removedDirs.push(p)
+  }) as never)
+  mockFs.statSync.mockImplementation((() => ({
+    size: 0,
+    mtime: new Date('2026-08-01T00:00:00Z')
+  })) as never)
+
+  mockExec.mockImplementation(((bin: string, args: string[], opts?: { cwd?: string }) => {
+    currentCwd = opts?.cwd ?? ''
+    return route(bin, args)
+  }) as never)
+})
+
+function scan(overrides: Partial<Parameters<typeof scanWorktreeInventory>[0]> = {}) {
+  return scanWorktreeInventory({
+    projects,
+    resolveRemote: () => undefined,
+    getActiveSessions: () => [],
+    ...overrides
+  })
+}
+
+describe('scanWorktreeInventory', () => {
+  it('reports the main worktree without measuring or offering it', () => {
+    const main = scan().projects[0].entries.find((e) => e.isMain)
+    expect(main).toBeDefined()
+    expect(main!.verdict.level).toBe('keep')
+    expect(main!.sizeBytes).toBe(0)
+    // No `du` was run against the project root.
+    expect(shellCalls.some((c) => c.startsWith('du') && c.includes(PROJECT + ' '))).toBe(false)
+  })
+
+  it('measures each linked worktree and splits build output from source', () => {
+    const a = scan().projects[0].entries.find((e) => e.path === WT_A)!
+    // One `du` for the tree, one for the two build directories find reported.
+    expect(a.sizeBytes).toBe(1024 * 1024)
+    expect(a.artifactBytes).toBe(2 * 1024 * 1024 > a.sizeBytes ? a.sizeBytes : 2 * 1024 * 1024)
+    expect(a.sizeMeasured).toBe(true)
+  })
+
+  it('never lets build output exceed the tree it lives in', () => {
+    const a = scan().projects[0].entries.find((e) => e.path === WT_A)!
+    expect(a.artifactBytes).toBeLessThanOrEqual(a.sizeBytes)
+  })
+
+  it('reads merged and upstream state from one pass over the refs', () => {
+    const [a, b] = [WT_A, WT_B].map((p) => scan().projects[0].entries.find((e) => e.path === p)!)
+    expect(a).toMatchObject({ isMerged: true, hasUpstream: false })
+    expect(b).toMatchObject({ isMerged: false, hasUpstream: true })
+    expect(b.verdict.level).toBe('reclaim')
+  })
+
+  it('carries uncommitted changes into the verdict', () => {
+    worktrees[WT_A].dirty = true
+    const a = scan().projects[0].entries.find((e) => e.path === WT_A)!
+    expect(a.isDirty).toBe(true)
+    expect(a.verdict.level).toBe('review')
+  })
+
+  it('marks a worktree with live sessions as keep', () => {
+    const a = scan({
+      getActiveSessions: (p) => (p === WT_A ? ['s1', 's2'] : [])
+    }).projects[0].entries.find((e) => e.path === WT_A)!
+    expect(a.activeSessionIds).toEqual(['s1', 's2'])
+    expect(a.verdict.level).toBe('keep')
+  })
+
+  it('finds directories on disk that git no longer lists', () => {
+    mockFs.readdirSync.mockImplementation(((dir: string) =>
+      dir === '/dev/.vorn-worktrees/repo'
+        ? [
+            { name: 'royal-stanza-a0494142', isDirectory: () => true },
+            { name: 'swift-spark-0f339ef6', isDirectory: () => true },
+            { name: '.DS_Store', isDirectory: () => false }
+          ]
+        : []) as never)
+
+    const orphan = scan().projects[0].entries.find((e) => e.kind === 'orphan-dir')
+    expect(orphan?.path).toBe(ORPHAN)
+    expect(orphan?.verdict.level).toBe('orphan')
+  })
+
+  it('lists branches left behind, and only vorn-generated ones', () => {
+    const { staleBranches } = scan().projects[0]
+    expect(staleBranches.map((b) => b.name)).toEqual(['gilded-sketch'])
+    expect(staleBranches[0].isMerged).toBe(true)
+  })
+
+  it('records a project that is not a git repository instead of throwing', () => {
+    mockExec.mockImplementation(((_b: string, args: string[]) =>
+      args.join(' ') === 'rev-parse --is-inside-work-tree' ? 'false' : '') as never)
+    const project = scan().projects[0]
+    expect(project.error).toBe('not a git repository')
+    expect(project.entries).toEqual([])
+  })
+
+  it('honours a retention threshold and pinned paths', () => {
+    const result = scan({
+      retention: { idleDaysThreshold: 0, pinnedPaths: [WT_A] }
+    }).projects[0]
+    expect(result.entries.find((e) => e.path === WT_A)!.verdict.level).toBe('keep')
+  })
+
+  it('limits the scan to the requested projects', () => {
+    expect(scan({ projectPaths: ['/other'] }).projects).toEqual([])
+  })
+
+  it('stamps the scan time', () => {
+    expect(Date.parse(scan().scannedAt)).not.toBeNaN()
+  })
+})
+
+describe('measureWorktree', () => {
+  it('serves a cached sample rather than re-running du', () => {
+    measureWorktree(WT_A, ['node_modules'])
+    const after = shellCalls.length
+    measureWorktree(WT_A, ['node_modules'])
+    expect(shellCalls.length).toBe(after)
+  })
+
+  it('re-measures when asked to refresh', () => {
+    measureWorktree(WT_A, ['node_modules'])
+    const after = shellCalls.length
+    measureWorktree(WT_A, ['node_modules'], undefined, true)
+    expect(shellCalls.length).toBeGreaterThan(after)
+  })
+
+  it('reports zero and flags itself unmeasured when du fails outright', () => {
+    failCommand = (c) => c.startsWith('du')
+    const sample = measureWorktree(WT_A, ['node_modules'])
+    expect(sample).toMatchObject({ sizeBytes: 0, artifactBytes: 0, measured: false })
+  })
+
+  it('prefers a stale number over zero when a later measurement fails', () => {
+    const first = measureWorktree(WT_A, ['node_modules'])
+    failCommand = (c) => c.startsWith('du')
+    const second = measureWorktree(WT_A, ['node_modules'], undefined, true)
+    expect(second.sizeBytes).toBe(first.sizeBytes)
+    expect(second.measured).toBe(true)
+  })
+
+  it('falls back to walking the tree when find fails', () => {
+    failCommand = (c) => c.startsWith('find')
+    mockFs.readdirSync.mockImplementation((() => []) as never)
+    expect(() => measureWorktree(WT_A, ['node_modules'])).not.toThrow()
+  })
+})
+
+describe('listOrphanDirs', () => {
+  it('returns nothing when the worktree root does not exist', () => {
+    mockFs.readdirSync.mockImplementation((() => {
+      throw new Error('ENOENT')
+    }) as never)
+    expect(listOrphanDirs(PROJECT, new Set())).toEqual([])
+  })
+
+  it('matches registered paths through a symlinked parent', () => {
+    mockFs.readdirSync.mockImplementation(((dir: string) =>
+      dir === '/dev/.vorn-worktrees/repo'
+        ? [{ name: 'royal-stanza-a0494142', isDirectory: () => true }]
+        : []) as never)
+    mockFs.realpathSync.mockImplementation((() => '/private' + WT_A) as never)
+    expect(listOrphanDirs(PROJECT, new Set(['/private' + WT_A]))).toEqual([])
+  })
+})
+
+describe('reclaimArtifacts', () => {
+  it('deletes every build directory inside the worktree and reports the bytes', () => {
+    const result = reclaimArtifacts([WT_A], ['node_modules', 'dist'], projects, () => undefined)
+    expect(result.succeeded).toEqual([WT_A])
+    expect(removedDirs).toEqual([`${WT_A}/node_modules`, `${WT_A}/packages/web/dist`])
+    expect(result.freedBytes).toBe(2 * 1024 * 1024)
+  })
+
+  it('succeeds without deleting anything when there is no build output', () => {
+    const result = reclaimArtifacts([WT_B], ['node_modules'], projects, () => undefined)
+    expect(result.succeeded).toEqual([WT_B])
+    expect(removedDirs).toEqual([])
+  })
+
+  it('refuses a path no project claims as a worktree', () => {
+    const result = reclaimArtifacts(
+      ['/Users/me/Documents'],
+      ['node_modules'],
+      projects,
+      () => undefined
+    )
+    expect(result.succeeded).toEqual([])
+    expect(result.failed[0].error).toMatch(/not a worktree of any known project/)
+    expect(removedDirs).toEqual([])
+  })
+
+  it('refuses the main worktree — the project itself is not build output', () => {
+    const result = reclaimArtifacts([PROJECT], ['node_modules'], projects, () => undefined)
+    expect(result.failed[0].error).toMatch(/not a worktree/)
+    expect(removedDirs).toEqual([])
+  })
+
+  it('stops a symlinked build directory from reaching outside the worktree', () => {
+    mockFs.realpathSync.mockImplementation(((p: string) =>
+      p === `${WT_A}/node_modules` ? '/usr/local/lib' : p) as never)
+    const result = reclaimArtifacts([WT_A], ['node_modules'], projects, () => undefined)
+    expect(result.failed[0].error).toMatch(/outside the worktree/)
+    expect(removedDirs).toEqual([])
+  })
+})
+
+describe('removeWorktrees', () => {
+  const sizeOf = () => 5 * 1024 * 1024
+
+  it('removes a worktree and reports the bytes it freed', () => {
+    const result = removeWorktrees(
+      [{ projectPath: PROJECT, worktreePath: WT_A }],
+      sizeOf,
+      projects,
+      () => undefined
+    )
+    expect(result.succeeded).toEqual([WT_A])
+    expect(result.freedBytes).toBe(5 * 1024 * 1024)
+  })
+
+  it('reports a branch as deleted only once it is actually gone', () => {
+    refs = refs.filter((r) => !r.startsWith('royal-stanza'))
+    const result = removeWorktrees(
+      [{ projectPath: PROJECT, worktreePath: WT_A, deleteBranch: true }],
+      sizeOf,
+      projects,
+      () => undefined
+    )
+    expect(result.deletedBranches).toEqual(['royal-stanza'])
+  })
+
+  it('does not claim a branch was deleted when it survived', () => {
+    const result = removeWorktrees(
+      [{ projectPath: PROJECT, worktreePath: WT_A, deleteBranch: true }],
+      sizeOf,
+      projects,
+      () => undefined
+    )
+    expect(result.deletedBranches).toEqual([])
+  })
+
+  it('refuses a path git does not report as a worktree', () => {
+    const result = removeWorktrees(
+      [{ projectPath: PROJECT, worktreePath: '/tmp/elsewhere' }],
+      sizeOf,
+      projects,
+      () => undefined
+    )
+    expect(result.failed[0].error).toMatch(/not a worktree of any known project/)
+  })
+
+  it('surfaces a git failure as a per-item error and frees nothing', () => {
+    mockExec.mockImplementation(((bin: string, args: string[], opts?: { cwd?: string }) => {
+      currentCwd = opts?.cwd ?? ''
+      if (args.join(' ').startsWith('worktree remove')) throw new Error('is dirty')
+      return route(bin, args)
+    }) as never)
+
+    const result = removeWorktrees(
+      [{ projectPath: PROJECT, worktreePath: WT_A }],
+      sizeOf,
+      projects,
+      () => undefined
+    )
+    expect(result.succeeded).toEqual([])
+    expect(result.freedBytes).toBe(0)
+    expect(result.failed[0].error).toMatch(/git worktree remove failed/)
+  })
+})
+
+describe('pruneOrphanDirs', () => {
+  const sizeOf = () => 1024
+
+  it('deletes a directory git has forgotten', () => {
+    mockExec.mockImplementation(((bin: string, args: string[], opts?: { cwd?: string }) => {
+      currentCwd = opts?.cwd ?? ''
+      // No git directory here — that is what makes it an orphan.
+      if (args.join(' ') === 'rev-parse --absolute-git-dir') throw new Error('not a repo')
+      return route(bin, args)
+    }) as never)
+
+    const result = pruneOrphanDirs([ORPHAN], sizeOf, () => undefined)
+    expect(result.succeeded).toEqual([ORPHAN])
+    expect(removedDirs).toEqual([ORPHAN])
+    expect(result.freedBytes).toBe(1024)
+  })
+
+  it('refuses a path git still claims — that one goes through git worktree remove', () => {
+    const result = pruneOrphanDirs([WT_A], sizeOf, () => undefined)
+    expect(result.failed[0].error).toMatch(/still registered with git/)
+    expect(removedDirs).toEqual([])
+  })
+
+  it('refuses anything outside the worktree root, whatever git says', () => {
+    const result = pruneOrphanDirs(['/Users/me/Documents'], sizeOf, () => undefined)
+    expect(result.failed[0].error).toMatch(/outside \.vorn-worktrees/)
+    expect(removedDirs).toEqual([])
+  })
+})
+
+describe('invalidateSizeCache', () => {
+  it('drops a measured path so the next read re-runs du', () => {
+    measureWorktree(WT_A, ['node_modules'])
+    invalidateSizeCache(WT_A)
+    const after = shellCalls.length
+    measureWorktree(WT_A, ['node_modules'])
+    expect(shellCalls.length).toBeGreaterThan(after)
+  })
+
+  it('drops everything beneath a prefix', () => {
+    measureWorktree(WT_A, ['node_modules'])
+    invalidateSizeCache('/dev/.vorn-worktrees')
+    const after = shellCalls.length
+    measureWorktree(WT_A, ['node_modules'])
+    expect(shellCalls.length).toBeGreaterThan(after)
+  })
+})

--- a/tests/worktree-inventory.test.ts
+++ b/tests/worktree-inventory.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => '')
+}))
+
+vi.mock('node:fs', () => ({
+  default: {
+    realpathSync: vi.fn((p: string) => p),
+    readdirSync: vi.fn(() => []),
+    rmSync: vi.fn(),
+    statSync: vi.fn(() => ({ size: 0, mtime: new Date(0) })),
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn(() => true)
+  }
+}))
+
+import fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import {
+  assertInsideWorktree,
+  assertRemovablePath,
+  findOwningWorktree,
+  collectStaleBranches,
+  computeVerdict,
+  worktreeBaseDir,
+  type VerdictInput
+} from '../packages/server/src/worktree-inventory'
+
+const mockFs = vi.mocked(fs)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFs.realpathSync.mockImplementation(((p: string) => p) as never)
+})
+
+const GB = 1024 ** 3
+
+function input(overrides: Partial<VerdictInput> = {}): VerdictInput {
+  return {
+    isMain: false,
+    kind: 'registered',
+    isDirty: false,
+    isMerged: true,
+    hasUpstream: true,
+    activeSessionCount: 0,
+    isPinned: false,
+    sizeBytes: GB,
+    artifactBytes: GB / 2,
+    idleDays: 90,
+    ...overrides
+  }
+}
+
+describe('computeVerdict', () => {
+  it('never offers to touch the main worktree', () => {
+    const verdict = computeVerdict(input({ isMain: true }), 14)
+    expect(verdict.level).toBe('keep')
+    expect(verdict.freesBytes).toBe(0)
+    expect(verdict.autoSelect).toBe(false)
+  })
+
+  it('keeps a worktree with live sessions, even when it is merged and idle', () => {
+    const verdict = computeVerdict(input({ activeSessionCount: 2 }), 14)
+    expect(verdict.level).toBe('keep')
+    expect(verdict.reasons).toEqual(['2 active sessions'])
+  })
+
+  it('live sessions outrank uncommitted changes', () => {
+    const verdict = computeVerdict(input({ activeSessionCount: 1, isDirty: true }), 14)
+    expect(verdict.level).toBe('keep')
+  })
+
+  it('keeps a pinned worktree', () => {
+    expect(computeVerdict(input({ isPinned: true }), 14).level).toBe('keep')
+  })
+
+  it('flags a directory git has forgotten as an orphan worth its full size', () => {
+    const verdict = computeVerdict(input({ kind: 'orphan-dir', isMerged: false }), 14)
+    expect(verdict.level).toBe('orphan')
+    expect(verdict.freesBytes).toBe(GB)
+    // Never pre-selected: deleting it bypasses git entirely.
+    expect(verdict.autoSelect).toBe(false)
+  })
+
+  it('sends uncommitted changes to review and frees nothing', () => {
+    const verdict = computeVerdict(input({ isDirty: true }), 14)
+    expect(verdict.level).toBe('review')
+    expect(verdict.freesBytes).toBe(0)
+    expect(verdict.autoSelect).toBe(false)
+  })
+
+  it('sends unmerged, never-pushed work to review — removal would be unrecoverable', () => {
+    const verdict = computeVerdict(input({ isMerged: false, hasUpstream: false }), 14)
+    expect(verdict.level).toBe('review')
+    expect(verdict.reasons).toContain('unmerged and never pushed')
+  })
+
+  it('offers build output only when the branch is unmerged but pushed', () => {
+    const verdict = computeVerdict(input({ isMerged: false, hasUpstream: true }), 14)
+    expect(verdict.level).toBe('reclaim')
+    expect(verdict.freesBytes).toBe(GB / 2)
+    expect(verdict.autoSelect).toBe(false)
+  })
+
+  it('marks a merged, clean, idle worktree removable and pre-selects it', () => {
+    const verdict = computeVerdict(input({ idleDays: 92 }), 14)
+    expect(verdict.level).toBe('remove')
+    expect(verdict.freesBytes).toBe(GB)
+    expect(verdict.autoSelect).toBe(true)
+    expect(verdict.reasons).toEqual(['merged', 'idle 92 days'])
+  })
+
+  it('still allows removing a merged worktree touched yesterday, but does not pre-select it', () => {
+    const verdict = computeVerdict(input({ idleDays: 1 }), 14)
+    expect(verdict.level).toBe('remove')
+    expect(verdict.autoSelect).toBe(false)
+    expect(verdict.reasons).toEqual(['merged', 'idle 1 day'])
+  })
+
+  it('does not pre-select when the age is unknown', () => {
+    expect(computeVerdict(input({ idleDays: null }), 14).autoSelect).toBe(false)
+  })
+
+  it('honours a zero threshold by pre-selecting every removable worktree', () => {
+    expect(computeVerdict(input({ idleDays: 0 }), 0).autoSelect).toBe(true)
+  })
+})
+
+describe('assertRemovablePath', () => {
+  const root = '/Users/dev/.vorn-worktrees/vorn'
+
+  it('accepts a worktree directory', () => {
+    expect(() => assertRemovablePath(`${root}/royal-stanza-a0494142`)).not.toThrow()
+  })
+
+  it('accepts a build directory inside a worktree', () => {
+    expect(() => assertRemovablePath(`${root}/royal-stanza-a0494142/node_modules`)).not.toThrow()
+  })
+
+  it('refuses anything outside the worktree root', () => {
+    expect(() => assertRemovablePath('/Users/dev/vorn')).toThrow(/outside \.vorn-worktrees/)
+    expect(() => assertRemovablePath('/')).toThrow(/outside \.vorn-worktrees/)
+  })
+
+  it('refuses the worktree root itself and a whole project folder', () => {
+    expect(() => assertRemovablePath('/Users/dev/.vorn-worktrees')).toThrow(
+      /not a worktree directory/
+    )
+    expect(() => assertRemovablePath(root)).toThrow(/not a worktree directory/)
+  })
+
+  it('refuses an empty path', () => {
+    expect(() => assertRemovablePath('')).toThrow(/empty path/)
+    expect(() => assertRemovablePath('   ')).toThrow(/empty path/)
+  })
+
+  it('resolves symlinks first, so a link out of the root cannot be followed', () => {
+    mockFs.realpathSync.mockImplementation((() => '/Users/dev/vorn/src') as never)
+    expect(() => assertRemovablePath(`${root}/escape/node_modules`)).toThrow(
+      /outside \.vorn-worktrees/
+    )
+  })
+
+  it('still guards a path that does not exist yet', () => {
+    mockFs.realpathSync.mockImplementation((() => {
+      throw new Error('ENOENT')
+    }) as never)
+    expect(() => assertRemovablePath('/etc/passwd')).toThrow(/outside \.vorn-worktrees/)
+    expect(() => assertRemovablePath(`${root}/gone`)).not.toThrow()
+  })
+})
+
+describe('assertInsideWorktree', () => {
+  const wt = '/Users/dev/.vorn-worktrees/vorn/royal-stanza-a0494142'
+
+  it('accepts the worktree itself and anything beneath it', () => {
+    expect(() => assertInsideWorktree(wt, wt)).not.toThrow()
+    expect(() => assertInsideWorktree(`${wt}/packages/server/node_modules`, wt)).not.toThrow()
+  })
+
+  it('refuses a sibling whose name merely starts the same', () => {
+    expect(() => assertInsideWorktree(`${wt}-backup/node_modules`, wt)).toThrow(
+      /outside the worktree/
+    )
+  })
+
+  it('refuses a path that escapes upward', () => {
+    expect(() => assertInsideWorktree('/Users/dev/vorn/node_modules', wt)).toThrow(
+      /outside the worktree/
+    )
+  })
+
+  it('refuses an empty target', () => {
+    expect(() => assertInsideWorktree('', wt)).toThrow(/empty path/)
+  })
+
+  it('compares real paths, so a symlink out of the worktree is caught', () => {
+    mockFs.realpathSync.mockImplementation(((p: string) =>
+      p === `${wt}/node_modules` ? '/Users/dev/vorn/node_modules' : p) as never)
+    expect(() => assertInsideWorktree(`${wt}/node_modules`, wt)).toThrow(/outside the worktree/)
+  })
+})
+
+describe('findOwningWorktree', () => {
+  const projects = [{ name: 'eclat', path: '/Users/dev/eclat', preferredAgents: [] }]
+  const porcelain = [
+    'worktree /Users/dev/eclat',
+    'HEAD abc',
+    'branch refs/heads/main',
+    '',
+    'worktree /Users/dev/eclat-codex-oauth',
+    'HEAD def',
+    'branch refs/heads/codex-oauth'
+  ].join('\n')
+
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReturnValue(porcelain as never)
+  })
+
+  it('finds a worktree git owns even though it sits outside .vorn-worktrees', () => {
+    const owner = findOwningWorktree('/Users/dev/eclat-codex-oauth', projects, () => undefined)
+    expect(owner).toEqual({
+      projectPath: '/Users/dev/eclat',
+      worktreePath: '/Users/dev/eclat-codex-oauth',
+      remote: undefined
+    })
+  })
+
+  it('never returns the main worktree — the project itself is not a cleanup target', () => {
+    expect(findOwningWorktree('/Users/dev/eclat', projects, () => undefined)).toBeNull()
+  })
+
+  it('returns null for a path no project claims', () => {
+    expect(findOwningWorktree('/Users/dev/somewhere-else', projects, () => undefined)).toBeNull()
+  })
+
+  it('lists each project only once across a batch', () => {
+    const cache = new Map()
+    findOwningWorktree('/Users/dev/eclat-codex-oauth', projects, () => undefined, cache)
+    const callsAfterFirst = vi.mocked(execFileSync).mock.calls.length
+    findOwningWorktree('/Users/dev/eclat-codex-oauth', projects, () => undefined, cache)
+    expect(vi.mocked(execFileSync).mock.calls.length).toBe(callsAfterFirst)
+  })
+})
+
+describe('worktreeBaseDir', () => {
+  it('sits beside the project, not inside it', () => {
+    expect(worktreeBaseDir('/Users/dev/vorn')).toBe('/Users/dev/.vorn-worktrees/vorn')
+  })
+
+  it('uses posix separators for a remote host', () => {
+    const remote = { id: 'h1', label: 'box', hostname: 'h', user: 'u', port: 22 }
+    expect(worktreeBaseDir('/srv/code/vorn', remote)).toBe('/srv/code/.vorn-worktrees/vorn')
+  })
+})
+
+describe('collectStaleBranches', () => {
+  const info = new Map([
+    ['main', { upstream: 'origin/main', committerDate: '2026-08-07T16:18:15-06:00' }],
+    ['royal-stanza', { upstream: null, committerDate: '2026-05-07T18:22:48-06:00' }],
+    ['ivory-relic', { upstream: 'origin/ivory-relic', committerDate: '2026-08-07T16:18:15-06:00' }],
+    ['gilded-sketch-2a9c9f51', { upstream: null, committerDate: '2026-05-07T18:22:48-06:00' }],
+    ['feat/headless-run-diagnostics', { upstream: 'origin/feat', committerDate: null }],
+    ['obsidian-study', { upstream: null, committerDate: null }]
+  ])
+
+  it('reports only branches vorn generated, and only those without a worktree', () => {
+    const stale = collectStaleBranches(
+      info,
+      new Set(['main', 'obsidian-study']),
+      new Set(['royal-stanza', 'gilded-sketch-2a9c9f51']),
+      'main'
+    )
+    expect(stale.map((b) => b.name)).toEqual([
+      'gilded-sketch-2a9c9f51',
+      'ivory-relic',
+      'royal-stanza'
+    ])
+  })
+
+  it('never proposes a branch the user named themselves', () => {
+    const stale = collectStaleBranches(info, new Set(), new Set(), 'main')
+    expect(stale.map((b) => b.name)).not.toContain('feat/headless-run-diagnostics')
+  })
+
+  it('carries merged and upstream state through for the UI', () => {
+    const stale = collectStaleBranches(info, new Set(), new Set(['royal-stanza']), 'main')
+    const royal = stale.find((b) => b.name === 'royal-stanza')
+    expect(royal).toMatchObject({ isMerged: true, hasUpstream: false })
+    const ivory = stale.find((b) => b.name === 'ivory-relic')
+    expect(ivory).toMatchObject({ isMerged: false, hasUpstream: true })
+  })
+
+  it('leaves the default branch alone even when it looks generated', () => {
+    const stale = collectStaleBranches(info, new Set(), new Set(), 'royal-stanza')
+    expect(stale.map((b) => b.name)).not.toContain('royal-stanza')
+  })
+})

--- a/tests/worktree-settings.test.tsx
+++ b/tests/worktree-settings.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+import type {
+  WorktreeInventory,
+  WorktreeInventoryEntry,
+  WorktreeProjectInventory
+} from '../src/shared/types'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }),
+  writable: true
+})
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag: string) =>
+        React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((props, ref) =>
+          React.createElement(tag, { ...props, ref })
+        )
+    }
+  )
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: Object.assign((msg: string) => msg, {
+    loading: () => 'toast-id',
+    update: vi.fn(),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn()
+  })
+}))
+
+const mockGetInventory = vi.fn()
+const mockReclaim = vi.fn()
+const mockRemoveMany = vi.fn()
+const mockPrune = vi.fn()
+const mockDeleteBranches = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    getWorktreeInventory: (...a: unknown[]) => mockGetInventory(...a),
+    reclaimWorktreeArtifacts: (...a: unknown[]) => mockReclaim(...a),
+    removeWorktrees: (...a: unknown[]) => mockRemoveMany(...a),
+    pruneOrphanWorktrees: (...a: unknown[]) => mockPrune(...a),
+    deleteBranches: (...a: unknown[]) => mockDeleteBranches(...a)
+  },
+  writable: true
+})
+
+import { WorktreeSettings } from '../src/renderer/components/settings/WorktreeSettings'
+
+const MB = 1024 ** 2
+const GB = 1024 ** 3
+
+function entry(over: Partial<WorktreeInventoryEntry> = {}): WorktreeInventoryEntry {
+  return {
+    path: '/dev/.vorn-worktrees/vorn/royal-stanza-a0494142',
+    name: 'royal-stanza-a0494142',
+    projectPath: '/dev/vorn',
+    projectName: 'vorn',
+    kind: 'registered',
+    branch: 'royal-stanza',
+    isMain: false,
+    sizeBytes: GB,
+    artifactBytes: 983 * MB,
+    sizeMeasured: true,
+    lastCommitAt: '2026-05-07T18:22:48-06:00',
+    lastTouchedAt: '2026-05-07T18:22:48-06:00',
+    idleDays: 92,
+    isDirty: false,
+    isMerged: true,
+    hasUpstream: true,
+    activeSessionIds: [],
+    verdict: { level: 'remove', freesBytes: GB, reasons: ['merged'], autoSelect: true },
+    ...over
+  }
+}
+
+function inventory(
+  entries: WorktreeInventoryEntry[],
+  over: Partial<WorktreeProjectInventory> = {}
+) {
+  const project: WorktreeProjectInventory = {
+    projectPath: '/dev/vorn',
+    projectName: 'vorn',
+    defaultBranch: 'main',
+    remoteHostId: null,
+    entries,
+    staleBranches: [],
+    ...over
+  }
+  return { projects: [project], scannedAt: '2026-08-07T19:00:00Z' } satisfies WorktreeInventory
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetInventory.mockResolvedValue(inventory([entry()]))
+})
+
+describe('WorktreeSettings', () => {
+  it('scans on mount and shows the total on disk', async () => {
+    render(<WorktreeSettings />)
+    await waitFor(() => expect(screen.getAllByText('1.0 GB').length).toBeGreaterThan(0))
+    expect(screen.getByText('On disk')).toBeInTheDocument()
+    expect(mockGetInventory).toHaveBeenCalledWith({ refresh: false })
+  })
+
+  it('offers the reclaim action sized in bytes, and only acts on the second click', async () => {
+    mockReclaim.mockResolvedValue({
+      succeeded: ['/dev/.vorn-worktrees/vorn/royal-stanza-a0494142'],
+      failed: [],
+      freedBytes: 983 * MB,
+      deletedBranches: []
+    })
+    render(<WorktreeSettings />)
+
+    const button = await screen.findByRole('button', { name: /Reclaim 983 MB of build output/ })
+    fireEvent.click(button)
+    expect(mockReclaim).not.toHaveBeenCalled()
+
+    fireEvent.click(await screen.findByRole('button', { name: /frees 983 MB/ }))
+    await waitFor(() =>
+      expect(mockReclaim).toHaveBeenCalledWith(['/dev/.vorn-worktrees/vorn/royal-stanza-a0494142'])
+    )
+  })
+
+  it('will not let a worktree with a live session be selected', async () => {
+    mockGetInventory.mockResolvedValue(
+      inventory([
+        entry({
+          activeSessionIds: ['s1'],
+          verdict: {
+            level: 'keep',
+            freesBytes: 0,
+            reasons: ['1 active session'],
+            autoSelect: false
+          }
+        })
+      ])
+    )
+    render(<WorktreeSettings />)
+    const checkbox = await screen.findByRole('checkbox', { name: /royal-stanza/ })
+    expect(checkbox).toBeDisabled()
+  })
+
+  it('spells out the byte count before removing, and warns about uncommitted changes', async () => {
+    mockGetInventory.mockResolvedValue(
+      inventory([
+        entry({
+          isDirty: true,
+          verdict: {
+            level: 'review',
+            freesBytes: 0,
+            reasons: ['uncommitted changes'],
+            autoSelect: false
+          }
+        })
+      ])
+    )
+    mockRemoveMany.mockResolvedValue({
+      succeeded: ['/dev/.vorn-worktrees/vorn/royal-stanza-a0494142'],
+      failed: [],
+      freedBytes: GB,
+      deletedBranches: []
+    })
+    render(<WorktreeSettings />)
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /royal-stanza/ }))
+    expect(await screen.findByText(/uncommitted changes that will be lost/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(mockRemoveMany).not.toHaveBeenCalled()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Yes — remove 1 and free 1\.0 GB/ }))
+    await waitFor(() => expect(mockRemoveMany).toHaveBeenCalled())
+    // A dirty worktree needs --force, and its branch is not merged so it stays.
+    expect(mockRemoveMany.mock.calls[0][0]).toEqual([
+      {
+        projectPath: '/dev/vorn',
+        worktreePath: '/dev/.vorn-worktrees/vorn/royal-stanza-a0494142',
+        force: true,
+        deleteBranch: true
+      }
+    ])
+  })
+
+  it('routes orphan directories to the prune call, not to git', async () => {
+    mockGetInventory.mockResolvedValue(
+      inventory([
+        entry({
+          path: '/dev/.vorn-worktrees/vorn/swift-spark-0f339ef6',
+          name: 'swift-spark-0f339ef6',
+          kind: 'orphan-dir',
+          branch: null,
+          sizeBytes: 816 * 1024,
+          artifactBytes: 0,
+          isMerged: false,
+          verdict: {
+            level: 'orphan',
+            freesBytes: 816 * 1024,
+            reasons: ['not registered with git'],
+            autoSelect: false
+          }
+        })
+      ])
+    )
+    mockPrune.mockResolvedValue({
+      succeeded: ['/dev/.vorn-worktrees/vorn/swift-spark-0f339ef6'],
+      failed: [],
+      freedBytes: 816 * 1024,
+      deletedBranches: []
+    })
+    render(<WorktreeSettings />)
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /swift-spark/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    fireEvent.click(await screen.findByRole('button', { name: /Yes — remove 1/ }))
+
+    await waitFor(() =>
+      expect(mockPrune).toHaveBeenCalledWith(['/dev/.vorn-worktrees/vorn/swift-spark-0f339ef6'])
+    )
+    expect(mockRemoveMany).not.toHaveBeenCalled()
+  })
+
+  it('lists branches left behind and deletes only the ones picked', async () => {
+    mockGetInventory.mockResolvedValue(
+      inventory([entry()], {
+        staleBranches: [
+          { name: 'ivory-relic', isMerged: true, hasUpstream: false, lastCommitAt: null },
+          { name: 'sienna-etching', isMerged: false, hasUpstream: true, lastCommitAt: null }
+        ]
+      })
+    )
+    mockDeleteBranches.mockResolvedValue({ deleted: ['ivory-relic'], failed: [] })
+    render(<WorktreeSettings />)
+
+    expect(
+      await screen.findByText(/2 branches left behind by removed worktrees — 1 already merged/)
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Select 1 merged' }))
+    fireEvent.click(screen.getByRole('button', { name: /Delete 1 branch/ }))
+
+    await waitFor(() =>
+      expect(mockDeleteBranches).toHaveBeenCalledWith('/dev/vorn', ['ivory-relic'], false)
+    )
+  })
+
+  it('excludes the main worktree from the list entirely', async () => {
+    mockGetInventory.mockResolvedValue(
+      inventory([
+        entry({ path: '/dev/vorn', name: 'vorn', isMain: true, sizeBytes: 0, artifactBytes: 0 }),
+        entry()
+      ])
+    )
+    render(<WorktreeSettings />)
+    await screen.findByRole('checkbox', { name: /royal-stanza/ })
+    expect(screen.queryByRole('checkbox', { name: 'Select vorn' })).not.toBeInTheDocument()
+  })
+
+  it('says so plainly when there is nothing to clean up', async () => {
+    mockGetInventory.mockResolvedValue(inventory([]))
+    render(<WorktreeSettings />)
+    expect(await screen.findByText(/No worktrees yet/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
`~/dev/.vorn-worktrees` had grown to **1.9 GB** across six directories, **94% of it `node_modules`** in two worktrees whose branches were merged months ago. vorn created worktrees freely and removed them one at a time from a sidebar trash icon; nothing ever measured them.

## Three separate leaks, none of them visible in the app

- **Build output outlives the work.** Every worktree gets its own `node_modules` the first time an agent installs in it. Nothing deletes them, and deleting them costs nothing — a reinstall rebuilds them exactly.
- **Removing a worktree left its branch behind.** `removeWorktree()` shelled out to `git worktree remove` and stopped there. 13 local branches now match vorn's own generated adjective-noun naming with no worktree attached; 11 are already merged into `main`.
- **Directories git has forgotten are invisible.** `git worktree prune` reports nothing once the administrative entry is gone, so only a filesystem scan finds them.

## What this adds

`packages/server/src/worktree-inventory.ts` — one scan per project producing size, build-output size, staleness, merged/upstream state, live sessions and orphan directories, plus a verdict naming the safest action available (`keep` / `review` / `reclaim` / `remove` / `orphan`).

- Sizing is `find -prune` + `du -sk` — two commands, not a file walk — behind a five-minute cache, with a Node fallback for Windows.
- Activity comes from the worktree's own git index mtime, so a fresh `yarn install` doesn't make a dead worktree look active.
- Branch state for a whole repo comes from one `for-each-ref` plus one `branch --merged`, not a call per branch.

Five methods across the existing RPC spine (`protocol.ts` → `register-methods.ts` → preload + web shim), and a **Worktrees** settings panel grouped by project: summary header with a non-destructive `Reclaim N of build output` primary, a stale-branch strip, and a selection footer that spells out the byte count before a second, explicit confirm.

Retention lives in `AppConfig.defaults.worktreeRetention` (idle threshold, artifact directory list, pinned paths). Remote hosts are threaded through the way every other git helper does.

## Safety

Split by what can actually go wrong:

- **`git worktree remove` is guarded by git's own record, not a path prefix.** It refuses anything it doesn't own and won't drop uncommitted work unless forced — so a worktree created by hand outside `.vorn-worktrees/` is as safe to remove as one vorn made. (Caught in review: guarding on the path prefix would have shown a removable 1.6 GB row whose button then failed.)
- **Raw `fs.rm` carries the strict checks.** Build output must resolve inside its own worktree, canonicalised on both sides so a symlink can't escape; orphan directories must sit under `.vorn-worktrees/<project>/` and must no longer be claimed by git.
- Live sessions are re-checked immediately before every action, not read off the scan.
- Uncommitted changes and unpushed work are never pre-selected; branch deletion uses `-d`, so git refuses anything unmerged.

Also fixes the leak at its source: `removeWorktree()` takes a `deleteBranch` option, so the sidebar trash button and the end-of-session toast stop creating new orphans.

## Verification

Ran the shipped scanner against this machine's 8 configured projects via the live WebSocket RPC, not just unit tests. It reads `royal-stanza` as `review` (3 uncommitted files) and `obsidian-study` as `review` (never merged) — both stricter than a branch-only read, and both confirmed against `git` directly.

- 2581 tests across 222 files
- Patch coverage 86% (gate is 80%)
- `yarn typecheck`, `yarn lint`, `yarn format:check`, `lint:lockfile`, completion-index check all clean
- `build:server` and `electron-vite build` both succeed