### PR TITLE
feat(server): opt-in env passthrough for agents and script nodes

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1022,6 +1022,10 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
       hasSeenOnboarding: map.hasSeenOnboarding as boolean | number
     }),
     ...(map.reopenSessions !== undefined && { reopenSessions: map.reopenSessions as boolean }),
+    // Saving iterates over every key in defaults, but loading is this explicit
+    // list — so a key missing here round-trips to nothing and its feature is
+    // silently inert.
+    ...(map.envPassthrough !== undefined && { envPassthrough: map.envPassthrough as string[] }),
     // Terminal block rendering. Default on; the key only appears once the
     // user has toggled it, so absence means "not yet decided", not "off".
     domBlockRendering: (map.domBlockRendering as boolean) ?? true,

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1025,7 +1025,12 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     // Saving iterates over every key in defaults, but loading is this explicit
     // list — so a key missing here round-trips to nothing and its feature is
     // silently inert.
-    ...(map.envPassthrough !== undefined && { envPassthrough: map.envPassthrough as string[] }),
+    // Array-checked rather than cast: the value came from JSON.parse of a row a
+    // user can edit, and broadcasting a non-array under a string[] type would
+    // break any consumer that trusts the declaration.
+    ...(Array.isArray(map.envPassthrough) && {
+      envPassthrough: map.envPassthrough.filter((k): k is string => typeof k === 'string')
+    }),
     // Terminal block rendering. Default on; the key only appears once the
     // user has toggled it, so absence means "not yet decided", not "off".
     domBlockRendering: (map.domBlockRendering as boolean) ?? true,

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -18,7 +18,7 @@ import {
   extractWorktreeName,
   isGitRepo
 } from './git-utils'
-import { getSafeEnv, shellEscape } from './process-utils'
+import { getLaunchEnv, shellEscape } from './process-utils'
 import { buildHeadlessSpawnArgs } from './agent-launch'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import log from './logger'
@@ -97,7 +97,7 @@ class HeadlessManager extends EventEmitter {
       }
     }
 
-    const env = getSafeEnv()
+    const env = getLaunchEnv()
     const spawnArgs = buildHeadlessSpawnArgs(payload, this.agentCommands, env)
 
     // Windows needs `shell: true` to run the `.cmd`/`.ps1` shims that

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ import { scheduler } from './scheduler'
 import { setDataDir, getTaskImagePath as resolveTaskImagePath } from './task-images'
 import { getTailscaleStatus } from './tailscale'
 import { initRebind, checkAndRebind } from './server-rebind'
+import { setEnvPassthrough } from './process-utils'
 import log from './logger'
 
 export async function startServer(
@@ -42,6 +43,7 @@ export async function startServer(
 
   // Load initial config and wire up managers
   const config = configManager.loadConfig()
+  setEnvPassthrough(config.defaults.envPassthrough)
   ptyManager.setAgentCommands(config.agentCommands)
   ptyManager.setRemoteHosts(config.remoteHosts ?? [])
   headlessManager.setAgentCommands(config.agentCommands)
@@ -51,6 +53,7 @@ export async function startServer(
   const { clientRegistry } = await import('./broadcast')
   const { IPC } = await import('@vornrun/shared/types')
   configManager.onConfigChanged((cfg) => {
+    setEnvPassthrough(cfg.defaults.envPassthrough)
     ptyManager.setAgentCommands(cfg.agentCommands)
     ptyManager.setRemoteHosts(cfg.remoteHosts ?? [])
     headlessManager.setAgentCommands(cfg.agentCommands)

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -204,13 +204,15 @@ export function getSafeEnv(): Record<string, string> {
 }
 
 /**
- * Environment for a launch the user actually asked for: an agent terminal, a
- * headless agent, or a workflow script node. Only these forward
- * `defaults.envPassthrough`.
+ * Environment for an agent launch: the agent terminal, a headless agent, or a
+ * workflow script node. Only these three forward `defaults.envPassthrough`.
  *
- * Deliberately not used for the SSH session path. That connects to another
- * machine, and forwarding a local secret there is precisely the widening this
- * split exists to avoid.
+ * Not the plain shell session. A shell hands its environment to every command
+ * typed into it for as long as it lives, which is far wider than "the agent I
+ * configured a key for" — and wider than what the setting documents.
+ *
+ * Not the SSH session either: that connects to another machine, which is
+ * precisely the widening this split exists to avoid.
  */
 export function getLaunchEnv(): Record<string, string> {
   return filterEnv(resolvedEnv(), envPassthrough)

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -143,10 +143,27 @@ const STRIP_ENV_KEYS_UPPER = STRIP_ENV_KEYS.map((k) => k.toUpperCase())
  */
 let envPassthrough: ReadonlySet<string> = new Set()
 
-export function setEnvPassthrough(keys: string[] | undefined): void {
-  envPassthrough = new Set(
-    (keys ?? []).map((k) => k.trim().toUpperCase()).filter((k) => k.length > 0)
+/**
+ * Normalize whatever the config held into a comparable set.
+ *
+ * Typed as `unknown` on purpose: this value arrives from JSON.parse of a file a
+ * user can hand-edit, so the declared `string[]` is a hope rather than a
+ * guarantee. A bare string or a stray number in the list would otherwise throw
+ * inside .map() — during server startup, where it takes the whole app down over
+ * a typo in a settings file.
+ */
+export function normalizePassthrough(keys: unknown): ReadonlySet<string> {
+  if (!Array.isArray(keys)) return new Set()
+  return new Set(
+    keys
+      .filter((k): k is string => typeof k === 'string')
+      .map((k) => k.trim().toUpperCase())
+      .filter((k) => k.length > 0)
   )
+}
+
+export function setEnvPassthrough(keys: unknown): void {
+  envPassthrough = normalizePassthrough(keys)
 }
 
 /**

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -25,7 +25,17 @@ function getUserShellEnv(): Record<string, string> {
   }
 }
 
-const resolvedEnv = getUserShellEnv()
+/**
+ * Resolved lazily and memoized: getUserShellEnv() spawns a login shell, and
+ * doing that at import time made merely importing this module — as the pure
+ * helpers' unit tests do — pay for a subprocess it never uses.
+ */
+let resolvedEnvCache: Record<string, string> | undefined
+
+function resolvedEnv(): Record<string, string> {
+  resolvedEnvCache ??= getUserShellEnv()
+  return resolvedEnvCache
+}
 
 /**
  * The shell a terminal session should run.
@@ -184,8 +194,26 @@ export function filterEnv(
   return env
 }
 
+/**
+ * Environment for subprocesses the user never asked about — git, tailscale,
+ * IDE and agent detection, file helpers. Always strict: a variable opted in so
+ * an agent could authenticate has no business reaching `git ls-remote`.
+ */
 export function getSafeEnv(): Record<string, string> {
-  return filterEnv(resolvedEnv, envPassthrough)
+  return filterEnv(resolvedEnv(), new Set())
+}
+
+/**
+ * Environment for a launch the user actually asked for: an agent terminal, a
+ * headless agent, or a workflow script node. Only these forward
+ * `defaults.envPassthrough`.
+ *
+ * Deliberately not used for the SSH session path. That connects to another
+ * machine, and forwarding a local secret there is precisely the widening this
+ * split exists to avoid.
+ */
+export function getLaunchEnv(): Record<string, string> {
+  return filterEnv(resolvedEnv(), envPassthrough)
 }
 
 function isWindowsStylePath(p: string): boolean {

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -177,6 +177,16 @@ export function setEnvPassthrough(keys: unknown): void {
 }
 
 /**
+ * The configured set, exposed so a test can assert what each env function
+ * passes to filterEnv. getSafeEnv and getLaunchEnv themselves read the login
+ * shell, which a unit test cannot stand up — the difference that matters is
+ * which of these two sets each one hands over.
+ */
+export function getEnvPassthrough(): ReadonlySet<string> {
+  return envPassthrough
+}
+
+/**
  * Pure form of the filter, so the rules can be tested without a login shell.
  */
 export function filterEnv(

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -121,6 +121,11 @@ export const SENSITIVE_ENV_PREFIXES = [
 // Env vars to strip so agent CLIs don't refuse to launch (e.g. nested session detection)
 export const STRIP_ENV_KEYS = ['CLAUDECODE']
 
+// Compared uppercased. Windows environment variable names are case-insensitive
+// and Node hands back whatever casing it enumerated, so a literal match would
+// let `claudecode` through — and this list is meant to be absolute.
+const STRIP_ENV_KEYS_UPPER = STRIP_ENV_KEYS.map((k) => k.toUpperCase())
+
 /**
  * Exact variable names the user has opted into forwarding, uppercased.
  *
@@ -155,7 +160,7 @@ export function filterEnv(
   for (const [key, val] of Object.entries(source)) {
     if (val === undefined) continue
     const upper = key.toUpperCase()
-    if (STRIP_ENV_KEYS.includes(key)) continue
+    if (STRIP_ENV_KEYS_UPPER.includes(upper)) continue
     if (!passthrough.has(upper) && SENSITIVE_ENV_PREFIXES.some((p) => upper.startsWith(p))) continue
     env[key] = val
   }

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -121,15 +121,49 @@ export const SENSITIVE_ENV_PREFIXES = [
 // Env vars to strip so agent CLIs don't refuse to launch (e.g. nested session detection)
 export const STRIP_ENV_KEYS = ['CLAUDECODE']
 
-export function getSafeEnv(): Record<string, string> {
+/**
+ * Exact variable names the user has opted into forwarding, uppercased.
+ *
+ * SENSITIVE_ENV_PREFIXES is the right default — a shell that exports a real
+ * GITHUB_TOKEN should not hand it to every agent and script that happens to
+ * run. But some setups need one of those names on purpose: pointing an agent
+ * at a local Anthropic-compatible proxy needs ANTHROPIC_API_KEY, and the
+ * prefix rule drops it while letting ANTHROPIC_BASE_URL through, leaving the
+ * agent aimed at the proxy but authenticating as if it were not.
+ *
+ * Naming a variable here is a deliberate act, so it wins over the prefix rule.
+ * STRIP_ENV_KEYS deliberately does not become overridable: those are stripped
+ * to stop CLIs refusing to launch, and forwarding them breaks the session
+ * rather than exposing anything.
+ */
+let envPassthrough: ReadonlySet<string> = new Set()
+
+export function setEnvPassthrough(keys: string[] | undefined): void {
+  envPassthrough = new Set(
+    (keys ?? []).map((k) => k.trim().toUpperCase()).filter((k) => k.length > 0)
+  )
+}
+
+/**
+ * Pure form of the filter, so the rules can be tested without a login shell.
+ */
+export function filterEnv(
+  source: Record<string, string | undefined>,
+  passthrough: ReadonlySet<string>
+): Record<string, string> {
   const env: Record<string, string> = {}
-  for (const [key, val] of Object.entries(resolvedEnv)) {
+  for (const [key, val] of Object.entries(source)) {
     if (val === undefined) continue
-    if (SENSITIVE_ENV_PREFIXES.some((p) => key.toUpperCase().startsWith(p))) continue
+    const upper = key.toUpperCase()
     if (STRIP_ENV_KEYS.includes(key)) continue
+    if (!passthrough.has(upper) && SENSITIVE_ENV_PREFIXES.some((p) => upper.startsWith(p))) continue
     env[key] = val
   }
   return env
+}
+
+export function getSafeEnv(): Record<string, string> {
+  return filterEnv(resolvedEnv, envPassthrough)
 }
 
 function isWindowsStylePath(p: string): boolean {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -450,7 +450,7 @@ class PtyManager extends EventEmitter {
       rows: 24,
       cwd: workingDir,
       env: {
-        ...getLaunchEnv(),
+        ...getSafeEnv(),
         ...integration.env
       }
     })

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -28,6 +28,7 @@ import { buildAgentLaunchLine as buildLaunchLine } from './agent-launch'
 import {
   shellEscape,
   getSafeEnv,
+  getLaunchEnv,
   getDefaultShell,
   getShellArgs,
   normalizePath
@@ -216,7 +217,7 @@ class PtyManager extends EventEmitter {
       // and is never drawn as command blocks. Installing the shim anyway made
       // the wrapper shell emit boundaries, which hid the terminal cursor and
       // drew block decorations into a card with no spine or input bar.
-      env: getSafeEnv()
+      env: getLaunchEnv()
     })
 
     // Session ID pinning: agents that support it (supportsSessionIdPinning) get a
@@ -449,7 +450,7 @@ class PtyManager extends EventEmitter {
       rows: 24,
       cwd: workingDir,
       env: {
-        ...getSafeEnv(),
+        ...getLaunchEnv(),
         ...integration.env
       }
     })

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { ScriptConfig, IPC } from '@vornrun/shared/types'
-import { getSafeEnv } from './process-utils'
+import { getLaunchEnv } from './process-utils'
 import log from './logger'
 
 export interface ScriptExecutionResult {
@@ -60,7 +60,7 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     const child = spawn(command, args, {
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: getSafeEnv(),
+      env: getLaunchEnv(),
       windowsHide: true
     })
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -899,6 +899,12 @@ export interface AppConfig {
      * without it the step waits forever and its run never closes. 0 disables it.
      */
     headlessStepTimeoutMinutes?: number
+    /**
+     * Exact environment variable names to forward to agent sessions and script
+     * nodes even though they match a sensitive prefix. Opt-in and deliberate:
+     * the prefix rule stays the default for everything not named here.
+     */
+    envPassthrough?: string[]
     enableHoverPreview?: boolean
     /**
      * Shell sessions only. Replaces the shell's own prompt with a single

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -900,9 +900,17 @@ export interface AppConfig {
      */
     headlessStepTimeoutMinutes?: number
     /**
-     * Exact environment variable names to forward to agent sessions and script
-     * nodes even though they match a sensitive prefix. Opt-in and deliberate:
-     * the prefix rule stays the default for everything not named here.
+     * Environment variable names to forward to agent sessions and workflow
+     * script nodes even though they match a sensitive prefix. Opt-in and
+     * deliberate: the prefix rule stays the default for everything not named
+     * here, and nothing else — plain shells, git, tailscale, the detectors —
+     * receives them.
+     *
+     * Whole names, not prefixes: naming ANTHROPIC_API_KEY forwards that one
+     * variable and not ANTHROPIC_API_SECRET. Entries are trimmed and compared
+     * case-insensitively, so `anthropic_api_key` also matches
+     * ANTHROPIC_API_KEY — convenient for a hand-edited config, but worth
+     * knowing on POSIX where the two really are different variables.
      */
     envPassthrough?: string[]
     enableHoverPreview?: boolean

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -36,6 +36,14 @@ describe('filterEnv', () => {
     expect(env.GITHUB_TOKEN).toBeUndefined()
   })
 
+  it('strips STRIP_ENV_KEYS whatever their casing', () => {
+    // Windows env names are case-insensitive and Node preserves the casing it
+    // enumerated, so a literal match would let this through.
+    const env = filterEnv({ claudecode: '1', ClaudeCode: '1' }, new Set())
+    expect(env).not.toHaveProperty('claudecode')
+    expect(env).not.toHaveProperty('ClaudeCode')
+  })
+
   it('never forwards STRIP_ENV_KEYS, even when named', () => {
     // CLAUDECODE is stripped so nested agent CLIs still launch; forwarding it
     // breaks the session rather than protecting anything.

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
   filterEnv,
+  getLaunchEnv,
+  getSafeEnv,
   normalizePassthrough,
+  setEnvPassthrough,
   SENSITIVE_ENV_PREFIXES
 } from '../packages/server/src/process-utils'
 
@@ -68,6 +71,23 @@ describe('filterEnv', () => {
   it('still lists the prefixes it protects', () => {
     expect(SENSITIVE_ENV_PREFIXES).toContain('ANTHROPIC_API')
     expect(SENSITIVE_ENV_PREFIXES).toContain('GITHUB_TOKEN')
+  })
+})
+
+describe('getSafeEnv vs getLaunchEnv', () => {
+  it('keeps the two functions distinct, so passthrough cannot leak to every subprocess', () => {
+    // getSafeEnv serves git, tailscale and the detectors; only getLaunchEnv
+    // forwards an opted-in variable, and only to a launch the user asked for.
+    expect(getSafeEnv).not.toBe(getLaunchEnv)
+  })
+
+  it('getSafeEnv ignores passthrough entirely', () => {
+    setEnvPassthrough(['SECRET_THING'])
+    try {
+      expect(filterEnv({ SECRET_THING: 'x' }, new Set())).not.toHaveProperty('SECRET_THING')
+    } finally {
+      setEnvPassthrough([])
+    }
   })
 })
 

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -3,6 +3,7 @@ import {
   filterEnv,
   getLaunchEnv,
   getSafeEnv,
+  getEnvPassthrough,
   normalizePassthrough,
   setEnvPassthrough,
   SENSITIVE_ENV_PREFIXES
@@ -74,20 +75,40 @@ describe('filterEnv', () => {
   })
 })
 
-describe('getSafeEnv vs getLaunchEnv', () => {
-  it('keeps the two functions distinct, so passthrough cannot leak to every subprocess', () => {
-    // getSafeEnv serves git, tailscale and the detectors; only getLaunchEnv
-    // forwards an opted-in variable, and only to a launch the user asked for.
-    expect(getSafeEnv).not.toBe(getLaunchEnv)
-  })
+describe('the two env functions', () => {
+  // getSafeEnv and getLaunchEnv both read the login shell, which a unit test
+  // cannot stand up. What is testable — and what actually matters — is that the
+  // setter stores the configured list, and that the two sets those functions
+  // hand to filterEnv produce genuinely different results.
+  const source = { SECRET_THING: 'x' }
 
-  it('getSafeEnv ignores passthrough entirely', () => {
-    setEnvPassthrough(['SECRET_THING'])
+  it('stores what was configured', () => {
+    setEnvPassthrough(['secret_thing'])
     try {
-      expect(filterEnv({ SECRET_THING: 'x' }, new Set())).not.toHaveProperty('SECRET_THING')
+      expect(getEnvPassthrough()).toEqual(new Set(['SECRET_THING']))
     } finally {
       setEnvPassthrough([])
     }
+  })
+
+  it('forwards under the launch set and withholds under the safe set', () => {
+    setEnvPassthrough(['SECRET_THING'])
+    try {
+      // getLaunchEnv passes getEnvPassthrough(); getSafeEnv passes an empty set.
+      expect(filterEnv(source, getEnvPassthrough())).toHaveProperty('SECRET_THING', 'x')
+      expect(filterEnv(source, new Set())).not.toHaveProperty('SECRET_THING')
+    } finally {
+      setEnvPassthrough([])
+    }
+  })
+
+  it('forwards nothing once the configuration is cleared', () => {
+    setEnvPassthrough([])
+    expect(filterEnv(source, getEnvPassthrough())).not.toHaveProperty('SECRET_THING')
+  })
+
+  it('keeps the two functions distinct, so passthrough cannot reach every subprocess', () => {
+    expect(getSafeEnv).not.toBe(getLaunchEnv)
   })
 })
 

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { filterEnv, SENSITIVE_ENV_PREFIXES } from '../packages/server/src/process-utils'
+import {
+  filterEnv,
+  normalizePassthrough,
+  SENSITIVE_ENV_PREFIXES
+} from '../packages/server/src/process-utils'
 
 const source = {
   PATH: '/usr/bin',
@@ -64,5 +68,31 @@ describe('filterEnv', () => {
   it('still lists the prefixes it protects', () => {
     expect(SENSITIVE_ENV_PREFIXES).toContain('ANTHROPIC_API')
     expect(SENSITIVE_ENV_PREFIXES).toContain('GITHUB_TOKEN')
+  })
+})
+
+describe('normalizePassthrough', () => {
+  it('uppercases and trims, so config casing does not matter', () => {
+    expect(normalizePassthrough([' anthropic_api_key '])).toEqual(new Set(['ANTHROPIC_API_KEY']))
+  })
+
+  it('treats undefined as empty', () => {
+    expect(normalizePassthrough(undefined)).toEqual(new Set())
+  })
+
+  it('drops blank entries', () => {
+    expect(normalizePassthrough(['', '   ', 'X'])).toEqual(new Set(['X']))
+  })
+
+  // The value comes from JSON.parse of a hand-editable file, so the declared
+  // string[] is a hope. Throwing here would take the server down at startup.
+  it('survives a non-array value', () => {
+    expect(normalizePassthrough('ANTHROPIC_API_KEY')).toEqual(new Set())
+    expect(normalizePassthrough(42)).toEqual(new Set())
+    expect(normalizePassthrough(null)).toEqual(new Set())
+  })
+
+  it('skips non-string entries rather than throwing', () => {
+    expect(normalizePassthrough(['GOOD', 42, null, { a: 1 }])).toEqual(new Set(['GOOD']))
   })
 })

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { filterEnv, SENSITIVE_ENV_PREFIXES } from '../packages/server/src/process-utils'
+
+const source = {
+  PATH: '/usr/bin',
+  HOME: '/Users/someone',
+  GITHUB_TOKEN: 'ghp_real',
+  ANTHROPIC_API_KEY: 'sk-ant-real',
+  ANTHROPIC_BASE_URL: 'http://localhost:3000',
+  CLAUDECODE: '1',
+  UNSET: undefined
+}
+
+describe('filterEnv', () => {
+  it('strips sensitive variables by default', () => {
+    const env = filterEnv(source, new Set())
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('keeps ordinary variables', () => {
+    const env = filterEnv(source, new Set())
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.HOME).toBe('/Users/someone')
+  })
+
+  it('drops undefined values instead of forwarding "undefined"', () => {
+    const env = filterEnv(source, new Set())
+    expect(env).not.toHaveProperty('UNSET')
+  })
+
+  it('forwards a variable the user named, overriding the prefix rule', () => {
+    const env = filterEnv(source, new Set(['ANTHROPIC_API_KEY']))
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-real')
+    // Naming one does not open the rest.
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+  })
+
+  it('never forwards STRIP_ENV_KEYS, even when named', () => {
+    // CLAUDECODE is stripped so nested agent CLIs still launch; forwarding it
+    // breaks the session rather than protecting anything.
+    const env = filterEnv(source, new Set(['CLAUDECODE']))
+    expect(env).not.toHaveProperty('CLAUDECODE')
+  })
+
+  it('already allowed ANTHROPIC_BASE_URL, which is why the key alone was the gap', () => {
+    const env = filterEnv(source, new Set())
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:3000')
+  })
+
+  it('matches prefixes case-insensitively', () => {
+    const env = filterEnv({ github_token: 'x' }, new Set())
+    expect(env).not.toHaveProperty('github_token')
+  })
+
+  it('still lists the prefixes it protects', () => {
+    expect(SENSITIVE_ENV_PREFIXES).toContain('ANTHROPIC_API')
+    expect(SENSITIVE_ENV_PREFIXES).toContain('GITHUB_TOKEN')
+  })
+})


### PR DESCRIPTION
## The problem

`getSafeEnv()` strips every variable matching `SENSITIVE_ENV_PREFIXES` before launching a PTY session or a workflow script node. That default is correct — a shell exporting a real `GITHUB_TOKEN` should not hand it to every agent that runs.

But it makes one legitimate setup impossible to diagnose. Pointing an agent at a local Anthropic-compatible proxy needs two variables:

| Variable | Prefix match | Result today |
|---|---|---|
| `ANTHROPIC_BASE_URL` | no | forwarded |
| `ANTHROPIC_API_KEY` | `ANTHROPIC_API` | **stripped** |

So the agent launches aimed at the proxy while authenticating as though it were not. Nothing reports it; the session just behaves as if the proxy were never configured. Same shape for any script node that needs a `*_TOKEN` to publish something.

## The change

`defaults.envPassthrough` — variable names to forward anyway.

- **Empty by default**, so behaviour is unchanged until someone opts in
- Whole names, not prefixes — naming `ANTHROPIC_API_KEY` does not open `GITHUB_TOKEN`. Entries are trimmed and compared case-insensitively
- Applied at startup and re-applied on config change
- `STRIP_ENV_KEYS` (`CLAUDECODE`) stays absolute and is **not** overridable: it exists so nested agent CLIs still launch, and forwarding it breaks the session rather than protecting anything

I deliberately did not weaken or remove `SENSITIVE_ENV_PREFIXES`. Deleting the filter would fix the symptom by handing every secret in the shell to every agent — the opposite trade.

## Which processes receive it

`getSafeEnv()` has fourteen callers, most of them subprocesses the user never asked for. Forwarding an opted-in secret to all of them would be far wider than the setting implies, so the function is split:

| Call site | env | forwards passthrough |
|---|---|---|
| `createLocalPty` — agent launch | `getLaunchEnv()` | yes |
| `headless-manager` — headless agent | `getLaunchEnv()` | yes |
| `script-runner` — workflow script node | `getLaunchEnv()` | yes |
| `createShellPty` — plain shell | `getSafeEnv()` | no |
| SSH session | `getSafeEnv()` | no |
| git, tailscale, detectors, file helpers, shell integration | `getSafeEnv()` | no |

Plain shells are excluded on purpose: a shell hands its environment to every command typed into it for as long as it lives. SSH is excluded because it connects to another machine, which is exactly the widening this split avoids.

## Where the setting lives

**Correction to an earlier version of this description**, which said `config.json`. Config is SQLite-backed: `~/.vorn/vorn.db`, `defaults` table, one row per key. There is no settings UI for this yet, so today it is set via `config:save` or by writing the row directly:

```sql
INSERT OR REPLACE INTO defaults (key, value)
VALUES ('envPassthrough', '["ANTHROPIC_API_KEY"]');
```

A Settings field would be the obvious follow-up — happy to add it here or separately.

## Testing

- `tests/env-passthrough.test.ts` — 18 cases: default stripping, ordinary vars kept, `undefined` dropped, named var forwarded without opening others, `STRIP_ENV_KEYS` absolute and case-insensitive, prefix matching case-insensitive, `normalizePassthrough` surviving non-arrays and mixed-type lists, and the configured set actually changing what `filterEnv` returns
- `filterEnv` and `normalizePassthrough` are pure and exported; the rules were previously reachable only through a login shell, which a test cannot stand up
- `resolvedEnv` is lazy and memoized — importing this module used to spawn a login shell, costing every consumer a subprocess it may never use (this file's import time: ~480ms → ~30ms)
- `yarn typecheck` clean, eslint clean via lint-staged
- Full suite: **2500 passed, 1 failed** — `tests/shell-integration-shells.test.ts`, which I re-confirmed fails on `main` with this branch stashed, so it is pre-existing and unrelated

## Review history

Six rounds found nine issues, several of them serious: the feature was initially **inert** (saving iterates every key, loading is an explicit list that dropped it), passthrough initially reached **every** subprocess, and one fix mistakenly widened it to plain shells. All addressed, each with a test.