### PR TITLE
chore(release): v0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-kusto/package.json
+++ b/packages/connector-kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-kusto",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Trigger Vorn workflows from an Azure Data Explorer (Kusto) query",
   "type": "module",
   "license": "MIT",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cuts v0.5.5, shipping the work merged in #422.

## What users get

- **Step results survive a reload.** `workflow_run_nodes` gains `output`, `structured_output` and `iteration`, so a parsed verdict is no longer lost on restart — which mattered most for a run parked at an approval gate, the one kind that outlives one.
- **The inline log panel shows the end of an agent's output**, not its preamble. An agent's answer is the last thing it writes.
- **A bounded `loop` node**, drawn as an enclosure around the steps it repeats, with the budget in its header and the exit condition in its footer. Authorable from the `+` menu.
- **Workflow export/import**, with machine-specific paths rewritten to `{{project.path}}` so a workflow can be committed beside the code it drives.

Also fixes a pre-existing editor hang: `buildFlowFromNode` walked the graph with no visited set, so a single back edge spun the canvas forever.

## Migration

Additive, runs at startup. An install carrying 0.5.4 data needs no intervention.

## Note on the v0.5.4 draft

`v0.5.4` is still an unpublished draft, so `v0.5.3` is what users currently have. Everything in 0.5.4 is contained in this release, so that draft can be deleted rather than published.