### PR TITLE
feat(mcp): add execute_workflow, with declared parameters

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -118,11 +118,28 @@ export const workflowInputDefSchema = z
     }
   })
 
+// Two inputs sharing a key cannot both survive under one `{{inputs.<key>}}`.
+// The editor already flags this as an error the author has to resolve, so MCP
+// authoring must not be the way an ambiguous workflow gets persisted.
+export const workflowInputsSchema = z.array(workflowInputDefSchema).superRefine((inputs, ctx) => {
+  const seen = new Set<string>()
+  inputs.forEach((def, index) => {
+    if (seen.has(def.key)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: [index, 'key'],
+        message: `duplicate input key "${def.key}" — only one value can survive under {{inputs.${def.key}}}`
+      })
+    }
+    seen.add(def.key)
+  })
+})
+
 const triggerConfigSchema = z.union([
   z.object({
     triggerType: z.literal('manual'),
     contextual: z.boolean().optional(),
-    inputs: z.array(workflowInputDefSchema).optional()
+    inputs: workflowInputsSchema.optional()
   }),
   z.object({ triggerType: z.literal('once'), runAt: V.shortText }),
   z.object({
@@ -251,25 +268,45 @@ export function resolveWorkflowInputs(
     const provided = Object.prototype.hasOwnProperty.call(supplied, def.key)
     const raw = provided ? supplied[def.key] : def.defaultValue
 
-    if (raw === undefined || raw === '') {
+    // A declared toggle always carries an answer. defaultInputValue seeds
+    // `false` when nothing was authored and areInputsValid counts `false` as a
+    // real answer, so omitting it here would expand `{{inputs.x}}` to '' on an
+    // MCP run and 'false' on a UI run — and dedupe them as different runs.
+    if (def.type === 'boolean') {
+      if (raw === undefined) {
+        values[def.key] = false
+      } else if (typeof raw === 'boolean') {
+        values[def.key] = raw
+      } else if (raw === 'true' || raw === 'false') {
+        values[def.key] = raw === 'true'
+      } else {
+        errors.push(`input "${def.key}" must be a boolean, got ${JSON.stringify(raw)}`)
+      }
+      continue
+    }
+
+    // Whitespace-only is "no value", matching areInputsValid's String(v).trim().
+    if (raw === undefined || (typeof raw === 'string' && raw.trim() === '')) {
       if (def.required) errors.push(`missing required input "${def.key}" (${def.label})`)
       continue
     }
 
     switch (def.type) {
       case 'number': {
-        const n = typeof raw === 'number' ? raw : Number(raw)
-        if (Number.isNaN(n)) {
+        // parseNumberInput rejects anything non-finite because NaN and Infinity
+        // do not survive JSON — they corrupt the persisted run, the template
+        // expansion and the dedupe fingerprint alike. A boolean is not a number
+        // either, however willingly Number() turns it into one.
+        if (typeof raw === 'boolean') {
           errors.push(`input "${def.key}" must be a number, got ${JSON.stringify(raw)}`)
+          break
+        }
+        const n = typeof raw === 'number' ? raw : Number(String(raw).trim())
+        if (!Number.isFinite(n)) {
+          errors.push(`input "${def.key}" must be a finite number, got ${JSON.stringify(raw)}`)
         } else {
           values[def.key] = n
         }
-        break
-      }
-      case 'boolean': {
-        if (typeof raw === 'boolean') values[def.key] = raw
-        else if (raw === 'true' || raw === 'false') values[def.key] = raw === 'true'
-        else errors.push(`input "${def.key}" must be a boolean, got ${JSON.stringify(raw)}`)
         break
       }
       case 'select': {

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -244,6 +244,28 @@ export function resolveWorkflowInputs(
   return { values, errors }
 }
 
+/**
+ * The workflow tools grew two names for one argument: the read tools take
+ * `workflow_id`, while update/delete took `id`. Nothing signals which a given
+ * tool wants, so reaching for the wrong one costs a failed call and a re-read
+ * of the schema.
+ *
+ * `workflow_id` is canonical now — it is what the majority already used.
+ * `id` keeps working, because breaking every existing caller to win
+ * consistency would be a poor trade.
+ */
+export function resolveWorkflowId(args: {
+  workflow_id?: string
+  id?: string
+}): { id: string } | { error: string } {
+  const id = args.workflow_id ?? args.id
+  if (!id) return { error: 'provide workflow_id' }
+  if (args.workflow_id && args.id && args.workflow_id !== args.id) {
+    return { error: 'workflow_id and id disagree — pass only workflow_id' }
+  }
+  return { id }
+}
+
 export function registerWorkflowTools(server: McpServer): void {
   server.tool(
     'list_workflows',
@@ -321,7 +343,8 @@ export function registerWorkflowTools(server: McpServer): void {
     'update_workflow',
     "Update a workflow's properties",
     {
-      id: V.id.describe('Workflow ID'),
+      workflow_id: V.id.optional().describe('Workflow ID (from list_workflows)'),
+      id: V.id.optional().describe('Deprecated alias for workflow_id'),
       name: V.title.optional(),
       nodes: z.array(nodeSchema).optional(),
       edges: z.array(edgeSchema).optional(),
@@ -331,11 +354,15 @@ export function registerWorkflowTools(server: McpServer): void {
       stagger_delay_ms: z.number().optional()
     },
     async (args) => {
+      const resolved = resolveWorkflowId(args)
+      if ('error' in resolved) {
+        return { content: [{ type: 'text', text: `Error: ${resolved.error}` }], isError: true }
+      }
       const workflows = dbListWorkflows()
-      const workflow = workflows.find((w) => w.id === args.id)
+      const workflow = workflows.find((w) => w.id === resolved.id)
       if (!workflow) {
         return {
-          content: [{ type: 'text', text: `Error: workflow "${args.id}" not found` }],
+          content: [{ type: 'text', text: `Error: workflow "${resolved.id}" not found` }],
           isError: true
         }
       }
@@ -349,7 +376,7 @@ export function registerWorkflowTools(server: McpServer): void {
       if (args.enabled !== undefined) updates.enabled = args.enabled
       if (args.stagger_delay_ms !== undefined) updates.staggerDelayMs = args.stagger_delay_ms
 
-      dbUpdateWorkflow(args.id, updates)
+      dbUpdateWorkflow(resolved.id, updates)
       dbSignalChange()
 
       return {
@@ -361,18 +388,25 @@ export function registerWorkflowTools(server: McpServer): void {
   server.tool(
     'delete_workflow',
     'Delete a workflow',
-    { id: V.id.describe('Workflow ID') },
+    {
+      workflow_id: V.id.optional().describe('Workflow ID (from list_workflows)'),
+      id: V.id.optional().describe('Deprecated alias for workflow_id')
+    },
     async (args) => {
+      const resolved = resolveWorkflowId(args)
+      if ('error' in resolved) {
+        return { content: [{ type: 'text', text: `Error: ${resolved.error}` }], isError: true }
+      }
       const workflows = dbListWorkflows()
-      const workflow = workflows.find((w) => w.id === args.id)
+      const workflow = workflows.find((w) => w.id === resolved.id)
       if (!workflow) {
         return {
-          content: [{ type: 'text', text: `Error: workflow "${args.id}" not found` }],
+          content: [{ type: 'text', text: `Error: workflow "${resolved.id}" not found` }],
           isError: true
         }
       }
 
-      dbDeleteWorkflow(args.id)
+      dbDeleteWorkflow(resolved.id)
       dbSignalChange()
 
       return { content: [{ type: 'text', text: `Deleted workflow: ${workflow.name}` }] }

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -7,7 +7,8 @@ import type {
   WorkflowNode,
   WorkflowEdge,
   TriggerConfig,
-  LaunchAgentConfig
+  LaunchAgentConfig,
+  WorkflowInputDef
 } from '@vornrun/shared/types'
 import type { ScheduleLogEntry } from '@vornrun/shared/types'
 import {
@@ -52,10 +53,31 @@ const launchAgentConfigSchema = z
     path: ['outputSchema']
   })
 
+// Parameters the run dialog prompts for, declared on the manual trigger so they
+// travel with the definition. Without this here, a workflow authored over MCP
+// could never declare the `{{inputs.*}}` it reads.
+const workflowInputDefSchema = z.object({
+  key: z
+    .string()
+    .regex(
+      /^[A-Za-z_][A-Za-z0-9_]*$/,
+      'key must be a valid identifier — it becomes {{inputs.<key>}}'
+    )
+    .max(100),
+  label: V.shortText,
+  type: z.enum(['text', 'textarea', 'number', 'select', 'boolean', 'project', 'branch']),
+  required: z.boolean().optional(),
+  defaultValue: V.shortText.optional(),
+  options: z.array(z.object({ value: V.shortText, label: V.shortText })).optional(),
+  placeholder: V.shortText.optional(),
+  description: V.shortText.optional()
+})
+
 const triggerConfigSchema = z.union([
   z.object({
     triggerType: z.literal('manual'),
-    contextual: z.boolean().optional()
+    contextual: z.boolean().optional(),
+    inputs: z.array(workflowInputDefSchema).optional()
   }),
   z.object({ triggerType: z.literal('once'), runAt: V.shortText }),
   z.object({
@@ -154,6 +176,72 @@ function buildGraphFromFlat(
   }
 
   return { nodes, edges }
+}
+
+/**
+ * Match supplied values against the parameters a workflow declares.
+ *
+ * The run dialog does this for a human — applies defaults, enforces required,
+ * limits a select to its options. An agent calling the tool gets no dialog, so
+ * without this a typo'd key would sail through and surface as an empty
+ * `{{inputs.*}}` somewhere deep in the run, which is a miserable thing to debug.
+ */
+export function resolveWorkflowInputs(
+  defs: WorkflowInputDef[],
+  supplied: Record<string, string | number | boolean>
+): { values: Record<string, unknown>; errors: string[] } {
+  const errors: string[] = []
+  const known = new Set(defs.map((d) => d.key))
+
+  for (const key of Object.keys(supplied)) {
+    if (!known.has(key)) {
+      errors.push(
+        `unknown input "${key}" — this workflow declares: ${Array.from(known).join(', ') || '(none)'}`
+      )
+    }
+  }
+
+  const values: Record<string, unknown> = {}
+  for (const def of defs) {
+    const provided = Object.prototype.hasOwnProperty.call(supplied, def.key)
+    const raw = provided ? supplied[def.key] : def.defaultValue
+
+    if (raw === undefined || raw === '') {
+      if (def.required) errors.push(`missing required input "${def.key}" (${def.label})`)
+      continue
+    }
+
+    switch (def.type) {
+      case 'number': {
+        const n = typeof raw === 'number' ? raw : Number(raw)
+        if (Number.isNaN(n)) {
+          errors.push(`input "${def.key}" must be a number, got ${JSON.stringify(raw)}`)
+        } else {
+          values[def.key] = n
+        }
+        break
+      }
+      case 'boolean': {
+        if (typeof raw === 'boolean') values[def.key] = raw
+        else if (raw === 'true' || raw === 'false') values[def.key] = raw === 'true'
+        else errors.push(`input "${def.key}" must be a boolean, got ${JSON.stringify(raw)}`)
+        break
+      }
+      case 'select': {
+        const allowed = (def.options ?? []).map((o) => o.value)
+        if (allowed.length > 0 && !allowed.includes(String(raw))) {
+          errors.push(`input "${def.key}" must be one of: ${allowed.join(', ')}`)
+        } else {
+          values[def.key] = String(raw)
+        }
+        break
+      }
+      default:
+        values[def.key] = String(raw)
+    }
+  }
+
+  return { values, errors }
 }
 
 export function registerWorkflowTools(server: McpServer): void {
@@ -360,6 +448,75 @@ export function registerWorkflowTools(server: McpServer): void {
           content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : err}` }],
           isError: true
         }
+      }
+    }
+  )
+
+  server.tool(
+    'execute_workflow',
+    "Run a workflow now, as if triggered manually. Supply values for any parameters the workflow declares (see the trigger node's inputs); declared defaults fill in anything omitted. Requires the Vorn app to be running. Returns as soon as the run is queued — poll list_workflow_runs for the outcome.",
+    {
+      workflow_id: V.id.describe('Workflow ID (from list_workflows)'),
+      inputs: z
+        .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+        .optional()
+        .describe('Values for the declared parameters, keyed by input key ({{inputs.<key>}})')
+    },
+    async (args) => {
+      const workflow = dbListWorkflows().find((w) => w.id === args.workflow_id)
+      if (!workflow) {
+        return {
+          content: [{ type: 'text', text: `Error: no workflow with id ${args.workflow_id}` }],
+          isError: true
+        }
+      }
+
+      const trigger = workflow.nodes.find((n) => n.type === 'trigger')?.config as
+        | TriggerConfig
+        | undefined
+      const defs = trigger?.triggerType === 'manual' ? (trigger.inputs ?? []) : []
+      const supplied = args.inputs ?? {}
+
+      let inputs: Record<string, unknown> | undefined
+      if (defs.length > 0) {
+        const { values, errors } = resolveWorkflowInputs(defs, supplied)
+        if (errors.length > 0) {
+          return {
+            content: [
+              { type: 'text', text: `Error: invalid inputs\n  - ${errors.join('\n  - ')}` }
+            ],
+            isError: true
+          }
+        }
+        inputs = Object.keys(values).length > 0 ? values : undefined
+      } else if (Object.keys(supplied).length > 0) {
+        // Nothing declared to validate against. Pass the values through rather
+        // than rejecting them: a non-manual trigger cannot declare inputs, but
+        // its nodes may still read `{{inputs.*}}`.
+        inputs = supplied
+      }
+
+      try {
+        await rpcCall('workflow:runManual', { workflowId: args.workflow_id, inputs })
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : err}` }],
+          isError: true
+        }
+      }
+
+      // A disabled workflow still runs when triggered by hand — the flag only
+      // stops the scheduler. Say so, so the result is not a surprise.
+      const disabled =
+        workflow.enabled === false ? ' (workflow is disabled; manual runs still execute)' : ''
+      const shown = inputs ? `\ninputs: ${JSON.stringify(inputs, null, 2)}` : '\nno inputs'
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Queued "${workflow.name}"${disabled}${shown}\n\nRun history: list_workflow_runs with workflow_id ${args.workflow_id}`
+          }
+        ]
       }
     }
   )

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -229,7 +229,13 @@ export function resolveWorkflowInputs(
       }
       case 'select': {
         const allowed = (def.options ?? []).map((o) => o.value)
-        if (allowed.length > 0 && !allowed.includes(String(raw))) {
+        if (allowed.length === 0) {
+          // The run dialog can only offer what the select declares, so a select
+          // with no options can produce no value at all. Accepting an arbitrary
+          // string here would let a tool caller past a constraint the UI
+          // enforces absolutely.
+          errors.push(`input "${def.key}" is a select but declares no options`)
+        } else if (!allowed.includes(String(raw))) {
           errors.push(`input "${def.key}" must be one of: ${allowed.join(', ')}`)
         } else {
           values[def.key] = String(raw)
@@ -522,7 +528,12 @@ export function registerWorkflowTools(server: McpServer): void {
             isError: true
           }
         }
-        inputs = Object.keys(values).length > 0 ? values : undefined
+        // Always an object once the workflow declares inputs, even when every
+        // value resolved empty. resolveTemplate skips the whole `inputs`
+        // namespace when context.inputs is absent, which leaves a literal
+        // `{{inputs.topic}}` in the agent's prompt; an empty object resolves it
+        // to an empty string instead. Wrong-but-blank beats raw template text.
+        inputs = values
       } else if (Object.keys(supplied).length > 0) {
         // Nothing declared to validate against. Pass the values through rather
         // than rejecting them: a non-manual trigger cannot declare inputs, but

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -89,11 +89,14 @@ export const workflowInputDefSchema = z
 
     if (def.defaultValue === undefined) return
 
-    if (def.type === 'number' && Number.isNaN(Number(def.defaultValue))) {
+    // Finite, not merely numeric: "Infinity" and "1e999" parse but do not
+    // survive JSON, and resolveWorkflowInputs rejects them at run time. Letting
+    // one be authored would only defer the same failure to a worse moment.
+    if (def.type === 'number' && !Number.isFinite(Number(def.defaultValue))) {
       ctx.addIssue({
         code: 'custom',
         path: ['defaultValue'],
-        message: `default "${def.defaultValue}" for number input "${def.key}" is not a number`
+        message: `default "${def.defaultValue}" for number input "${def.key}" is not a finite number`
       })
     }
 
@@ -588,7 +591,7 @@ export function registerWorkflowTools(server: McpServer): void {
       const workflow = dbListWorkflows().find((w) => w.id === args.workflow_id)
       if (!workflow) {
         return {
-          content: [{ type: 'text', text: `Error: no workflow with id ${args.workflow_id}` }],
+          content: [{ type: 'text', text: `Error: workflow "${args.workflow_id}" not found` }],
           isError: true
         }
       }
@@ -611,7 +614,8 @@ export function registerWorkflowTools(server: McpServer): void {
           }
         }
         // Always an object once the workflow declares inputs, even when every
-        // value resolved empty. resolveTemplate skips the whole `inputs`
+        // value resolved empty. resolveTemplateVars
+        // (src/renderer/lib/template-vars.ts) skips the whole `inputs`
         // namespace when context.inputs is absent, which leaves a literal
         // `{{inputs.topic}}` in the agent's prompt; an empty object resolves it
         // to an empty string instead. Wrong-but-blank beats raw template text.

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -56,22 +56,67 @@ const launchAgentConfigSchema = z
 // Parameters the run dialog prompts for, declared on the manual trigger so they
 // travel with the definition. Without this here, a workflow authored over MCP
 // could never declare the `{{inputs.*}}` it reads.
-const workflowInputDefSchema = z.object({
-  key: z
-    .string()
-    .regex(
-      /^[A-Za-z_][A-Za-z0-9_]*$/,
-      'key must be a valid identifier — it becomes {{inputs.<key>}}'
-    )
-    .max(100),
-  label: V.shortText,
-  type: z.enum(['text', 'textarea', 'number', 'select', 'boolean', 'project', 'branch']),
-  required: z.boolean().optional(),
-  defaultValue: V.shortText.optional(),
-  options: z.array(z.object({ value: V.shortText, label: V.shortText })).optional(),
-  placeholder: V.shortText.optional(),
-  description: V.shortText.optional()
-})
+export const workflowInputDefSchema = z
+  .object({
+    key: z
+      .string()
+      .regex(
+        /^[A-Za-z_][A-Za-z0-9_]*$/,
+        'key must be a valid identifier — it becomes {{inputs.<key>}}'
+      )
+      .max(100),
+    label: V.shortText,
+    type: z.enum(['text', 'textarea', 'number', 'select', 'boolean', 'project', 'branch']),
+    required: z.boolean().optional(),
+    defaultValue: V.shortText.optional(),
+    options: z.array(z.object({ value: V.shortText, label: V.shortText })).optional(),
+    placeholder: V.shortText.optional(),
+    description: V.shortText.optional()
+  })
+  // Reject a declaration that can never be satisfied at the moment it is
+  // authored, rather than letting it become a run-time error later. A workflow
+  // that cannot be run correctly should not be storable.
+  .superRefine((def, ctx) => {
+    const options = def.options ?? []
+
+    if (def.type === 'select' && options.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['options'],
+        message: `select input "${def.key}" declares no options, so the run dialog could offer nothing`
+      })
+    }
+
+    if (def.defaultValue === undefined) return
+
+    if (def.type === 'number' && Number.isNaN(Number(def.defaultValue))) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['defaultValue'],
+        message: `default "${def.defaultValue}" for number input "${def.key}" is not a number`
+      })
+    }
+
+    if (def.type === 'boolean' && !['true', 'false'].includes(def.defaultValue)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['defaultValue'],
+        message: `default "${def.defaultValue}" for boolean input "${def.key}" must be "true" or "false"`
+      })
+    }
+
+    if (
+      def.type === 'select' &&
+      options.length > 0 &&
+      !options.some((o) => o.value === def.defaultValue)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['defaultValue'],
+        message: `default "${def.defaultValue}" for select input "${def.key}" is not one of its options`
+      })
+    }
+  })
 
 const triggerConfigSchema = z.union([
   z.object({

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   resolveWorkflowInputs,
   resolveWorkflowId,
-  workflowInputDefSchema
+  workflowInputDefSchema,
+  workflowInputsSchema
 } from '../packages/mcp/src/tools/workflows'
 import type { WorkflowInputDef } from '../packages/shared/src/types'
 
@@ -53,7 +54,7 @@ describe('resolveWorkflowInputs', () => {
 
   it('rejects a non-numeric value for a number input', () => {
     const { errors } = resolveWorkflowInputs(defs, { topic: 'a', hours: 'soon' })
-    expect(errors).toEqual(['input "hours" must be a number, got "soon"'])
+    expect(errors).toEqual(['input "hours" must be a finite number, got "soon"'])
   })
 
   it('limits a select to its declared options', () => {
@@ -71,6 +72,27 @@ describe('resolveWorkflowInputs', () => {
     const { values, errors } = resolveWorkflowInputs(defs, { topic: 'a', tier: 'primary' })
     expect(errors).toEqual([])
     expect(values.tier).toBe('primary')
+  })
+
+  it('treats a whitespace-only string as no value, like areInputsValid', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: '   ' })
+    expect(errors).toEqual(['missing required input "topic" (Topic)'])
+  })
+
+  it('always supplies a declared boolean, matching the dialog seeding false', () => {
+    const toggle: WorkflowInputDef[] = [{ key: 'publish', label: 'Publish', type: 'boolean' }]
+    const { values } = resolveWorkflowInputs(toggle, {})
+    expect(values).toEqual({ publish: false })
+  })
+
+  it('rejects a non-finite number, which would not survive JSON', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: 'a', hours: 'Infinity' })
+    expect(errors).toEqual(['input "hours" must be a finite number, got "Infinity"'])
+  })
+
+  it('does not let a boolean coerce into a number input', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: 'a', hours: true })
+    expect(errors).toEqual(['input "hours" must be a number, got true'])
   })
 
   it('omits an optional input with no value and no default', () => {
@@ -142,6 +164,25 @@ describe('workflowInputDefSchema', () => {
     expect(
       workflowInputDefSchema.safeParse({ key: '2fast', label: 'x', type: 'text' }).success
     ).toBe(false)
+  })
+})
+
+describe('workflowInputsSchema', () => {
+  it('accepts distinct keys', () => {
+    const result = workflowInputsSchema.safeParse([
+      { key: 'a', label: 'A', type: 'text' },
+      { key: 'b', label: 'B', type: 'text' }
+    ])
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects duplicate keys, which the editor already flags as an error', () => {
+    const result = workflowInputsSchema.safeParse([
+      { key: 'topic', label: 'One', type: 'text' },
+      { key: 'topic', label: 'Two', type: 'text' }
+    ])
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('duplicate input key')
   })
 })
 

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { resolveWorkflowInputs, resolveWorkflowId } from '../packages/mcp/src/tools/workflows'
+import {
+  resolveWorkflowInputs,
+  resolveWorkflowId,
+  workflowInputDefSchema
+} from '../packages/mcp/src/tools/workflows'
 import type { WorkflowInputDef } from '../packages/shared/src/types'
 
 const defs: WorkflowInputDef[] = [
@@ -78,6 +82,66 @@ describe('resolveWorkflowInputs', () => {
     const { values, errors } = resolveWorkflowInputs([], {})
     expect(values).toEqual({})
     expect(errors).toEqual([])
+  })
+})
+
+describe('workflowInputDefSchema', () => {
+  const base = { key: 'topic', label: 'Topic' }
+
+  it('accepts a well-formed declaration', () => {
+    expect(workflowInputDefSchema.safeParse({ ...base, type: 'text' }).success).toBe(true)
+  })
+
+  it('rejects a select with no options at authoring time, not at run time', () => {
+    const result = workflowInputDefSchema.safeParse({ ...base, type: 'select' })
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('declares no options')
+  })
+
+  it('rejects a non-numeric default on a number input', () => {
+    const result = workflowInputDefSchema.safeParse({
+      ...base,
+      type: 'number',
+      defaultValue: 'soon'
+    })
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('is not a number')
+  })
+
+  it('rejects a non-boolean default on a boolean input', () => {
+    const result = workflowInputDefSchema.safeParse({
+      ...base,
+      type: 'boolean',
+      defaultValue: 'yes'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a select default that is not one of its options', () => {
+    const result = workflowInputDefSchema.safeParse({
+      ...base,
+      type: 'select',
+      defaultValue: 'tertiary',
+      options: [{ value: 'primary', label: 'Primary' }]
+    })
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error?.issues)).toContain('not one of its options')
+  })
+
+  it('accepts a select default that is one of its options', () => {
+    const result = workflowInputDefSchema.safeParse({
+      ...base,
+      type: 'select',
+      defaultValue: 'primary',
+      options: [{ value: 'primary', label: 'Primary' }]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a key that could not be referenced as a template', () => {
+    expect(
+      workflowInputDefSchema.safeParse({ key: '2fast', label: 'x', type: 'text' }).success
+    ).toBe(false)
   })
 })
 

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -57,6 +57,12 @@ describe('resolveWorkflowInputs', () => {
     expect(errors).toEqual(['input "tier" must be one of: primary, secondary'])
   })
 
+  it('rejects a select that declares no options, which the dialog could never satisfy', () => {
+    const noOptions: WorkflowInputDef[] = [{ key: 'tier', label: 'Tier', type: 'select' }]
+    const { errors } = resolveWorkflowInputs(noOptions, { tier: 'anything' })
+    expect(errors).toEqual(['input "tier" is a select but declares no options'])
+  })
+
   it('accepts a valid select value', () => {
     const { values, errors } = resolveWorkflowInputs(defs, { topic: 'a', tier: 'primary' })
     expect(errors).toEqual([])

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -127,7 +127,14 @@ describe('workflowInputDefSchema', () => {
       defaultValue: 'soon'
     })
     expect(result.success).toBe(false)
-    expect(JSON.stringify(result.error?.issues)).toContain('is not a number')
+    expect(JSON.stringify(result.error?.issues)).toContain('is not a finite number')
+  })
+
+  it('rejects a non-finite number default, matching the run-time check', () => {
+    for (const defaultValue of ['Infinity', '1e999']) {
+      const result = workflowInputDefSchema.safeParse({ ...base, type: 'number', defaultValue })
+      expect(result.success).toBe(false)
+    }
   })
 
   it('rejects a non-boolean default on a boolean input', () => {

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveWorkflowInputs } from '../packages/mcp/src/tools/workflows'
+import { resolveWorkflowInputs, resolveWorkflowId } from '../packages/mcp/src/tools/workflows'
 import type { WorkflowInputDef } from '../packages/shared/src/types'
 
 const defs: WorkflowInputDef[] = [
@@ -72,5 +72,28 @@ describe('resolveWorkflowInputs', () => {
     const { values, errors } = resolveWorkflowInputs([], {})
     expect(values).toEqual({})
     expect(errors).toEqual([])
+  })
+})
+
+describe('resolveWorkflowId', () => {
+  it('accepts the canonical workflow_id', () => {
+    expect(resolveWorkflowId({ workflow_id: 'abc' })).toEqual({ id: 'abc' })
+  })
+
+  it('still accepts the deprecated id, so existing callers keep working', () => {
+    expect(resolveWorkflowId({ id: 'abc' })).toEqual({ id: 'abc' })
+  })
+
+  it('accepts both when they agree', () => {
+    expect(resolveWorkflowId({ workflow_id: 'abc', id: 'abc' })).toEqual({ id: 'abc' })
+  })
+
+  it('refuses two different ids rather than guessing which was meant', () => {
+    const result = resolveWorkflowId({ workflow_id: 'abc', id: 'xyz' })
+    expect(result).toEqual({ error: 'workflow_id and id disagree — pass only workflow_id' })
+  })
+
+  it('reports a missing id', () => {
+    expect(resolveWorkflowId({})).toEqual({ error: 'provide workflow_id' })
   })
 })

--- a/tests/mcp-execute-workflow.test.ts
+++ b/tests/mcp-execute-workflow.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWorkflowInputs } from '../packages/mcp/src/tools/workflows'
+import type { WorkflowInputDef } from '../packages/shared/src/types'
+
+const defs: WorkflowInputDef[] = [
+  { key: 'topic', label: 'Topic', type: 'text', required: true },
+  { key: 'hours', label: 'Window (hours)', type: 'number', defaultValue: '24' },
+  { key: 'publish', label: 'Publish', type: 'boolean', defaultValue: 'false' },
+  {
+    key: 'tier',
+    label: 'Tier',
+    type: 'select',
+    options: [
+      { value: 'primary', label: 'Primary' },
+      { value: 'secondary', label: 'Secondary' }
+    ]
+  }
+]
+
+describe('resolveWorkflowInputs', () => {
+  it('applies declared defaults for values that were not supplied', () => {
+    const { values, errors } = resolveWorkflowInputs(defs, { topic: 'agents' })
+    expect(errors).toEqual([])
+    expect(values).toEqual({ topic: 'agents', hours: 24, publish: false })
+  })
+
+  it('reports a missing required input', () => {
+    const { errors } = resolveWorkflowInputs(defs, {})
+    expect(errors).toEqual(['missing required input "topic" (Topic)'])
+  })
+
+  it('rejects an unknown key rather than silently dropping it', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: 'a', topci: 'typo' })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('unknown input "topci"')
+    expect(errors[0]).toContain('topic')
+  })
+
+  it('coerces numeric and boolean strings, since MCP args arrive as JSON scalars', () => {
+    const { values, errors } = resolveWorkflowInputs(defs, {
+      topic: 'a',
+      hours: '48',
+      publish: 'true'
+    })
+    expect(errors).toEqual([])
+    expect(values.hours).toBe(48)
+    expect(values.publish).toBe(true)
+  })
+
+  it('rejects a non-numeric value for a number input', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: 'a', hours: 'soon' })
+    expect(errors).toEqual(['input "hours" must be a number, got "soon"'])
+  })
+
+  it('limits a select to its declared options', () => {
+    const { errors } = resolveWorkflowInputs(defs, { topic: 'a', tier: 'tertiary' })
+    expect(errors).toEqual(['input "tier" must be one of: primary, secondary'])
+  })
+
+  it('accepts a valid select value', () => {
+    const { values, errors } = resolveWorkflowInputs(defs, { topic: 'a', tier: 'primary' })
+    expect(errors).toEqual([])
+    expect(values.tier).toBe('primary')
+  })
+
+  it('omits an optional input with no value and no default', () => {
+    const { values } = resolveWorkflowInputs(defs, { topic: 'a' })
+    expect(values).not.toHaveProperty('tier')
+  })
+
+  it('returns no values when nothing is declared', () => {
+    const { values, errors } = resolveWorkflowInputs([], {})
+    expect(values).toEqual({})
+    expect(errors).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Adds an `execute_workflow` tool to the Vorn MCP server, lets a manual trigger declare its parameters over MCP, and settles the `id` / `workflow_id` split across the workflow tools.

An agent could already create, update, delete and inspect workflows through MCP — but never run one. The gap was only in the tool surface: `scheduler.triggerWorkflow(workflowId, inputs)` and the `workflow:runManual` RPC already exist for the run dialog. This exposes what the UI has had all along.

## Why the parameter handling

A manual trigger can declare `WorkflowInputDef` entries that expand as `{{inputs.<key>}}`. The **run dialog** is what applies their defaults, enforces `required`, and holds a `select` to its options. A tool call gets no dialog, so `resolveWorkflowInputs` does the same work:

- declared defaults fill in anything omitted
- unknown keys are **rejected**, not silently dropped — a typo would otherwise surface as an empty template expansion deep inside a run
- numeric/boolean strings coerce, because MCP arguments arrive as JSON scalars
- a `select` is limited to its declared options

Declaring inputs over MCP was impossible too: the manual trigger schema only accepted `contextual`, so a workflow authored this way could never describe the parameters its own nodes read. The schema now carries them.

Workflows with **no** declared inputs pass supplied values through untouched — a cron or connector trigger cannot declare parameters, but its nodes may still read `{{inputs.*}}`, and rejecting those would break a legitimate shape.

## The id / workflow_id split

The workflow tools grew two names for one argument:

| Tool | Argument |
|---|---|
| `list_workflow_runs`, `get_workflow_schedule` | `workflow_id` |
| `update_workflow`, `delete_workflow` | `id` |

Nothing signals which a given tool wants, so reaching for the wrong one costs a failed call and a re-read of the schema — it cost exactly that while wiring a real workflow through this API.

`workflow_id` is canonical now, since it is what most of the surface already used and `execute_workflow` would otherwise have had to pick a side and widen the split. **`id` keeps working** — breaking every existing caller to win a rename would be a poor trade. Passing both is fine when they agree and an error when they disagree, rather than silently acting on an id the caller did not mean.

## Notes

- The run is fire-and-forget, matching `workflow:runManual`. The tool says so and points at `list_workflow_runs`.
- A disabled workflow still executes on a manual trigger (the flag only stops the scheduler). The response calls that out rather than letting it surprise someone.

## Testing

- `tests/mcp-execute-workflow.test.ts` — 14 cases covering defaults, required, unknown keys, coercion, select options, and both id spellings including the disagreement case. All pass.
- `yarn typecheck` clean, `eslint --max-warnings 0` clean via lint-staged.
- Exercised against a running Vorn v0.5.3: created a 4-node workflow (script → headless agent → script) through MCP, then updated it through the normalized argument.