### PR TITLE
chore(release): v0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only. Ships the connector work merged in #424 and the surface ladder in #425.

**Connectors now live in their own repository and ship on their own schedule.** The catalog is fetched at run time rather than compiled in, so a connector published this afternoon is offered without waiting for an app release — cached on disk, with a bundled seed so the list still renders offline and on a first run.

Entries carry what each connector says about itself: the triggers it fires on, the actions a workflow step can call, the settings it will ask for, and the version that would be installed. All generated upstream from each connector's own manifest, so the list cannot advertise a trigger that has since been renamed.

**The connectors page separates two things that were sharing a list.** Connections lead, grouped under the connector they belong to, with a sign-in problem reported on the connection it concerns rather than in a banner at the top of the page. Browse is a second view: one row per connector, what it does in a line, and one action.

`@vornrun/connector-kusto` is no longer published from here — the connectors repository owns it, and its `0.6.0` supersedes the `0.5.5` released from this repo. `@vornrun/connector-ado@0.2.0` joins it with two work-item actions.

**Surfaces sit on a named ladder** rather than each picking a shadow, and the worktree row gains a sessions-expand affordance with keyboard handling.