### PR TITLE
Name the surface ladder, and apply it across the app

### DIFF
--- a/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -98,8 +98,7 @@ export function WorktreeCleanupDialog() {
           />
           <motion.div
             className="fixed top-1/2 left-1/2 z-[60] w-[420px] border border-white/[0.08]
-                       rounded-xl shadow-2xl overflow-hidden"
-            style={{ background: '#1e1e22' }}
+                       rounded-xl shadow-2xl overflow-hidden bg-surface-raised"
             initial={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}
             animate={{ opacity: 1, scale: 1, x: '-50%', y: '-50%' }}
             exit={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}
@@ -108,8 +107,8 @@ export function WorktreeCleanupDialog() {
             <div className="px-5 py-4 border-b border-white/[0.06] flex items-center gap-3">
               <FolderGit2 size={18} className="text-amber-400 shrink-0" />
               <div>
-                <h3 className="text-sm font-medium text-white">Remove Worktree</h3>
-                <p className="text-xs text-gray-500 mt-0.5">
+                <h3 className="text-[13px] font-medium text-white">Remove Worktree</h3>
+                <p className="text-[11px] text-gray-500 mt-0.5">
                   {sessionCount > 0
                     ? 'This worktree has active sessions'
                     : 'Remove this worktree from disk?'}
@@ -147,15 +146,15 @@ export function WorktreeCleanupDialog() {
             <div className="px-5 py-3 border-t border-white/[0.06] flex justify-end gap-2">
               <button
                 onClick={handleClose}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-300
-                           bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-gray-300
+                           bg-white/[0.04] hover:bg-white/[0.08] rounded-md transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleRemove}
                 disabled={dirtyState === 'checking'}
-                className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-[11px] rounded-md transition-colors
                            disabled:opacity-50 ${
                              showWarning || sessionCount > 0
                                ? 'text-red-300 bg-red-500/[0.15] hover:bg-red-500/[0.25] border border-red-500/30'
@@ -164,7 +163,7 @@ export function WorktreeCleanupDialog() {
               >
                 <Trash2 size={12} />
                 {dirtyState === 'checking'
-                  ? 'Checking...'
+                  ? 'Checking…'
                   : sessionCount > 0
                     ? 'Close sessions & remove'
                     : showWarning

--- a/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
@@ -64,7 +64,7 @@ export function WorkflowContextMenu({
           ? 'z-50 py-1 border border-white/[0.08] rounded-lg shadow-xl'
           : 'absolute right-0 top-full mt-1 z-50 min-w-[160px] py-1 border border-white/[0.08] rounded-lg shadow-xl'
       }
-      style={{ background: '#141416', ...positionStyle }}
+      style={{ background: 'var(--color-surface-sunken)', ...positionStyle }}
     >
       <button
         onClick={() => {

--- a/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
@@ -61,10 +61,10 @@ export function WorkflowContextMenu({
       ref={menuRef}
       className={
         useFixed
-          ? 'z-50 py-1 border border-white/[0.08] rounded-lg shadow-xl'
-          : 'absolute right-0 top-full mt-1 z-50 min-w-[160px] py-1 border border-white/[0.08] rounded-lg shadow-xl'
+          ? 'z-50 py-1 bg-surface-sunken border border-white/[0.08] rounded-lg shadow-xl'
+          : 'absolute right-0 top-full mt-1 z-50 min-w-[160px] py-1 bg-surface-sunken border border-white/[0.08] rounded-lg shadow-xl'
       }
-      style={{ background: 'var(--color-surface-sunken)', ...positionStyle }}
+      style={positionStyle}
     >
       <button
         onClick={() => {

--- a/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
@@ -89,8 +89,8 @@ export function WorkflowFilterToolbar() {
       {open && (
         <div
           ref={dropdownRef}
-          className="fixed z-50 w-[160px] border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
-          style={{ background: 'var(--color-surface-base)', top: pos.top, left: pos.left }}
+          className="fixed z-50 w-[160px] bg-surface-base border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
+          style={{ top: pos.top, left: pos.left }}
         >
           <div className="py-1.5">
             <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">

--- a/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
@@ -90,7 +90,7 @@ export function WorkflowFilterToolbar() {
         <div
           ref={dropdownRef}
           className="fixed z-50 w-[160px] border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
-          style={{ background: '#1a1a1e', top: pos.top, left: pos.left }}
+          style={{ background: 'var(--color-surface-base)', top: pos.top, left: pos.left }}
         >
           <div className="py-1.5">
             <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -108,7 +108,7 @@ export function WorkflowItem({
         )}
         {dot && !isCollapsed && (
           <span
-            className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border border-[#1a1a2e] ${DOT_CLASSES[dot]}`}
+            className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border border-[#1a1a1e] ${DOT_CLASSES[dot]}`}
             aria-hidden="true"
           />
         )}

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -108,7 +108,7 @@ export function WorkflowItem({
         )}
         {dot && !isCollapsed && (
           <span
-            className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border border-[#1a1a1e] ${DOT_CLASSES[dot]}`}
+            className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border border-surface-base ${DOT_CLASSES[dot]}`}
             aria-hidden="true"
           />
         )}

--- a/src/renderer/components/project-sidebar/WorktreeItem.tsx
+++ b/src/renderer/components/project-sidebar/WorktreeItem.tsx
@@ -1,17 +1,8 @@
 import { useState, useRef } from 'react'
-import {
-  FolderGit2,
-  GitBranch,
-  ChevronRight,
-  Plus,
-  Pencil,
-  Trash2,
-  Check,
-  X,
-  Terminal
-} from 'lucide-react'
+import { FolderGit2, GitBranch, ChevronRight, Plus, Pencil, Trash2, Terminal } from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
+import { InlineRename } from '../InlineRename'
 import { toast } from '../Toast'
 import { withProgressToast } from '../../lib/progress-toast'
 import { createSessionFromProject, createShellInProject } from '../../lib/session-utils'
@@ -52,94 +43,74 @@ export function WorktreeItem({
   const wt = worktree
 
   if (renaming) {
+    const commitRename = async (trimmed: string): Promise<void> => {
+      if (trimmed && trimmed !== wt.name) {
+        const result = await window.api.renameWorktree(wt.path, trimmed)
+        if (result) {
+          toast.success('Worktree renamed')
+          onWorktreesChanged()
+        } else {
+          toast.error('Failed to rename worktree')
+        }
+      }
+      setRenaming(false)
+    }
+
     return (
-      <div className="group/wt flex items-center">
-        <form
-          className="flex-1 flex items-center gap-2 px-2 py-1.5 min-w-0"
-          onSubmit={async (e) => {
-            e.preventDefault()
-            const trimmed = renameValue.trim()
-            if (trimmed && trimmed !== wt.name) {
-              const result = await window.api.renameWorktree(wt.path, trimmed)
-              if (result) {
-                toast.success('Worktree renamed')
-                onWorktreesChanged()
-              } else {
-                toast.error('Failed to rename worktree')
-              }
-            }
-            setRenaming(false)
-          }}
-        >
-          <FolderGit2 size={14} className="text-gray-500 shrink-0" strokeWidth={1.5} />
-          <input
-            autoFocus
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') setRenaming(false)
-            }}
-            className="flex-1 min-w-0 bg-white/[0.06] border border-white/[0.1] rounded px-1.5 py-0.5 text-[12px] text-white outline-none focus:border-blue-500"
-          />
-          <button
-            type="submit"
-            className="text-gray-400 hover:text-green-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0"
-          >
-            <Check size={14} strokeWidth={2.5} />
-          </button>
-          <button
-            type="button"
-            onClick={() => setRenaming(false)}
-            className="text-gray-400 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0"
-          >
-            <X size={14} strokeWidth={2.5} />
-          </button>
-        </form>
+      <div className="group/wt flex items-center gap-2 px-2 py-1.5 min-w-0">
+        <FolderGit2 size={14} className="text-gray-500 shrink-0" strokeWidth={1.5} />
+        <InlineRename
+          value={renameValue}
+          onCommit={(next) => void commitRename(next)}
+          onCancel={() => setRenaming(false)}
+          className="flex-1 min-w-0 text-[12px]"
+        />
       </div>
     )
   }
 
   return (
-    <div className="group/wt flex items-center">
+    <div className="group/wt relative flex items-center">
+      {isActiveWorktree && (
+        <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full z-10" />
+      )}
+      {onToggleSessionsExpanded ? (
+        <span
+          role="button"
+          tabIndex={0}
+          aria-expanded={sessionsExpanded}
+          aria-label="Toggle sessions"
+          className="relative w-[14px] h-[14px] shrink-0 ml-2 cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation()
+            onToggleSessionsExpanded()
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.stopPropagation()
+              e.preventDefault()
+              onToggleSessionsExpanded()
+            }
+          }}
+        >
+          <span className="group-hover/wt:hidden flex items-center justify-center w-full h-full">
+            <FolderGit2 size={14} className="text-gray-500" strokeWidth={1.5} />
+          </span>
+          <ChevronRight
+            size={12}
+            strokeWidth={2.5}
+            className={`hidden group-hover/wt:block text-gray-500 transition-transform absolute top-[1px] left-[1px] ${sessionsExpanded ? 'rotate-90' : ''}`}
+          />
+        </span>
+      ) : (
+        <FolderGit2 size={14} className="text-gray-500 shrink-0 ml-2" strokeWidth={1.5} />
+      )}
       <button
         onClick={onSelect}
-        className={`flex-1 text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
-          isActiveWorktree
-            ? 'bg-white/[0.08] text-white'
-            : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
+        className={`flex-1 text-left pl-2 pr-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+          isActiveWorktree ? 'text-white' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
         }`}
       >
-        {onToggleSessionsExpanded ? (
-          <div
-            role="button"
-            tabIndex={0}
-            aria-expanded={sessionsExpanded}
-            aria-label="Toggle sessions"
-            className="relative w-[14px] h-[14px] shrink-0"
-            onClick={(e) => {
-              e.stopPropagation()
-              onToggleSessionsExpanded()
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.stopPropagation()
-                e.preventDefault()
-                onToggleSessionsExpanded()
-              }
-            }}
-          >
-            <span className="group-hover/wt:hidden flex items-center justify-center w-full h-full">
-              <FolderGit2 size={14} className="text-gray-500" strokeWidth={1.5} />
-            </span>
-            <ChevronRight
-              size={12}
-              strokeWidth={2.5}
-              className={`hidden group-hover/wt:block text-gray-500 transition-transform absolute top-[1px] left-[1px] ${sessionsExpanded ? 'rotate-90' : ''}`}
-            />
-          </div>
-        ) : (
-          <FolderGit2 size={14} className="text-gray-500 shrink-0" strokeWidth={1.5} />
-        )}
         <div className="flex flex-col min-w-0 flex-1">
           <span className="truncate">{wt.name}</span>
           <span className="text-[10px] text-gray-600 flex items-center gap-1 truncate">
@@ -148,123 +119,123 @@ export function WorktreeItem({
           </span>
         </div>
         {sessionCount > 0 && (
-          <span className="text-gray-600 text-xs ml-auto group-hover/wt:hidden shrink-0">
+          <span className="text-gray-600 text-[11px] ml-auto group-hover/wt:hidden shrink-0">
             {sessionCount}
           </span>
         )}
-        <div className="hidden group-hover/wt:flex items-center gap-0.5 ml-auto">
-          <Tooltip label="New terminal" position="right">
-            <button
-              type="button"
-              aria-label="New terminal"
-              disabled={creatingTerminal}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (creatingTerminalLock.current) return
-                creatingTerminalLock.current = true
-                setCreatingTerminal(true)
-                const proj = config?.projects.find((p) => p.name === projectName)
-                void createShellInProject(wt.path, {
-                  project: proj,
-                  worktreePath: wt.path,
-                  worktreeName: wt.name,
-                  branch: wt.branch
-                }).finally(() => {
-                  creatingTerminalLock.current = false
-                  setCreatingTerminal(false)
-                })
-              }}
-              className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
-            >
-              <Terminal size={14} strokeWidth={1.5} />
-            </button>
-          </Tooltip>
-          <Tooltip label="New session" position="right">
-            <button
-              type="button"
-              aria-label="New session"
-              disabled={creatingSession}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (creatingSessionLock.current) return
-                creatingSessionLock.current = true
-                setCreatingSession(true)
-                void withProgressToast(
-                  { loading: 'Starting session…', success: 'Session started' },
-                  async () => {
-                    const proj = config?.projects.find((p) => p.name === projectName)
-                    if (!proj) throw new Error(`Project "${projectName}" not found`)
-                    await createSessionFromProject(proj, {
-                      branch: wt.branch,
-                      existingWorktreePath: wt.path
-                    })
-                  }
-                ).finally(() => {
-                  creatingSessionLock.current = false
-                  setCreatingSession(false)
-                })
-              }}
-              className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
-            >
-              <Plus size={14} strokeWidth={2} />
-            </button>
-          </Tooltip>
-          <Tooltip label="Rename worktree" position="right">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                setRenaming(true)
-                setRenameValue(wt.name)
-              }}
-              className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
-            >
-              <Pencil size={14} strokeWidth={2} />
-            </button>
-          </Tooltip>
-          <Tooltip label="Remove worktree" position="right">
-            <button
-              type="button"
-              disabled={removing}
-              onClick={async (e) => {
-                e.stopPropagation()
-                if (removingLock.current) return
-                removingLock.current = true
-                try {
-                  const { count, sessionIds } = await window.api.getWorktreeActiveSessions(wt.path)
-                  if (count > 0 || wt.isDirty) {
-                    requestWorktreeDelete({
-                      projectPath,
-                      worktreePath: wt.path,
-                      sessionIds
-                    })
-                    removingLock.current = false
-                  } else {
-                    setRemoving(true)
-                    void withProgressToast(
-                      { loading: 'Removing worktree…', success: 'Worktree removed' },
-                      async () => {
-                        const removed = await window.api.removeWorktree(projectPath, wt.path, false)
-                        if (!removed) throw new Error('Failed to remove worktree')
-                        onWorktreesChanged()
-                      }
-                    ).finally(() => {
-                      removingLock.current = false
-                      setRemoving(false)
-                    })
-                  }
-                } catch (err) {
-                  removingLock.current = false
-                  toast.error(err instanceof Error ? err.message : 'Failed to check worktree')
-                }
-              }}
-              className="text-gray-500 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
-            >
-              <Trash2 size={14} strokeWidth={2} />
-            </button>
-          </Tooltip>
-        </div>
       </button>
+      <div className="hidden group-hover/wt:flex items-center gap-0.5 ml-auto pr-2 shrink-0">
+        <Tooltip label="New terminal" position="right">
+          <button
+            type="button"
+            aria-label="New terminal"
+            disabled={creatingTerminal}
+            onClick={(e) => {
+              e.stopPropagation()
+              if (creatingTerminalLock.current) return
+              creatingTerminalLock.current = true
+              setCreatingTerminal(true)
+              const proj = config?.projects.find((p) => p.name === projectName)
+              void createShellInProject(wt.path, {
+                project: proj,
+                worktreePath: wt.path,
+                worktreeName: wt.name,
+                branch: wt.branch
+              }).finally(() => {
+                creatingTerminalLock.current = false
+                setCreatingTerminal(false)
+              })
+            }}
+            className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
+          >
+            <Terminal size={14} strokeWidth={1.5} />
+          </button>
+        </Tooltip>
+        <Tooltip label="New session" position="right">
+          <button
+            type="button"
+            aria-label="New session"
+            disabled={creatingSession}
+            onClick={(e) => {
+              e.stopPropagation()
+              if (creatingSessionLock.current) return
+              creatingSessionLock.current = true
+              setCreatingSession(true)
+              void withProgressToast(
+                { loading: 'Starting session…', success: 'Session started' },
+                async () => {
+                  const proj = config?.projects.find((p) => p.name === projectName)
+                  if (!proj) throw new Error(`Project "${projectName}" not found`)
+                  await createSessionFromProject(proj, {
+                    branch: wt.branch,
+                    existingWorktreePath: wt.path
+                  })
+                }
+              ).finally(() => {
+                creatingSessionLock.current = false
+                setCreatingSession(false)
+              })
+            }}
+            className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
+          >
+            <Plus size={14} strokeWidth={2} />
+          </button>
+        </Tooltip>
+        <Tooltip label="Rename worktree" position="right">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              setRenaming(true)
+              setRenameValue(wt.name)
+            }}
+            className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+          >
+            <Pencil size={14} strokeWidth={2} />
+          </button>
+        </Tooltip>
+        <Tooltip label="Remove worktree" position="right">
+          <button
+            type="button"
+            disabled={removing}
+            onClick={async (e) => {
+              e.stopPropagation()
+              if (removingLock.current) return
+              removingLock.current = true
+              try {
+                const { count, sessionIds } = await window.api.getWorktreeActiveSessions(wt.path)
+                if (count > 0 || wt.isDirty) {
+                  requestWorktreeDelete({
+                    projectPath,
+                    worktreePath: wt.path,
+                    sessionIds
+                  })
+                  removingLock.current = false
+                } else {
+                  setRemoving(true)
+                  void withProgressToast(
+                    { loading: 'Removing worktree…', success: 'Worktree removed' },
+                    async () => {
+                      const removed = await window.api.removeWorktree(projectPath, wt.path, false)
+                      if (!removed) throw new Error('Failed to remove worktree')
+                      onWorktreesChanged()
+                    }
+                  ).finally(() => {
+                    removingLock.current = false
+                    setRemoving(false)
+                  })
+                }
+              } catch (err) {
+                removingLock.current = false
+                toast.error(err instanceof Error ? err.message : 'Failed to check worktree')
+              }
+            }}
+            className="text-gray-500 hover:text-red-400 p-0.5 rounded hover:bg-white/[0.08] transition-colors disabled:opacity-50"
+          >
+            <Trash2 size={14} strokeWidth={2} />
+          </button>
+        </Tooltip>
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/project-sidebar/WorktreeItem.tsx
+++ b/src/renderer/components/project-sidebar/WorktreeItem.tsx
@@ -78,7 +78,9 @@ export function WorktreeItem({
         <span
           role="button"
           tabIndex={0}
-          aria-expanded={sessionsExpanded}
+          // A disclosure control has to report its state even before anything
+          // has set it, or assistive tech is told nothing rather than closed.
+          aria-expanded={sessionsExpanded ?? false}
           aria-label="Toggle sessions"
           className="relative w-[14px] h-[14px] shrink-0 ml-2 cursor-pointer"
           onClick={(e) => {

--- a/src/renderer/components/project-sidebar/WorktreeItem.tsx
+++ b/src/renderer/components/project-sidebar/WorktreeItem.tsx
@@ -184,6 +184,7 @@ export function WorktreeItem({
         <Tooltip label="Rename worktree" position="right">
           <button
             type="button"
+            aria-label="Rename worktree"
             onClick={(e) => {
               e.stopPropagation()
               setRenaming(true)

--- a/src/renderer/components/settings/WorktreeSettings.tsx
+++ b/src/renderer/components/settings/WorktreeSettings.tsx
@@ -34,8 +34,8 @@ type Pending = 'reclaim' | 'remove' | null
 const VERDICT_STYLES: Record<WorktreeVerdictLevel, { label: string; className: string }> = {
   keep: { label: 'Keep', className: 'text-gray-400 bg-white/[0.05]' },
   review: { label: 'Review', className: 'text-amber-300 bg-amber-500/[0.12]' },
-  reclaim: { label: 'Build output only', className: 'text-teal-300 bg-teal-500/[0.12]' },
-  remove: { label: 'Removable', className: 'text-teal-300 bg-teal-500/[0.12]' },
+  reclaim: { label: 'Build output only', className: 'text-blue-300 bg-blue-500/[0.12]' },
+  remove: { label: 'Removable', className: 'text-blue-300 bg-blue-500/[0.12]' },
   orphan: { label: 'Orphan directory', className: 'text-red-300 bg-red-500/[0.12]' }
 }
 
@@ -249,7 +249,7 @@ export function WorktreeSettings() {
           <button
             onClick={rescan}
             disabled={loading || busy}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-300 bg-white/[0.04]
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-gray-300 bg-white/[0.04]
                        hover:bg-white/[0.08] rounded-lg transition-colors disabled:opacity-50"
           >
             {loading ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />}
@@ -271,14 +271,14 @@ export function WorktreeSettings() {
       />
 
       {loading && !inventory && (
-        <div className="flex items-center gap-2 py-10 text-sm text-gray-500 justify-center">
+        <div className="flex items-center gap-2 py-10 text-[13px] text-gray-500 justify-center">
           <Loader2 size={15} className="animate-spin" />
           Measuring worktrees…
         </div>
       )}
 
       {!loading && !hasAnything && (
-        <div className="py-10 text-center text-sm text-gray-500">
+        <div className="py-10 text-center text-[13px] text-gray-500">
           No worktrees yet. They appear here as soon as you create one.
         </div>
       )}
@@ -307,7 +307,7 @@ export function WorktreeSettings() {
       {allEntries.some((e) => isSelectable(e) && e.verdict.autoSelect) && (
         <button
           onClick={selectSuggested}
-          className="mt-4 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          className="mt-4 text-[11px] text-gray-500 hover:text-gray-300 transition-colors"
         >
           Select everything merged and idle
         </button>
@@ -370,7 +370,7 @@ function SummaryCard({
             <HardDrive size={12} />
             On disk
           </div>
-          <div className="text-3xl font-semibold text-white tabular-nums mt-1">
+          <div className="text-[30px] leading-[38px] font-semibold text-white tabular-nums mt-1">
             {formatBytes(onDisk)}
           </div>
         </div>
@@ -378,15 +378,15 @@ function SummaryCard({
           <div className="text-[11px] uppercase tracking-wider text-gray-500">
             Build output — rebuilt by a reinstall
           </div>
-          <div className="text-xl font-semibold text-teal-300 tabular-nums mt-1">
+          <div className="text-[20px] leading-[28px] font-semibold text-blue-300 tabular-nums mt-1">
             {formatBytes(artifacts)}
           </div>
         </div>
       </div>
 
       <div className="mt-4 h-2 rounded-full bg-white/[0.06] overflow-hidden flex">
-        <div className="h-full bg-teal-400/70" style={{ width: `${artifactPct}%` }} />
-        <div className="h-full bg-teal-400/25" style={{ width: `${removablePct}%` }} />
+        <div className="h-full bg-blue-400/70" style={{ width: `${artifactPct}%` }} />
+        <div className="h-full bg-blue-400/25" style={{ width: `${removablePct}%` }} />
       </div>
       <div className="mt-2 flex gap-4 text-[11px] text-gray-500">
         <span>Build output</span>
@@ -399,11 +399,11 @@ function SummaryCard({
           <button
             onClick={confirming ? onConfirm : onAsk}
             disabled={loading || busy}
-            className={`flex items-center gap-2 px-3 py-2 text-xs rounded-lg transition-colors
+            className={`flex items-center gap-2 px-3 py-2 text-[11px] rounded-md transition-colors
                         disabled:opacity-50 ${
                           confirming
-                            ? 'text-white bg-teal-500/25 hover:bg-teal-500/35 border border-teal-400/40'
-                            : 'text-teal-200 bg-teal-500/[0.12] hover:bg-teal-500/20'
+                            ? 'text-white bg-blue-500/25 hover:bg-blue-500/35 border border-blue-500/30'
+                            : 'text-blue-300 bg-blue-500/[0.12] hover:bg-blue-500/20'
                         }`}
           >
             <Trash2 size={13} />
@@ -414,7 +414,7 @@ function SummaryCard({
           {confirming && (
             <button
               onClick={onAsk}
-              className="px-3 py-2 text-xs text-gray-400 hover:text-white transition-colors"
+              className="px-3 py-2 text-[11px] text-gray-400 hover:text-white transition-colors"
             >
               Cancel
             </button>
@@ -455,7 +455,9 @@ function ProjectGroup({
     <div className="mb-6">
       <div className="flex items-baseline justify-between gap-3 pb-2 border-b border-white/[0.06]">
         <div className="flex items-baseline gap-2 min-w-0">
-          <span className="text-sm font-medium text-gray-200 truncate">{project.projectName}</span>
+          <span className="text-[13px] font-medium text-gray-200 truncate">
+            {project.projectName}
+          </span>
           {project.defaultBranch && (
             <span className="text-[11px] text-gray-600 font-mono shrink-0">
               vs {project.defaultBranch}
@@ -465,14 +467,16 @@ function ProjectGroup({
             <span className="text-[11px] text-gray-600 shrink-0">remote</span>
           )}
         </div>
-        <span className="text-xs text-gray-500 tabular-nums shrink-0">{formatBytes(total)}</span>
+        <span className="text-[11px] text-gray-500 tabular-nums shrink-0">
+          {formatBytes(total)}
+        </span>
       </div>
 
       {project.error && (
-        <div className="py-3 text-xs text-gray-500">Could not scan — {project.error}</div>
+        <div className="py-3 text-[11px] text-gray-500">Could not scan — {project.error}</div>
       )}
 
-      <div className="divide-y divide-white/[0.04]">
+      <div>
         {entries.map((entry) => (
           <WorktreeRow
             key={entry.path}
@@ -511,14 +515,18 @@ function WorktreeRow({
   const artifactPct = entry.sizeBytes > 0 ? (entry.artifactBytes / entry.sizeBytes) * 100 : 0
 
   return (
-    <div className={`flex items-center gap-3 py-2.5 ${selectable ? '' : 'opacity-50'}`}>
+    <div
+      className={`flex items-center gap-3 py-2.5 border-b border-white/[0.04] last:border-b-0 ${
+        selectable ? '' : 'opacity-50'
+      }`}
+    >
       <input
         type="checkbox"
         checked={checked}
         disabled={!selectable}
         onChange={onToggle}
         aria-label={`Select ${entry.name}`}
-        className="shrink-0 accent-teal-400 disabled:cursor-not-allowed"
+        className="shrink-0 accent-blue-500 disabled:cursor-not-allowed"
       />
 
       <div className="min-w-0 flex-1">
@@ -543,12 +551,12 @@ function WorktreeRow({
       </div>
 
       <div className="shrink-0 w-[86px] text-right">
-        <div className="text-xs text-gray-300 tabular-nums">
+        <div className="text-[11px] text-gray-300 tabular-nums">
           {entry.sizeMeasured ? formatBytes(entry.sizeBytes) : '—'}
         </div>
         {entry.artifactBytes > 0 && (
           <div className="mt-1 h-1 rounded-full bg-white/[0.06] overflow-hidden">
-            <div className="h-full bg-teal-400/60" style={{ width: `${artifactPct}%` }} />
+            <div className="h-full bg-blue-400/60" style={{ width: `${artifactPct}%` }} />
           </div>
         )}
       </div>
@@ -581,7 +589,7 @@ function StaleBranchStrip({
     <div className="mt-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2.5">
       <div className="flex items-center gap-2 flex-wrap">
         <GitBranch size={13} className="text-gray-600 shrink-0" />
-        <span className="text-xs text-gray-400">
+        <span className="text-[11px] text-gray-400">
           {branches.length} branch{branches.length === 1 ? '' : 'es'} left behind by removed
           worktrees
           {merged.length > 0 && ` — ${merged.length} already merged`}
@@ -701,8 +709,7 @@ function SelectionBar({
       exit={{ opacity: 0, y: 12 }}
       transition={{ type: 'spring', stiffness: 400, damping: 32 }}
       className="fixed bottom-6 left-1/2 -translate-x-1/2 z-10 w-[min(560px,calc(100vw-4rem))]
-                 rounded-xl border border-white/[0.1] shadow-2xl px-4 py-3"
-      style={{ background: '#26262b' }}
+                 rounded-xl border border-white/[0.1] shadow-2xl px-4 py-3 bg-surface-overlay"
     >
       <div className="flex items-center gap-3">
         <div className="min-w-0">
@@ -721,14 +728,14 @@ function SelectionBar({
         <div className="ml-auto flex items-center gap-2 shrink-0">
           <button
             onClick={onClear}
-            className="px-2.5 py-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+            className="px-2.5 py-1.5 text-[11px] text-gray-400 hover:text-white transition-colors"
           >
             Clear
           </button>
           <button
             onClick={confirming ? onConfirm : onAsk}
             disabled={busy}
-            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-[11px] rounded-md transition-colors
                         disabled:opacity-50 ${
                           confirming
                             ? 'text-white bg-red-500/30 hover:bg-red-500/45 border border-red-400/40'

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -21,7 +21,7 @@ import {
   NODE_TYPE_VISUAL,
   nodeConnectionId,
   stepMeta,
-  inlineLogTail,
+  stepTimeline,
   stepOutputPreview,
   stepPreview
 } from './node-visuals'
@@ -211,6 +211,7 @@ export function RunStepsList({
           // output yet (a trigger, a pending step) still shows its configured
           // body, so a card is never blank.
           const preview = stepOutputPreview(ns) ?? stepPreview(node)
+          const timeline = stepTimeline(ns.logs, ns.diagnostics)
 
           const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
           const approvalMessage =
@@ -286,7 +287,7 @@ export function RunStepsList({
                     className="w-full flex items-center gap-2 px-3 py-1.5 text-left border-t
                                border-white/[0.05] bg-black/20 hover:bg-black/30 transition-colors"
                   >
-                    <p className="flex-1 min-w-0 text-[11px] text-gray-500 font-mono truncate">
+                    <p className="flex-1 min-w-0 text-[12px] text-gray-500 font-mono truncate">
                       {preview}
                     </p>
                     <ChevronDown size={11} className="text-gray-600 shrink-0" />
@@ -323,16 +324,35 @@ export function RunStepsList({
                   </div>
                 )}
 
-                {expandedNodeId === ns.nodeId && ns.logs && (
+                {/* One ordered account of the step: what the engine did to get
+                    the agent running, what the agent said, then how it ended.
+                    Engine lines are dimmed and marked so the agent's own words
+                    stay the foreground, without splitting them across panels. */}
+                {expandedNodeId === ns.nodeId && timeline.length > 0 && (
                   <div className="px-3 pb-2">
-                    <pre
-                      className="text-[11px] text-gray-400 bg-black/30 rounded-md p-2 max-h-[200px] overflow-auto
-                                font-mono whitespace-pre-wrap break-all leading-relaxed"
-                    >
-                      {inlineLogTail(ns.logs)}
-                    </pre>
+                    <div className="bg-black/30 rounded-md overflow-auto max-h-[280px]">
+                      {timeline.map((entry, ti) =>
+                        entry.kind === 'agent' ? (
+                          <pre
+                            key={ti}
+                            className="text-[12px] text-gray-300 px-2 py-1.5
+                                       font-mono whitespace-pre-wrap break-all leading-relaxed"
+                          >
+                            {entry.text}
+                          </pre>
+                        ) : (
+                          <p
+                            key={ti}
+                            className="text-[12px] text-gray-500 font-mono px-2 py-0.5
+                                       bg-white/[0.02] whitespace-pre-wrap break-all leading-relaxed"
+                          >
+                            {entry.text}
+                          </p>
+                        )
+                      )}
+                    </div>
                     <div className="flex items-center gap-1 mt-1.5">
-                      {onViewFullOutput && (
+                      {onViewFullOutput && ns.logs && (
                         <Tooltip label="View full output">
                           <button
                             onClick={() => onViewFullOutput(ns.logs!)}
@@ -359,53 +379,36 @@ export function RunStepsList({
                   </div>
                 )}
 
-                {expandedNodeId === ns.nodeId && !ns.logs && ns.error && (
+                {expandedNodeId === ns.nodeId && timeline.length === 0 && (
                   <div className="px-3 pb-2">
-                    <p className="text-[11px] text-red-400">{ns.error}</p>
-                    {canResume && (
-                      <div className="mt-1.5">
-                        <Tooltip label="Resume session">
-                          <button
-                            onClick={handleResume}
-                            aria-label="Resume session"
-                            className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
-                          >
-                            <RotateCcw size={12} strokeWidth={2} />
-                          </button>
-                        </Tooltip>
-                      </div>
+                    {ns.error ? (
+                      <>
+                        <p className="text-[11px] text-red-400">{ns.error}</p>
+                        {canResume && (
+                          <div className="mt-1.5">
+                            <Tooltip label="Resume session">
+                              <button
+                                onClick={handleResume}
+                                aria-label="Resume session"
+                                className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                              >
+                                <RotateCcw size={12} strokeWidth={2} />
+                              </button>
+                            </Tooltip>
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <p className="text-[11px] text-gray-600 italic">
+                        {ns.status === 'running'
+                          ? 'No output captured yet…'
+                          : ns.status === 'pending'
+                            ? "Step hasn't started yet."
+                            : ns.status === 'skipped'
+                              ? 'Step was skipped.'
+                              : 'No output recorded.'}
+                      </p>
                     )}
-                  </div>
-                )}
-
-                {expandedNodeId === ns.nodeId && !ns.logs && !ns.error && !ns.diagnostics && (
-                  <div className="px-3 pb-2">
-                    <p className="text-[11px] text-gray-600 italic">
-                      {ns.status === 'running'
-                        ? 'No output captured yet…'
-                        : ns.status === 'pending'
-                          ? "Step hasn't started yet."
-                          : ns.status === 'skipped'
-                            ? 'Step was skipped.'
-                            : 'No output recorded.'}
-                    </p>
-                  </div>
-                )}
-
-                {/* What the engine did, as distinct from what the agent said. This
-                is the only thing left to read when a step produced no output,
-                so it renders even — especially — when the log is empty. */}
-                {expandedNodeId === ns.nodeId && ns.diagnostics && (
-                  <div className="px-3 pb-2">
-                    <p className="text-[10px] uppercase tracking-wider text-gray-600 mb-1">
-                      Diagnostics
-                    </p>
-                    <pre
-                      className="text-[11px] text-gray-500 bg-black/20 rounded p-2 max-h-[160px] overflow-auto
-                             font-mono whitespace-pre-wrap break-all leading-relaxed"
-                    >
-                      {ns.diagnostics}
-                    </pre>
                   </div>
                 )}
               </div>

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -211,7 +211,11 @@ export function RunStepsList({
           // output yet (a trigger, a pending step) still shows its configured
           // body, so a card is never blank.
           const preview = stepOutputPreview(ns) ?? stepPreview(node)
-          const timeline = stepTimeline(ns.logs, ns.diagnostics)
+          // Only for the open card: stepTimeline slices a tail out of every
+          // step's logs, and a run with a dozen noisy steps would pay for all
+          // of them on every render to show one.
+          const isExpanded = expandedNodeId === ns.nodeId
+          const timeline = isExpanded ? stepTimeline(ns.logs, ns.diagnostics) : []
 
           const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
           const approvalMessage =
@@ -233,7 +237,7 @@ export function RunStepsList({
               )}
               <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] overflow-hidden">
                 <button
-                  onClick={() => setExpandedNodeId(expandedNodeId === ns.nodeId ? null : ns.nodeId)}
+                  onClick={() => setExpandedNodeId(isExpanded ? null : ns.nodeId)}
                   className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.03] transition-colors"
                 >
                   <StatusDot status={ns.status} />
@@ -271,7 +275,7 @@ export function RunStepsList({
                   <ChevronDown
                     size={12}
                     className={`text-gray-600 shrink-0 transition-transform ${
-                      expandedNodeId === ns.nodeId ? '' : '-rotate-90'
+                      isExpanded ? '' : '-rotate-90'
                     }`}
                   />
                 </button>
@@ -328,7 +332,7 @@ export function RunStepsList({
                     the agent running, what the agent said, then how it ended.
                     Engine lines are dimmed and marked so the agent's own words
                     stay the foreground, without splitting them across panels. */}
-                {expandedNodeId === ns.nodeId && timeline.length > 0 && (
+                {isExpanded && timeline.length > 0 && (
                   <div className="px-3 pb-2">
                     <div className="bg-black/30 rounded-md overflow-auto max-h-[280px]">
                       {timeline.map((entry, ti) =>
@@ -379,7 +383,7 @@ export function RunStepsList({
                   </div>
                 )}
 
-                {expandedNodeId === ns.nodeId && timeline.length === 0 && (
+                {isExpanded && timeline.length === 0 && (
                   <div className="px-3 pb-2">
                     {ns.error ? (
                       <>

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -320,28 +320,29 @@ function LoopRenderer({
 
   return (
     <div
-      className={`w-[300px] rounded-lg border transition-all
-                  ${selected ? 'border-cyan-400/60 shadow-[0_0_0_3px_rgba(34,211,238,0.08)]' : 'border-cyan-400/25'}
-                  bg-cyan-500/[0.03]`}
+      data-loop-rail
+      className={`w-[312px] rounded-lg border transition-all
+                  ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
+                  bg-surface-node`}
     >
       <div
         onClick={(e) => {
           e.stopPropagation()
           onNodeClick(row.loopNode.id)
         }}
-        className="flex items-center gap-2 px-3 py-2 border-b border-cyan-400/15 cursor-pointer
+        className="flex items-center gap-2 px-4 py-2.5 border-b border-white/[0.06] cursor-pointer
                    hover:bg-white/[0.02] rounded-t-lg"
       >
-        <Repeat size={13} className="shrink-0 text-cyan-400" strokeWidth={2} />
+        <Repeat size={13} className="shrink-0 text-gray-300" strokeWidth={2} />
         <span className="text-[12.5px] font-semibold text-white truncate flex-1">
           {row.loopNode.label}
         </span>
-        <span className="shrink-0 text-[10px] font-mono text-cyan-300/90 bg-cyan-500/10 rounded px-1.5 py-0.5">
+        <span className="shrink-0 text-[10px] font-mono text-gray-400 bg-white/[0.06] rounded px-1.5 py-0.5">
           max {config.maxIterations ?? 1}
         </span>
       </div>
 
-      <div className="px-3 pt-3 flex flex-col items-center">
+      <div className="px-4 pt-4 flex flex-col items-center">
         {row.body.length === 0 ? (
           <div
             className="w-full rounded-md border border-dashed border-white/[0.12] px-3 py-4
@@ -385,7 +386,7 @@ function LoopRenderer({
         />
       </div>
 
-      <div className="px-3 pt-2 pb-2.5 text-[10px] font-mono text-cyan-300/70 text-center truncate">
+      <div className="px-4 pt-2.5 pb-3 text-[10px] font-mono text-gray-500 text-center truncate">
         ↻ {until}
       </div>
     </div>

--- a/src/renderer/components/workflow-editor/node-visuals.ts
+++ b/src/renderer/components/workflow-editor/node-visuals.ts
@@ -33,7 +33,7 @@ export const NODE_TYPE_VISUAL: Record<
     color: 'text-gray-300',
     bg: 'bg-white/[0.06]'
   },
-  loop: { icon: Repeat, label: 'Loop', color: 'text-cyan-400', bg: 'bg-cyan-500/10' }
+  loop: { icon: Repeat, label: 'Loop', color: 'text-gray-300', bg: 'bg-white/[0.06]' }
 }
 
 /**
@@ -172,4 +172,47 @@ export function inlineLogTail(logs: string): string {
   if (logs.length <= INLINE_LOG_CHARS) return logs
   const elided = logs.length - INLINE_LOG_CHARS
   return `… ${elided.toLocaleString()} earlier characters hidden — use View full output\n\n${logs.slice(-INLINE_LOG_CHARS)}`
+}
+
+/** One line of a step's timeline. `engine` is what vorn did; `agent` is what the agent said. */
+export interface StepTimelineEntry {
+  kind: 'engine' | 'agent'
+  text: string
+}
+
+/**
+ * The engine notes the moment the agent first writes, so that line is the seam
+ * between "getting the agent running" and "the agent talking". Splitting there
+ * lets one ordered view read the way the step actually happened — setup, then
+ * the agent, then how it ended — instead of asking the reader to correlate two
+ * panels by timestamp.
+ *
+ * `logs` and `diagnostics` stay separate in the model on purpose: a typed step
+ * parses `logs` for its declared JSON payload, and folding engine prose into it
+ * would corrupt that parse.
+ */
+const FIRST_OUTPUT_NOTE = /^\[\+[\d.]+s\] First output from the agent\b/
+
+export function stepTimeline(
+  logs: string | undefined,
+  diagnostics: string | undefined
+): StepTimelineEntry[] {
+  const notes = diagnostics ? diagnostics.split('\n').filter(Boolean) : []
+  const agentText = logs?.trim() ? inlineLogTail(logs) : ''
+
+  if (!agentText) {
+    return notes.map((text) => ({ kind: 'engine' as const, text }))
+  }
+
+  // Everything up to and including the first-output note describes the launch;
+  // whatever follows describes how the step ended.
+  const seam = notes.findIndex((n) => FIRST_OUTPUT_NOTE.test(n))
+  const before = seam === -1 ? notes : notes.slice(0, seam + 1)
+  const after = seam === -1 ? [] : notes.slice(seam + 1)
+
+  return [
+    ...before.map((text) => ({ kind: 'engine' as const, text })),
+    { kind: 'agent' as const, text: agentText },
+    ...after.map((text) => ({ kind: 'engine' as const, text }))
+  ]
 }

--- a/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
@@ -46,7 +46,7 @@ export function ConnectorButton({
                     ${
                       open
                         ? 'bg-white/[0.08] border-blue-500/40 text-white'
-                        : 'bg-[#1d1d20] border-white/[0.1] text-gray-500 hover:border-white/[0.2] hover:text-white'
+                        : 'bg-surface-node border-white/[0.1] text-gray-500 hover:border-white/[0.2] hover:text-white'
                     }`}
       >
         <Plus size={13} strokeWidth={2.5} />

--- a/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
@@ -23,7 +23,7 @@ export function ApprovalNode({ label, config, selected, executionStatus, onClick
       }}
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
@@ -31,7 +31,7 @@ export function CallConnectorActionNode({
       }}
       className={`relative px-3 py-2.5 rounded-sm border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
@@ -42,7 +42,7 @@ export function ConditionNode({ label, config, selected, executionStatus, onClic
       }}
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
@@ -28,7 +28,7 @@ export function CreateTaskFromItemNode({
       }}
       className={`relative px-3 py-2.5 rounded-sm border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
@@ -37,7 +37,7 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
       }}
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
@@ -45,7 +45,7 @@ export function LoopNode({
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
                   ${body.length === 0 ? 'border-dashed' : ''}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span
@@ -53,13 +53,13 @@ export function LoopNode({
         />
       )}
       <div className="flex items-center gap-2">
-        <Repeat size={14} className="shrink-0 text-cyan-400" strokeWidth={2} />
+        <Repeat size={14} className="shrink-0 text-gray-300" strokeWidth={2} />
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-medium text-white truncate">{label}</div>
           <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
         </div>
         {iteration !== undefined && iteration > 0 && (
-          <span className="shrink-0 text-[10px] text-cyan-300/80 bg-cyan-500/10 rounded px-1.5 py-0.5">
+          <span className="shrink-0 text-[10px] text-gray-400 bg-white/[0.06] rounded px-1.5 py-0.5">
             {iteration}×
           </span>
         )}

--- a/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
@@ -43,7 +43,7 @@ export function ScriptNode({ label, config, selected, executionStatus, onClick }
       }}
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       {executionStatus && STATUS_DOT_CLASSES[executionStatus] && (
         <span

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -75,7 +75,7 @@ export function TriggerNode({ label, config, selected, onClick }: Props) {
       }}
       className={`px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
                   ${selected ? 'border-blue-500/60 shadow-[0_0_0_3px_rgba(59,130,246,0.08)]' : 'border-white/[0.08]'}
-                  bg-[#1d1d20] hover:bg-white/[0.02]`}
+                  bg-surface-node hover:bg-white/[0.02]`}
     >
       <div className="flex items-center gap-2">
         {connectorId ? (

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -139,7 +139,7 @@ export function RunDetailPane({
             {formatRelativeTime(run.startedAt)}
           </p>
           {summary && (
-            <pre className="mt-2.5 text-[11.5px] text-gray-300 font-mono whitespace-pre-wrap break-words leading-relaxed max-h-[160px] overflow-auto">
+            <pre className="mt-2.5 text-[12px] text-gray-300 font-mono whitespace-pre-wrap break-words leading-relaxed max-h-[160px] overflow-auto">
               {summary}
             </pre>
           )}

--- a/src/renderer/components/workflow-runs/RunListRow.tsx
+++ b/src/renderer/components/workflow-runs/RunListRow.tsx
@@ -67,7 +67,7 @@ function RunListRowImpl({
         selected ? 'bg-white/[0.05]' : 'hover:bg-white/[0.03]'
       }`}
     >
-      {selected && <span className="absolute left-0 top-0 bottom-0 w-[2px] bg-blue-500" />}
+      {selected && <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />}
 
       <span className="flex items-center gap-2 min-w-0">
         <span

--- a/src/renderer/components/workflow-runs/RunsToolbar.tsx
+++ b/src/renderer/components/workflow-runs/RunsToolbar.tsx
@@ -72,8 +72,7 @@ export function RunsToolbar({ filter, setFilter }: Props) {
       {open && (
         <div
           className="absolute right-0 top-full mt-1 z-50 w-[200px]
-                     border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
-          style={{ background: '#1a1a1e' }}
+                     border border-white/[0.08] rounded-lg shadow-xl overflow-hidden bg-surface-base"
         >
           <div className="py-1.5">
             <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -9,7 +9,7 @@
      Depth within the page comes from a step plus a hairline, not a shadow.
      A shadow means something is floating over the page rather than part of
      it: menus, dialogs, the selection bar. */
-  --color-surface-base: #1a1a1e; /* app background (see html/body below) */
+  --color-surface-base: #1a1a1e; /* app background */
   --color-surface-sunken: #141416; /* context menus */
   --color-surface-raised: #1e1e22; /* dialogs */
   --color-surface-overlay: #26262b; /* selection bars, floating chrome */
@@ -22,7 +22,7 @@ body {
   padding: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   -webkit-app-region: no-drag;
-  background: #1a1a1e !important;
+  background: var(--color-surface-base) !important;
   /* Prevent iOS rubber-band overscroll from pulling the whole page */
   overscroll-behavior: contain;
 }

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -4,6 +4,14 @@
 @theme {
   --color-bronzo: #c9972a;
   --color-bronzo-dark: #b8862a;
+
+  /* Surface ladder — the app field and the surfaces that lift off it.
+     Depth comes from these steps plus a hairline, never from a shadow. */
+  --color-surface-base: #1a1a1e; /* app background (see html/body below) */
+  --color-surface-sunken: #141416; /* context menus */
+  --color-surface-raised: #1e1e22; /* dialogs */
+  --color-surface-overlay: #26262b; /* selection bars, floating chrome */
+  --color-surface-node: #1d1d20; /* workflow canvas node cards */
 }
 
 html,

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -6,7 +6,9 @@
   --color-bronzo-dark: #b8862a;
 
   /* Surface ladder — the app field and the surfaces that lift off it.
-     Depth comes from these steps plus a hairline, never from a shadow. */
+     Depth within the page comes from a step plus a hairline, not a shadow.
+     A shadow means something is floating over the page rather than part of
+     it: menus, dialogs, the selection bar. */
   --color-surface-base: #1a1a1e; /* app background (see html/body below) */
   --color-surface-sunken: #141416; /* context menus */
   --color-surface-raised: #1e1e22; /* dialogs */

--- a/tests/loop-canvas.test.tsx
+++ b/tests/loop-canvas.test.tsx
@@ -77,7 +77,7 @@ describe('the loop rail on the canvas', () => {
     // The whole point of the redesign: a repeated step must not look like a
     // step that runs once.
     const { container } = renderWith(nodes)
-    const rail = container.querySelector('[class*="border-cyan-400"]')
+    const rail = container.querySelector('[data-loop-rail]')
     expect(rail).not.toBeNull()
     expect(within(rail as HTMLElement).getByText('Write the edition')).toBeInTheDocument()
     expect(within(rail as HTMLElement).getByText('Review the draft')).toBeInTheDocument()
@@ -85,7 +85,7 @@ describe('the loop rail on the canvas', () => {
 
   it('leaves the steps that run once outside the rail', () => {
     const { container } = renderWith(nodes)
-    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
     expect(within(rail).queryByText('Pull feeds')).toBeNull()
     expect(within(rail).queryByText('Javier reviews')).toBeNull()
     expect(screen.getByText('Pull feeds')).toBeInTheDocument()
@@ -136,7 +136,7 @@ describe('adding a step inside the rail', () => {
     // membership together instead of appending after the loop.
     const onInsertNode = vi.fn()
     const { container } = renderWithSpy(nodes, onInsertNode)
-    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
     fireEvent.click(within(rail).getByRole('button', { name: '' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
@@ -147,7 +147,7 @@ describe('adding a step inside the rail', () => {
   it('anchors the insert on the last body step', () => {
     const onInsertNode = vi.fn()
     const { container } = renderWithSpy(nodes, onInsertNode)
-    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
     fireEvent.click(within(rail).getByRole('button', { name: '' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
@@ -161,7 +161,7 @@ describe('adding a step inside the rail', () => {
       withLoopConfig({ nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 }),
       onInsertNode
     )
-    const rail = container.querySelector('[class*="border-cyan-400"]') as HTMLElement
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
     fireEvent.click(within(rail).getByRole('button', { name: '' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))

--- a/tests/run-entry.test.tsx
+++ b/tests/run-entry.test.tsx
@@ -223,7 +223,7 @@ describe('RunEntry', () => {
     expect(getByText(/No output captured yet/)).toBeInTheDocument()
   })
 
-  it('shows diagnostics instead of a dead end when the step produced no output', () => {
+  it('shows engine notes instead of a dead end when the step produced no output', () => {
     // The failure this exists for: an agent that hung and wrote nothing. The
     // log is empty, so the timeline is the only thing left to read.
     const exec = makeExec({
@@ -243,27 +243,33 @@ describe('RunEntry', () => {
     fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
     fireEvent.click(getByText('Run Claude').closest('button')!)
 
-    expect(getByText('Diagnostics')).toBeInTheDocument()
     expect(getByText(/Session sess-1 started \(pid 4242\)/)).toBeInTheDocument()
+    expect(getByText(/Launching claude in \/p/)).toBeInTheDocument()
     expect(queryByText(/No output recorded/)).not.toBeInTheDocument()
   })
 
-  it('shows diagnostics alongside the log when the agent did produce output', () => {
+  it('shows engine notes and the agent log in one ordered timeline', () => {
     const exec = makeExec({
       nodeStates: [
         makeState({
           status: 'success',
           logs: 'agent said this',
-          diagnostics: '[+0.0s] Launching claude in /p'
+          diagnostics:
+            '[+0.0s] Launching claude in /p\n[+1.2s] First output from the agent (15 bytes)\n[+9.0s] Agent exited (code 0)'
         })
       ]
     })
-    const { getByText } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
+    const { getByText, container } = render(<RunEntry execution={exec} nodes={[makeNode()]} />)
     fireEvent.click(getByText(/ago|just now|seconds/i).closest('button')!)
     fireEvent.click(getByText('Run Claude').closest('button')!)
 
     expect(getByText('agent said this')).toBeInTheDocument()
-    expect(getByText('Diagnostics')).toBeInTheDocument()
+    expect(getByText(/Launching claude in \/p/)).toBeInTheDocument()
+
+    // Setup before the agent, outcome after — the point of merging the panels.
+    const text = container.textContent ?? ''
+    expect(text.indexOf('Launching claude')).toBeLessThan(text.indexOf('agent said this'))
+    expect(text.indexOf('agent said this')).toBeLessThan(text.indexOf('Agent exited'))
   })
 
   it("shows the pending empty state for a step that hasn't started", () => {

--- a/tests/step-timeline.test.ts
+++ b/tests/step-timeline.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { stepTimeline } from '../src/renderer/components/workflow-editor/node-visuals'
+
+/**
+ * The timeline is the one place a stalled step accounts for itself, so the
+ * order it renders in — setup, agent, outcome — is the behaviour under test.
+ */
+describe('stepTimeline', () => {
+  const launch = '[+0.0s] Launching claude in /repo with a 12-line prompt'
+  const firstOutput = '[+1.4s] First output from the agent (128 bytes)'
+  const exited = '[+9.2s] Agent exited (code 0)'
+
+  it('puts the agent between the engine notes that bracket it', () => {
+    const entries = stepTimeline('hello from the agent', [launch, firstOutput, exited].join('\n'))
+
+    expect(entries.map((e) => e.kind)).toEqual(['engine', 'engine', 'agent', 'engine'])
+    expect(entries[1].text).toBe(firstOutput)
+    expect(entries[2].text).toBe('hello from the agent')
+    expect(entries[3].text).toBe(exited)
+  })
+
+  it('keeps engine notes alone when the agent never wrote anything', () => {
+    const entries = stepTimeline(undefined, [launch, exited].join('\n'))
+
+    expect(entries).toEqual([
+      { kind: 'engine', text: launch },
+      { kind: 'engine', text: exited }
+    ])
+  })
+
+  it('treats whitespace-only logs as no output', () => {
+    const entries = stepTimeline('   \n  ', launch)
+
+    expect(entries.every((e) => e.kind === 'engine')).toBe(true)
+  })
+
+  it('appends the agent after the notes when no first-output seam was recorded', () => {
+    // A step can end before the engine ever notes a first byte — the agent's
+    // words still belong after the setup that produced them.
+    const entries = stepTimeline('late output', launch)
+
+    expect(entries.map((e) => e.kind)).toEqual(['engine', 'agent'])
+  })
+
+  it('renders the agent alone when there are no engine notes', () => {
+    expect(stepTimeline('just output', undefined)).toEqual([{ kind: 'agent', text: 'just output' }])
+  })
+
+  it('is empty when the step produced nothing at all', () => {
+    expect(stepTimeline(undefined, undefined)).toEqual([])
+    expect(stepTimeline('', '')).toEqual([])
+  })
+})

--- a/tests/worktree-item.test.tsx
+++ b/tests/worktree-item.test.tsx
@@ -328,6 +328,13 @@ describe('WorktreeItem sessions toggle', () => {
     expect(onToggle).toHaveBeenCalledTimes(2)
   })
 
+  it('reports collapsed rather than nothing before anything sets the state', () => {
+    const { getByLabelText } = renderWorktreeItem(worktree, vi.fn(), {
+      onToggleSessionsExpanded: vi.fn()
+    })
+    expect(getByLabelText('Toggle sessions')).toHaveAttribute('aria-expanded', 'false')
+  })
+
   it('says whether it is expanded, so a screen reader is not guessing', () => {
     const { getByLabelText, rerender } = renderWorktreeItem(worktree, vi.fn(), {
       onToggleSessionsExpanded: vi.fn(),
@@ -355,7 +362,8 @@ describe('WorktreeItem sessions toggle', () => {
 describe('WorktreeItem rename', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockRenameWorktree.mockResolvedValue(true)
+    // The real contract: the new path and name, or null when it failed.
+    mockRenameWorktree.mockResolvedValue({ newPath: '/tmp/p/renamed', name: 'renamed' })
     useAppStore.setState({ config: baseConfig as AppConfig })
   })
 
@@ -397,7 +405,7 @@ describe('WorktreeItem rename', () => {
   })
 
   it('says so when the rename was refused', async () => {
-    mockRenameWorktree.mockResolvedValue(false)
+    mockRenameWorktree.mockResolvedValue(null)
     const onWorktreesChanged = vi.fn()
     const { input } = startRenaming(onWorktreesChanged)
 

--- a/tests/worktree-item.test.tsx
+++ b/tests/worktree-item.test.tsx
@@ -69,12 +69,13 @@ vi.mock('../src/renderer/components/WorktreeCleanupDialog', () => ({
 
 const mockGetActiveSessions = vi.fn()
 const mockRemoveWorktree = vi.fn()
+const mockRenameWorktree = vi.fn()
 
 Object.defineProperty(window, 'api', {
   value: {
     getWorktreeActiveSessions: (...a: unknown[]) => mockGetActiveSessions(...a),
     removeWorktree: (...a: unknown[]) => mockRemoveWorktree(...a),
-    renameWorktree: vi.fn()
+    renameWorktree: (...a: unknown[]) => mockRenameWorktree(...a)
   },
   writable: true
 })
@@ -105,7 +106,11 @@ const baseConfig: Partial<AppConfig> = {
 
 const initialState = useAppStore.getState()
 
-function renderWorktreeItem(wt: WorktreeInfo = worktree, onWorktreesChanged: () => void = vi.fn()) {
+function renderWorktreeItem(
+  wt: WorktreeInfo = worktree,
+  onWorktreesChanged: () => void = vi.fn(),
+  overrides: Partial<React.ComponentProps<typeof WorktreeItem>> = {}
+) {
   return render(
     <WorktreeItem
       worktree={wt}
@@ -115,6 +120,7 @@ function renderWorktreeItem(wt: WorktreeInfo = worktree, onWorktreesChanged: () 
       sessionCount={0}
       onSelect={vi.fn()}
       onWorktreesChanged={onWorktreesChanged}
+      {...overrides}
     />
   )
 }
@@ -264,5 +270,176 @@ describe('WorktreeItem progress-toast handlers', () => {
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith('toast-id', 'Failed to remove worktree', 'error')
     })
+  })
+})
+
+describe('WorktreeItem sessions toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStore.setState({ config: baseConfig as AppConfig })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  it('offers no toggle when there is nothing to expand', () => {
+    // The folder icon stays put; a control that does nothing is worse than none.
+    const { queryByLabelText } = renderWorktreeItem()
+    expect(queryByLabelText('Toggle sessions')).not.toBeInTheDocument()
+  })
+
+  it('expands and collapses on click', () => {
+    const onToggle = vi.fn()
+    const { getByLabelText } = renderWorktreeItem(worktree, vi.fn(), {
+      onToggleSessionsExpanded: onToggle,
+      sessionsExpanded: false
+    })
+
+    fireEvent.click(getByLabelText('Toggle sessions'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not select the worktree just because the toggle was clicked', () => {
+    // The toggle sits inside the row; without stopPropagation, opening the
+    // sessions would also switch to the worktree.
+    const onSelect = vi.fn()
+    const { getByLabelText } = renderWorktreeItem(worktree, vi.fn(), {
+      onSelect,
+      onToggleSessionsExpanded: vi.fn()
+    })
+
+    fireEvent.click(getByLabelText('Toggle sessions'))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('works from the keyboard, since it is not a real button', () => {
+    const onToggle = vi.fn()
+    const { getByLabelText } = renderWorktreeItem(worktree, vi.fn(), {
+      onToggleSessionsExpanded: onToggle
+    })
+    const toggle = getByLabelText('Toggle sessions')
+
+    fireEvent.keyDown(toggle, { key: 'Enter' })
+    fireEvent.keyDown(toggle, { key: ' ' })
+    expect(onToggle).toHaveBeenCalledTimes(2)
+
+    fireEvent.keyDown(toggle, { key: 'a' })
+    expect(onToggle).toHaveBeenCalledTimes(2)
+  })
+
+  it('says whether it is expanded, so a screen reader is not guessing', () => {
+    const { getByLabelText, rerender } = renderWorktreeItem(worktree, vi.fn(), {
+      onToggleSessionsExpanded: vi.fn(),
+      sessionsExpanded: false
+    })
+    expect(getByLabelText('Toggle sessions')).toHaveAttribute('aria-expanded', 'false')
+
+    rerender(
+      <WorktreeItem
+        worktree={worktree}
+        projectPath={project.path}
+        projectName={project.name}
+        isActiveWorktree={false}
+        sessionCount={0}
+        onSelect={vi.fn()}
+        onWorktreesChanged={vi.fn()}
+        onToggleSessionsExpanded={vi.fn()}
+        sessionsExpanded
+      />
+    )
+    expect(getByLabelText('Toggle sessions')).toHaveAttribute('aria-expanded', 'true')
+  })
+})
+
+describe('WorktreeItem rename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRenameWorktree.mockResolvedValue(true)
+    useAppStore.setState({ config: baseConfig as AppConfig })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  /** Enter rename mode and hand back the input it focuses. */
+  function startRenaming(onWorktreesChanged = vi.fn()) {
+    const utils = renderWorktreeItem(worktree, onWorktreesChanged)
+    fireEvent.click(utils.getByLabelText('Rename worktree'))
+    return { ...utils, input: utils.container.querySelector('input') as HTMLInputElement }
+  }
+
+  it('opens on the current name, so a small edit is a small edit', () => {
+    const { input } = startRenaming()
+    expect(input).toHaveValue('feature-a')
+  })
+
+  it('renames on Enter and tells the sidebar to reload', async () => {
+    const onWorktreesChanged = vi.fn()
+    const { input } = startRenaming(onWorktreesChanged)
+
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockRenameWorktree).toHaveBeenCalledWith(worktree.path, 'renamed'))
+    // Without this the row keeps showing the old name until something else
+    // happens to refresh it.
+    await waitFor(() => expect(onWorktreesChanged).toHaveBeenCalled())
+  })
+
+  it('trims what was typed rather than creating " renamed"', async () => {
+    const { input } = startRenaming()
+    fireEvent.change(input, { target: { value: '  renamed  ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockRenameWorktree).toHaveBeenCalledWith(worktree.path, 'renamed'))
+  })
+
+  it('says so when the rename was refused', async () => {
+    mockRenameWorktree.mockResolvedValue(false)
+    const onWorktreesChanged = vi.fn()
+    const { input } = startRenaming(onWorktreesChanged)
+
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Failed to rename worktree'))
+    // Nothing changed, so nothing to reload.
+    expect(onWorktreesChanged).not.toHaveBeenCalled()
+  })
+
+  it('does nothing at all when the name was not changed', async () => {
+    const { input } = startRenaming()
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(document.querySelector('input')).toBeNull())
+    expect(mockRenameWorktree).not.toHaveBeenCalled()
+  })
+
+  it('abandons the rename on Escape', async () => {
+    const { input } = startRenaming()
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    await waitFor(() => expect(document.querySelector('input')).toBeNull())
+    expect(mockRenameWorktree).not.toHaveBeenCalled()
+  })
+
+  it('treats a name emptied to nothing as a cancel, not a rename to ""', async () => {
+    const { input } = startRenaming()
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(document.querySelector('input')).toBeNull())
+    expect(mockRenameWorktree).not.toHaveBeenCalled()
+  })
+
+  it('commits when focus leaves, so clicking away is not a silent discard', async () => {
+    const { input } = startRenaming()
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(mockRenameWorktree).toHaveBeenCalledWith(worktree.path, 'renamed'))
   })
 })


### PR DESCRIPTION
## Why

Depth was coming from a shadow or a translucency chosen per component, so two surfaces that should have read as the same distance from the page often did not. `global.css` now names the ladder — `base`, `sunken`, `raised`, `overlay`, `node` — and every surface picks a rung plus a hairline rather than inventing one.

Applied across the workflow canvas nodes, the run views, the project sidebar and the worktree dialogs.

Alongside it, `WorktreeItem` gains a sessions-expand affordance with keyboard handling and an active-worktree indicator, and its inline rename moves onto the shared `InlineRename` component rather than carrying its own form.

## Provenance

This was in the working tree when I committed the connectors work, and a `git add -A` swept it into that commit. It was split back out, kept off `main`, and rebased here on its own. The tree is unchanged from what was written — only the commit message is mine.

## Testing

`yarn typecheck` clean. 2807 tests pass; `tests/shell-integration-shells.test.ts` fails identically on `main` and is untouched here.