### PR TITLE
chore(release): v0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-kusto/package.json
+++ b/packages/connector-kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-kusto",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Trigger Vorn workflows from an Azure Data Explorer (Kusto) query",
   "type": "module",
   "license": "MIT",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -12,6 +12,7 @@ PACKAGES=(
   "packages/shared"
   "packages/mcp"
   "packages/connector-sdk"
+  "packages/connector-kusto"
 )
 
 OUT_OF_SYNC=0


### PR DESCRIPTION
Bumps every workspace package to **0.5.4**. Tagging `v0.5.4` after this merges kicks off the release build.

## What ships in 0.5.4

8 commits since v0.5.3:

**Features**
- `#418` — worktree manager: measures what every worktree costs on disk and reclaims it (new Worktrees settings panel, `worktree-inventory` scanner, five RPC methods)
- `#420` — opt-in env passthrough for agents and script nodes
- `#419` — `execute_workflow` MCP tool, with declared parameters
- `#415` — Inbox rebuilt as a list + detail surface

**Dependencies**
- fastify 5.8.5 → 5.11.0 (`#417`)
- react / react-dom / @types/react → 19.2.8 / 19.2.18 (`#416`)
- vite-plugin-pwa 1.2.0 → 1.3.0 (`#412`)
- @vitest/coverage-v8 4.1.6 → 4.1.10 (`#411`)

## One fix beyond the bump

`packages/connector-kusto` was the only publishable package missing from `scripts/sync-versions.sh`, so its version stayed behind on every release and had to be bumped by hand — it was still reading 0.5.3 when the other seven synced. Added to the list.

npm was never affected: the release workflow re-syncs all three publishable packages from the tag before publishing. It was the committed tree that drifted.