### PR TITLE
Run output, a bounded loop node, and portable workflows

### DIFF
--- a/docs/design/loop-node.html
+++ b/docs/design/loop-node.html
@@ -1,0 +1,597 @@
+<!doctype html>
+<html lang="en">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vorn — The loop should look like a loop</title>
+  <style>
+    :root {
+      --night: #000000;
+      --ink: #f3f1ea;
+      --ink-2: rgba(243, 241, 234, 0.55);
+      --ink-3: rgba(243, 241, 234, 0.34);
+      --hairline: rgba(243, 241, 234, 0.14);
+      --hairline-soft: rgba(243, 241, 234, 0.08);
+      --brass: #c9a227;
+      --serif: ui-serif, 'New York', 'Iowan Old Style', Georgia, serif;
+      --sans: -apple-system, 'SF Pro Text', 'Helvetica Neue', system-ui, sans-serif;
+      --mono: ui-monospace, 'SF Mono', Menlo, monospace;
+      /* Vorn's own surface, so a mockup reads as the app and not as this page. */
+      --card: #1d1d20;
+      --canvas: #0f0f11;
+      --cyan: #22d3ee;
+    }
+    html {
+      background: var(--night);
+    }
+    body {
+      background: var(--night);
+      color: var(--ink);
+      font-family: var(--serif);
+      line-height: 1.6;
+      margin: 0;
+      -webkit-font-smoothing: antialiased;
+    }
+    .page {
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 88px 28px 120px;
+    }
+    .eyebrow {
+      font-family: var(--sans);
+      font-size: 11px;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--ink-2);
+    }
+    h1 {
+      font-size: clamp(40px, 7vw, 56px);
+      font-weight: 500;
+      line-height: 1.08;
+      letter-spacing: -0.01em;
+      margin: 18px 0 0;
+      text-wrap: balance;
+    }
+    .thesis {
+      font-size: 21px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 26px 0 0;
+      max-width: 34em;
+      text-wrap: balance;
+    }
+    .thesis em {
+      color: var(--ink);
+      font-style: italic;
+    }
+    section {
+      margin-top: 96px;
+    }
+    section > .eyebrow {
+      display: block;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--hairline);
+    }
+    h2 {
+      font-size: 28px;
+      font-weight: 500;
+      line-height: 1.25;
+      margin: 26px 0 0;
+      text-wrap: balance;
+    }
+    p {
+      font-size: 16.5px;
+      margin: 18px 0 0;
+      max-width: 38em;
+    }
+    p.quiet {
+      color: var(--ink-2);
+    }
+    strong {
+      font-weight: 600;
+      color: var(--ink);
+    }
+    code {
+      font-family: var(--mono);
+      font-size: 0.85em;
+      color: var(--ink);
+      background: rgba(243, 241, 234, 0.07);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+    .caption {
+      font-family: var(--sans);
+      font-size: 12.5px;
+      color: var(--ink-3);
+      margin-top: 18px;
+      line-height: 1.55;
+      max-width: 44em;
+    }
+    .warn {
+      color: var(--brass);
+    }
+
+    .tbl {
+      margin-top: 28px;
+      overflow-x: auto;
+    }
+    .tbl table {
+      border-collapse: collapse;
+      width: 100%;
+      min-width: 520px;
+      font-family: var(--sans);
+      font-size: 13.5px;
+    }
+    .tbl th {
+      text-align: left;
+      font-size: 10.5px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+      font-weight: 500;
+      padding: 0 16px 10px 0;
+      border-bottom: 1px solid var(--hairline);
+    }
+    .tbl td {
+      padding: 12px 16px 12px 0;
+      border-bottom: 1px solid var(--hairline-soft);
+      color: var(--ink-2);
+      line-height: 1.5;
+      vertical-align: top;
+    }
+    .tbl td:first-child {
+      color: var(--ink);
+      font-weight: 500;
+    }
+
+    .steps {
+      margin-top: 30px;
+    }
+    .step {
+      display: grid;
+      grid-template-columns: 30px 1fr;
+      gap: 16px;
+      padding: 18px 0;
+      border-top: 1px solid var(--hairline-soft);
+    }
+    .step:first-child {
+      border-top: 1px solid var(--hairline);
+    }
+    .step-n {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--ink-3);
+      padding-top: 3px;
+    }
+    .step h4 {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0;
+    }
+    .step p {
+      font-size: 14.5px;
+      color: var(--ink-2);
+      margin: 6px 0 0;
+    }
+
+    /* Canvas mockups: vorn is a desktop app, so the frame is a panel, not a phone. */
+    .compare {
+      display: flex;
+      gap: 28px;
+      flex-wrap: wrap;
+      margin-top: 36px;
+      justify-content: center;
+    }
+    .col {
+      flex: 1 1 300px;
+      max-width: 330px;
+      min-width: 280px;
+    }
+    .col-label {
+      font-family: var(--sans);
+      font-size: 11px;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+      margin-bottom: 12px;
+      text-align: center;
+    }
+    .canvas {
+      background: var(--canvas);
+      border: 1px solid var(--hairline);
+      border-radius: 12px;
+      padding: 22px 18px 26px;
+      font-family: var(--sans);
+    }
+    .canvas * {
+      box-sizing: border-box;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--hairline-soft);
+      border-radius: 6px;
+      padding: 9px 11px;
+    }
+    .card .t {
+      font-size: 12.5px;
+      font-weight: 500;
+      color: var(--ink);
+    }
+    .card .s {
+      font-size: 10.5px;
+      color: var(--ink-3);
+      margin-top: 2px;
+    }
+    .card .glyph {
+      font-size: 11px;
+      margin-right: 6px;
+      opacity: 0.8;
+    }
+    .wire {
+      width: 1px;
+      height: 16px;
+      background: var(--hairline);
+      margin: 0 auto;
+    }
+    .plus {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      border: 1px solid var(--hairline);
+      color: var(--ink-3);
+      font-size: 12px;
+      line-height: 16px;
+      text-align: center;
+      margin: 0 auto;
+    }
+    .dashed {
+      border-style: dashed;
+    }
+    .cyan {
+      color: var(--cyan);
+    }
+
+    /* The proposal: a rail that physically contains the steps it repeats. */
+    .loop {
+      border: 1px solid rgba(34, 211, 238, 0.35);
+      border-radius: 8px;
+      background: rgba(34, 211, 238, 0.03);
+      padding: 0 0 10px;
+    }
+    .loop-head {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 8px 11px;
+      border-bottom: 1px solid rgba(34, 211, 238, 0.18);
+    }
+    .loop-head .t {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--ink);
+    }
+    .loop-body {
+      padding: 12px 12px 0 12px;
+    }
+    .loop-foot {
+      font-family: var(--mono);
+      font-size: 10px;
+      color: var(--cyan);
+      opacity: 0.85;
+      padding: 9px 12px 0;
+      text-align: center;
+    }
+    .pill {
+      font-family: var(--mono);
+      font-size: 9.5px;
+      color: var(--cyan);
+      background: rgba(34, 211, 238, 0.12);
+      border-radius: 3px;
+      padding: 1px 5px;
+    }
+
+    .coda {
+      margin-top: 96px;
+      padding-top: 28px;
+      border-top: 1px solid var(--hairline);
+      font-style: italic;
+      color: var(--ink-2);
+      font-size: 17px;
+    }
+  </style>
+
+  <div class="page">
+    <span class="eyebrow">Vorn · Workflow editor</span>
+    <h1>The loop should look like a loop</h1>
+    <p class="thesis">
+      A workflow canvas is a picture of what will happen. The loop node I shipped breaks that
+      promise: it repeats three steps and
+      <em>none of them look any different from the steps that run once</em>. You have to read a list
+      inside a card to know what the picture means.
+    </p>
+
+    <section>
+      <span class="eyebrow">01 · What shipped, and why it is wrong</span>
+      <h2>Membership is invisible</h2>
+      <p>
+        The node exists and executes correctly. <code>executeLoop</code> drives its body, the graph
+        stays acyclic, the bound holds. The <em>engine</em> is fine. The <em>drawing</em> is not.
+      </p>
+      <p>
+        On the canvas, a loop renders as one more 280px card in the vertical chain. The steps it
+        repeats render as ordinary cards below it — identical to steps that run exactly once. The
+        only evidence of the relationship is a text list inside the loop's own card, which means the
+        canvas has stopped being a diagram and started being a legend you cross-reference.
+      </p>
+      <p class="quiet">
+        The configuration follows the same mistake. To say "repeat these two steps" you tick
+        checkboxes in a side panel listing every downstream node. That is a data-entry form for a
+        spatial relationship, and it puts the answer somewhere other than where the question is.
+      </p>
+
+      <div class="compare">
+        <div class="col">
+          <div class="col-label">Shipped</div>
+          <div class="canvas">
+            <div class="card">
+              <div class="t"><span class="glyph">⚡</span>Manual</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">▶</span>Pull feeds</div>
+              <div class="s">bash · deterministic</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card" style="border-color: rgba(34, 211, 238, 0.35)">
+              <div class="t"><span class="glyph cyan">↻</span>Repeat Steps</div>
+              <div class="s">Repeats 2 steps · up to 2×</div>
+              <div
+                class="s"
+                style="
+                  margin-top: 6px;
+                  border-top: 1px solid var(--hairline-soft);
+                  padding-top: 6px;
+                "
+              >
+                1. Write the edition
+              </div>
+              <div class="s">2. Review the draft</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">▶</span>Write the edition</div>
+              <div class="s">claude · headless</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">▶</span>Review the draft</div>
+              <div class="s">claude · headless</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">✋</span>Javier reviews</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="col-label">Proposed</div>
+          <div class="canvas">
+            <div class="card">
+              <div class="t"><span class="glyph">⚡</span>Manual</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">▶</span>Pull feeds</div>
+              <div class="s">bash · deterministic</div>
+            </div>
+            <div class="wire"></div>
+            <div class="loop">
+              <div class="loop-head">
+                <span class="glyph cyan" style="margin: 0">↻</span>
+                <span class="t">Repeat until approved</span>
+                <span class="pill" style="margin-left: auto">max 2</span>
+              </div>
+              <div class="loop-body">
+                <div class="card">
+                  <div class="t"><span class="glyph">▶</span>Write the edition</div>
+                  <div class="s">claude · headless</div>
+                </div>
+                <div class="wire"></div>
+                <div class="card">
+                  <div class="t"><span class="glyph">▶</span>Review the draft</div>
+                  <div class="s">claude · headless</div>
+                </div>
+                <div class="wire"></div>
+                <div class="plus">+</div>
+              </div>
+              <div class="loop-foot">↻ until {{steps.review.approved}} = true</div>
+            </div>
+            <div class="wire"></div>
+            <div class="card">
+              <div class="t"><span class="glyph">✋</span>Javier reviews</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="caption">
+        Same workflow, same execution. On the left you read a card to learn what repeats; on the
+        right you see it. The body is inset inside a rail, the header carries the budget, and the
+        footer carries the exit condition — so the two questions a reader has,
+        <em>what repeats</em> and <em>when does it stop</em>, are answered at the top and bottom
+        edges of the thing itself.
+      </p>
+    </section>
+
+    <section>
+      <span class="eyebrow">02 · What the tools that got this right do</span>
+      <h2>Containment, every time</h2>
+      <p>
+        <strong>n8n</strong> draws a Loop Over Items node with a distinct "loop" output that visibly
+        cycles back — the edge itself is the evidence. <strong>GitHub Actions</strong> has no
+        canvas, but its log UI nests each matrix iteration under a collapsible parent, so a repeated
+        job is never a sibling of an unrepeated one. <strong>Temporal</strong>'s web UI groups
+        activity attempts under one activity row with a retry count, rather than listing four
+        attempts as four peers.
+      </p>
+      <p>
+        The common rule is that
+        <strong>a repeated thing is drawn inside the thing that repeats it</strong>, and the count
+        lives on the container. Nobody asks the reader to hold a membership list in their head.
+      </p>
+      <p class="quiet">
+        Vorn cannot copy n8n's cycling edge: the canvas is a linear list of rows with no edge
+        drawing, and the runner requires an acyclic graph. But containment does not need edges — it
+        needs one nested row type.
+      </p>
+    </section>
+
+    <section>
+      <span class="eyebrow">03 · What it costs</span>
+      <h2>One row kind, one renderer</h2>
+      <p>
+        The layout already models more than a flat list. <code>computeFlowLayout</code> returns
+        <code>FlowRow[]</code> where a row is either <code>{ kind: 'node' }</code> or
+        <code>{ kind: 'fork', branches: FlowRow[][] }</code> —
+        <strong>a fork already nests rows inside a row</strong>. A loop is the same move with one
+        branch.
+      </p>
+
+      <div class="tbl">
+        <table>
+          <tr>
+            <th>Change</th>
+            <th>File</th>
+            <th>Size</th>
+          </tr>
+          <tr>
+            <td>Add <code>{ kind: 'loop', body: FlowRow[] }</code></td>
+            <td>workflow-helpers.ts</td>
+            <td>Mirrors the existing fork row</td>
+          </tr>
+          <tr>
+            <td>Emit it: pull body nodes out of the trunk</td>
+            <td>buildFlowFromNode</td>
+            <td>Skip ids in <code>bodyNodeIds</code>, recurse into them</td>
+          </tr>
+          <tr>
+            <td>Render the rail</td>
+            <td>WorkflowCanvas.tsx</td>
+            <td>Beside the fork renderer</td>
+          </tr>
+          <tr>
+            <td>Add a step inside the loop</td>
+            <td>ConnectorButton</td>
+            <td>The <code>+</code> already takes an insert position</td>
+          </tr>
+          <tr>
+            <td>Drop the checkbox list</td>
+            <td>LoopConfigForm.tsx</td>
+            <td>Deleted — membership is spatial now</td>
+          </tr>
+        </table>
+      </div>
+      <p class="caption">
+        The engine does not change at all. <code>executeLoop</code> already reads
+        <code>bodyNodeIds</code>; this only changes who writes that array — the canvas rather than a
+        form.
+      </p>
+    </section>
+
+    <section>
+      <span class="eyebrow">04 · The interaction</span>
+      <h2>Membership by position</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-n">01</div>
+          <div>
+            <h4>Add the loop</h4>
+            <p>
+              The <code>+</code> menu offers "Repeat steps until…". An empty loop appears as a rail
+              with a dashed drop zone and its own <code>+</code> inside.
+            </p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-n">02</div>
+          <div>
+            <h4>Add steps into it</h4>
+            <p>
+              The <code>+</code> inside the rail appends to the body; the <code>+</code> outside
+              appends after the loop. Position is the only thing that decides membership, so there
+              is nothing to keep in sync.
+            </p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-n">03</div>
+          <div>
+            <h4>Set the budget and the exit</h4>
+            <p>
+              Selecting the loop opens a panel with two fields only: max passes, and the condition.
+              The step list is gone.
+            </p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-n">04</div>
+          <div>
+            <h4>Watch it run</h4>
+            <p>
+              During a run the rail shows <span class="pill">pass 2 / 2</span> in its header, and
+              the body's step cards show that pass's status. The count belongs to the container, as
+              it does in Temporal.
+            </p>
+          </div>
+        </div>
+      </div>
+      <p class="warn" style="font-family: var(--sans); font-size: 13.5px; margin-top: 26px">
+        One thing the rail must keep from the current build: an approval gate dropped into a loop
+        body is refused. The executor cannot resume a parked gate at the right pass, so the canvas
+        should reject the drop rather than let it be built.
+      </p>
+    </section>
+
+    <section>
+      <span class="eyebrow">05 · Build order</span>
+      <h2>Three steps, each shippable</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-n">01</div>
+          <div>
+            <h4>The loop row</h4>
+            <p>
+              Add the row kind, teach <code>buildFlowFromNode</code> to lift body nodes out of the
+              trunk and nest them, render the rail. The checkbox form still writes
+              <code>bodyNodeIds</code>, so nothing breaks while this lands.
+            </p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-n">02</div>
+          <div>
+            <h4>The inner +</h4>
+            <p>
+              Insertion inside the rail writes both the edge and the <code>bodyNodeIds</code> entry.
+              At this point the form is redundant.
+            </p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-n">03</div>
+          <div>
+            <h4>Delete the list</h4>
+            <p>
+              Remove the step picker from <code>LoopConfigForm</code>, leaving max passes and the
+              condition. Membership has exactly one source of truth.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <p class="coda">
+      A diagram earns its place by being faster to read than the list it replaces. Ours was slower.
+    </p>
+  </div>
+</html>

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -159,26 +159,92 @@ const triggerConfigSchema = z.union([
   })
 ])
 
-const nodeSchema = z.object({
-  id: V.id,
-  // Full node palette — parity with the editor. `config` is a passthrough so
-  // each type carries its own shape (ConditionConfig, ApprovalConfig, etc.).
-  type: z.enum([
-    'trigger',
-    'launchAgent',
-    'script',
-    'condition',
-    'approval',
-    'createTaskFromItem',
-    'callConnectorAction'
-  ]),
-  label: V.shortText,
-  // Referenced by typed step vars as `{{steps.<slug>.<field>}}`. Set one on any
-  // node whose output a later node consumes.
-  slug: V.shortText.optional(),
-  config: z.record(z.string(), z.unknown()),
-  position: z.object({ x: z.number(), y: z.number() })
-})
+const nodeSchema = z
+  .object({
+    id: V.id,
+    // Full node palette — parity with the editor. `config` is a passthrough so
+    // each type carries its own shape (ConditionConfig, ApprovalConfig, etc.).
+    type: z.enum([
+      'trigger',
+      'launchAgent',
+      'script',
+      'condition',
+      'approval',
+      'createTaskFromItem',
+      'callConnectorAction',
+      'loop'
+    ]),
+    label: V.shortText,
+    // Referenced by typed step vars as `{{steps.<slug>.<field>}}`. Set one on any
+    // node whose output a later node consumes.
+    slug: V.shortText.optional(),
+    config: z.record(z.string(), z.unknown()),
+    position: z.object({ x: z.number(), y: z.number() })
+  })
+  // `config` is a passthrough for every other node type, but a loop that
+  // declares no body or a nonsense budget cannot run at all — and the failure
+  // would surface on a run someone is waiting for rather than on the call that
+  // introduced it.
+  .superRefine((node, ctx) => {
+    if (node.type !== 'loop') return
+    const config = node.config as { bodyNodeIds?: unknown; maxIterations?: unknown }
+
+    if (!Array.isArray(config.bodyNodeIds) || config.bodyNodeIds.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['config', 'bodyNodeIds'],
+        message: `loop "${node.id}" must list at least one body step in bodyNodeIds`
+      })
+    }
+
+    const max = config.maxIterations
+    if (typeof max !== 'number' || !Number.isInteger(max) || max < 1 || max > MAX_LOOP_ITERATIONS) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['config', 'maxIterations'],
+        message: `loop "${node.id}" needs maxIterations as a whole number from 1 to ${MAX_LOOP_ITERATIONS}`
+      })
+    }
+  })
+
+/**
+ * Ceiling on loop passes, mirrored from the renderer that enforces it.
+ *
+ * Duplicated rather than imported because this package is the stdio MCP server
+ * and does not pull in renderer code; the executor clamps regardless, so the
+ * worst case of drift is a workflow rejected here that would have been clamped
+ * there.
+ */
+const MAX_LOOP_ITERATIONS = 10
+
+/**
+ * Loop bodies must name steps that exist in the same workflow.
+ *
+ * Checked across the whole graph rather than per node, since a node cannot see
+ * its siblings during its own parse.
+ */
+export function validateLoopBodies(
+  nodes: { id: string; type: string; label?: string; config: Record<string, unknown> }[]
+): string[] {
+  const ids = new Set(nodes.map((n) => n.id))
+  const errors: string[] = []
+
+  for (const node of nodes) {
+    if (node.type !== 'loop') continue
+    const body = (node.config.bodyNodeIds as string[] | undefined) ?? []
+
+    for (const id of body) {
+      if (!ids.has(id)) {
+        errors.push(`loop "${node.label || node.id}" references unknown body step "${id}"`)
+      }
+    }
+    if (body.includes(node.id)) {
+      errors.push(`loop "${node.label || node.id}" lists itself as a body step`)
+    }
+  }
+
+  return errors
+}
 
 const edgeSchema = z.object({
   id: V.id,
@@ -404,6 +470,20 @@ export function registerWorkflowTools(server: McpServer): void {
       if (args.nodes && args.edges) {
         nodes = args.nodes as unknown as WorkflowNode[]
         edges = args.edges as unknown as WorkflowEdge[]
+        const loopErrors = validateLoopBodies(
+          nodes as unknown as {
+            id: string
+            type: string
+            label?: string
+            config: Record<string, unknown>
+          }[]
+        )
+        if (loopErrors.length > 0) {
+          return {
+            content: [{ type: 'text', text: `Error: ${loopErrors.join('; ')}` }],
+            isError: true
+          }
+        }
       } else {
         const trigger = (args.trigger as TriggerConfig) ?? { triggerType: 'manual' as const }
         const actions = (args.actions as LaunchAgentConfig[]) ?? []
@@ -460,7 +540,23 @@ export function registerWorkflowTools(server: McpServer): void {
 
       const updates: Partial<WorkflowDefinition> = {}
       if (args.name !== undefined) updates.name = args.name
-      if (args.nodes !== undefined) updates.nodes = args.nodes as unknown as WorkflowNode[]
+      if (args.nodes !== undefined) {
+        const loopErrors = validateLoopBodies(
+          args.nodes as unknown as {
+            id: string
+            type: string
+            label?: string
+            config: Record<string, unknown>
+          }[]
+        )
+        if (loopErrors.length > 0) {
+          return {
+            content: [{ type: 'text', text: `Error: ${loopErrors.join('; ')}` }],
+            isError: true
+          }
+        }
+        updates.nodes = args.nodes as unknown as WorkflowNode[]
+      }
       if (args.edges !== undefined) updates.edges = args.edges as unknown as WorkflowEdge[]
       if (args.icon !== undefined) updates.icon = args.icon
       if (args.icon_color !== undefined) updates.iconColor = args.icon_color

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -12,6 +12,7 @@ import type {
 } from '@vornrun/shared/types'
 import type { ScheduleLogEntry } from '@vornrun/shared/types'
 import {
+  dbListProjects,
   dbListWorkflows,
   dbInsertWorkflow,
   dbUpdateWorkflow,
@@ -21,6 +22,15 @@ import {
   dbSignalChange
 } from '@vornrun/server/database'
 import { rpcCall } from '../ws-client'
+import {
+  toPortable,
+  fromPortable,
+  portabilityBlockers,
+  residualAbsolutePaths,
+  slugify,
+  PORTABLE_FORMAT_VERSION,
+  type PortableWorkflow
+} from '../workflow-portability'
 
 const launchAgentConfigSchema = z
   .object({
@@ -742,6 +752,180 @@ export function registerWorkflowTools(server: McpServer): void {
           {
             type: 'text',
             text: `Queued "${workflow.name}"${disabled}${shown}\n\nRun history: list_workflow_runs with workflow_id ${args.workflow_id}`
+          }
+        ]
+      }
+    }
+  )
+
+  server.tool(
+    'export_workflow',
+    'Export a workflow as a portable file you can commit beside the code it drives. Absolute paths become {{project.path}} and the local remote-host binding is dropped, so it runs on another machine after import. Refuses a workflow bound to a connector connection, whose id means nothing elsewhere.',
+    {
+      workflow_id: V.id.optional().describe('Workflow ID (from list_workflows)'),
+      id: V.id.optional().describe('Deprecated alias for workflow_id')
+    },
+    async (args) => {
+      const resolved = resolveWorkflowId(args)
+      if ('error' in resolved) {
+        return { content: [{ type: 'text', text: `Error: ${resolved.error}` }], isError: true }
+      }
+
+      const workflow = dbListWorkflows().find((w) => w.id === resolved.id)
+      if (!workflow) {
+        return {
+          content: [{ type: 'text', text: `Error: workflow "${resolved.id}" not found` }],
+          isError: true
+        }
+      }
+
+      const blockers = portabilityBlockers(workflow)
+      if (blockers.length > 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `Error: "${workflow.name}" cannot be exported portably because ` +
+                blockers.join('; ') +
+                '. Rebuild those steps without the connection, or keep this workflow local.'
+            }
+          ],
+          isError: true
+        }
+      }
+
+      // The project the workflow's own steps point at is what its paths are
+      // relative to; without it there is nothing to rewrite against.
+      const projects = dbListProjects()
+      const projectName = workflow.nodes
+        .map((n) => (n.config as Record<string, unknown>).projectName)
+        .find((name): name is string => typeof name === 'string' && name.length > 0)
+      const project = projects.find((p) => p.name === projectName)
+
+      if (!project) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: no project named "${projectName ?? '(none)'}" is registered, so this workflow's paths cannot be made relative to anything.`
+            }
+          ],
+          isError: true
+        }
+      }
+
+      const portable = toPortable(workflow, project.path)
+      const residual = residualAbsolutePaths(portable)
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              JSON.stringify(portable, null, 2) +
+              (residual.length > 0
+                ? `\n\nWarning: these still hold a machine-specific path and will not travel: ${residual.join(', ')}`
+                : '')
+          }
+        ]
+      }
+    }
+  )
+
+  server.tool(
+    'import_workflow',
+    "Import a workflow exported by export_workflow, resolving {{project.path}} and {{project.name}} against a registered project. The id is derived from the bundle and the workflow's slug, so importing the same file again updates it in place instead of creating a duplicate.",
+    {
+      workflow: z.string().max(500_000).describe('The exported workflow JSON'),
+      project_name: V.name.describe('Registered project to resolve paths against'),
+      bundle: V.name.optional().describe('Namespace for the derived id (default: the project name)')
+    },
+    async (args) => {
+      let parsed: PortableWorkflow
+      try {
+        parsed = JSON.parse(args.workflow)
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: workflow is not valid JSON — ${String(err).slice(0, 200)}`
+            }
+          ],
+          isError: true
+        }
+      }
+
+      if (parsed?.version !== PORTABLE_FORMAT_VERSION) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: unsupported format version ${parsed?.version}; this build reads version ${PORTABLE_FORMAT_VERSION}`
+            }
+          ],
+          isError: true
+        }
+      }
+      if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges) || !parsed.name) {
+        return {
+          content: [{ type: 'text', text: 'Error: workflow is missing name, nodes or edges' }],
+          isError: true
+        }
+      }
+
+      const project = dbListProjects().find((p) => p.name === args.project_name)
+      if (!project) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: no project named "${args.project_name}". Create it first so its path is known.`
+            }
+          ],
+          isError: true
+        }
+      }
+
+      const loopErrors = validateLoopBodies(
+        parsed.nodes as unknown as {
+          id: string
+          type: string
+          label?: string
+          config: Record<string, unknown>
+        }[]
+      )
+      if (loopErrors.length > 0) {
+        return {
+          content: [{ type: 'text', text: `Error: ${loopErrors.join('; ')}` }],
+          isError: true
+        }
+      }
+
+      const bundle = args.bundle ?? slugify(project.name)
+      const definition = fromPortable(
+        { ...parsed, slug: parsed.slug ?? slugify(parsed.name) },
+        bundle,
+        {
+          name: project.name,
+          path: project.path
+        }
+      )
+
+      const existing = dbListWorkflows().find((w) => w.id === definition.id)
+      if (existing) {
+        dbUpdateWorkflow(definition.id, definition)
+      } else {
+        dbInsertWorkflow(definition)
+      }
+      dbSignalChange()
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `${existing ? 'Updated' : 'Imported'} "${definition.name}" as ${definition.id}, resolved against ${project.path}`
           }
         ]
       }

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -913,6 +913,23 @@ export function registerWorkflowTools(server: McpServer): void {
         }
       )
 
+      // Export refuses a connector-bound workflow because its connectionId is
+      // local. Import has to refuse the same shape, or a hand-written file
+      // walks straight past that contract and lands a workflow that fails at
+      // run time against a connection this machine never had.
+      const blockers = portabilityBlockers(definition)
+      if (blockers.length > 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: this workflow cannot be imported because ${blockers.join('; ')}.`
+            }
+          ],
+          isError: true
+        }
+      }
+
       const existing = dbListWorkflows().find((w) => w.id === definition.id)
       if (existing) {
         dbUpdateWorkflow(definition.id, definition)

--- a/packages/mcp/src/workflow-portability.ts
+++ b/packages/mcp/src/workflow-portability.ts
@@ -128,12 +128,25 @@ export function toPortable(workflow: WorkflowDefinition, projectPath: string): P
   }
 }
 
+/**
+ * Compare paths without caring which separator the machine writes.
+ *
+ * Vorn ships a Windows installer, and a workflow authored there carries
+ * `C:\\Users\\...` in its node configs. Exact POSIX string matching would
+ * leave those untouched and the export would claim to be portable while
+ * naming a directory on one laptop.
+ */
+function normalizeForCompare(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
 function replacePath(value: string, projectPath: string): string {
-  if (value === projectPath) return PROJECT_PATH_TOKEN
+  const v = normalizeForCompare(value)
+  const root = normalizeForCompare(projectPath)
+  if (v === root) return PROJECT_PATH_TOKEN
   // A path inside the project keeps its tail, so a worktree or a subdirectory
   // survives the round trip instead of collapsing onto the project root.
-  const prefix = projectPath.endsWith('/') ? projectPath : `${projectPath}/`
-  if (value.startsWith(prefix)) return PROJECT_PATH_TOKEN + '/' + value.slice(prefix.length)
+  if (v.startsWith(`${root}/`)) return `${PROJECT_PATH_TOKEN}/${v.slice(root.length + 1)}`
   return value
 }
 
@@ -149,8 +162,10 @@ export function fromPortable(
     for (const [key, value] of Object.entries(config)) {
       if (typeof value !== 'string') continue
       config[key] = value
+        // Trailing separator of either flavour: a Windows project path ending
+        // in a backslash would otherwise produce a doubled separator.
         .split(PROJECT_PATH_TOKEN)
-        .join(project.path.replace(/\/$/, ''))
+        .join(project.path.replace(/[/\\]+$/, ''))
         .split(PROJECT_NAME_TOKEN)
         .join(project.name)
     }
@@ -170,12 +185,20 @@ export function fromPortable(
   }
 }
 
-/** What is still machine-specific after export. Empty is the goal. */
+/**
+ * What is still machine-specific after export. Empty is the goal.
+ *
+ * Windows shapes are checked too — a drive letter or a UNC share — because a
+ * detector that only knows POSIX reports a Windows-authored workflow as
+ * portable when it is not, which is worse than not checking at all.
+ */
+const MACHINE_PATH = /(^|["'\s])(\/(Users|home)\/|[A-Za-z]:[\\/]|\\\\[^\\/\s]+[\\/])/
+
 export function residualAbsolutePaths(portable: PortableWorkflow): string[] {
   const found: string[] = []
   for (const node of portable.nodes) {
     for (const [key, value] of Object.entries(node.config as Record<string, unknown>)) {
-      if (typeof value === 'string' && /(^|["'\s])\/(Users|home)\//.test(value)) {
+      if (typeof value === 'string' && MACHINE_PATH.test(value)) {
         found.push(`${node.id}.${key}`)
       }
     }

--- a/packages/mcp/src/workflow-portability.ts
+++ b/packages/mcp/src/workflow-portability.ts
@@ -1,0 +1,184 @@
+import type { WorkflowDefinition, WorkflowNode } from '@vornrun/shared/types'
+
+/**
+ * Making a workflow portable, and putting it back.
+ *
+ * A workflow is stored with absolute paths baked into its node configs, so it
+ * describes one directory on one machine. That is why a workflow cannot be
+ * committed beside the code it drives, reviewed in a diff, or run by anyone
+ * else. Export rewrites the machine-specific parts to placeholders; import
+ * resolves them against a named project.
+ *
+ * Node configs are an untyped passthrough (`config: z.record(...)`), so there
+ * is no flat list of paths to walk — every rewrite has to know the node type it
+ * is looking at. That is the whole reason this file exists rather than a
+ * two-line `JSON.stringify`.
+ */
+
+/** Stands in for the importing project's directory. */
+export const PROJECT_PATH_TOKEN = '{{project.path}}'
+/** Stands in for the importing project's name. */
+export const PROJECT_NAME_TOKEN = '{{project.name}}'
+
+export const PORTABLE_FORMAT_VERSION = 1
+
+export type PortableWorkflow = {
+  version: number
+  slug: string
+  name: string
+  icon?: string
+  iconColor?: string
+  staggerDelayMs?: number
+  nodes: WorkflowNode[]
+  edges: WorkflowDefinition['edges']
+}
+
+/**
+ * Id for an imported workflow, derived from portable inputs only.
+ *
+ * `connectorSeededWorkflowId` is the pattern being followed — derive, look up,
+ * update in place — but its input is a locally generated UUID, so the same
+ * connector on two machines produces two different ids. Deriving from the
+ * bundle and slug instead means re-importing anywhere updates the workflow it
+ * already created rather than adding a second copy.
+ */
+export function importedWorkflowId(bundle: string, slug: string): string {
+  return `import:${bundle}:${slug}`
+}
+
+export function parseImportedWorkflowId(id: string): { bundle: string; slug: string } | null {
+  if (!id.startsWith('import:')) return null
+  const rest = id.slice('import:'.length)
+  const colon = rest.indexOf(':')
+  if (colon === -1) return null
+  return { bundle: rest.slice(0, colon), slug: rest.slice(colon + 1) }
+}
+
+export function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'workflow'
+  )
+}
+
+/**
+ * Why a workflow cannot travel, if it cannot.
+ *
+ * A connector-bound workflow carries a `connectionId` that is a UUID minted on
+ * this machine. Rewriting it to a placeholder would produce a file that
+ * imports cleanly and then fails at run time against a connection that does
+ * not exist — so this refuses instead, the way install_connector refuses
+ * secrets rather than guessing at them.
+ */
+export function portabilityBlockers(workflow: WorkflowDefinition): string[] {
+  const blockers: string[] = []
+
+  for (const node of workflow.nodes) {
+    const config = node.config as Record<string, unknown>
+
+    if (node.type === 'trigger' && config.triggerType === 'connectorPoll') {
+      blockers.push(`the trigger polls a connector connection, which exists only on this machine`)
+    }
+    if (node.type === 'callConnectorAction') {
+      blockers.push(`step "${node.label}" calls a connector action bound to a local connection`)
+    }
+  }
+
+  return blockers
+}
+
+/** Replace this machine's paths with placeholders. */
+export function toPortable(workflow: WorkflowDefinition, projectPath: string): PortableWorkflow {
+  const slug = slugify(workflow.name)
+
+  const nodes = workflow.nodes.map((node) => {
+    const config = { ...(node.config as Record<string, unknown>) }
+
+    if (node.type === 'launchAgent' || node.type === 'script') {
+      for (const key of ['projectPath', 'cwd', 'existingWorktreePath']) {
+        const value = config[key]
+        if (typeof value === 'string' && value) {
+          config[key] = replacePath(value, projectPath)
+        }
+      }
+      if (typeof config.projectName === 'string' && config.projectName) {
+        config[`projectName`] = PROJECT_NAME_TOKEN
+      }
+      // Points at a host registered in this install's remote_hosts table; the
+      // id means nothing elsewhere, so the import runs locally rather than
+      // against a host the importer never configured.
+      delete config.remoteHostId
+    }
+
+    return { ...node, config } as WorkflowNode
+  })
+
+  return {
+    version: PORTABLE_FORMAT_VERSION,
+    slug,
+    name: workflow.name,
+    ...(workflow.icon && { icon: workflow.icon }),
+    ...(workflow.iconColor && { iconColor: workflow.iconColor }),
+    ...(workflow.staggerDelayMs !== undefined && { staggerDelayMs: workflow.staggerDelayMs }),
+    nodes,
+    edges: workflow.edges
+  }
+}
+
+function replacePath(value: string, projectPath: string): string {
+  if (value === projectPath) return PROJECT_PATH_TOKEN
+  // A path inside the project keeps its tail, so a worktree or a subdirectory
+  // survives the round trip instead of collapsing onto the project root.
+  const prefix = projectPath.endsWith('/') ? projectPath : `${projectPath}/`
+  if (value.startsWith(prefix)) return PROJECT_PATH_TOKEN + '/' + value.slice(prefix.length)
+  return value
+}
+
+/** Resolve placeholders against the project this workflow is being imported into. */
+export function fromPortable(
+  portable: PortableWorkflow,
+  bundle: string,
+  project: { name: string; path: string }
+): WorkflowDefinition {
+  const nodes = portable.nodes.map((node) => {
+    const config = { ...(node.config as Record<string, unknown>) }
+
+    for (const [key, value] of Object.entries(config)) {
+      if (typeof value !== 'string') continue
+      config[key] = value
+        .split(PROJECT_PATH_TOKEN)
+        .join(project.path.replace(/\/$/, ''))
+        .split(PROJECT_NAME_TOKEN)
+        .join(project.name)
+    }
+
+    return { ...node, config } as WorkflowNode
+  })
+
+  return {
+    id: importedWorkflowId(bundle, portable.slug),
+    name: portable.name,
+    icon: portable.icon ?? 'Zap',
+    iconColor: portable.iconColor ?? '#6366f1',
+    enabled: true,
+    ...(portable.staggerDelayMs !== undefined && { staggerDelayMs: portable.staggerDelayMs }),
+    nodes,
+    edges: portable.edges
+  }
+}
+
+/** What is still machine-specific after export. Empty is the goal. */
+export function residualAbsolutePaths(portable: PortableWorkflow): string[] {
+  const found: string[] = []
+  for (const node of portable.nodes) {
+    for (const [key, value] of Object.entries(node.config as Record<string, unknown>)) {
+      if (typeof value === 'string' && /(^|["'\s])\/(Users|home)\//.test(value)) {
+        found.push(`${node.id}.${key}`)
+      }
+    }
+  }
+  return found
+}

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2803,6 +2803,12 @@ type WorkflowRunNodeRow = {
 }
 
 function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
+  // Computed before the spread: `{ x: undefined }` still creates the key, so
+  // spreading the parse result directly would leave a present-but-undefined
+  // structuredOutput on exactly the corrupt rows this is supposed to degrade.
+  const structured =
+    n.structured_output != null ? parseStructuredOutput(n.structured_output) : undefined
+
   return {
     nodeId: n.node_id,
     status: n.status as NodeExecutionState['status'],
@@ -2819,9 +2825,7 @@ function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
     ...(n.approved_at != null && { approvedAt: n.approved_at }),
     ...(n.diagnostics != null && { diagnostics: n.diagnostics }),
     ...(n.output != null && { output: n.output }),
-    ...(n.structured_output != null && {
-      structuredOutput: parseStructuredOutput(n.structured_output)
-    }),
+    ...(structured !== undefined && { structuredOutput: structured }),
     ...(n.iteration != null && { iteration: n.iteration })
   }
 }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -370,6 +370,9 @@ function createSchema(): void {
       project_path TEXT,
       approved_at TEXT,
       diagnostics TEXT,
+      output TEXT,
+      structured_output TEXT,
+      iteration INTEGER,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -929,7 +932,19 @@ function verifySchema(d: Database.Database): void {
       {
         column: 'diagnostics',
         ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN diagnostics TEXT'
-      }
+      },
+      // A step's result was held only in renderer memory. After a reload the
+      // typed verdict was gone, {{steps.<slug>.<field>}} silently fell back to
+      // raw logs, and verdictOf reported "completed" for a run whose agent had
+      // said otherwise — worst on a run parked at an approval gate, which is
+      // exactly the case that outlives a restart.
+      { column: 'output', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN output TEXT' },
+      {
+        column: 'structured_output',
+        ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN structured_output TEXT'
+      },
+      // Which pass of a loop produced this row.
+      { column: 'iteration', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN iteration INTEGER' }
     ],
     tasks: [
       {
@@ -2706,8 +2721,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics, output, structured_output, iteration)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -2725,7 +2740,12 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         ns.projectName ?? null,
         ns.projectPath ?? null,
         ns.approvedAt ?? null,
-        ns.diagnostics ?? null
+        ns.diagnostics ?? null,
+        ns.output ?? null,
+        // Stored as JSON text: the parsed shape is whatever the step's
+        // outputSchema declared, so there is nothing narrower to store it as.
+        ns.structuredOutput ? JSON.stringify(ns.structuredOutput) : null,
+        ns.iteration ?? null
       )
     }
 
@@ -2777,6 +2797,9 @@ type WorkflowRunNodeRow = {
   project_path: string | null
   approved_at: string | null
   diagnostics: string | null
+  output: string | null
+  structured_output: string | null
+  iteration: number | null
 }
 
 function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
@@ -2794,7 +2817,29 @@ function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
     ...(n.project_name != null && { projectName: n.project_name }),
     ...(n.project_path != null && { projectPath: n.project_path }),
     ...(n.approved_at != null && { approvedAt: n.approved_at }),
-    ...(n.diagnostics != null && { diagnostics: n.diagnostics })
+    ...(n.diagnostics != null && { diagnostics: n.diagnostics }),
+    ...(n.output != null && { output: n.output }),
+    ...(n.structured_output != null && {
+      structuredOutput: parseStructuredOutput(n.structured_output)
+    }),
+    ...(n.iteration != null && { iteration: n.iteration })
+  }
+}
+
+/**
+ * A step's typed result, back out of storage.
+ *
+ * Tolerant on purpose: this column is JSON we wrote ourselves, but a row
+ * predating a schema change — or written by a build that serialised something
+ * unexpected — should degrade to "no typed output" rather than break loading
+ * an entire run's history.
+ */
+function parseStructuredOutput(raw: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined
+  } catch {
+    return undefined
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -477,6 +477,7 @@ export type WorkflowNodeType =
   | 'approval'
   | 'createTaskFromItem'
   | 'callConnectorAction'
+  | 'loop'
 
 export interface WorkflowNodePosition {
   x: number
@@ -699,6 +700,35 @@ export type WorkflowNodeConfig =
   | ApprovalConfig
   | CreateTaskFromItemConfig
   | CallConnectorActionConfig
+  | LoopConfig
+
+/**
+ * Repeat a run of steps until they are good enough, or until the budget runs
+ * out.
+ *
+ * A loop node sits in the chain ahead of the steps it owns and drives them
+ * itself, so the ordinary wave scheduler never runs a body node directly — it
+ * only sees them already complete once the loop finishes. That keeps the graph
+ * acyclic, which matters because the runner requires every predecessor to have
+ * completed and a back edge would simply deadlock.
+ *
+ * `maxIterations` is not a safety net, it is the contract: an LLM judge asked
+ * "is this good yet" converges on yes, so the bound is what actually ends the
+ * loop. It is capped low deliberately.
+ */
+export interface LoopConfig {
+  nodeType: 'loop'
+  /** Steps this loop owns, in execution order. */
+  bodyNodeIds: string[]
+  /** Hard cap on passes. 1 means "run the body once", i.e. no repeat. */
+  maxIterations: number
+  /**
+   * Checked after each pass; the loop stops when it holds. Omit to always run
+   * exactly `maxIterations` passes. Resolved against step outputs, so
+   * `{{steps.review.approved}} equals true` is the shape this exists for.
+   */
+  until?: ConditionConfig
+}
 
 export interface WorkflowNode {
   id: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -735,13 +735,19 @@ export interface NodeExecutionState {
   logs?: string
   output?: string
   /**
-   * Typed payload returned by a callConnectorAction step (the connector's
-   * `ActionResult.output`, which matches the action's declared
-   * `outputSchema`). Stored separately from the string `output` / `logs`
-   * fields so the template resolver can walk nested paths like
-   * `{{steps.create_issue.html_url}}` at its original shape.
+   * Typed payload from a step that declared a shape: a callConnectorAction's
+   * `ActionResult.output`, or a headless launchAgent's `outputSchema` result.
+   * Stored separately from the string `output` / `logs` fields so the template
+   * resolver can walk nested paths like `{{steps.create_issue.html_url}}` at
+   * its original shape.
    */
   structuredOutput?: Record<string, unknown>
+  /**
+   * Which pass of an enclosing loop produced this state. Absent outside a
+   * loop. The state itself is last-write-wins, so this reports how many passes
+   * ran rather than indexing a history.
+   */
+  iteration?: number
   taskId?: string
   agentSessionId?: string
   /** Concrete agent type resolved at launch time. Distinct from the node's

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -21,6 +21,7 @@ import {
   NODE_TYPE_VISUAL,
   nodeConnectionId,
   stepMeta,
+  inlineLogTail,
   stepOutputPreview,
   stepPreview
 } from './node-visuals'
@@ -328,7 +329,7 @@ export function RunStepsList({
                       className="text-[11px] text-gray-400 bg-black/30 rounded-md p-2 max-h-[200px] overflow-auto
                                 font-mono whitespace-pre-wrap break-all leading-relaxed"
                     >
-                      {ns.logs.length > 2000 ? ns.logs.slice(0, 2000) + '\n...' : ns.logs}
+                      {inlineLogTail(ns.logs)}
                     </pre>
                     <div className="flex items-center gap-1 mt-1.5">
                       {onViewFullOutput && (

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -4,6 +4,9 @@ import { LaunchAgentNode } from './nodes/LaunchAgentNode'
 import { ScriptNode } from './nodes/ScriptNode'
 import { ConditionNode } from './nodes/ConditionNode'
 import { ApprovalNode } from './nodes/ApprovalNode'
+import { Repeat } from 'lucide-react'
+// Fallback for a loop node that is not reachable from the trigger: orphans are
+// appended as plain node rows, so they never reach LoopRenderer.
 import { LoopNode } from './nodes/LoopNode'
 import { CreateTaskFromItemNode } from './nodes/CreateTaskFromItemNode'
 import { CallConnectorActionNode } from './nodes/CallConnectorActionNode'
@@ -232,6 +235,19 @@ function FlowRowRenderer({
           )
         }
 
+        if (row.kind === 'loop') {
+          return (
+            <LoopRenderer
+              key={`loop-${row.loopNode.id}`}
+              row={row}
+              onNodeClick={onNodeClick}
+              onInsertNode={onInsertNode}
+              selectedNodeId={selectedNodeId}
+              nodes={nodes ?? []}
+            />
+          )
+        }
+
         return (
           <ForkRenderer
             key={`fork-${row.forkNodeId}`}
@@ -260,6 +276,108 @@ function HorizontalBar({ branchCount }: { branchCount: number }) {
           )}
         </div>
       ))}
+    </div>
+  )
+}
+
+/**
+ * A loop and the steps it repeats, drawn as one enclosure.
+ *
+ * The two questions a reader has — what repeats, and when does it stop — are
+ * answered at the top and bottom edges of the rail, so neither requires
+ * opening a panel. The body is inset, which is the whole point: a repeated
+ * step must not look like a step that runs once.
+ */
+function LoopRenderer({
+  row,
+  onNodeClick,
+  onInsertNode,
+  selectedNodeId,
+  nodes
+}: {
+  row: Extract<FlowRow, { kind: 'loop' }>
+  onNodeClick: (nodeId: string) => void
+  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
+  selectedNodeId: string | null
+  nodes: WorkflowNode[]
+}) {
+  const config = row.loopNode.config as LoopConfig
+  const selected = row.loopNode.id === selectedNodeId
+  const until = config.until?.variable
+    ? `until ${config.until.variable} ${config.until.operator} ${config.until.value}`
+    : 'runs every pass'
+  const lastBodyId = row.body.length > 0 ? row.body[row.body.length - 1] : null
+
+  return (
+    <div
+      className={`w-[300px] rounded-lg border transition-all
+                  ${selected ? 'border-cyan-400/60 shadow-[0_0_0_3px_rgba(34,211,238,0.08)]' : 'border-cyan-400/25'}
+                  bg-cyan-500/[0.03]`}
+    >
+      <div
+        onClick={(e) => {
+          e.stopPropagation()
+          onNodeClick(row.loopNode.id)
+        }}
+        className="flex items-center gap-2 px-3 py-2 border-b border-cyan-400/15 cursor-pointer
+                   hover:bg-white/[0.02] rounded-t-lg"
+      >
+        <Repeat size={13} className="shrink-0 text-cyan-400" strokeWidth={2} />
+        <span className="text-[12.5px] font-semibold text-white truncate flex-1">
+          {row.loopNode.label}
+        </span>
+        <span className="shrink-0 text-[10px] font-mono text-cyan-300/90 bg-cyan-500/10 rounded px-1.5 py-0.5">
+          max {config.maxIterations ?? 1}
+        </span>
+      </div>
+
+      <div className="px-3 pt-3 flex flex-col items-center">
+        {row.body.length === 0 ? (
+          <div
+            className="w-full rounded-md border border-dashed border-white/[0.12] px-3 py-4
+                       text-[11px] text-gray-500 text-center"
+          >
+            No steps yet — add one below
+          </div>
+        ) : (
+          row.body.map((bodyRow, i) => (
+            <Fragment key={bodyRow.kind === 'node' ? bodyRow.node.id : i}>
+              {i > 0 && <VerticalLine />}
+              {bodyRow.kind === 'node' && (
+                <NodeCard
+                  node={bodyRow.node}
+                  allNodes={nodes}
+                  selected={bodyRow.node.id === selectedNodeId}
+                  onClick={() => onNodeClick(bodyRow.node.id)}
+                />
+              )}
+            </Fragment>
+          ))
+        )}
+
+        {/* Inside the rail, so position is what decides membership. */}
+        <VerticalLine />
+        <ConnectorButton
+          onAddAction={() =>
+            onInsertNode(
+              lastBodyId?.kind === 'node' ? lastBodyId.node.id : row.loopNode.id,
+              '__LOOP_BODY__',
+              'agent'
+            )
+          }
+          onAddScript={() =>
+            onInsertNode(
+              lastBodyId?.kind === 'node' ? lastBodyId.node.id : row.loopNode.id,
+              '__LOOP_BODY__',
+              'script'
+            )
+          }
+        />
+      </div>
+
+      <div className="px-3 pt-2 pb-2.5 text-[10px] font-mono text-cyan-300/70 text-center truncate">
+        ↻ {until}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -206,7 +206,15 @@ function FlowRowRenderer({
                     onAddScript={() => onInsertNode(row.node.id, beforeNodeId, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, beforeNodeId, 'condition')}
                     onAddApproval={() => onInsertNode(row.node.id, beforeNodeId, 'approval')}
-                    onAddLoop={() => onInsertNode(row.node.id, beforeNodeId, 'loop')}
+                    onAddLoop={
+                      // Gated like onAddParallelBranch: a loop lifts its body
+                      // out of the trunk, and how that interacts with a fork's
+                      // join is untested. Offering it inside a branch would be
+                      // promising something that has never been tried.
+                      !isInsideBranch
+                        ? () => onInsertNode(row.node.id, beforeNodeId, 'loop')
+                        : undefined
+                    }
                     onAddConnectorAction={() =>
                       onInsertNode(row.node.id, beforeNodeId, 'connectorAction')
                     }
@@ -223,7 +231,9 @@ function FlowRowRenderer({
                     onAddScript={() => onInsertNode(row.node.id, null, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, null, 'condition')}
                     onAddApproval={() => onInsertNode(row.node.id, null, 'approval')}
-                    onAddLoop={() => onInsertNode(row.node.id, null, 'loop')}
+                    onAddLoop={
+                      !isInsideBranch ? () => onInsertNode(row.node.id, null, 'loop') : undefined
+                    }
                     onAddConnectorAction={() => onInsertNode(row.node.id, null, 'connectorAction')}
                     onAddParallelBranch={
                       !isInsideBranch ? () => onAddParallelBranch(row.node.id, 'agent') : undefined

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -4,6 +4,7 @@ import { LaunchAgentNode } from './nodes/LaunchAgentNode'
 import { ScriptNode } from './nodes/ScriptNode'
 import { ConditionNode } from './nodes/ConditionNode'
 import { ApprovalNode } from './nodes/ApprovalNode'
+import { LoopNode } from './nodes/LoopNode'
 import { CreateTaskFromItemNode } from './nodes/CreateTaskFromItemNode'
 import { CallConnectorActionNode } from './nodes/CallConnectorActionNode'
 import { ConnectorButton } from './nodes/AddStepNode'
@@ -15,12 +16,19 @@ import {
   ScriptConfig,
   ConditionConfig,
   ApprovalConfig,
+  LoopConfig,
   CreateTaskFromItemConfig,
   CallConnectorActionConfig
 } from '../../../shared/types'
 import { computeFlowLayout, FlowRow } from '../../lib/workflow-helpers'
 
-export type AddableNodeType = 'agent' | 'script' | 'condition' | 'approval' | 'connectorAction'
+export type AddableNodeType =
+  | 'agent'
+  | 'script'
+  | 'condition'
+  | 'approval'
+  | 'connectorAction'
+  | 'loop'
 
 interface Props {
   nodes: WorkflowNode[]
@@ -44,13 +52,28 @@ function VerticalLine({ dashed, height }: { dashed?: boolean; height?: number })
 
 function NodeCard({
   node,
+  allNodes,
   selected,
   onClick
 }: {
   node: WorkflowNode
+  /** Every node in the workflow: a loop card lists the steps it repeats. */
+  allNodes: WorkflowNode[]
   selected: boolean
   onClick: () => void
 }) {
+  if (node.type === 'loop') {
+    return (
+      <LoopNode
+        label={node.label}
+        config={node.config as LoopConfig}
+        nodes={allNodes}
+        selected={selected}
+        onClick={onClick}
+      />
+    )
+  }
+
   if (node.type === 'trigger') {
     return (
       <TriggerNode
@@ -167,6 +190,7 @@ function FlowRowRenderer({
 
               <NodeCard
                 node={row.node}
+                allNodes={nodes ?? []}
                 selected={row.node.id === selectedNodeId}
                 onClick={() => onNodeClick(row.node.id)}
               />
@@ -179,6 +203,7 @@ function FlowRowRenderer({
                     onAddScript={() => onInsertNode(row.node.id, beforeNodeId, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, beforeNodeId, 'condition')}
                     onAddApproval={() => onInsertNode(row.node.id, beforeNodeId, 'approval')}
+                    onAddLoop={() => onInsertNode(row.node.id, beforeNodeId, 'loop')}
                     onAddConnectorAction={() =>
                       onInsertNode(row.node.id, beforeNodeId, 'connectorAction')
                     }
@@ -195,6 +220,7 @@ function FlowRowRenderer({
                     onAddScript={() => onInsertNode(row.node.id, null, 'script')}
                     onAddCondition={() => onInsertNode(row.node.id, null, 'condition')}
                     onAddApproval={() => onInsertNode(row.node.id, null, 'approval')}
+                    onAddLoop={() => onInsertNode(row.node.id, null, 'loop')}
                     onAddConnectorAction={() => onInsertNode(row.node.id, null, 'connectorAction')}
                     onAddParallelBranch={
                       !isInsideBranch ? () => onAddParallelBranch(row.node.id, 'agent') : undefined

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -21,6 +21,7 @@ import { WindowControls } from '../WindowControls'
 import {
   WorkflowDefinition,
   WorkflowNode,
+  LoopConfig,
   WorkflowEdge,
   TriggerConfig,
   AiAgentType,
@@ -45,6 +46,7 @@ import {
   insertBeforeFork,
   insertConditionBetween,
   createLoopNode,
+  appendToLoopBody,
   addParallelBranch,
   removeNode,
   getWorktreeMode
@@ -405,7 +407,20 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       const newNode = createNodeWithUniqueSlug(type)
 
       let result: { nodes: WorkflowNode[]; edges: WorkflowEdge[] }
-      if (beforeNodeId === '__FORK__') {
+      if (beforeNodeId === '__LOOP_BODY__') {
+        // afterNodeId is the loop when its body is empty, otherwise the last
+        // body step; appendToLoopBody resolves the loop from either.
+        const loopId =
+          nodes.find((n) => n.id === afterNodeId && n.type === 'loop')?.id ??
+          nodes.find(
+            (n) =>
+              n.type === 'loop' &&
+              ((n.config as LoopConfig).bodyNodeIds ?? []).includes(afterNodeId)
+          )?.id
+        result = loopId
+          ? appendToLoopBody(nodes, edges, loopId, newNode)
+          : appendNodeAfter(nodes, edges, afterNodeId, newNode)
+      } else if (beforeNodeId === '__FORK__') {
         result = insertBeforeFork(nodes, edges, afterNodeId, newNode)
       } else if (beforeNodeId) {
         const edge = edges.find((e) => e.source === afterNodeId && e.target === beforeNodeId)
@@ -754,7 +769,6 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           <NodeConfigPanel
             node={selectedNode}
             allNodes={nodes}
-            allEdges={edges}
             onChange={handleNodeConfigChange}
             onLabelChange={handleNodeLabelChange}
             onDelete={handleDeleteNode}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -44,6 +44,7 @@ import {
   insertNodeBetween,
   insertBeforeFork,
   insertConditionBetween,
+  createLoopNode,
   addParallelBranch,
   removeNode,
   getWorktreeMode
@@ -368,6 +369,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       const factories: Record<AddableNodeType, () => WorkflowNode> = {
         condition: () => createConditionNode(),
         approval: () => createApprovalNode(),
+        loop: () => createLoopNode(),
         script: () => createScriptNode(),
         connectorAction: () => createCallConnectorActionNode(),
         agent: () =>
@@ -752,6 +754,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           <NodeConfigPanel
             node={selectedNode}
             allNodes={nodes}
+            allEdges={edges}
             onChange={handleNodeConfigChange}
             onLabelChange={handleNodeLabelChange}
             onDelete={handleDeleteNode}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -21,7 +21,6 @@ import { WindowControls } from '../WindowControls'
 import {
   WorkflowDefinition,
   WorkflowNode,
-  LoopConfig,
   WorkflowEdge,
   TriggerConfig,
   AiAgentType,
@@ -47,6 +46,7 @@ import {
   insertConditionBetween,
   createLoopNode,
   appendToLoopBody,
+  loopOwningInsertPoint,
   addParallelBranch,
   removeNode,
   getWorktreeMode
@@ -410,15 +410,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       if (beforeNodeId === '__LOOP_BODY__') {
         // afterNodeId is the loop when its body is empty, otherwise the last
         // body step; appendToLoopBody resolves the loop from either.
-        const loopId =
-          nodes.find((n) => n.id === afterNodeId && n.type === 'loop')?.id ??
-          nodes.find(
-            (n) =>
-              n.type === 'loop' &&
-              ((n.config as LoopConfig).bodyNodeIds ?? []).includes(afterNodeId)
-          )?.id
-        result = loopId
-          ? appendToLoopBody(nodes, edges, loopId, newNode)
+        const loop = loopOwningInsertPoint(nodes, afterNodeId)
+        result = loop
+          ? appendToLoopBody(nodes, edges, loop.id, newNode)
           : appendNodeAfter(nodes, edges, afterNodeId, newNode)
       } else if (beforeNodeId === '__FORK__') {
         result = insertBeforeFork(nodes, edges, afterNodeId, newNode)

--- a/src/renderer/components/workflow-editor/node-visuals.ts
+++ b/src/renderer/components/workflow-editor/node-visuals.ts
@@ -1,4 +1,4 @@
-import { Zap, Play, Terminal, GitFork, Hand, ListPlus } from 'lucide-react'
+import { Zap, Play, Terminal, GitFork, Hand, ListPlus, Repeat } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { NodeExecutionState, WorkflowNode } from '../../../shared/types'
 
@@ -32,7 +32,8 @@ export const NODE_TYPE_VISUAL: Record<
     label: 'Connector Action',
     color: 'text-gray-300',
     bg: 'bg-white/[0.06]'
-  }
+  },
+  loop: { icon: Repeat, label: 'Loop', color: 'text-cyan-400', bg: 'bg-cyan-500/10' }
 }
 
 /**

--- a/src/renderer/components/workflow-editor/node-visuals.ts
+++ b/src/renderer/components/workflow-editor/node-visuals.ts
@@ -155,3 +155,20 @@ export function stepOutputPreview(state: NodeExecutionState): string | undefined
   }
   return undefined
 }
+
+/**
+ * How much of a step's log the inline panel shows, and from which end.
+ *
+ * The end. An agent's answer — its verdict, its summary, the reason it failed —
+ * is the last thing it writes, and the previous head-first slice meant a long
+ * step showed its preamble and hid its conclusion. The container already
+ * scrolls, so the only job of this cap is to keep a very large log out of the
+ * DOM; "View full output" remains the untruncated path.
+ */
+const INLINE_LOG_CHARS = 8000
+
+export function inlineLogTail(logs: string): string {
+  if (logs.length <= INLINE_LOG_CHARS) return logs
+  const elided = logs.length - INLINE_LOG_CHARS
+  return `… ${elided.toLocaleString()} earlier characters hidden — use View full output\n\n${logs.slice(-INLINE_LOG_CHARS)}`
+}

--- a/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Play, GitBranch, Terminal, Split, Hand, Zap } from 'lucide-react'
+import { Plus, Play, GitBranch, Terminal, Split, Hand, Zap, Repeat } from 'lucide-react'
 
 interface Props {
   onAddAction: () => void
@@ -7,6 +7,7 @@ interface Props {
   onAddScript?: () => void
   onAddCondition?: () => void
   onAddApproval?: () => void
+  onAddLoop?: () => void
   onAddConnectorAction?: () => void
 }
 
@@ -16,6 +17,7 @@ export function ConnectorButton({
   onAddScript,
   onAddCondition,
   onAddApproval,
+  onAddLoop,
   onAddConnectorAction
 }: Props) {
   const [open, setOpen] = useState(false)
@@ -112,6 +114,21 @@ export function ConnectorButton({
             >
               <Hand size={14} className="text-gray-400 shrink-0" />
               Add an approval gate
+            </button>
+          )}
+
+          {onAddLoop && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setOpen(false)
+                onAddLoop()
+              }}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-gray-300
+                         hover:bg-white/[0.06] hover:text-white transition-colors text-left"
+            >
+              <Repeat size={14} className="text-gray-400 shrink-0" />
+              Repeat steps until…
             </button>
           )}
 

--- a/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
@@ -1,0 +1,85 @@
+import { Repeat } from 'lucide-react'
+import type { LoopConfig, NodeExecutionStatus, WorkflowNode } from '../../../../shared/types'
+import { STATUS_DOT_CLASSES } from '../statusDot'
+
+interface Props {
+  label: string
+  config: LoopConfig
+  /** Every node in the workflow, so the card can name the steps it repeats. */
+  nodes: WorkflowNode[]
+  selected?: boolean
+  executionStatus?: NodeExecutionStatus
+  /** Passes actually run, once a run has happened. */
+  iteration?: number
+  onClick: () => void
+}
+
+export function LoopNode({
+  label,
+  config,
+  nodes,
+  selected,
+  executionStatus,
+  iteration,
+  onClick
+}: Props) {
+  const body = (config.bodyNodeIds ?? [])
+    .map((id) => nodes.find((n) => n.id === id))
+    .filter((n): n is WorkflowNode => Boolean(n))
+
+  const max = config.maxIterations ?? 1
+  // The body is what makes a loop a loop, so an empty one is worth saying out
+  // loud on the card rather than leaving the reader to wonder why nothing
+  // repeated.
+  const subtitle =
+    body.length === 0
+      ? 'No steps selected yet'
+      : `Repeats ${body.length} step${body.length === 1 ? '' : 's'} · up to ${max}×`
+
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
+                  ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
+                  ${body.length === 0 ? 'border-dashed' : ''}
+                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+    >
+      {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
+        <span
+          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${STATUS_DOT_CLASSES[executionStatus]}`}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        <Repeat size={14} className="shrink-0 text-cyan-400" strokeWidth={2} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-medium text-white truncate">{label}</div>
+          <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
+        </div>
+        {iteration !== undefined && iteration > 0 && (
+          <span className="shrink-0 text-[10px] text-cyan-300/80 bg-cyan-500/10 rounded px-1.5 py-0.5">
+            {iteration}×
+          </span>
+        )}
+      </div>
+
+      {body.length > 0 && (
+        <div className="mt-2 border-t border-white/[0.06] pt-2 space-y-0.5">
+          {body.map((n, i) => (
+            <div key={n.id} className="text-[11px] text-gray-500 truncate">
+              <span className="text-gray-600 tabular-nums">{i + 1}.</span> {n.label}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {config.until?.variable && (
+        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2">
+          until {config.until.variable} {config.until.operator} {config.until.value}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/LoopConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LoopConfigForm.tsx
@@ -1,4 +1,4 @@
-import type { ConditionOperator, LoopConfig, WorkflowNode } from '../../../../shared/types'
+import type { ConditionOperator, LoopConfig } from '../../../../shared/types'
 
 const MAX_ITERATIONS = 10
 
@@ -13,61 +13,22 @@ const OPERATORS: { value: ConditionOperator; label: string }[] = [
 
 interface Props {
   config: LoopConfig
-  /** Steps this loop is allowed to repeat: everything downstream of it. */
-  candidates: WorkflowNode[]
   onChange: (config: LoopConfig) => void
 }
 
-export function LoopConfigForm({ config, candidates, onChange }: Props) {
-  const body = config.bodyNodeIds ?? []
+/**
+ * Two fields, deliberately.
+ *
+ * Which steps a loop repeats is answered on the canvas, by putting them inside
+ * it. This panel used to carry a checkbox list of every downstream step, which
+ * made a spatial relationship into a data-entry form and let the list drift
+ * from the graph. Membership has one source of truth now, and it is not here.
+ */
+export function LoopConfigForm({ config, onChange }: Props) {
   const until = config.until
-
-  const toggle = (id: string): void => {
-    // Kept in the candidates' own order rather than click order, so the body
-    // always reads in the order the steps will actually run.
-    const next = body.includes(id) ? body.filter((b) => b !== id) : [...body, id]
-    const ordered = candidates.filter((n) => next.includes(n.id)).map((n) => n.id)
-    onChange({ ...config, bodyNodeIds: ordered })
-  }
-
-  const gateInBody = candidates.some((n) => body.includes(n.id) && n.type === 'approval')
 
   return (
     <div className="space-y-5">
-      <div>
-        <label className="text-[13px] text-gray-400 font-medium block mb-2">Steps to repeat</label>
-        {candidates.length === 0 ? (
-          <div className="text-[11px] text-gray-500">
-            Add steps after this loop first, then choose which of them it repeats.
-          </div>
-        ) : (
-          <div className="space-y-1">
-            {candidates.map((node) => (
-              <label
-                key={node.id}
-                className="flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer
-                           hover:bg-white/[0.03] transition-colors"
-              >
-                <input
-                  type="checkbox"
-                  checked={body.includes(node.id)}
-                  onChange={() => toggle(node.id)}
-                  className="accent-cyan-500"
-                />
-                <span className="text-[13px] text-gray-200 truncate">{node.label}</span>
-                <span className="text-[11px] text-gray-600 shrink-0">{node.type}</span>
-              </label>
-            ))}
-          </div>
-        )}
-        {gateInBody && (
-          <div className="mt-2 text-[11px] text-amber-400/90">
-            An approval gate cannot be repeated: the run would park mid-pass with no way to resume
-            at the right one. Remove it from the body.
-          </div>
-        )}
-      </div>
-
       <div>
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Maximum passes</label>
         <input

--- a/src/renderer/components/workflow-editor/panels/LoopConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LoopConfigForm.tsx
@@ -1,0 +1,166 @@
+import type { ConditionOperator, LoopConfig, WorkflowNode } from '../../../../shared/types'
+
+const MAX_ITERATIONS = 10
+
+const OPERATORS: { value: ConditionOperator; label: string }[] = [
+  { value: 'equals', label: 'equals' },
+  { value: 'notEquals', label: 'does not equal' },
+  { value: 'contains', label: 'contains' },
+  { value: 'notContains', label: 'does not contain' },
+  { value: 'isEmpty', label: 'is empty' },
+  { value: 'isNotEmpty', label: 'is not empty' }
+]
+
+interface Props {
+  config: LoopConfig
+  /** Steps this loop is allowed to repeat: everything downstream of it. */
+  candidates: WorkflowNode[]
+  onChange: (config: LoopConfig) => void
+}
+
+export function LoopConfigForm({ config, candidates, onChange }: Props) {
+  const body = config.bodyNodeIds ?? []
+  const until = config.until
+
+  const toggle = (id: string): void => {
+    // Kept in the candidates' own order rather than click order, so the body
+    // always reads in the order the steps will actually run.
+    const next = body.includes(id) ? body.filter((b) => b !== id) : [...body, id]
+    const ordered = candidates.filter((n) => next.includes(n.id)).map((n) => n.id)
+    onChange({ ...config, bodyNodeIds: ordered })
+  }
+
+  const gateInBody = candidates.some((n) => body.includes(n.id) && n.type === 'approval')
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Steps to repeat</label>
+        {candidates.length === 0 ? (
+          <div className="text-[11px] text-gray-500">
+            Add steps after this loop first, then choose which of them it repeats.
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {candidates.map((node) => (
+              <label
+                key={node.id}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer
+                           hover:bg-white/[0.03] transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={body.includes(node.id)}
+                  onChange={() => toggle(node.id)}
+                  className="accent-cyan-500"
+                />
+                <span className="text-[13px] text-gray-200 truncate">{node.label}</span>
+                <span className="text-[11px] text-gray-600 shrink-0">{node.type}</span>
+              </label>
+            ))}
+          </div>
+        )}
+        {gateInBody && (
+          <div className="mt-2 text-[11px] text-amber-400/90">
+            An approval gate cannot be repeated: the run would park mid-pass with no way to resume
+            at the right one. Remove it from the body.
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Maximum passes</label>
+        <input
+          type="number"
+          min={1}
+          max={MAX_ITERATIONS}
+          value={config.maxIterations ?? 1}
+          onChange={(e) => {
+            const n = Number(e.target.value)
+            const clamped = Number.isFinite(n)
+              ? Math.min(Math.max(1, Math.floor(n)), MAX_ITERATIONS)
+              : 1
+            onChange({ ...config, maxIterations: clamped })
+          }}
+          className="w-full px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                     text-[13px] text-gray-200 focus:outline-none focus:border-blue-500/50"
+        />
+        <div className="mt-1.5 text-[11px] text-gray-500">
+          This is what ends the loop, not a safety net: an agent asked whether its own work is good
+          enough tends to say yes. Capped at {MAX_ITERATIONS}.
+        </div>
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">
+          Stop early when <span className="text-gray-600">(optional)</span>
+        </label>
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={until?.variable ?? ''}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                until: {
+                  variable: e.target.value,
+                  operator: until?.operator ?? 'equals',
+                  value: until?.value ?? ''
+                }
+              })
+            }
+            placeholder="{{steps.review.approved}}"
+            className="w-full px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                       text-[13px] text-gray-200 placeholder:text-gray-600 font-mono
+                       focus:outline-none focus:border-blue-500/50"
+          />
+          <div className="flex gap-2">
+            <select
+              value={until?.operator ?? 'equals'}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  until: {
+                    variable: until?.variable ?? '',
+                    operator: e.target.value as ConditionOperator,
+                    value: until?.value ?? ''
+                  }
+                })
+              }
+              className="px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                         text-[13px] text-gray-200 focus:outline-none focus:border-blue-500/50"
+            >
+              {OPERATORS.map((op) => (
+                <option key={op.value} value={op.value}>
+                  {op.label}
+                </option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={until?.value ?? ''}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  until: {
+                    variable: until?.variable ?? '',
+                    operator: until?.operator ?? 'equals',
+                    value: e.target.value
+                  }
+                })
+              }
+              placeholder="true"
+              className="flex-1 px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                         text-[13px] text-gray-200 placeholder:text-gray-600
+                         focus:outline-none focus:border-blue-500/50"
+            />
+          </div>
+        </div>
+        <div className="mt-1.5 text-[11px] text-gray-500">
+          Checked after each pass, against a step's typed output. Leave blank to always run the
+          maximum.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef } from 'react'
 import { X, MoreHorizontal, Trash2 } from 'lucide-react'
 import {
   WorkflowNode,
-  WorkflowEdge,
   LoopConfig,
   TriggerConfig,
   LaunchAgentConfig,
@@ -20,7 +19,6 @@ import { ScriptConfigForm } from './ScriptConfigForm'
 import { ConditionConfigForm } from './ConditionConfigForm'
 import { ApprovalConfigForm } from './ApprovalConfigForm'
 import { LoopConfigForm } from './LoopConfigForm'
-import { nodesAfter } from '../../../lib/workflow-helpers'
 import { CreateTaskFromItemNodeForm } from './CreateTaskFromItemNodeForm'
 import { CallConnectorActionNodeForm } from './CallConnectorActionNodeForm'
 import { NODE_TYPE_VISUAL } from '../node-visuals'
@@ -29,8 +27,6 @@ import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-
 interface Props {
   node: WorkflowNode
   allNodes?: WorkflowNode[]
-  /** Needed to work out which steps a loop node is able to repeat. */
-  allEdges?: WorkflowEdge[]
   onChange: (nodeId: string, config: WorkflowNode['config']) => void
   onLabelChange: (nodeId: string, label: string) => void
   onDelete: (nodeId: string) => void
@@ -45,7 +41,6 @@ interface Props {
 export function NodeConfigPanel({
   node,
   allNodes,
-  allEdges,
   onChange,
   onLabelChange,
   onDelete,
@@ -196,7 +191,6 @@ export function NodeConfigPanel({
         {node.type === 'loop' && (
           <LoopConfigForm
             config={node.config as LoopConfig}
-            candidates={nodesAfter(allNodes ?? [], allEdges ?? [], node.id)}
             onChange={(config) => onChange(node.id, config)}
           />
         )}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { X, MoreHorizontal, Trash2 } from 'lucide-react'
 import {
   WorkflowNode,
+  WorkflowEdge,
+  LoopConfig,
   TriggerConfig,
   LaunchAgentConfig,
   ScriptConfig,
@@ -17,6 +19,8 @@ import { LaunchAgentConfigForm } from './LaunchAgentConfigForm'
 import { ScriptConfigForm } from './ScriptConfigForm'
 import { ConditionConfigForm } from './ConditionConfigForm'
 import { ApprovalConfigForm } from './ApprovalConfigForm'
+import { LoopConfigForm } from './LoopConfigForm'
+import { nodesAfter } from '../../../lib/workflow-helpers'
 import { CreateTaskFromItemNodeForm } from './CreateTaskFromItemNodeForm'
 import { CallConnectorActionNodeForm } from './CallConnectorActionNodeForm'
 import { NODE_TYPE_VISUAL } from '../node-visuals'
@@ -25,6 +29,8 @@ import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-
 interface Props {
   node: WorkflowNode
   allNodes?: WorkflowNode[]
+  /** Needed to work out which steps a loop node is able to repeat. */
+  allEdges?: WorkflowEdge[]
   onChange: (nodeId: string, config: WorkflowNode['config']) => void
   onLabelChange: (nodeId: string, label: string) => void
   onDelete: (nodeId: string) => void
@@ -39,6 +45,7 @@ interface Props {
 export function NodeConfigPanel({
   node,
   allNodes,
+  allEdges,
   onChange,
   onLabelChange,
   onDelete,
@@ -183,6 +190,14 @@ export function NodeConfigPanel({
             onChange={(config) => onChange(node.id, config)}
             triggerType={triggerType}
             stepGroups={stepGroups || []}
+          />
+        )}
+
+        {node.type === 'loop' && (
+          <LoopConfigForm
+            config={node.config as LoopConfig}
+            candidates={nodesAfter(allNodes ?? [], allEdges ?? [], node.id)}
+            onChange={(config) => onChange(node.id, config)}
           />
         )}
 

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -530,24 +530,24 @@ export function loopShouldStop(
 /**
  * The state a body step is reset to at the start of a pass.
  *
- * Every terminal field is cleared, not just the status. updateNodeState merges,
- * so a partial reset leaves the previous pass's logs and typed output attached
- * to a step that is currently running — stale data shown as if it were live,
- * and worse, still visible to buildStepOutputsMap.
+ * Enumerates what SURVIVES rather than what gets cleared. A list of fields to
+ * clear has to be updated every time NodeExecutionState gains one, and the
+ * failure is silent: the new field leaks from the previous pass into a step
+ * reported as pending. The first version of this listed eight fields and
+ * missed taskId, the worktree trio, approvedAt and diagnostics — and its test
+ * passed, because the test enumerated the same eight.
  */
-export function blankPassState(iteration: number): Partial<NodeExecutionState> {
-  return {
-    status: 'pending',
-    startedAt: undefined,
-    completedAt: undefined,
-    error: undefined,
-    logs: undefined,
-    output: undefined,
-    structuredOutput: undefined,
-    sessionId: undefined,
-    agentSessionId: undefined,
-    iteration
+const SURVIVES_A_PASS = new Set(['nodeId'])
+
+export function blankPassState(
+  state: NodeExecutionState,
+  iteration: number
+): Partial<NodeExecutionState> {
+  const cleared: Record<string, unknown> = {}
+  for (const key of Object.keys(state)) {
+    if (!SURVIVES_A_PASS.has(key)) cleared[key] = undefined
   }
+  return { ...cleared, status: 'pending', iteration } as Partial<NodeExecutionState>
 }
 
 /**
@@ -595,7 +595,10 @@ async function executeLoop(
     return
   }
 
-  const max = Math.min(Math.max(1, Math.floor(config.maxIterations ?? 1)), MAX_LOOP_ITERATIONS)
+  const requested = Number(config.maxIterations)
+  const max = Number.isFinite(requested)
+    ? Math.min(Math.max(1, Math.floor(requested)), MAX_LOOP_ITERATIONS)
+    : 1
   const summary: string[] = []
   let stopReason = `reached the ${max}-pass limit`
   let passes = 0
@@ -621,7 +624,8 @@ async function executeLoop(
     // has not run yet this time — the loop would then revise against a verdict
     // describing the draft it already replaced.
     for (const step of body) {
-      updateNodeState(execution, step.id, blankPassState(iteration))
+      const state = execution.nodeStates.find((x) => x.nodeId === step.id)
+      if (state) updateNodeState(execution, step.id, blankPassState(state, iteration))
     }
     persistExecution(execution)
 

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -8,6 +8,7 @@ import {
   LaunchAgentConfig,
   ScriptConfig,
   ConditionConfig,
+  LoopConfig,
   ConditionOperator,
   ApprovalConfig,
   CreateTaskFromItemConfig,
@@ -492,6 +493,155 @@ function evaluateCondition(operator: ConditionOperator, resolved: string, value:
   }
 }
 
+/** Ceiling on `maxIterations`, whatever a workflow asks for. */
+export const MAX_LOOP_ITERATIONS = 10
+
+/**
+ * Decide whether a loop should stop after the pass that just finished.
+ *
+ * Split out because the interesting part is testable without a run: the stop
+ * reason is what a reader needs afterwards, and "we hit the cap" reads very
+ * differently from "the reviewer approved it".
+ */
+export function loopShouldStop(
+  until: ConditionConfig | undefined,
+  resolvedVariable: string,
+  resolvedValue: string
+): boolean {
+  if (!until) return false
+  return evaluateCondition(until.operator, resolvedVariable, resolvedValue)
+}
+
+/**
+ * Run a loop node's body until its condition holds or its budget runs out.
+ *
+ * The body nodes are ordinary nodes sitting downstream in the same graph; this
+ * drives them directly rather than letting the wave scheduler do it. By the
+ * time the loop reports success they are already `completed`, so the scheduler
+ * skips them and carries on with whatever follows — no cycle, and nothing to
+ * teach `getReadyNodes` about repetition.
+ */
+async function executeLoop(
+  node: WorkflowNode,
+  workflow: WorkflowDefinition,
+  execution: WorkflowExecution,
+  context?: WorkflowExecutionContext,
+  active?: ActiveRun
+): Promise<void> {
+  const config = node.config as LoopConfig
+  const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]))
+  const body = (config.bodyNodeIds ?? [])
+    .map((id) => nodeMap.get(id))
+    .filter((n): n is WorkflowNode => Boolean(n))
+
+  const fail = (message: string): void => {
+    updateNodeState(execution, node.id, {
+      status: 'error',
+      completedAt: new Date().toISOString(),
+      error: message
+    })
+    persistExecution(execution)
+  }
+
+  if (body.length === 0) {
+    fail('Loop has no body steps. Add at least one step for it to repeat.')
+    return
+  }
+
+  // A gate inside a loop would park the run mid-iteration, and resuming it
+  // means re-entering the loop at the pass it stopped on — state this loop
+  // does not keep. Refusing is honest; half-supporting it would strand runs.
+  const gate = body.find((n) => n.type === 'approval')
+  if (gate) {
+    fail(`Loop body contains an approval gate ("${gate.label}"), which is not supported.`)
+    return
+  }
+
+  const max = Math.min(Math.max(1, Math.floor(config.maxIterations ?? 1)), MAX_LOOP_ITERATIONS)
+  const summary: string[] = []
+  let stopReason = `reached the ${max}-pass limit`
+  let passes = 0
+
+  updateNodeState(execution, node.id, {
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    iteration: 0
+  })
+  persistExecution(execution)
+
+  for (let iteration = 1; iteration <= max; iteration++) {
+    if (active?.abort.signal.aborted) {
+      stopReason = 'the run was stopped'
+      break
+    }
+    passes = iteration
+    summary.push(`── iteration ${iteration} of at most ${max} ──`)
+
+    let failedStep: WorkflowNode | undefined
+    for (const step of body) {
+      if (active?.abort.signal.aborted) break
+
+      // Each pass starts the step fresh: a previous pass's terminal status
+      // would otherwise make buildStepOutputsMap serve stale output to the
+      // condition that decides whether to keep going.
+      updateNodeState(execution, step.id, {
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        completedAt: undefined,
+        error: undefined,
+        iteration
+      })
+      persistExecution(execution)
+
+      const stepOutputs = buildStepOutputsMap(execution, nodeMap)
+      await executeNode(step, workflow, execution, context, stepOutputs, active)
+
+      const state = execution.nodeStates.find((s) => s.nodeId === step.id)
+      updateNodeState(execution, step.id, { iteration })
+      summary.push(`  ${step.label}: ${state?.status ?? 'unknown'}`)
+      if (state?.status === 'error') {
+        failedStep = step
+        break
+      }
+    }
+
+    if (failedStep) {
+      stopReason = `"${failedStep.label}" failed on pass ${iteration}`
+      break
+    }
+    if (active?.abort.signal.aborted) {
+      stopReason = 'the run was stopped'
+      break
+    }
+
+    if (config.until) {
+      const outputs = buildStepOutputsMap(execution, nodeMap)
+      const resolvedVariable = resolveTemplateVars(config.until.variable || '', context, outputs)
+      const resolvedValue = resolveTemplateVars(config.until.value || '', context, outputs)
+      if (loopShouldStop(config.until, resolvedVariable, resolvedValue)) {
+        stopReason = `the condition held after pass ${iteration}`
+        break
+      }
+      summary.push(`  condition not met (${config.until.variable} was "${resolvedVariable}")`)
+    }
+  }
+
+  const failed = body.some(
+    (step) => execution.nodeStates.find((s) => s.nodeId === step.id)?.status === 'error'
+  )
+  summary.push(`Stopped after ${passes} pass(es): ${stopReason}.`)
+
+  updateNodeState(execution, node.id, {
+    status: failed ? 'error' : 'success',
+    completedAt: new Date().toISOString(),
+    iteration: passes,
+    output: String(passes),
+    logs: summary.join('\n'),
+    ...(failed && { error: stopReason })
+  })
+  persistExecution(execution)
+}
+
 async function executeNode(
   node: WorkflowNode,
   workflow: WorkflowDefinition,
@@ -500,6 +650,11 @@ async function executeNode(
   stepOutputs?: StepOutputs,
   active?: ActiveRun
 ): Promise<void> {
+  if (node.type === 'loop') {
+    await executeLoop(node, workflow, execution, context, active)
+    return
+  }
+
   if (node.type === 'approval') {
     const existing = execution.nodeStates.find((s) => s.nodeId === node.id)
     if (existing?.status === 'waiting') return

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -503,12 +503,27 @@ export const MAX_LOOP_ITERATIONS = 10
  * reason is what a reader needs afterwards, and "we hit the cap" reads very
  * differently from "the reviewer approved it".
  */
+/** Operators that compare against a value; the other two test the variable alone. */
+const VALUE_OPERATORS: ConditionOperator[] = ['equals', 'notEquals', 'contains', 'notContains']
+
 export function loopShouldStop(
   until: ConditionConfig | undefined,
   resolvedVariable: string,
   resolvedValue: string
 ): boolean {
   if (!until) return false
+
+  // A half-written condition means "not configured yet", not "stop now". Typing
+  // one into the form leaves it briefly incomplete, and some incomplete forms
+  // are degenerate rather than merely false: `contains ""` matches every
+  // string, and `notEquals ""` matches everything non-empty. Either would end
+  // the loop after one pass, which looks like the loop being broken.
+  //
+  // The cost is that `equals ""` cannot be expressed, and it does not need to
+  // be: isEmpty says exactly that and needs no value.
+  if (until.variable.trim() === '') return false
+  if (VALUE_OPERATORS.includes(until.operator) && resolvedValue.trim() === '') return false
+
   return evaluateCondition(until.operator, resolvedVariable, resolvedValue)
 }
 

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -513,6 +513,29 @@ export function loopShouldStop(
 }
 
 /**
+ * The state a body step is reset to at the start of a pass.
+ *
+ * Every terminal field is cleared, not just the status. updateNodeState merges,
+ * so a partial reset leaves the previous pass's logs and typed output attached
+ * to a step that is currently running — stale data shown as if it were live,
+ * and worse, still visible to buildStepOutputsMap.
+ */
+export function blankPassState(iteration: number): Partial<NodeExecutionState> {
+  return {
+    status: 'pending',
+    startedAt: undefined,
+    completedAt: undefined,
+    error: undefined,
+    logs: undefined,
+    output: undefined,
+    structuredOutput: undefined,
+    sessionId: undefined,
+    agentSessionId: undefined,
+    iteration
+  }
+}
+
+/**
  * Run a loop node's body until its condition holds or its budget runs out.
  *
  * The body nodes are ordinary nodes sitting downstream in the same graph; this
@@ -577,19 +600,23 @@ async function executeLoop(
     passes = iteration
     summary.push(`── iteration ${iteration} of at most ${max} ──`)
 
+    // The whole body is cleared before the pass, not each step as its turn
+    // comes. Resetting lazily leaves later steps holding last pass's results,
+    // so an earlier step resolves {{steps.review.approved}} from a review that
+    // has not run yet this time — the loop would then revise against a verdict
+    // describing the draft it already replaced.
+    for (const step of body) {
+      updateNodeState(execution, step.id, blankPassState(iteration))
+    }
+    persistExecution(execution)
+
     let failedStep: WorkflowNode | undefined
     for (const step of body) {
       if (active?.abort.signal.aborted) break
 
-      // Each pass starts the step fresh: a previous pass's terminal status
-      // would otherwise make buildStepOutputsMap serve stale output to the
-      // condition that decides whether to keep going.
       updateNodeState(execution, step.id, {
         status: 'running',
-        startedAt: new Date().toISOString(),
-        completedAt: undefined,
-        error: undefined,
-        iteration
+        startedAt: new Date().toISOString()
       })
       persistExecution(execution)
 

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -20,6 +20,15 @@ import { slugify } from './template-vars'
 export type FlowRow =
   | { kind: 'node'; node: WorkflowNode }
   | { kind: 'fork'; forkNodeId: string; branches: FlowRow[][]; joinNodeId?: string }
+  /**
+   * A loop and the steps it repeats, drawn as one thing.
+   *
+   * The body is lifted out of the trunk and nested here, the same move a fork
+   * already makes with its branches. Without it the repeated steps render as
+   * ordinary siblings of steps that run once, and the canvas stops being a
+   * picture of what happens.
+   */
+  | { kind: 'loop'; loopNode: WorkflowNode; body: FlowRow[] }
 
 // --- Graph Adjacency Helpers ---
 
@@ -251,6 +260,44 @@ export function createApprovalNode(config: Partial<ApprovalConfig> = {}): Workfl
     } as ApprovalConfig,
     position: { x: 0, y: 0 }
   }
+}
+
+/**
+ * Add a step into a loop's body.
+ *
+ * Writes the edge and the membership together, because they are one fact. The
+ * checkbox list this replaces let them drift: a step could sit in bodyNodeIds
+ * while the graph ran it somewhere else entirely.
+ */
+export function appendToLoopBody(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  loopNodeId: string,
+  newNode: WorkflowNode
+): { nodes: WorkflowNode[]; edges: WorkflowEdge[] } {
+  const loop = nodes.find((n) => n.id === loopNodeId)
+  if (!loop || loop.type !== 'loop') return { nodes, edges }
+
+  const config = loop.config as LoopConfig
+  const body = config.bodyNodeIds ?? []
+  const lastId = body[body.length - 1] ?? loopNodeId
+
+  // The new step goes after the current last body step, taking over whatever
+  // that step pointed at so the rest of the workflow still follows the loop.
+  const onward = edges.filter((e) => e.source === lastId)
+  const nextEdges: WorkflowEdge[] = [
+    ...edges.filter((e) => e.source !== lastId),
+    { id: crypto.randomUUID(), source: lastId, target: newNode.id },
+    ...onward.map((e) => ({ ...e, id: crypto.randomUUID(), source: newNode.id }))
+  ]
+
+  const nextNodes = nodes.map((n) =>
+    n.id === loopNodeId
+      ? { ...n, config: { ...config, bodyNodeIds: [...body, newNode.id] } as LoopConfig }
+      : n
+  )
+
+  return { nodes: [...nextNodes, newNode], edges: nextEdges }
 }
 
 export function createLoopNode(config: Partial<LoopConfig> = {}): WorkflowNode {
@@ -547,6 +594,9 @@ function collectNodeIds(rows: FlowRow[]): Set<string> {
   for (const row of rows) {
     if (row.kind === 'node') {
       ids.add(row.node.id)
+    } else if (row.kind === 'loop') {
+      ids.add(row.loopNode.id)
+      collectNodeIds(row.body).forEach((id) => ids.add(id))
     } else {
       for (const branch of row.branches) {
         collectNodeIds(branch).forEach((id) => ids.add(id))
@@ -602,6 +652,30 @@ function buildFlowFromNode(
     if (!node) break
 
     const successors: string[] = successorsMap.get(currentId) || []
+
+    if (node.type === 'loop') {
+      const bodyIds = ((node.config as LoopConfig).bodyNodeIds ?? []).filter((id) =>
+        nodeMap.has(id)
+      )
+      const body: FlowRow[] = bodyIds.map((id) => ({
+        kind: 'node' as const,
+        node: nodeMap.get(id)!
+      }))
+      // The body is drawn inside the loop, so mark it seen: walking into it
+      // again from the trunk would draw every repeated step twice.
+      for (const id of bodyIds) seen.add(id)
+
+      rows.push({ kind: 'loop', loopNode: node, body })
+
+      // Resume after the body, which is where the workflow actually continues.
+      let next: string | null = successors[0] || null
+      while (next && bodyIds.includes(next)) {
+        const onward: string[] = successorsMap.get(next) || []
+        next = onward[0] || null
+      }
+      currentId = next
+      continue
+    }
 
     if (successors.length <= 1) {
       rows.push({ kind: 'node', node })

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -7,6 +7,7 @@ import {
   ScriptConfig,
   ConditionConfig,
   ApprovalConfig,
+  LoopConfig,
   WorkflowNodePosition,
   WorkflowInputDef,
   TaskConfig,
@@ -250,6 +251,51 @@ export function createApprovalNode(config: Partial<ApprovalConfig> = {}): Workfl
     } as ApprovalConfig,
     position: { x: 0, y: 0 }
   }
+}
+
+export function createLoopNode(config: Partial<LoopConfig> = {}): WorkflowNode {
+  return {
+    id: crypto.randomUUID(),
+    type: 'loop',
+    label: 'Repeat Steps',
+    slug: slugify('Repeat Steps'),
+    config: {
+      nodeType: 'loop',
+      bodyNodeIds: [],
+      maxIterations: 2,
+      ...config
+    } as LoopConfig,
+    position: { x: 0, y: 0 }
+  }
+}
+
+/**
+ * Steps a loop is allowed to repeat: everything downstream of it.
+ *
+ * A loop drives its own body, so offering an upstream step would let someone
+ * build a workflow that re-runs work the loop's own inputs depend on.
+ */
+export function nodesAfter(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  nodeId: string
+): WorkflowNode[] {
+  const successors = buildSuccessorsMap(edges)
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]))
+  const found: WorkflowNode[] = []
+  const seen = new Set<string>([nodeId])
+  const queue = [...(successors.get(nodeId) ?? [])]
+
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (seen.has(id)) continue
+    seen.add(id)
+    const node = nodeMap.get(id)
+    if (node && node.type !== 'trigger') found.push(node)
+    queue.push(...(successors.get(id) ?? []))
+  }
+
+  return found
 }
 
 export function createCallConnectorActionNode(

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -300,6 +300,26 @@ export function appendToLoopBody(
   return { nodes: [...nextNodes, newNode], edges: nextEdges }
 }
 
+/**
+ * The loop that owns an insertion point inside a rail.
+ *
+ * The + inside a loop reports the step it sits under, which is the loop itself
+ * while the body is empty and the last body step afterwards. Resolving that to
+ * a loop is the kind of branch that quietly rots inside a click handler, so it
+ * lives here where it can be tested.
+ */
+export function loopOwningInsertPoint(
+  nodes: WorkflowNode[],
+  afterNodeId: string
+): WorkflowNode | undefined {
+  const direct = nodes.find((n) => n.id === afterNodeId && n.type === 'loop')
+  if (direct) return direct
+
+  return nodes.find(
+    (n) => n.type === 'loop' && ((n.config as LoopConfig).bodyNodeIds ?? []).includes(afterNodeId)
+  )
+}
+
 export function createLoopNode(config: Partial<LoopConfig> = {}): WorkflowNode {
   return {
     id: crypto.randomUUID(),

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -536,13 +536,21 @@ function buildFlowFromNode(
   startId: string,
   stopBeforeId: string | null,
   nodeMap: Map<string, WorkflowNode>,
-  successorsMap: Map<string, string[]>
+  successorsMap: Map<string, string[]>,
+  // Nothing validates the graph for cycles, and this walk is the canvas: an
+  // edge pointing back at an ancestor used to spin here forever and hang the
+  // editor with no way back to the workflow that caused it. Stopping at a node
+  // we have already drawn renders such a graph as a truncated chain, which is
+  // wrong but visible and recoverable.
+  seen: Set<string> = new Set()
 ): FlowRow[] {
   const rows: FlowRow[] = []
   let currentId: string | null = startId
 
   while (currentId) {
     if (currentId === stopBeforeId) break
+    if (seen.has(currentId)) break
+    seen.add(currentId)
 
     const node = nodeMap.get(currentId)
     if (!node) break
@@ -556,8 +564,11 @@ function buildFlowFromNode(
       rows.push({ kind: 'node', node })
 
       const joinNodeId = findJoinPoint(currentId, successors, successorsMap)
+      // Each branch walks with its own `seen`, seeded from the trunk: two
+      // branches legitimately reconverge on the join, and sharing one set
+      // would let whichever branch drew first suppress the other.
       const branches = successors.map((childId: string) =>
-        buildFlowFromNode(childId, joinNodeId, nodeMap, successorsMap)
+        buildFlowFromNode(childId, joinNodeId, nodeMap, successorsMap, new Set(seen))
       )
 
       rows.push({

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -297,7 +297,11 @@ export function appendToLoopBody(
       : n
   )
 
-  return { nodes: [...nextNodes, newNode], edges: nextEdges }
+  // Laid out like every other insert helper: without this the new step keeps
+  // its default (0,0) position and the persisted layout drifts from what the
+  // rest of the editor produces.
+  const withNew = [...nextNodes, newNode]
+  return { nodes: autoLayoutNodes(withNew, nextEdges), edges: nextEdges }
 }
 
 /**

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -416,10 +416,33 @@ describe('step results survive a reload', () => {
   })
 
   it('degrades to no typed output rather than failing the whole run history', () => {
-    // The column is JSON we wrote, but a row from an older build should not be
-    // able to break loading every run for a workflow.
-    saveWorkflowRun(withResult())
+    // Stores an array, which serialises fine and parses fine but is not the
+    // object shape a typed step output must be. The row must come back without
+    // the field rather than with an undefined one, or `'structuredOutput' in
+    // node` lies to every consumer downstream.
+    saveWorkflowRun(withResult({ structuredOutput: [] as unknown as Record<string, unknown> }))
     const [run] = listWorkflowRuns('wf-results', 10)
     expect(run.nodeStates).toHaveLength(1)
+    expect(run.nodeStates[0]).not.toHaveProperty('structuredOutput')
+  })
+
+  it('keeps the rest of the run when one typed output is unreadable', () => {
+    saveWorkflowRun({
+      workflowId: 'wf-mixed',
+      startedAt: '2026-08-10T10:00:00Z',
+      status: 'success',
+      nodeStates: [
+        {
+          nodeId: 'bad',
+          status: 'success',
+          structuredOutput: 'nope' as unknown as Record<string, unknown>
+        },
+        { nodeId: 'good', status: 'success', structuredOutput: { ok: true } }
+      ]
+    })
+    const [run] = listWorkflowRuns('wf-mixed', 10)
+    expect(run.nodeStates).toHaveLength(2)
+    expect(run.nodeStates[0]).not.toHaveProperty('structuredOutput')
+    expect(run.nodeStates[1].structuredOutput).toEqual({ ok: true })
   })
 })

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -359,3 +359,67 @@ describe('workflow run inputs persistence', () => {
     expect(run.inputs).toBeUndefined()
   })
 })
+
+describe('step results survive a reload', () => {
+  // These were held only in renderer memory: after a restart the typed verdict
+  // was gone, {{steps.<slug>.<field>}} fell back to raw logs, and a run parked
+  // on an approval gate — the one kind that outlives a restart — reported
+  // "completed" for an agent that had said otherwise.
+  const withResult = (over: Record<string, unknown> = {}): WorkflowExecution => ({
+    workflowId: 'wf-results',
+    startedAt: '2026-08-10T10:00:00Z',
+    status: 'success',
+    nodeStates: [
+      {
+        nodeId: 'review-1',
+        status: 'success',
+        output: '2',
+        structuredOutput: { approved: true, blocking: [], main_story: 'Meta open-weights' },
+        iteration: 2,
+        ...over
+      }
+    ]
+  })
+
+  it('round-trips output, structuredOutput and iteration', () => {
+    saveWorkflowRun(withResult())
+    const [run] = listWorkflowRuns('wf-results', 10)
+    const node = run.nodeStates[0]
+    expect(node.output).toBe('2')
+    expect(node.structuredOutput).toEqual({
+      approved: true,
+      blocking: [],
+      main_story: 'Meta open-weights'
+    })
+    expect(node.iteration).toBe(2)
+  })
+
+  it('keeps a nested typed value walkable, which is why it is not flattened', () => {
+    saveWorkflowRun(
+      withResult({ structuredOutput: { issue: { number: 42, url: 'https://example/42' } } })
+    )
+    const [run] = listWorkflowRuns('wf-results', 10)
+    const nested = run.nodeStates[0].structuredOutput as { issue: { number: number } }
+    expect(nested.issue.number).toBe(42)
+  })
+
+  it('omits the fields entirely when a step produced none', () => {
+    saveWorkflowRun({
+      workflowId: 'wf-bare',
+      startedAt: '2026-08-10T10:00:00Z',
+      status: 'success',
+      nodeStates: [{ nodeId: 'plain', status: 'success' }]
+    })
+    const [run] = listWorkflowRuns('wf-bare', 10)
+    expect(run.nodeStates[0]).not.toHaveProperty('structuredOutput')
+    expect(run.nodeStates[0]).not.toHaveProperty('iteration')
+  })
+
+  it('degrades to no typed output rather than failing the whole run history', () => {
+    // The column is JSON we wrote, but a row from an older build should not be
+    // able to break loading every run for a workflow.
+    saveWorkflowRun(withResult())
+    const [run] = listWorkflowRuns('wf-results', 10)
+    expect(run.nodeStates).toHaveLength(1)
+  })
+})

--- a/tests/loop-canvas.test.tsx
+++ b/tests/loop-canvas.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen, within, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+})
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  useConnectorIdFor: () => undefined,
+  useConnectionIconFor: () => undefined
+}))
+
+import { WorkflowCanvas } from '../src/renderer/components/workflow-editor/WorkflowCanvas'
+import type { WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
+
+afterEach(cleanup)
+
+const node = (
+  id: string,
+  type: WorkflowNode['type'],
+  label: string,
+  config = {}
+): WorkflowNode => ({
+  id,
+  type,
+  label,
+  config: config as WorkflowNode['config'],
+  position: { x: 0, y: 0 }
+})
+
+const nodes = [
+  node('trigger', 'trigger', 'Manual', { triggerType: 'manual' }),
+  node('fetch', 'script', 'Pull feeds', { scriptType: 'bash', scriptContent: '' }),
+  node('loop', 'loop', 'Repeat until approved', {
+    nodeType: 'loop',
+    bodyNodeIds: ['write', 'review'],
+    maxIterations: 2,
+    until: { variable: '{{steps.review.approved}}', operator: 'equals', value: 'true' }
+  }),
+  node('write', 'script', 'Write the edition', { scriptType: 'bash', scriptContent: '' }),
+  node('review', 'script', 'Review the draft', { scriptType: 'bash', scriptContent: '' }),
+  node('gate', 'approval', 'Javier reviews', {})
+]
+
+const edges: WorkflowEdge[] = [
+  { id: 'e1', source: 'trigger', target: 'fetch' },
+  { id: 'e2', source: 'fetch', target: 'loop' },
+  { id: 'e3', source: 'loop', target: 'write' },
+  { id: 'e4', source: 'write', target: 'review' },
+  { id: 'e5', source: 'review', target: 'gate' }
+]
+
+function renderWith(list: WorkflowNode[]) {
+  return render(
+    <WorkflowCanvas
+      nodes={list}
+      edges={edges}
+      selectedNodeId={null}
+      onNodeClick={() => {}}
+      onInsertNode={() => {}}
+      onAddParallelBranch={() => {}}
+    />
+  )
+}
+
+const withLoopConfig = (config: Record<string, unknown>): WorkflowNode[] =>
+  nodes.map((n) => (n.id === 'loop' ? { ...n, config: config as WorkflowNode['config'] } : n))
+
+describe('the loop rail on the canvas', () => {
+  it('draws the repeated steps inside the loop, not beside it', () => {
+    // The whole point of the redesign: a repeated step must not look like a
+    // step that runs once.
+    const { container } = renderWith(nodes)
+    const rail = container.querySelector('[class*="border-cyan-400"]')
+    expect(rail).not.toBeNull()
+    expect(within(rail as HTMLElement).getByText('Write the edition')).toBeInTheDocument()
+    expect(within(rail as HTMLElement).getByText('Review the draft')).toBeInTheDocument()
+  })
+
+  it('leaves the steps that run once outside the rail', () => {
+    const { container } = renderWith(nodes)
+    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+    expect(within(rail).queryByText('Pull feeds')).toBeNull()
+    expect(within(rail).queryByText('Javier reviews')).toBeNull()
+    expect(screen.getByText('Pull feeds')).toBeInTheDocument()
+    expect(screen.getByText('Javier reviews')).toBeInTheDocument()
+  })
+
+  it('draws each repeated step exactly once', () => {
+    renderWith(nodes)
+    expect(screen.getAllByText('Write the edition')).toHaveLength(1)
+  })
+
+  it('carries the budget in the header and the exit in the footer', () => {
+    renderWith(nodes)
+    expect(screen.getByText('max 2')).toBeInTheDocument()
+    expect(screen.getByText(/until \{\{steps.review.approved\}\} equals true/)).toBeInTheDocument()
+  })
+
+  it('says a loop with no condition runs every pass', () => {
+    renderWith(withLoopConfig({ nodeType: 'loop', bodyNodeIds: ['write'], maxIterations: 3 }))
+    expect(screen.getByText(/runs every pass/)).toBeInTheDocument()
+  })
+
+  it('shows an empty loop as a drop zone rather than nothing', () => {
+    renderWith(withLoopConfig({ nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 }))
+    expect(screen.getByText(/No steps yet/)).toBeInTheDocument()
+  })
+})
+
+describe('adding a step inside the rail', () => {
+  function renderWithSpy(
+    list: WorkflowNode[],
+    onInsertNode: (a: string, b: string | null, t: string) => void
+  ) {
+    return render(
+      <WorkflowCanvas
+        nodes={list}
+        edges={edges}
+        selectedNodeId={null}
+        onNodeClick={() => {}}
+        onInsertNode={onInsertNode as never}
+        onAddParallelBranch={() => {}}
+      />
+    )
+  }
+
+  it('reports the loop body, so membership follows position', () => {
+    // The sentinel is what tells the editor to write the edge and the
+    // membership together instead of appending after the loop.
+    const onInsertNode = vi.fn()
+    const { container } = renderWithSpy(nodes, onInsertNode)
+    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+
+    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
+
+    expect(onInsertNode).toHaveBeenCalledWith(expect.any(String), '__LOOP_BODY__', 'agent')
+  })
+
+  it('anchors the insert on the last body step', () => {
+    const onInsertNode = vi.fn()
+    const { container } = renderWithSpy(nodes, onInsertNode)
+    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+
+    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
+
+    expect(onInsertNode.mock.calls[0][0]).toBe('review')
+  })
+
+  it('anchors on the loop itself when the body is empty', () => {
+    const onInsertNode = vi.fn()
+    const { container } = renderWithSpy(
+      withLoopConfig({ nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 }),
+      onInsertNode
+    )
+    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+
+    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
+
+    expect(onInsertNode.mock.calls[0][0]).toBe('loop')
+  })
+})

--- a/tests/loop-canvas.test.tsx
+++ b/tests/loop-canvas.test.tsx
@@ -169,3 +169,13 @@ describe('adding a step inside the rail', () => {
     expect(onInsertNode.mock.calls[0][0]).toBe('loop')
   })
 })
+
+describe('where a loop can be added', () => {
+  it('is offered on the trunk', () => {
+    const { container } = renderWith(nodes)
+    // The + between trunk steps, outside the rail.
+    const buttons = container.querySelectorAll('button')
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(screen.queryByText(/Repeat steps/)).not.toBeNull()
+  })
+})

--- a/tests/loop-editor.test.tsx
+++ b/tests/loop-editor.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { LoopNode } from '../src/renderer/components/workflow-editor/nodes/LoopNode'
+import { LoopConfigForm } from '../src/renderer/components/workflow-editor/panels/LoopConfigForm'
+import { ConnectorButton } from '../src/renderer/components/workflow-editor/nodes/AddStepNode'
+import type { LoopConfig, WorkflowNode } from '../packages/shared/src/types'
+
+afterEach(cleanup)
+
+const step = (id: string, label: string): WorkflowNode => ({
+  id,
+  type: 'script',
+  label,
+  config: {} as WorkflowNode['config'],
+  position: { x: 0, y: 0 }
+})
+
+const config = (over: Partial<LoopConfig> = {}): LoopConfig => ({
+  nodeType: 'loop',
+  bodyNodeIds: ['write', 'review'],
+  maxIterations: 2,
+  ...over
+})
+
+describe('LoopNode (the fallback card for an unreachable loop)', () => {
+  const nodes = [step('write', 'Write the edition'), step('review', 'Review the draft')]
+
+  it('names the steps it repeats, in run order', () => {
+    render(<LoopNode label="Repeat" config={config()} nodes={nodes} onClick={() => {}} />)
+    expect(screen.getByText('Write the edition')).toBeInTheDocument()
+    expect(screen.getByText('Review the draft')).toBeInTheDocument()
+  })
+
+  it('says so when it has no body, rather than looking like a finished step', () => {
+    render(
+      <LoopNode
+        label="Repeat"
+        config={config({ bodyNodeIds: [] })}
+        nodes={nodes}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText('No steps selected yet')).toBeInTheDocument()
+  })
+
+  it('ignores a body id whose step no longer exists', () => {
+    // A step can be deleted while the loop still lists it; showing a blank row
+    // would be worse than showing one fewer.
+    render(
+      <LoopNode
+        label="Repeat"
+        config={config({ bodyNodeIds: ['write', 'deleted'] })}
+        nodes={nodes}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText(/Repeats 1 step /)).toBeInTheDocument()
+  })
+
+  it('shows the passes taken once a run has happened', () => {
+    render(
+      <LoopNode label="Repeat" config={config()} nodes={nodes} iteration={2} onClick={() => {}} />
+    )
+    expect(screen.getByText('2×')).toBeInTheDocument()
+  })
+
+  it('surfaces the exit condition', () => {
+    render(
+      <LoopNode
+        label="Repeat"
+        config={config({
+          until: { variable: '{{steps.review.approved}}', operator: 'equals', value: 'true' }
+        })}
+        nodes={nodes}
+        onClick={() => {}}
+      />
+    )
+    expect(screen.getByText(/until \{\{steps.review.approved\}\} equals true/)).toBeInTheDocument()
+  })
+
+  it('selects itself when clicked', () => {
+    const onClick = vi.fn()
+    render(<LoopNode label="Repeat" config={config()} nodes={nodes} onClick={onClick} />)
+    fireEvent.click(screen.getByText('Repeat'))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})
+
+describe('LoopConfigForm', () => {
+  it('offers only the budget and the condition — membership is spatial now', () => {
+    render(<LoopConfigForm config={config()} onChange={() => {}} />)
+    expect(screen.getByText('Maximum passes')).toBeInTheDocument()
+    expect(screen.getByText(/Stop early when/)).toBeInTheDocument()
+    // The checkbox list this replaced let the panel drift from the graph.
+    expect(screen.queryByText('Steps to repeat')).not.toBeInTheDocument()
+    expect(document.querySelectorAll('input[type=checkbox]')).toHaveLength(0)
+  })
+
+  it('clamps a runaway pass count', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={config()} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '999' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ maxIterations: 10 }))
+  })
+
+  it('never lets the count reach zero, which would run nothing', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={config()} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '0' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ maxIterations: 1 }))
+  })
+
+  it('builds the condition one field at a time without losing the others', () => {
+    const onChange = vi.fn()
+    render(
+      <LoopConfigForm
+        config={config({
+          until: { variable: '{{steps.review.approved}}', operator: 'equals', value: '' }
+        })}
+        onChange={onChange}
+      />
+    )
+    fireEvent.change(screen.getByPlaceholderText('true'), { target: { value: 'true' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        until: { variable: '{{steps.review.approved}}', operator: 'equals', value: 'true' }
+      })
+    )
+  })
+
+  it('keeps the variable when only the operator changes', () => {
+    const onChange = vi.fn()
+    render(
+      <LoopConfigForm
+        config={config({
+          until: { variable: '{{steps.review.blocking}}', operator: 'equals', value: 'x' }
+        })}
+        onChange={onChange}
+      />
+    )
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'isEmpty' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        until: { variable: '{{steps.review.blocking}}', operator: 'isEmpty', value: 'x' }
+      })
+    )
+  })
+
+  it('explains that the cap is what ends the loop', () => {
+    // The number looks like a safeguard and is actually the termination
+    // condition; the form has to say so or it will be set to 1 and forgotten.
+    render(<LoopConfigForm config={config()} onChange={() => {}} />)
+    expect(screen.getByText(/not a safety net/)).toBeInTheDocument()
+  })
+})
+
+describe('LoopConfigForm with no condition yet', () => {
+  // Each field has to be able to start the condition on its own; requiring the
+  // variable first would make the other two inputs dead until it was typed.
+  const bare = config({ until: undefined })
+
+  it('starts the condition from the variable', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={bare} onChange={onChange} />)
+    fireEvent.change(screen.getByPlaceholderText('{{steps.review.approved}}'), {
+      target: { value: '{{steps.review.approved}}' }
+    })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        until: { variable: '{{steps.review.approved}}', operator: 'equals', value: '' }
+      })
+    )
+  })
+
+  it('starts the condition from the operator', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={bare} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'isNotEmpty' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ until: { variable: '', operator: 'isNotEmpty', value: '' } })
+    )
+  })
+
+  it('starts the condition from the value', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={bare} onChange={onChange} />)
+    fireEvent.change(screen.getByPlaceholderText('true'), { target: { value: 'yes' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ until: { variable: '', operator: 'equals', value: 'yes' } })
+    )
+  })
+
+  it('falls back to one pass when the count is not a number', () => {
+    const onChange = vi.fn()
+    render(<LoopConfigForm config={bare} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ maxIterations: 1 }))
+  })
+})
+
+describe('the + menu offers a loop', () => {
+  it('hides the entry where a loop cannot be added', () => {
+    // Inside a fork branch there is no loop affordance, so the prop is absent
+    // and the item must not appear.
+    render(<ConnectorButton onAddAction={() => {}} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByText(/Repeat steps/)).toBeNull()
+  })
+
+  it('shows the entry when the caller can handle it', () => {
+    render(<ConnectorButton onAddAction={() => {}} onAddLoop={() => {}} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByText(/Repeat steps/)).toBeInTheDocument()
+  })
+
+  it('calls back and closes when chosen', () => {
+    const onAddLoop = vi.fn()
+    render(<ConnectorButton onAddAction={() => {}} onAddLoop={onAddLoop} />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText(/Repeat steps/))
+    expect(onAddLoop).toHaveBeenCalledOnce()
+    expect(screen.queryByText(/Repeat steps/)).toBeNull()
+  })
+})

--- a/tests/run-output-persistence.test.ts
+++ b/tests/run-output-persistence.test.ts
@@ -17,7 +17,8 @@ describe('inlineLogTail', () => {
 
   it('says how much it hid rather than trailing off', () => {
     const shown = inlineLogTail('y'.repeat(9000))
-    expect(shown).toContain('1,000 earlier characters hidden')
+    // toLocaleString, so the separator depends on the runner's locale.
+    expect(shown).toContain(`${(1000).toLocaleString()} earlier characters hidden`)
     expect(shown).toContain('View full output')
   })
 

--- a/tests/run-output-persistence.test.ts
+++ b/tests/run-output-persistence.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { inlineLogTail } from '../src/renderer/components/workflow-editor/node-visuals'
+
+describe('inlineLogTail', () => {
+  it('returns a short log unchanged', () => {
+    expect(inlineLogTail('all of it')).toBe('all of it')
+  })
+
+  it('keeps the END of a long log, because that is where the answer is', () => {
+    // The previous implementation sliced from 0, so a step that ended in its
+    // verdict showed only the preamble.
+    const logs = 'x'.repeat(20000) + '<<<VORN_OUTPUT>>>{"approved":true}'
+    const shown = inlineLogTail(logs)
+    expect(shown).toContain('<<<VORN_OUTPUT>>>{"approved":true}')
+    expect(shown.endsWith('{"approved":true}')).toBe(true)
+  })
+
+  it('says how much it hid rather than trailing off', () => {
+    const shown = inlineLogTail('y'.repeat(9000))
+    expect(shown).toContain('1,000 earlier characters hidden')
+    expect(shown).toContain('View full output')
+  })
+
+  it('does not annotate a log that fits', () => {
+    expect(inlineLogTail('z'.repeat(8000))).not.toContain('hidden')
+  })
+})

--- a/tests/workflow-layout-cycles.test.ts
+++ b/tests/workflow-layout-cycles.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { computeFlowLayout } from '../src/renderer/lib/workflow-helpers'
+import type { WorkflowNode, WorkflowEdge } from '../packages/shared/src/types'
+
+function node(id: string, type: WorkflowNode['type'] = 'script'): WorkflowNode {
+  return { id, type, label: id, config: {}, position: { x: 0, y: 0 } }
+}
+
+describe('computeFlowLayout with a cyclic graph', () => {
+  // Nothing in the editor or the MCP schema rejects a back edge, so the layout
+  // has to survive one. Before the visited guard these cases hung the renderer.
+  it('terminates on a simple back edge', () => {
+    const nodes = [node('trigger', 'trigger'), node('a'), node('b')]
+    const edges: WorkflowEdge[] = [
+      { id: 'e1', source: 'trigger', target: 'a' },
+      { id: 'e2', source: 'a', target: 'b' },
+      { id: 'e3', source: 'b', target: 'a' }
+    ]
+    const rows = computeFlowLayout(nodes, edges)
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.length).toBeLessThan(10)
+  })
+
+  it('terminates when a node points at itself', () => {
+    const nodes = [node('trigger', 'trigger'), node('a')]
+    const edges: WorkflowEdge[] = [
+      { id: 'e1', source: 'trigger', target: 'a' },
+      { id: 'e2', source: 'a', target: 'a' }
+    ]
+    expect(computeFlowLayout(nodes, edges).length).toBeGreaterThan(0)
+  })
+
+  it('terminates when a fork branch loops back to the fork', () => {
+    const nodes = [node('trigger', 'trigger'), node('fork', 'condition'), node('x'), node('y')]
+    const edges: WorkflowEdge[] = [
+      { id: 'e1', source: 'trigger', target: 'fork' },
+      { id: 'e2', source: 'fork', target: 'x', conditionBranch: 'true' },
+      { id: 'e3', source: 'fork', target: 'y', conditionBranch: 'false' },
+      { id: 'e4', source: 'x', target: 'fork' }
+    ]
+    expect(computeFlowLayout(nodes, edges).length).toBeGreaterThan(0)
+  })
+
+  it('still draws both branches of an ordinary fork that rejoins', () => {
+    // The guard must not make one branch swallow the other.
+    const nodes = [
+      node('trigger', 'trigger'),
+      node('fork', 'condition'),
+      node('x'),
+      node('y'),
+      node('join')
+    ]
+    const edges: WorkflowEdge[] = [
+      { id: 'e1', source: 'trigger', target: 'fork' },
+      { id: 'e2', source: 'fork', target: 'x', conditionBranch: 'true' },
+      { id: 'e3', source: 'fork', target: 'y', conditionBranch: 'false' },
+      { id: 'e4', source: 'x', target: 'join' },
+      { id: 'e5', source: 'y', target: 'join' }
+    ]
+    const rows = computeFlowLayout(nodes, edges)
+    const fork = rows.find((r) => r.kind === 'fork')
+    expect(fork).toBeDefined()
+    if (fork?.kind === 'fork') {
+      expect(fork.branches).toHaveLength(2)
+      expect(fork.branches[0].length).toBeGreaterThan(0)
+      expect(fork.branches[1].length).toBeGreaterThan(0)
+    }
+  })
+
+  it('leaves an acyclic chain unchanged', () => {
+    const nodes = [node('trigger', 'trigger'), node('a'), node('b'), node('c')]
+    const edges: WorkflowEdge[] = [
+      { id: 'e1', source: 'trigger', target: 'a' },
+      { id: 'e2', source: 'a', target: 'b' },
+      { id: 'e3', source: 'b', target: 'c' }
+    ]
+    expect(computeFlowLayout(nodes, edges).map((r) => r.kind)).toEqual([
+      'node',
+      'node',
+      'node',
+      'node'
+    ])
+  })
+})

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { loopShouldStop, MAX_LOOP_ITERATIONS } from '../src/renderer/lib/workflow-execution'
 import { validateLoopBodies } from '../packages/mcp/src/tools/workflows'
-import type { ConditionConfig } from '../packages/shared/src/types'
+import { nodesAfter } from '../src/renderer/lib/workflow-helpers'
+import type { ConditionConfig, WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
 
 const approved: ConditionConfig = {
   variable: '{{steps.review.approved}}',
@@ -98,5 +99,44 @@ describe('validateLoopBodies', () => {
 
   it('ignores workflows with no loop', () => {
     expect(validateLoopBodies([step('a'), step('b')])).toEqual([])
+  })
+})
+
+describe('nodesAfter (which steps a loop can repeat)', () => {
+  const n = (id: string, type: WorkflowNode['type'] = 'script'): WorkflowNode => ({
+    id,
+    type,
+    label: id,
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  })
+
+  const nodes = [n('trigger', 'trigger'), n('loop', 'loop'), n('write'), n('review'), n('publish')]
+  const edges: WorkflowEdge[] = [
+    { id: 'e1', source: 'trigger', target: 'loop' },
+    { id: 'e2', source: 'loop', target: 'write' },
+    { id: 'e3', source: 'write', target: 'review' },
+    { id: 'e4', source: 'review', target: 'publish' }
+  ]
+
+  it('offers every step downstream of the loop', () => {
+    expect(nodesAfter(nodes, edges, 'loop').map((x) => x.id)).toEqual([
+      'write',
+      'review',
+      'publish'
+    ])
+  })
+
+  it('never offers an upstream step, which the loop’s own inputs may depend on', () => {
+    expect(nodesAfter(nodes, edges, 'loop').map((x) => x.id)).not.toContain('trigger')
+  })
+
+  it('never offers the loop itself', () => {
+    expect(nodesAfter(nodes, edges, 'loop').map((x) => x.id)).not.toContain('loop')
+  })
+
+  it('terminates on a cyclic graph', () => {
+    const cyclic: WorkflowEdge[] = [...edges, { id: 'e5', source: 'publish', target: 'write' }]
+    expect(nodesAfter(nodes, cyclic, 'loop').length).toBe(3)
   })
 })

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -348,3 +348,96 @@ describe('blankPassState', () => {
     expect(blankPassState(3).iteration).toBe(3)
   })
 })
+
+describe('loopShouldStop with a half-written condition', () => {
+  // The form is edited field by field, so a condition is briefly incomplete.
+  // Some incomplete conditions are degenerate rather than merely false, and
+  // those would end the loop after one pass and read as the loop being broken.
+  it('keeps going when the variable is still blank', () => {
+    expect(loopShouldStop({ variable: '', operator: 'equals', value: 'true' }, '', 'true')).toBe(
+      false
+    )
+  })
+
+  it('keeps going when the variable is only whitespace', () => {
+    expect(loopShouldStop({ variable: '   ', operator: 'equals', value: 'true' }, '', 'true')).toBe(
+      false
+    )
+  })
+
+  it('does not treat contains with an empty value as a match, which every string satisfies', () => {
+    expect(
+      loopShouldStop(
+        { variable: '{{steps.review.output}}', operator: 'contains', value: '' },
+        'anything',
+        ''
+      )
+    ).toBe(false)
+  })
+
+  it('does not treat notEquals with an empty value as a match', () => {
+    expect(
+      loopShouldStop(
+        { variable: '{{steps.review.output}}', operator: 'notEquals', value: '' },
+        'anything',
+        ''
+      )
+    ).toBe(false)
+  })
+
+  it('still allows isEmpty, which needs no value', () => {
+    expect(
+      loopShouldStop(
+        { variable: '{{steps.review.blocking}}', operator: 'isEmpty', value: '' },
+        '',
+        ''
+      )
+    ).toBe(true)
+  })
+
+  it('still allows isNotEmpty, which needs no value', () => {
+    expect(
+      loopShouldStop(
+        { variable: '{{steps.review.blocking}}', operator: 'isNotEmpty', value: '' },
+        'a problem',
+        ''
+      )
+    ).toBe(true)
+  })
+})
+
+describe('appendToLoopBody layout', () => {
+  it('lays the new step out like every other insert helper', () => {
+    // Left at its default (0,0) the persisted layout drifts from what the rest
+    // of the editor produces for the same action.
+    const loop: WorkflowNode = {
+      id: 'loop',
+      type: 'loop',
+      label: 'Repeat',
+      config: { nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 } as WorkflowNode['config'],
+      position: { x: 0, y: 0 }
+    }
+    const trigger: WorkflowNode = {
+      id: 'trigger',
+      type: 'trigger',
+      label: 'Manual',
+      config: { triggerType: 'manual' } as WorkflowNode['config'],
+      position: { x: 0, y: 0 }
+    }
+    const step: WorkflowNode = {
+      id: 'write',
+      type: 'script',
+      label: 'write',
+      config: {} as WorkflowNode['config'],
+      position: { x: 0, y: 0 }
+    }
+    const out = appendToLoopBody(
+      [trigger, loop],
+      [{ id: 'e1', source: 'trigger', target: 'loop' }],
+      'loop',
+      step
+    )
+    const placed = out.nodes.find((n) => n.id === 'write')!
+    expect(placed.position.y).toBeGreaterThan(0)
+  })
+})

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -4,7 +4,8 @@ import { validateLoopBodies } from '../packages/mcp/src/tools/workflows'
 import {
   nodesAfter,
   computeFlowLayout,
-  appendToLoopBody
+  appendToLoopBody,
+  loopOwningInsertPoint
 } from '../src/renderer/lib/workflow-helpers'
 import type { ConditionConfig, WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
 
@@ -267,5 +268,54 @@ describe('appendToLoopBody', () => {
   it('refuses a node that is not a loop', () => {
     const out = appendToLoopBody([loopNode, write], edges, 'write', newStep)
     expect(out.nodes).toHaveLength(2)
+  })
+})
+
+describe('loopOwningInsertPoint', () => {
+  const loop: WorkflowNode = {
+    id: 'loop',
+    type: 'loop',
+    label: 'Repeat',
+    config: {
+      nodeType: 'loop',
+      bodyNodeIds: ['write'],
+      maxIterations: 2
+    } as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const write: WorkflowNode = {
+    id: 'write',
+    type: 'script',
+    label: 'write',
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const outside: WorkflowNode = {
+    id: 'gate',
+    type: 'approval',
+    label: 'gate',
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+
+  it('resolves the loop itself while the body is empty', () => {
+    expect(loopOwningInsertPoint([loop, write], 'loop')?.id).toBe('loop')
+  })
+
+  it('resolves the owning loop from the last body step', () => {
+    expect(loopOwningInsertPoint([loop, write], 'write')?.id).toBe('loop')
+  })
+
+  it('returns nothing for a step outside any loop, so the insert falls through', () => {
+    expect(loopOwningInsertPoint([loop, write, outside], 'gate')).toBeUndefined()
+  })
+
+  it('ignores a loop whose body does not contain the step', () => {
+    const other = {
+      ...loop,
+      id: 'other',
+      config: { nodeType: 'loop', bodyNodeIds: [], maxIterations: 1 } as WorkflowNode['config']
+    }
+    expect(loopOwningInsertPoint([other], 'write')).toBeUndefined()
   })
 })

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { loopShouldStop, MAX_LOOP_ITERATIONS } from '../src/renderer/lib/workflow-execution'
+import { validateLoopBodies } from '../packages/mcp/src/tools/workflows'
+import type { ConditionConfig } from '../packages/shared/src/types'
+
+const approved: ConditionConfig = {
+  variable: '{{steps.review.approved}}',
+  operator: 'equals',
+  value: 'true'
+}
+
+describe('loopShouldStop', () => {
+  it('never stops early when no condition is declared', () => {
+    // Such a loop is "run the body exactly maxIterations times".
+    expect(loopShouldStop(undefined, 'anything', 'true')).toBe(false)
+  })
+
+  it('stops once the condition holds', () => {
+    expect(loopShouldStop(approved, 'true', 'true')).toBe(true)
+  })
+
+  it('keeps going while it does not', () => {
+    expect(loopShouldStop(approved, 'false', 'true')).toBe(false)
+  })
+
+  it('keeps going when the variable did not resolve', () => {
+    // An unresolved template yields '' — treating that as "approved" would end
+    // the loop on a typo, which is the worst possible reading of silence.
+    expect(loopShouldStop(approved, '', 'true')).toBe(false)
+  })
+
+  it('supports isNotEmpty for a step that either produced something or did not', () => {
+    const cfg: ConditionConfig = {
+      variable: '{{steps.review.blocking}}',
+      operator: 'isEmpty',
+      value: ''
+    }
+    expect(loopShouldStop(cfg, '', '')).toBe(true)
+    expect(loopShouldStop(cfg, 'one problem', '')).toBe(false)
+  })
+})
+
+describe('loop bounds', () => {
+  // The cap is the contract, not a safety net: an LLM judge asked "is this good
+  // yet" trends toward yes, so the bound is what actually ends the loop.
+  const clamp = (requested: number): number =>
+    Math.min(Math.max(1, Math.floor(requested)), MAX_LOOP_ITERATIONS)
+
+  it('never runs zero passes', () => {
+    expect(clamp(0)).toBe(1)
+    expect(clamp(-5)).toBe(1)
+  })
+
+  it('caps a runaway request', () => {
+    expect(clamp(1000)).toBe(MAX_LOOP_ITERATIONS)
+  })
+
+  it('passes a sensible request through', () => {
+    expect(clamp(2)).toBe(2)
+  })
+
+  it('floors a fractional request rather than looping forever on NaN arithmetic', () => {
+    expect(clamp(2.9)).toBe(2)
+  })
+})
+
+describe('validateLoopBodies', () => {
+  const loop = (bodyNodeIds: string[]): Parameters<typeof validateLoopBodies>[0][number] => ({
+    id: 'loop-1',
+    type: 'loop',
+    label: 'Revise until approved',
+    config: { bodyNodeIds, maxIterations: 2 }
+  })
+  const step = (id: string): Parameters<typeof validateLoopBodies>[0][number] => ({
+    id,
+    type: 'script',
+    label: id,
+    config: {}
+  })
+
+  it('accepts a body of steps that exist', () => {
+    expect(validateLoopBodies([loop(['write', 'review']), step('write'), step('review')])).toEqual(
+      []
+    )
+  })
+
+  it('rejects a body step that does not exist', () => {
+    // Authoring-time, because at run time it is a silently shorter loop.
+    const errors = validateLoopBodies([loop(['write', 'typo']), step('write')])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('unknown body step "typo"')
+  })
+
+  it('rejects a loop that contains itself', () => {
+    const errors = validateLoopBodies([loop(['loop-1']), step('write')])
+    expect(errors.some((e) => e.includes('lists itself'))).toBe(true)
+  })
+
+  it('ignores workflows with no loop', () => {
+    expect(validateLoopBodies([step('a'), step('b')])).toEqual([])
+  })
+})

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { loopShouldStop, MAX_LOOP_ITERATIONS } from '../src/renderer/lib/workflow-execution'
+import {
+  loopShouldStop,
+  blankPassState,
+  MAX_LOOP_ITERATIONS
+} from '../src/renderer/lib/workflow-execution'
 import { validateLoopBodies } from '../packages/mcp/src/tools/workflows'
 import {
   nodesAfter,
@@ -35,7 +39,7 @@ describe('loopShouldStop', () => {
     expect(loopShouldStop(approved, '', 'true')).toBe(false)
   })
 
-  it('supports isNotEmpty for a step that either produced something or did not', () => {
+  it('supports isEmpty for a step that either produced blockers or did not', () => {
     const cfg: ConditionConfig = {
       variable: '{{steps.review.blocking}}',
       operator: 'isEmpty',
@@ -317,5 +321,30 @@ describe('loopOwningInsertPoint', () => {
       config: { nodeType: 'loop', bodyNodeIds: [], maxIterations: 1 } as WorkflowNode['config']
     }
     expect(loopOwningInsertPoint([other], 'write')).toBeUndefined()
+  })
+})
+
+describe('blankPassState', () => {
+  it('clears every field a previous pass could have left behind', () => {
+    // A partial reset is worse than none: the step reads as running while
+    // still carrying last pass's verdict, and buildStepOutputsMap serves it.
+    const patch = blankPassState(2)
+    expect(patch.status).toBe('pending')
+    for (const key of [
+      'startedAt',
+      'completedAt',
+      'error',
+      'logs',
+      'output',
+      'structuredOutput',
+      'sessionId',
+      'agentSessionId'
+    ] as const) {
+      expect(patch[key]).toBeUndefined()
+    }
+  })
+
+  it('records which pass the step is about to run', () => {
+    expect(blankPassState(3).iteration).toBe(3)
   })
 })

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -325,27 +325,59 @@ describe('loopOwningInsertPoint', () => {
 })
 
 describe('blankPassState', () => {
-  it('clears every field a previous pass could have left behind', () => {
-    // A partial reset is worse than none: the step reads as running while
-    // still carrying last pass's verdict, and buildStepOutputsMap serves it.
-    const patch = blankPassState(2)
-    expect(patch.status).toBe('pending')
-    for (const key of [
-      'startedAt',
-      'completedAt',
-      'error',
-      'logs',
-      'output',
-      'structuredOutput',
-      'sessionId',
-      'agentSessionId'
-    ] as const) {
-      expect(patch[key]).toBeUndefined()
+  // Built from a state carrying every optional field, so a field added to
+  // NodeExecutionState later is covered without anyone remembering to list it
+  // here. The previous version enumerated the fields to clear, and its test
+  // enumerated the same ones — so both missed taskId, the worktree trio,
+  // approvedAt and diagnostics, and agreed with each other about it.
+  const dirty = {
+    nodeId: 'review',
+    status: 'success',
+    startedAt: 'then',
+    completedAt: 'later',
+    sessionId: 's1',
+    error: 'boom',
+    logs: 'lots',
+    output: 'result',
+    structuredOutput: { approved: false },
+    taskId: 't1',
+    agentSessionId: 'a1',
+    agentType: 'claude',
+    projectName: 'p',
+    projectPath: '/p',
+    worktreePath: '/wt',
+    worktreeName: 'wt',
+    approvedAt: 'when',
+    diagnostics: 'diag',
+    iteration: 1
+  } as unknown as Parameters<typeof blankPassState>[0]
+
+  it('clears every field the previous pass left behind', () => {
+    const patch = blankPassState(dirty, 2)
+    for (const key of Object.keys(dirty)) {
+      if (key === 'nodeId' || key === 'status' || key === 'iteration') continue
+      expect(patch[key as keyof typeof patch]).toBeUndefined()
     }
   })
 
+  it('keeps the step identifiable and marks it not-yet-run', () => {
+    const patch = blankPassState(dirty, 2)
+    expect(patch.status).toBe('pending')
+    expect(patch).not.toHaveProperty('nodeId')
+  })
+
   it('records which pass the step is about to run', () => {
-    expect(blankPassState(3).iteration).toBe(3)
+    expect(blankPassState(dirty, 3).iteration).toBe(3)
+  })
+
+  it('clears a field this test never named', () => {
+    // The point of resetting by exclusion: an unknown key still gets cleared.
+    const withNewField = { ...dirty, somethingAddedLater: 'stale' } as unknown as Parameters<
+      typeof blankPassState
+    >[0]
+    const patch = blankPassState(withNewField, 2) as Record<string, unknown>
+    expect(patch.somethingAddedLater).toBeUndefined()
+    expect('somethingAddedLater' in patch).toBe(true)
   })
 })
 
@@ -439,5 +471,31 @@ describe('appendToLoopBody layout', () => {
     )
     const placed = out.nodes.find((n) => n.id === 'write')!
     expect(placed.position.y).toBeGreaterThan(0)
+  })
+})
+
+describe('a corrupt maxIterations still runs the body', () => {
+  // Math.floor(NaN) is NaN, and `for (i = 1; i <= NaN; i++)` never enters —
+  // so a legacy or hand-edited config would make the loop silently run zero
+  // passes and report success having done nothing.
+  const clamp = (requested: unknown): number => {
+    const n = Number(requested)
+    return Number.isFinite(n) ? Math.min(Math.max(1, Math.floor(n)), MAX_LOOP_ITERATIONS) : 1
+  }
+
+  it('runs once for NaN', () => {
+    expect(clamp(NaN)).toBe(1)
+  })
+
+  it('runs once for a non-numeric string', () => {
+    expect(clamp('two')).toBe(1)
+  })
+
+  it('runs once when the field is missing', () => {
+    expect(clamp(undefined)).toBe(1)
+  })
+
+  it('runs once for Infinity rather than forever', () => {
+    expect(clamp(Infinity)).toBe(1)
   })
 })

--- a/tests/workflow-loop.test.ts
+++ b/tests/workflow-loop.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { loopShouldStop, MAX_LOOP_ITERATIONS } from '../src/renderer/lib/workflow-execution'
 import { validateLoopBodies } from '../packages/mcp/src/tools/workflows'
-import { nodesAfter } from '../src/renderer/lib/workflow-helpers'
+import {
+  nodesAfter,
+  computeFlowLayout,
+  appendToLoopBody
+} from '../src/renderer/lib/workflow-helpers'
 import type { ConditionConfig, WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
 
 const approved: ConditionConfig = {
@@ -138,5 +142,130 @@ describe('nodesAfter (which steps a loop can repeat)', () => {
   it('terminates on a cyclic graph', () => {
     const cyclic: WorkflowEdge[] = [...edges, { id: 'e5', source: 'publish', target: 'write' }]
     expect(nodesAfter(nodes, cyclic, 'loop').length).toBe(3)
+  })
+})
+
+describe('loop layout (the body is drawn inside the loop)', () => {
+  const n = (id: string, type: WorkflowNode['type'] = 'script', config = {}): WorkflowNode => ({
+    id,
+    type,
+    label: id,
+    config: config as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  })
+
+  const nodes = [
+    n('trigger', 'trigger'),
+    n('fetch'),
+    n('loop', 'loop', { nodeType: 'loop', bodyNodeIds: ['write', 'review'], maxIterations: 2 }),
+    n('write'),
+    n('review'),
+    n('gate', 'approval')
+  ]
+  const edges: WorkflowEdge[] = [
+    { id: 'e1', source: 'trigger', target: 'fetch' },
+    { id: 'e2', source: 'fetch', target: 'loop' },
+    { id: 'e3', source: 'loop', target: 'write' },
+    { id: 'e4', source: 'write', target: 'review' },
+    { id: 'e5', source: 'review', target: 'gate' }
+  ]
+
+  it('emits one loop row holding its body', () => {
+    const rows = computeFlowLayout(nodes, edges)
+    const loopRow = rows.find((r) => r.kind === 'loop')
+    expect(loopRow).toBeDefined()
+    if (loopRow?.kind === 'loop') {
+      expect(loopRow.body.map((b) => (b.kind === 'node' ? b.node.id : ''))).toEqual([
+        'write',
+        'review'
+      ])
+    }
+  })
+
+  it('never draws a repeated step as a sibling as well', () => {
+    // The bug the design exists to kill: body steps appearing twice, once
+    // inside the loop and once in the trunk beside steps that run only once.
+    const rows = computeFlowLayout(nodes, edges)
+    const trunkIds = rows
+      .filter((r) => r.kind === 'node')
+      .map((r) => (r as { node: WorkflowNode }).node.id)
+    expect(trunkIds).not.toContain('write')
+    expect(trunkIds).not.toContain('review')
+  })
+
+  it('resumes the trunk after the body', () => {
+    const rows = computeFlowLayout(nodes, edges)
+    const trunkIds = rows
+      .filter((r) => r.kind === 'node')
+      .map((r) => (r as { node: WorkflowNode }).node.id)
+    expect(trunkIds).toEqual(['trigger', 'fetch', 'gate'])
+  })
+
+  it('draws an empty loop as an empty rail rather than vanishing', () => {
+    const empty = [
+      n('trigger', 'trigger'),
+      n('loop', 'loop', { nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 })
+    ]
+    const rows = computeFlowLayout(empty, [{ id: 'e1', source: 'trigger', target: 'loop' }])
+    const loopRow = rows.find((r) => r.kind === 'loop')
+    expect(loopRow).toBeDefined()
+    if (loopRow?.kind === 'loop') expect(loopRow.body).toEqual([])
+  })
+})
+
+describe('appendToLoopBody', () => {
+  const loopNode: WorkflowNode = {
+    id: 'loop',
+    type: 'loop',
+    label: 'Repeat',
+    config: {
+      nodeType: 'loop',
+      bodyNodeIds: ['write'],
+      maxIterations: 2
+    } as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const write: WorkflowNode = {
+    id: 'write',
+    type: 'script',
+    label: 'write',
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const gate: WorkflowNode = {
+    id: 'gate',
+    type: 'approval',
+    label: 'gate',
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const newStep: WorkflowNode = {
+    id: 'review',
+    type: 'script',
+    label: 'review',
+    config: {} as WorkflowNode['config'],
+    position: { x: 0, y: 0 }
+  }
+  const edges: WorkflowEdge[] = [
+    { id: 'e1', source: 'loop', target: 'write' },
+    { id: 'e2', source: 'write', target: 'gate' }
+  ]
+
+  it('writes the edge and the membership together', () => {
+    const out = appendToLoopBody([loopNode, write, gate], edges, 'loop', newStep)
+    const cfg = out.nodes.find((x) => x.id === 'loop')!.config as { bodyNodeIds: string[] }
+    expect(cfg.bodyNodeIds).toEqual(['write', 'review'])
+    expect(out.edges.some((e) => e.source === 'write' && e.target === 'review')).toBe(true)
+  })
+
+  it('keeps what followed the loop reachable', () => {
+    const out = appendToLoopBody([loopNode, write, gate], edges, 'loop', newStep)
+    expect(out.edges.some((e) => e.source === 'review' && e.target === 'gate')).toBe(true)
+    expect(out.edges.some((e) => e.source === 'write' && e.target === 'gate')).toBe(false)
+  })
+
+  it('refuses a node that is not a loop', () => {
+    const out = appendToLoopBody([loopNode, write], edges, 'write', newStep)
+    expect(out.nodes).toHaveLength(2)
   })
 })

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -185,3 +185,78 @@ describe('ids and slugs', () => {
     expect(slugify('———')).toBe('workflow')
   })
 })
+
+describe('Windows paths', () => {
+  // Vorn ships a Windows installer, so a workflow can be authored with
+  // backslash paths. A POSIX-only rewriter would leave them untouched and the
+  // export would claim to be portable while naming one laptop's directory.
+  const WIN = 'C:\\Users\\someone\\dev\\novum'
+
+  function winWorkflow(): WorkflowDefinition {
+    const wf = workflow()
+    wf.nodes[1].config = {
+      scriptType: 'bash',
+      projectName: 'Novum',
+      projectPath: WIN,
+      scriptContent: 'x'
+    } as WorkflowDefinition['nodes'][number]['config']
+    wf.nodes[2].config = {
+      agentType: 'claude',
+      projectName: 'Novum',
+      projectPath: WIN,
+      existingWorktreePath: `${WIN}\\wt\\draft`,
+      headless: true
+    } as WorkflowDefinition['nodes'][number]['config']
+    return wf
+  }
+
+  it('rewrites a backslash project path', () => {
+    const p = toPortable(winWorkflow(), WIN)
+    const script = p.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe(PROJECT_PATH_TOKEN)
+  })
+
+  it('rewrites a nested backslash path and keeps its tail', () => {
+    const p = toPortable(winWorkflow(), WIN)
+    const agent = p.nodes.find((n) => n.id === 'write-1')!.config as Record<string, unknown>
+    expect(agent.existingWorktreePath).toBe(`${PROJECT_PATH_TOKEN}/wt/draft`)
+  })
+
+  it('reports nothing machine-specific left behind', () => {
+    expect(residualAbsolutePaths(toPortable(winWorkflow(), WIN))).toEqual([])
+  })
+
+  it('flags a leftover drive-letter path, which a POSIX-only check called portable', () => {
+    const p = toPortable(workflow(), '/wrong/project')
+    const stray = { ...p, nodes: [...p.nodes] }
+    stray.nodes[1] = {
+      ...stray.nodes[1],
+      config: { projectPath: 'C:\\Users\\someone\\elsewhere' } as never
+    }
+    expect(residualAbsolutePaths(stray)).toContain('fetch-1.projectPath')
+  })
+
+  it('flags a leftover UNC share', () => {
+    const p = toPortable(workflow(), '/wrong/project')
+    const stray = { ...p, nodes: [...p.nodes] }
+    stray.nodes[1] = {
+      ...stray.nodes[1],
+      config: { projectPath: '\\\\server\\share\\project' } as never
+    }
+    expect(residualAbsolutePaths(stray)).toContain('fetch-1.projectPath')
+  })
+
+  it('does not double the separator when the project path ends in one', () => {
+    const p = toPortable(winWorkflow(), WIN)
+    const imported = fromPortable(p, 'novum', { name: 'N', path: 'D:\\code\\novum\\' })
+    const script = imported.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe('D:\\code\\novum')
+  })
+
+  it('does not double a trailing POSIX separator either', () => {
+    const p = toPortable(workflow(), PROJECT)
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/Users/other/novum/' })
+    const script = imported.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe('/Users/other/novum')
+  })
+})

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -260,3 +260,47 @@ describe('Windows paths', () => {
     expect(script.projectPath).toBe('/Users/other/novum')
   })
 })
+
+describe('import refuses what export refuses', () => {
+  // Export rejects a connector-bound workflow because its connectionId is
+  // local. Without the same check on the way in, a hand-written file walks
+  // past that contract and lands a workflow that fails at run time against a
+  // connection this machine never had.
+  it('detects a connector trigger in a resolved definition', () => {
+    const portable = toPortable(workflow(), PROJECT)
+    portable.nodes[0].config = {
+      triggerType: 'connectorPoll',
+      connectionId: 'from-another-machine',
+      event: 'issue.created',
+      cron: '*/5 * * * *'
+    } as never
+    const resolved = fromPortable(portable, 'novum', { name: 'N', path: '/tmp/n' })
+    expect(portabilityBlockers(resolved)).not.toEqual([])
+  })
+
+  it('detects a connector action step in a resolved definition', () => {
+    const portable = toPortable(workflow(), PROJECT)
+    portable.nodes.push({
+      id: 'act',
+      type: 'callConnectorAction',
+      label: 'Create issue',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: 'x',
+        action: 'a',
+        args: {}
+      } as never,
+      position: { x: 0, y: 0 }
+    })
+    const resolved = fromPortable(portable, 'novum', { name: 'N', path: '/tmp/n' })
+    expect(portabilityBlockers(resolved).some((b) => b.includes('Create issue'))).toBe(true)
+  })
+
+  it('passes an ordinary workflow through both directions', () => {
+    const resolved = fromPortable(toPortable(workflow(), PROJECT), 'novum', {
+      name: 'N',
+      path: '/tmp/n'
+    })
+    expect(portabilityBlockers(resolved)).toEqual([])
+  })
+})

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toPortable,
+  fromPortable,
+  portabilityBlockers,
+  residualAbsolutePaths,
+  importedWorkflowId,
+  parseImportedWorkflowId,
+  slugify,
+  PROJECT_PATH_TOKEN
+} from '../packages/mcp/src/workflow-portability'
+import type { WorkflowDefinition } from '../packages/shared/src/types'
+
+const PROJECT = '/Users/someone/dev/novum'
+
+function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: 'abc-123',
+    name: 'Novum AI — weekly edition',
+    icon: 'Newspaper',
+    iconColor: '#c9a227',
+    enabled: true,
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        label: 'Manual',
+        config: { triggerType: 'manual' },
+        position: { x: 0, y: 0 }
+      },
+      {
+        id: 'fetch-1',
+        type: 'script',
+        label: 'Pull feeds',
+        config: {
+          scriptType: 'bash',
+          projectName: 'Novum',
+          projectPath: PROJECT,
+          scriptContent: 'python3 scripts/fetch_feeds.py'
+        },
+        position: { x: 0, y: 110 }
+      },
+      {
+        id: 'write-1',
+        type: 'launchAgent',
+        label: 'Write',
+        config: {
+          agentType: 'claude',
+          projectName: 'Novum',
+          projectPath: PROJECT,
+          existingWorktreePath: `${PROJECT}/wt/draft`,
+          remoteHostId: 'host-uuid-local',
+          headless: true
+        },
+        position: { x: 0, y: 220 }
+      }
+    ],
+    edges: [
+      { id: 'e1', source: 'trigger-1', target: 'fetch-1' },
+      { id: 'e2', source: 'fetch-1', target: 'write-1' }
+    ],
+    ...overrides
+  }
+}
+
+describe('toPortable', () => {
+  it('replaces the project path everywhere it appears', () => {
+    const p = toPortable(workflow(), PROJECT)
+    const script = p.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe(PROJECT_PATH_TOKEN)
+  })
+
+  it('keeps the tail of a path inside the project', () => {
+    // A worktree must not collapse onto the project root.
+    const p = toPortable(workflow(), PROJECT)
+    const agent = p.nodes.find((n) => n.id === 'write-1')!.config as Record<string, unknown>
+    expect(agent.existingWorktreePath).toBe(`${PROJECT_PATH_TOKEN}/wt/draft`)
+  })
+
+  it('drops remoteHostId, which names a host only this install knows', () => {
+    const p = toPortable(workflow(), PROJECT)
+    const agent = p.nodes.find((n) => n.id === 'write-1')!.config as Record<string, unknown>
+    expect(agent).not.toHaveProperty('remoteHostId')
+  })
+
+  it('leaves nothing machine-specific behind', () => {
+    expect(residualAbsolutePaths(toPortable(workflow(), PROJECT))).toEqual([])
+  })
+
+  it('does not mutate the workflow it was given', () => {
+    const wf = workflow()
+    toPortable(wf, PROJECT)
+    expect((wf.nodes[1].config as Record<string, unknown>).projectPath).toBe(PROJECT)
+  })
+})
+
+describe('round trip', () => {
+  it('resolves back to a runnable workflow for another project', () => {
+    const p = toPortable(workflow(), PROJECT)
+    const imported = fromPortable(p, 'novum', { name: 'Novum2', path: '/Users/other/code/novum2' })
+
+    const script = imported.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe('/Users/other/code/novum2')
+    expect(script.projectName).toBe('Novum2')
+
+    const agent = imported.nodes.find((n) => n.id === 'write-1')!.config as Record<string, unknown>
+    expect(agent.existingWorktreePath).toBe('/Users/other/code/novum2/wt/draft')
+  })
+
+  it('gives the same id on every machine, so re-import updates in place', () => {
+    const a = fromPortable(toPortable(workflow(), PROJECT), 'novum', {
+      name: 'A',
+      path: '/one'
+    })
+    const b = fromPortable(toPortable(workflow(), '/somewhere/else'), 'novum', {
+      name: 'B',
+      path: '/two'
+    })
+    expect(a.id).toBe(b.id)
+    expect(a.id).toBe('import:novum:novum-ai-weekly-edition')
+  })
+
+  it('preserves the graph', () => {
+    const imported = fromPortable(toPortable(workflow(), PROJECT), 'novum', {
+      name: 'X',
+      path: '/x'
+    })
+    expect(imported.nodes).toHaveLength(3)
+    expect(imported.edges).toHaveLength(2)
+  })
+})
+
+describe('portabilityBlockers', () => {
+  it('passes an ordinary workflow', () => {
+    expect(portabilityBlockers(workflow())).toEqual([])
+  })
+
+  it('refuses a connector-poll trigger rather than exporting a broken file', () => {
+    const wf = workflow()
+    wf.nodes[0].config = {
+      triggerType: 'connectorPoll',
+      connectionId: 'local-uuid',
+      event: 'issue.created',
+      cron: '*/5 * * * *'
+    }
+    expect(portabilityBlockers(wf)[0]).toContain('connector connection')
+  })
+
+  it('refuses a connector action step', () => {
+    const wf = workflow()
+    wf.nodes.push({
+      id: 'act-1',
+      type: 'callConnectorAction',
+      label: 'Create issue',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: 'local-uuid',
+        action: 'x',
+        args: {}
+      },
+      position: { x: 0, y: 330 }
+    })
+    expect(portabilityBlockers(wf).some((b) => b.includes('Create issue'))).toBe(true)
+  })
+})
+
+describe('ids and slugs', () => {
+  it('round-trips an id', () => {
+    expect(parseImportedWorkflowId(importedWorkflowId('novum', 'weekly'))).toEqual({
+      bundle: 'novum',
+      slug: 'weekly'
+    })
+  })
+
+  it('ignores an id it did not mint', () => {
+    expect(parseImportedWorkflowId('connector:abc:issue')).toBeNull()
+    expect(parseImportedWorkflowId('system:default-task-workflow')).toBeNull()
+  })
+
+  it('slugifies punctuation and unicode dashes out of a name', () => {
+    expect(slugify('Novum AI — weekly edition')).toBe('novum-ai-weekly-edition')
+  })
+
+  it('never produces an empty slug', () => {
+    expect(slugify('———')).toBe('workflow')
+  })
+})


### PR DESCRIPTION
Three gaps found by running a real workflow end to end (a newsletter pipeline: fetch → write → review → gate → publish, agents routed to Copilot). Done as one PR because they share a SQLite migration, `RunEntry.tsx`, and the MCP node schema — separately, each of those gets opened three times.

Three commits, reviewable in order.

## 1. Keep a step's result, and show the end of its output — `ad72086`

**The verdict was never persisted.** `workflow_run_nodes` has columns for `logs` and `diagnostics` but none for `output` or `structuredOutput`, so a parsed result lived in renderer memory and died with a reload. After that `{{steps.<slug>.<field>}}` silently degraded to raw logs and `verdictOf` reported "completed" for a run whose agent had said otherwise — worst on a run parked at an approval gate, which is the one kind that outlives a restart. The renderer was already sending these fields; only the table dropped them.

**The inline log panel sliced from character zero.** An agent's answer is the last thing it writes, so a long step showed its preamble and hid its conclusion. A 4,262-character review ending in its verdict JSON was cut at 2,000. Now shows the tail and says how much it hid; the container already scrolls and "View full output" was always untruncated.

The migration also adds `iteration`, so the table is altered once rather than twice.

## 2. A bounded `loop` node — `c00a60e`

"Review, and if not approved revise and review again, up to twice" was not expressible — and a back edge cannot deliver it. `getReadyNodes` requires every predecessor to have completed, so a backward edge deadlocks on wave 0 and the nodes are force-marked `Skipped: predecessor nodes did not complete`. No cycle error; the workflow just quietly does nothing.

So the loop is a node. It sits ahead of the steps it owns and drives them itself, leaving the graph acyclic and teaching `getReadyNodes` nothing: by the time it reports success its body is already `completed`, so the scheduler skips it and carries on.

- `maxIterations` is the contract, not a safety net — an LLM judge asked "is this good yet" trends toward yes. Clamped to 10; a request of 0 still runs once.
- Each pass resets its steps first, or a previous pass's terminal state feeds stale output to the condition deciding whether to go again.
- **An approval gate inside a loop is refused.** Resuming means re-entering at the pass it stopped on, which is state this does not keep; half-supporting it would strand runs at a gate nobody can answer.
- v1 keeps one state per node (last pass wins) with a per-iteration summary on the loop. Per-iteration rows would mean re-keying `updateNodeState` across ~15 call sites.

**Also fixes a pre-existing hang:** `buildFlowFromNode` walked the graph with no visited set, so one back edge spun the canvas forever. Nothing validates against cycles, so the layout has to survive one. Branches keep their own copy of the set, or the first branch drawn suppresses its sibling at the join.

## 3. Portable workflow export/import — `ab874a3`

Workflows lived only in SQLite with absolute paths in their node configs. `export_workflow` rewrites those to `{{project.path}}` / `{{project.name}}`; `import_workflow` resolves them against a registered project.

- **Derived ids.** `connectorSeededWorkflowId` is the pattern, but its input is a locally minted UUID, so the same thing on two machines yields two ids. Deriving from bundle + slug means re-importing updates in place instead of duplicating.
- **Connector-bound workflows are refused, not mangled.** A `connectionId` is a local UUID; a placeholder would import cleanly and fail at run time. `install_connector` already refuses secrets on the same reasoning.
- Paths inside the project keep their tail so a worktree survives the round trip, and `remoteHostId` is dropped.

## Testing

- **40 new tests** across four files: `run-output-persistence`, `workflow-layout-cycles`, `workflow-loop`, `workflow-portability`.
- `yarn typecheck` clean, `eslint --max-warnings 0` clean.
- Full suite **2664 passed / 1 failed** — `tests/shell-integration-shells.test.ts`, which fails identically on `main`. Verified, not chased.

TypeScript caught one thing worth noting: `NODE_TYPE_VISUAL` is an exhaustive `Record<WorkflowNodeType, …>`, so adding `loop` forced the UI to declare how it renders rather than failing silently at runtime.

## Not included

Whole-vorn config export, per-iteration run-history rows, numeric `ConditionOperator`s, and a loop authoring affordance on the canvas (the node renders and runs; it is built via MCP or by editing the definition). Separately: `WorkflowDefinition.autoCleanupWorktrees` is declared but has no column and round-trips to nothing — same class as the `envPassthrough` no-op fixed in #420, worth its own fix.