### PR TITLE
Make a packaged connector a first-class one

### DIFF
--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -26,5 +26,7 @@ export type {
   NormalizedItem,
   PollContext,
   PollOutcome,
-  TriggerDefinition
+  TriggerDefinition,
+  StatusSuggestion,
+  DefaultWorkflow
 } from './types'

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -1,5 +1,5 @@
 import { envNameFor } from './define'
-import type { Connector, ConnectorIcon } from './types'
+import type { Connector, ConnectorIcon, DefaultWorkflow, StatusSuggestion } from './types'
 
 /** MCP tool name a trigger is served under. */
 export function pollToolName(triggerType: string): string {
@@ -69,7 +69,16 @@ export interface ConnectorManifest {
   version: string
   description?: string
   icon?: ConnectorIcon
-  triggers: Array<{ type: string; label: string; description?: string; setup: ConnectionSetup }>
+  triggers: Array<{
+    type: string
+    label: string
+    description?: string
+    /** Seeds a connection's status mapping; absent when the connector was silent. */
+    statusMapping?: StatusSuggestion[]
+    /** Seeds the polling workflow created with the connection. */
+    defaultWorkflow?: DefaultWorkflow
+    setup: ConnectionSetup
+  }>
   actions: Array<{
     type: string
     label: string
@@ -90,6 +99,11 @@ export function connectorManifest(connector: Connector): ConnectorManifest {
       type: trigger.type,
       label: trigger.label,
       ...(trigger.description !== undefined && { description: trigger.description }),
+      // Carried through so the app can seed a connection's status mapping and
+      // its polling workflow. Absent when the connector said nothing, which is
+      // different from saying there is nothing.
+      ...(trigger.statusMapping !== undefined && { statusMapping: trigger.statusMapping }),
+      ...(trigger.defaultWorkflow !== undefined && { defaultWorkflow: trigger.defaultWorkflow }),
       setup: connectionSetup(connector, trigger.type)
     })),
     actions: connector.actions.map((action) => ({

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -113,11 +113,41 @@ export interface FetchContext {
   now(): string
 }
 
+/**
+ * What an upstream state should become when an item is imported as a task.
+ *
+ * A suggestion, not a rule: it seeds the connection form, and the person
+ * setting it up can change it. Without any, everything a connector imports
+ * lands as `todo` regardless of whether it was closed a year ago.
+ */
+export interface StatusSuggestion {
+  /** The value the connector reports in `ConnectorItem.status`. */
+  upstream: string
+  suggestedLocal: 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'
+}
+
+/**
+ * The workflow to create when a connection is made.
+ *
+ * A connector that fires on a schedule is useless until something polls it, and
+ * expecting every person to build that workflow by hand is how a connection
+ * ends up configured and silent. Seeded workflows are ordinary, visible and
+ * editable — the schedule is a starting point, not a fixed rule.
+ */
+export interface DefaultWorkflow {
+  name: string
+  defaultCronFromMinutes: number
+}
+
 interface TriggerBase {
   /** Event key, e.g. `workItemCreated`. Becomes the `poll_<type>` MCP tool. */
   type: string
   label: string
   description?: string
+  /** Seeds the connection's status mapping; the person setting it up owns it. */
+  statusMapping?: StatusSuggestion[]
+  /** Seeds a polling workflow when a connection is created. */
+  defaultWorkflow?: DefaultWorkflow
   /**
    * Representative items. `vorn-connector check` replays these through the
    * real dedupe pipeline, so a connector can be verified before anyone has

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -21,6 +21,7 @@ import type {
   ActionResult,
   PollResult,
   TriggerEvent,
+  ExternalItem,
   SourceConnection
 } from '@vornrun/shared/types'
 import { schemaProperties, schemaTypeHint, schemaRequired } from '@vornrun/shared/json-schema-utils'
@@ -407,6 +408,75 @@ export async function pollMcpConnection(
   return cfg.timestampField ? { events, nextCursor: newest ?? cursor } : { events }
 }
 
+/** Everything a backfill drains out of one poll page. */
+const MAX_BACKFILL_PAGES = 1_000
+
+/**
+ * Turn a poll event back into the reconciliation shape backfill upserts.
+ *
+ * `pollMcpConnection` already normalized the fields that matter — externalId,
+ * url, title — so this reads them back rather than re-deriving them from the
+ * raw item and risking a second, subtly different answer.
+ */
+function eventToExternalItem(event: TriggerEvent): ExternalItem {
+  const data = event.data as Record<string, unknown>
+  const str = (v: unknown): string => (v == null ? '' : String(v))
+  return {
+    externalId: str(data.externalId ?? event.id),
+    url: str(data.url),
+    title: str(data.title),
+    description: str(data.description ?? data.body),
+    // Backfill maps this through the connection's statusMapping; an item with
+    // no status upstream lands wherever that mapping sends the empty string.
+    status: str(data.status ?? data.state),
+    updatedAt: event.timestamp,
+    metadata: data
+  }
+}
+
+/**
+ * Drain everything an MCP connection's poll tool will return, from the start.
+ *
+ * Backfill exists to import what the cron cursor has already passed over, so it
+ * begins with no cursor and follows the tool's own paging. Like
+ * `pollMcpConnection` it takes the whole `SourceConnection`, because addressing
+ * the per-connection stdio client needs more than the flattened filters
+ * `VornConnector.listItemsPage` is handed — which is why `connection:backfill`
+ * routes MCP here rather than through the generic connector, mirroring how the
+ * scheduler routes polling.
+ *
+ * A connection with no `pollTool` is not a task source and says so, rather than
+ * reporting that it imported nothing.
+ */
+export async function backfillMcpConnection(
+  conn: SourceConnection,
+  visit: (item: ExternalItem) => void
+): Promise<void> {
+  const cfg = readPollConfig(conn)
+  if (!cfg.pollTool) {
+    throw new Error(
+      `Connection "${conn.name}" has no poll tool configured, so there is nothing to import.`
+    )
+  }
+
+  let cursor: string | undefined
+  for (let page = 0; page < MAX_BACKFILL_PAGES; page++) {
+    const result = await pollMcpConnection(conn, cursor)
+    result.events.forEach((event) => visit(eventToExternalItem(event)))
+
+    // Only a tool that takes the cursor is paging. Without `cursorArg` the
+    // cursor coming back is a client-side dedup watermark over a window the
+    // tool returns in full every call — following it would re-read the same
+    // items until the page cap.
+    if (!cfg.cursorArg) return
+
+    const next = result.nextCursor
+    if (result.events.length === 0 || next === undefined || next === cursor) return
+    cursor = next
+  }
+  throw new Error(`Connection "${conn.name}" exceeded ${MAX_BACKFILL_PAGES} backfill pages`)
+}
+
 function extractTextError(content: unknown): string | undefined {
   if (!Array.isArray(content)) return undefined
   for (const block of content) {
@@ -422,9 +492,11 @@ export const mcpConnector: VornConnector = {
   id: 'mcp',
   name: 'MCP',
   icon: 'mcp',
-  // 'triggers' is always declared; whether a given connection actually fires
-  // depends on it having a `pollTool` configured (see pollMcpConnection).
-  capabilities: ['actions', 'triggers'],
+  // 'triggers' and 'tasks' are always declared; whether a given connection
+  // actually fires or can be imported from depends on it having a `pollTool`
+  // configured, which is per-connection and so cannot be answered here (see
+  // pollMcpConnection and backfillMcpConnection).
+  capabilities: ['actions', 'triggers', 'tasks'],
 
   describe(): ConnectorManifest {
     return {

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -408,7 +408,7 @@ export async function pollMcpConnection(
   return cfg.timestampField ? { events, nextCursor: newest ?? cursor } : { events }
 }
 
-/** Everything a backfill drains out of one poll page. */
+/** Runaway guard: a tool that keeps handing back fresh cursors stops here. */
 const MAX_BACKFILL_PAGES = 1_000
 
 /**
@@ -448,6 +448,27 @@ function eventToExternalItem(event: TriggerEvent): ExternalItem {
  * A connection with no `pollTool` is not a task source and says so, rather than
  * reporting that it imported nothing.
  */
+/**
+ * The same connection with any pre-seeded cursor removed from its poll args.
+ *
+ * Returned as a copy: the stored connection is not ours to edit, and the seed
+ * still has to apply to ordinary polling.
+ */
+function withoutSeedCursor(conn: SourceConnection, cursorArg: string): SourceConnection {
+  const raw = conn.filters.pollArgs
+  if (typeof raw !== 'string' || !raw.includes(cursorArg)) return conn
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return conn
+    const { [cursorArg]: _seed, ...rest } = parsed
+    return { ...conn, filters: { ...conn.filters, pollArgs: JSON.stringify(rest) } }
+  } catch {
+    // Unparseable pollArgs is pollMcpConnection's error to report, with its
+    // own message; swallowing it here would turn it into a confusing one.
+    return conn
+  }
+}
+
 export async function backfillMcpConnection(
   conn: SourceConnection,
   visit: (item: ExternalItem) => void
@@ -459,9 +480,17 @@ export async function backfillMcpConnection(
     )
   }
 
+  // Backfill means "from the beginning", and a connection may carry a starting
+  // cursor in its pollArgs — pollMcpConnection deliberately leaves that in
+  // place when it has no stored cursor, treating it as the seed for the very
+  // first poll. Honouring it here would start the import from that point and
+  // silently skip everything before it, which is precisely what a backfill is
+  // for.
+  const fromTheStart = cfg.cursorArg ? withoutSeedCursor(conn, cfg.cursorArg) : conn
+
   let cursor: string | undefined
   for (let page = 0; page < MAX_BACKFILL_PAGES; page++) {
-    const result = await pollMcpConnection(conn, cursor)
+    const result = await pollMcpConnection(cursor === undefined ? fromTheStart : conn, cursor)
     result.events.forEach((event) => visit(eventToExternalItem(event)))
 
     // Only a tool that takes the cursor is paging. Without `cursorArg` the

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -190,6 +190,43 @@ function toManifest(payload: Record<string, unknown>): SdkConnectorManifest {
   const name = str(payload.name).trim()
   if (!id || !name) throw new Error('Connector manifest is missing an id or a name')
 
+  /** Local statuses a connector is allowed to suggest. */
+  const LOCAL_STATUSES = ['todo', 'in_progress', 'in_review', 'done', 'cancelled'] as const
+
+  /**
+   * Read a connector's suggested status mapping.
+   *
+   * This arrives from a third-party package, so an unrecognised local status is
+   * dropped rather than written into a connection where it would fail a
+   * constraint later, far from the connector that supplied it.
+   */
+  function readStatusMapping(
+    raw: unknown
+  ): Array<{ upstream: string; suggestedLocal: TaskStatus }> | undefined {
+    if (!Array.isArray(raw)) return undefined
+    const mapped = raw.filter(isRecord).flatMap((entry) => {
+      const upstream = str(entry.upstream).trim()
+      const local = str(entry.suggestedLocal).trim()
+      if (!upstream) return []
+      if (!(LOCAL_STATUSES as readonly string[]).includes(local)) return []
+      return [{ upstream, suggestedLocal: local as TaskStatus }]
+    })
+    return mapped.length > 0 ? mapped : undefined
+  }
+
+  /** Read a connector's suggested polling workflow, if it declared a usable one. */
+  function readDefaultWorkflow(
+    raw: unknown
+  ): { name: string; defaultCronFromMinutes: number } | undefined {
+    if (!isRecord(raw)) return undefined
+    const name = str(raw.name).trim()
+    const minutes = Number(raw.defaultCronFromMinutes)
+    // A zero or fractional interval would produce a cron that never fires or
+    // fires constantly; neither is worth guessing a correction for.
+    if (!name || !Number.isInteger(minutes) || minutes < 1 || minutes > 1440) return undefined
+    return { name, defaultCronFromMinutes: minutes }
+  }
+
   const rawTriggers = Array.isArray(payload.triggers) ? payload.triggers : []
   const triggers: SdkTrigger[] = []
   const env = new Map<string, SdkEnvVar>()
@@ -205,6 +242,12 @@ function toManifest(payload: Record<string, unknown>): SdkConnectorManifest {
       type,
       label: str(raw.label, type),
       ...(typeof raw.description === 'string' && { description: raw.description }),
+      ...(readStatusMapping(raw.statusMapping) && {
+        statusMapping: readStatusMapping(raw.statusMapping)
+      }),
+      ...(readDefaultWorkflow(raw.defaultWorkflow) && {
+        defaultWorkflow: readDefaultWorkflow(raw.defaultWorkflow)
+      }),
       filters: {
         pollTool: str(filters.pollTool, `poll_${type}`),
         itemsPath: str(filters.itemsPath, 'items'),

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -238,16 +238,15 @@ function toManifest(payload: Record<string, unknown>): SdkConnectorManifest {
     const setup = isRecord(raw.setup) ? raw.setup : {}
     const filters = isRecord(setup.filters) ? setup.filters : {}
 
+    const statusMapping = readStatusMapping(raw.statusMapping)
+    const defaultWorkflow = readDefaultWorkflow(raw.defaultWorkflow)
+
     triggers.push({
       type,
       label: str(raw.label, type),
       ...(typeof raw.description === 'string' && { description: raw.description }),
-      ...(readStatusMapping(raw.statusMapping) && {
-        statusMapping: readStatusMapping(raw.statusMapping)
-      }),
-      ...(readDefaultWorkflow(raw.defaultWorkflow) && {
-        defaultWorkflow: readDefaultWorkflow(raw.defaultWorkflow)
-      }),
+      ...(statusMapping && { statusMapping }),
+      ...(defaultWorkflow && { defaultWorkflow }),
       filters: {
         pollTool: str(filters.pollTool, `poll_${type}`),
         itemsPath: str(filters.itemsPath, 'items'),

--- a/packages/server/src/default-workflows.ts
+++ b/packages/server/src/default-workflows.ts
@@ -68,6 +68,22 @@ export function buildDefaultTaskWorkflow(): WorkflowDefinition {
 }
 
 /**
+ * A cron expression that fires every `minutes`.
+ *
+ * The minute field only counts to 59, so a step of 60 in it is not "hourly" —
+ * it is invalid, and a connector suggesting an hour would have been seeded with
+ * a schedule that never fires. An interval of an hour or more moves to the hour
+ * field instead; one that does not divide evenly into hours is rounded to the
+ * nearest hour rather than kept as an unschedulable minute step.
+ */
+export function cronEveryMinutes(minutes: number): string {
+  if (minutes <= 1) return '* * * * *'
+  if (minutes < 60) return `*/${minutes} * * * *`
+  const hours = Math.min(23, Math.round(minutes / 60))
+  return hours <= 1 ? '0 * * * *' : `0 */${hours} * * *`
+}
+
+/**
  * Build a seeded workflow for a (connection × manifest event). The graph is
  * `[connectorPoll trigger] → [createTaskFromItem node]`. Fully visible and
  * editable in the workflow editor — users can add condition/launchAgent nodes
@@ -82,8 +98,7 @@ export function buildConnectorSeededWorkflow(
   event: NonNullable<ConnectorManifest['defaultWorkflows']>[number]
 ): WorkflowDefinition {
   const id = connectorSeededWorkflowId(connection.id, event.event)
-  const minutes = Math.max(1, Math.round(event.defaultCronFromMinutes))
-  const cron = minutes === 1 ? '* * * * *' : `*/${minutes} * * * *`
+  const cron = cronEveryMinutes(Math.max(1, Math.round(event.defaultCronFromMinutes)))
 
   const triggerConfig: ConnectorPollTriggerConfig = {
     triggerType: 'connectorPoll',

--- a/packages/server/src/default-workflows.ts
+++ b/packages/server/src/default-workflows.ts
@@ -79,8 +79,13 @@ export function buildDefaultTaskWorkflow(): WorkflowDefinition {
 export function cronEveryMinutes(minutes: number): string {
   if (minutes <= 1) return '* * * * *'
   if (minutes < 60) return `*/${minutes} * * * *`
-  const hours = Math.min(23, Math.round(minutes / 60))
-  return hours <= 1 ? '0 * * * *' : `0 */${hours} * * *`
+  const hours = Math.round(minutes / 60)
+  if (hours <= 1) return '0 * * * *'
+  // A day is its own expression, not a 24-step in a field that counts 0-23.
+  // Capping to 23 instead would fire every 23 hours and drift a full hour
+  // earlier each day, which nobody asking for "daily" wants.
+  if (hours >= 24) return '0 0 * * *'
+  return `0 */${hours} * * *`
 }
 
 /**

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -128,8 +128,24 @@ export const SENSITIVE_ENV_PREFIXES = [
   'NODE_AUTH_TOKEN'
 ]
 
-// Env vars to strip so agent CLIs don't refuse to launch (e.g. nested session detection)
+/**
+ * Markers an agent CLI leaves in the environment to describe the session it is
+ * already inside.
+ *
+ * Vorn launches agents as subprocesses. When Vorn itself was started from an
+ * agent session — `yarn dev` typed into one, or the app opened from it — these
+ * propagate through the app into every agent it spawns, and each one then
+ * believes it is a nested child of that original session. The visible symptom
+ * is transcripts silently not being saved; the worse one is
+ * CLAUDE_CODE_MESSAGING_SOCKET, which points a freshly launched agent at
+ * another session's socket.
+ *
+ * The `CLAUDE_CODE_` prefix is stripped wholesale rather than by name because
+ * this list has been wrong once already: CLAUDECODE alone was stripped while
+ * five siblings went through untouched.
+ */
 export const STRIP_ENV_KEYS = ['CLAUDECODE']
+const STRIP_ENV_PREFIXES = ['CLAUDE_CODE_']
 
 // Compared uppercased. Windows environment variable names are case-insensitive
 // and Node hands back whatever casing it enumerated, so a literal match would
@@ -198,6 +214,7 @@ export function filterEnv(
     if (val === undefined) continue
     const upper = key.toUpperCase()
     if (STRIP_ENV_KEYS_UPPER.includes(upper)) continue
+    if (STRIP_ENV_PREFIXES.some((p) => upper.startsWith(p))) continue
     if (!passthrough.has(upper) && SENSITIVE_ENV_PREFIXES.some((p) => upper.startsWith(p))) continue
     env[key] = val
   }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -98,7 +98,7 @@ import {
   mcpConnectionActions,
   stopMcpClient
 } from './connectors'
-import { MCP_CONNECTOR_ID } from './connectors/mcp'
+import { MCP_CONNECTOR_ID, backfillMcpConnection } from './connectors/mcp'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { detectRepoSlug } from './connectors/github'
@@ -904,7 +904,12 @@ export function registerAllMethods(): void {
     const conn = dbGetSourceConnection(connectionId)
     if (!conn) return { imported: 0, updated: 0, error: 'Connection not found' }
     const connector = connectorRegistry.get(conn.connectorId)
-    if (!connector?.listItems && !connector?.listItemsPage) {
+    // MCP is polymorphic: draining it needs the full SourceConnection to
+    // address the per-connection stdio client, which the generic
+    // listItemsPage(filters) signature cannot carry — the same reason the
+    // scheduler routes MCP polling through pollMcpConnection.
+    const isMcp = conn.connectorId === MCP_CONNECTOR_ID
+    if (!isMcp && !connector?.listItems && !connector?.listItemsPage) {
       return {
         imported: 0,
         updated: 0,
@@ -918,7 +923,12 @@ export function registerAllMethods(): void {
     const projectName = conn.executionProject || conn.name
 
     try {
-      await forEachConnectorItem(connector, applyDecryptedCreds(conn), (item) => {
+      const drain = isMcp
+        ? (visit: (item: ExternalItem) => void) => backfillMcpConnection(conn, visit)
+        : (visit: (item: ExternalItem) => void) =>
+            forEachConnectorItem(connector!, applyDecryptedCreds(conn), visit)
+
+      await drain((item) => {
         const initialStatus = conn.statusMapping?.[item.status] || ('todo' as TaskStatus)
         const upserted = upsertExternalItem(
           conn,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -98,7 +98,7 @@ import {
   mcpConnectionActions,
   stopMcpClient
 } from './connectors'
-import { MCP_CONNECTOR_ID, backfillMcpConnection } from './connectors/mcp'
+import { MCP_CONNECTOR_ID, MCP_POLL_EVENT, backfillMcpConnection } from './connectors/mcp'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { detectRepoSlug } from './connectors/github'
@@ -721,14 +721,39 @@ export function registerAllMethods(): void {
     }
     dbInsertSourceConnection(conn)
 
-    // Seed visible + editable default workflows from the connector manifest.
+    // Seed visible + editable default workflows. A built-in declares them on
+    // its manifest; a packaged connector cannot, because the connector the
+    // registry resolves for it is the generic MCP one — so the caller passes
+    // through what the probe read from the package.
     const connector = connectorRegistry.get(conn.connectorId)
-    if (connector) {
-      const manifest = connector.describe()
-      for (const event of manifest.defaultWorkflows ?? []) {
+    const manifest = connector?.describe()
+    const seeded: Array<NonNullable<ConnectorManifest['defaultWorkflows']>[number]> = [
+      ...(manifest?.defaultWorkflows ?? []),
+      ...(params.seedWorkflow
+        ? [
+            {
+              name: params.seedWorkflow.name,
+              event: MCP_POLL_EVENT,
+              defaultCronFromMinutes: params.seedWorkflow.defaultCronFromMinutes,
+              downstream: 'createTaskFromItem' as const
+            }
+          ]
+        : [])
+    ]
+    if (manifest) {
+      for (const event of seeded) {
         const wfId = connectorSeededWorkflowId(conn.id, event.event)
         if (dbGetWorkflow(wfId)) continue
-        const wf = buildConnectorSeededWorkflow(conn, manifest, event)
+        // The connection's own mapping beats the connector's suggestion: it is
+        // what the person setting it up actually chose.
+        const withMapping: ConnectorManifest = {
+          ...manifest,
+          statusMapping: Object.entries(conn.statusMapping ?? {}).map(([upstream, local]) => ({
+            upstream,
+            suggestedLocal: local
+          }))
+        }
+        const wf = buildConnectorSeededWorkflow(conn, withMapping, event)
         dbInsertWorkflow(wf)
         log.info(`[connector] seeded workflow ${wfId} for connection ${conn.id}`)
       }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -729,7 +729,10 @@ export function registerAllMethods(): void {
     const manifest = connector?.describe()
     const seeded: Array<NonNullable<ConnectorManifest['defaultWorkflows']>[number]> = [
       ...(manifest?.defaultWorkflows ?? []),
-      ...(params.seedWorkflow
+      // Only for MCP: the event seeded is MCP_POLL_EVENT, which no other
+      // connector emits — seeding it for one would leave a workflow polling on
+      // a schedule for something that never fires.
+      ...(params.seedWorkflow && params.connectorId === MCP_CONNECTOR_ID
         ? [
             {
               name: params.seedWorkflow.name,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -258,7 +258,17 @@ export interface RequestMethods {
     params: Omit<
       SourceConnection,
       'id' | 'createdAt' | 'lastSyncAt' | 'lastSyncError' | 'syncCursor'
-    >
+    > & {
+      /**
+       * Polling workflow to seed alongside the connection.
+       *
+       * Built-ins declare this on their manifest, which the server reads
+       * directly. A packaged connector cannot: the connector the registry
+       * resolves for it is the generic MCP one, so what the probe read from
+       * the package is passed through here instead.
+       */
+      seedWorkflow?: { name: string; defaultCronFromMinutes: number }
+    }
     result: SourceConnection
   }
   'connection:update': {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1401,6 +1401,18 @@ export interface SdkTrigger {
   description?: string
   /** Connection filter values that make this trigger poll correctly. */
   filters: SdkSetupFilters
+  /**
+   * What an upstream status should become locally. Seeds the connection's own
+   * mapping, which the person setting it up then owns. Absent means the
+   * connector said nothing, and everything it imports lands as `todo`.
+   */
+  statusMapping?: Array<{ upstream: string; suggestedLocal: TaskStatus }>
+  /**
+   * The polling workflow to create with the connection. Without one a
+   * connector that fires on a schedule connects and then sits silent until
+   * somebody builds the workflow by hand.
+   */
+  defaultWorkflow?: { name: string; defaultCronFromMinutes: number }
 }
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -528,7 +528,7 @@ const api = {
     params: Omit<
       SourceConnection,
       'id' | 'createdAt' | 'lastSyncAt' | 'lastSyncError' | 'syncCursor'
-    >
+    > & { seedWorkflow?: { name: string; defaultCronFromMinutes: number } }
   ): Promise<SourceConnection> => ipcRenderer.invoke(IPC.CONNECTION_CREATE, params),
 
   updateConnection: (

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AlertCircle, Check, Loader2, Search } from 'lucide-react'
-import type { ConnectorCatalogItem, SdkConnectorManifest, TaskStatus } from '../../../shared/types'
+import type {
+  ConnectorCatalogItem,
+  SdkConnectorManifest,
+  SdkTrigger,
+  TaskStatus
+} from '../../../shared/types'
 import { useAppStore } from '../../stores'
 import { parseLaunchSpec } from './parse-launch-spec'
 import { ConnectorIcon } from '../ConnectorIcon'
@@ -17,6 +22,19 @@ const INPUT_CLASS =
  * generic MCP form, where a single typo produces a connection that silently
  * never fires. The connector already knows all of them, so it is asked.
  */
+/**
+ * Turn a connector's suggestions into the connection's own mapping.
+ *
+ * A suggestion, not a rule: this is the starting point the person setting up
+ * the connection then owns, which is why it is written onto the connection
+ * rather than read from the manifest every time.
+ */
+function seedStatusMapping(suggestions: SdkTrigger['statusMapping']): Record<string, TaskStatus> {
+  const mapping: Record<string, TaskStatus> = {}
+  for (const entry of suggestions ?? []) mapping[entry.upstream] = entry.suggestedLocal
+  return mapping
+}
+
 export function SdkConnectorForm({
   onDone,
   onCancel,
@@ -132,7 +150,12 @@ export function SdkConnectorForm({
         name: trigger ? `${manifest.name}: ${trigger.label}` : manifest.name,
         filters,
         syncIntervalMinutes: 5,
-        statusMapping: {} as Record<string, TaskStatus>,
+        // Seeded from what the connector suggests. Left empty, every item it
+        // ever imports lands as `todo` — a closed issue included.
+        statusMapping: seedStatusMapping(trigger?.statusMapping),
+        // Without this the connection is made and then sits silent: nothing
+        // polls it until somebody builds the workflow by hand.
+        ...(trigger?.defaultWorkflow && { seedWorkflow: trigger.defaultWorkflow }),
         executionProject: selectedProject
       })
       onDone()

--- a/tests/connector-sdk.test.ts
+++ b/tests/connector-sdk.test.ts
@@ -420,3 +420,52 @@ describe('connector icons', () => {
     expect(() => withIcon({ viewBox: '-1.5 -1.5 27 27', paths: ['M1 1h4v4z'] })).not.toThrow()
   })
 })
+
+describe('what a trigger says about setting up a connection', () => {
+  const withTrigger = (extra: Record<string, unknown>) =>
+    defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          poll: (() => ({ items: [] })) as never,
+          ...extra
+        } as never
+      ]
+    })
+
+  it('carries the status mapping a connection should start from', () => {
+    // Without it every item a connector imports lands as `todo`, a ticket
+    // closed a year ago included.
+    const connector = withTrigger({
+      statusMapping: [
+        { upstream: 'open', suggestedLocal: 'todo' },
+        { upstream: 'closed', suggestedLocal: 'done' }
+      ]
+    })
+    expect(connectorManifest(connector).triggers[0].statusMapping).toEqual([
+      { upstream: 'open', suggestedLocal: 'todo' },
+      { upstream: 'closed', suggestedLocal: 'done' }
+    ])
+  })
+
+  it('carries the polling workflow to seed with the connection', () => {
+    const connector = withTrigger({
+      defaultWorkflow: { name: 'Acme: new tickets', defaultCronFromMinutes: 5 }
+    })
+    expect(connectorManifest(connector).triggers[0].defaultWorkflow).toEqual({
+      name: 'Acme: new tickets',
+      defaultCronFromMinutes: 5
+    })
+  })
+
+  it('says nothing rather than nothing-in-particular when the connector was silent', () => {
+    // Absent has to stay absent: the app treats "no suggestion" differently
+    // from "suggested an empty mapping".
+    const trigger = connectorManifest(withTrigger({})).triggers[0]
+    expect(trigger.statusMapping).toBeUndefined()
+    expect(trigger.defaultWorkflow).toBeUndefined()
+  })
+})

--- a/tests/connector-seeded-workflow.test.ts
+++ b/tests/connector-seeded-workflow.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { buildConnectorSeededWorkflow } from '../packages/server/src/default-workflows'
+import {
+  buildConnectorSeededWorkflow,
+  cronEveryMinutes
+} from '../packages/server/src/default-workflows'
 import {
   connectorSeededWorkflowId,
   type SourceConnection,
@@ -122,5 +125,32 @@ describe('buildConnectorSeededWorkflow', () => {
     const node = wf.nodes.find((n) => n.type === 'createTaskFromItem')!
       .config as CreateTaskFromItemConfig
     expect(node.project).toBe('fromConnection')
+  })
+})
+
+describe('cronEveryMinutes', () => {
+  it('steps the minute field below an hour', () => {
+    expect(cronEveryMinutes(1)).toBe('* * * * *')
+    expect(cronEveryMinutes(5)).toBe('*/5 * * * *')
+    expect(cronEveryMinutes(59)).toBe('*/59 * * * *')
+  })
+
+  it('moves to the hour field at an hour, rather than emitting an invalid cron', () => {
+    // The minute field only counts to 59, so `*/60 * * * *` is not hourly — it
+    // is unschedulable, and a connector suggesting an hour would have been
+    // seeded with a workflow that never fires.
+    expect(cronEveryMinutes(60)).toBe('0 * * * *')
+    expect(cronEveryMinutes(120)).toBe('0 */2 * * *')
+    expect(cronEveryMinutes(720)).toBe('0 */12 * * *')
+  })
+
+  it('rounds an interval that does not divide into hours', () => {
+    expect(cronEveryMinutes(90)).toBe('0 */2 * * *')
+    expect(cronEveryMinutes(70)).toBe('0 * * * *')
+  })
+
+  it('caps at what the hour field can express', () => {
+    // A day is 24 hours and the field counts 0-23, so `*/24` would never fire.
+    expect(cronEveryMinutes(1440)).toBe('0 */23 * * *')
   })
 })

--- a/tests/connector-seeded-workflow.test.ts
+++ b/tests/connector-seeded-workflow.test.ts
@@ -149,8 +149,12 @@ describe('cronEveryMinutes', () => {
     expect(cronEveryMinutes(70)).toBe('0 * * * *')
   })
 
-  it('caps at what the hour field can express', () => {
-    // A day is 24 hours and the field counts 0-23, so `*/24` would never fire.
-    expect(cronEveryMinutes(1440)).toBe('0 */23 * * *')
+  it('treats a day as a day rather than every 23 hours', () => {
+    // The hour field counts 0-23, so a 24-step never fires. Capping to 23
+    // instead would drift a full hour earlier every day, which is not what
+    // anybody asking for "daily" means.
+    expect(cronEveryMinutes(1440)).toBe('0 0 * * *')
+    expect(cronEveryMinutes(1439)).toBe('0 0 * * *')
+    expect(cronEveryMinutes(23 * 60)).toBe('0 */23 * * *')
   })
 })

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -52,6 +52,36 @@ describe('filterEnv', () => {
     expect(env).not.toHaveProperty('ClaudeCode')
   })
 
+  it('strips every marker describing the session Vorn was started from', () => {
+    // Vorn launches agents as subprocesses. Started from an agent session
+    // itself, these propagate through the app into every agent it spawns, and
+    // each one believes it is a nested child of that original session —
+    // transcripts stop being saved, and the messaging socket points at
+    // somebody else's session.
+    const env = filterEnv(
+      {
+        PATH: '/usr/bin',
+        CLAUDE_CODE_CHILD_SESSION: '1',
+        CLAUDE_CODE_SESSION_ID: '691e659a',
+        CLAUDE_CODE_MESSAGING_SOCKET: '/tmp/cc-socks/17570.sock',
+        CLAUDE_CODE_WORKER_EPOCH: '1',
+        CLAUDE_CODE_ENTRYPOINT: 'sdk-cli'
+      },
+      new Set()
+    )
+    expect(Object.keys(env)).toEqual(['PATH'])
+  })
+
+  it('strips those markers whatever their casing, and even when named', () => {
+    // Same reasoning as CLAUDECODE: forwarding one breaks the session it
+    // reaches rather than protecting anything.
+    const env = filterEnv(
+      { claude_code_child_session: '1', CLAUDE_CODE_SESSION_ID: 'x' },
+      new Set(['CLAUDE_CODE_SESSION_ID'])
+    )
+    expect(env).toEqual({})
+  })
+
   it('never forwards STRIP_ENV_KEYS, even when named', () => {
     // CLAUDECODE is stripped so nested agent CLIs still launch; forwarding it
     // breaks the session rather than protecting anything.

--- a/tests/mcp-backfill.test.ts
+++ b/tests/mcp-backfill.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Same seam the poll tests use: control the MCP client so the drain never
+// spawns a server.
+const callTool = vi.fn()
+vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  getOrStartClient: vi.fn(async () => ({ callTool }))
+}))
+
+import { backfillMcpConnection } from '../packages/server/src/connectors/mcp'
+import type { ExternalItem, SourceConnection } from '../src/shared/types'
+
+function makeConn(pollFilters: Record<string, unknown>): SourceConnection {
+  return {
+    id: 'conn-1',
+    connectorId: 'mcp',
+    name: 'Work items',
+    filters: { command: 'npx', args: '[]', ...pollFilters },
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-01-01T00:00:00Z'
+  } as SourceConnection
+}
+
+function toolReturns(structuredContent: Record<string, unknown>) {
+  callTool.mockResolvedValueOnce({ structuredContent, isError: false })
+}
+
+/** The shape a connector built with the SDK is wired as: the tool owns paging. */
+const CURSORED = {
+  pollTool: 'poll_workItem',
+  itemsPath: 'items',
+  idField: 'externalId',
+  titleField: 'title',
+  urlField: 'url',
+  timestampField: 'updatedAt',
+  cursorArg: 'cursor',
+  cursorPath: 'nextCursor'
+}
+
+async function drain(conn: SourceConnection): Promise<ExternalItem[]> {
+  const seen: ExternalItem[] = []
+  await backfillMcpConnection(conn, (item) => seen.push(item))
+  return seen
+}
+
+beforeEach(() => {
+  callTool.mockReset()
+})
+
+describe('backfillMcpConnection', () => {
+  it('says a connection with no poll tool is not a task source', async () => {
+    // Reporting "imported 0" would read as "there was nothing there", which is
+    // a different and wrong answer.
+    await expect(backfillMcpConnection(makeConn({}), () => {})).rejects.toThrow(
+      /no poll tool configured/
+    )
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('follows the tool across pages, starting from no cursor', async () => {
+    // The point of a backfill: import what the cron cursor already passed over.
+    toolReturns({
+      items: [{ externalId: '1', title: 'One', updatedAt: '2026-01-01T00:00:00Z' }],
+      nextCursor: 'page-2'
+    })
+    toolReturns({
+      items: [{ externalId: '2', title: 'Two', updatedAt: '2026-01-02T00:00:00Z' }],
+      nextCursor: 'page-3'
+    })
+    toolReturns({ items: [], nextCursor: 'page-4' })
+
+    const items = await drain(makeConn(CURSORED))
+
+    expect(items.map((i) => i.externalId)).toEqual(['1', '2'])
+    expect(callTool).toHaveBeenCalledTimes(3)
+    // First call carries no cursor at all; the seed is the absence of one.
+    expect(callTool.mock.calls[0][0].arguments).not.toHaveProperty('cursor')
+    expect(callTool.mock.calls[1][0].arguments).toMatchObject({ cursor: 'page-2' })
+  })
+
+  it('stops when the tool stops moving its cursor', async () => {
+    // Otherwise a tool that answers the same page forever would drain until the
+    // page cap, thousands of calls later.
+    toolReturns({
+      items: [{ externalId: '1', updatedAt: '2026-01-01T00:00:00Z' }],
+      nextCursor: 'x'
+    })
+    toolReturns({
+      items: [{ externalId: '2', updatedAt: '2026-01-02T00:00:00Z' }],
+      nextCursor: 'x'
+    })
+
+    const items = await drain(makeConn(CURSORED))
+
+    expect(items.map((i) => i.externalId)).toEqual(['1', '2'])
+    expect(callTool).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads one page from a connection that dedupes client-side', async () => {
+    // Without a cursorArg the tool returns its whole window every call, so a
+    // second pass would re-read the same items indefinitely. It still hands
+    // back a cursor — the newest timestamp it saw — and following that as
+    // though it were a paging token is exactly the trap.
+    toolReturns({
+      items: [
+        { externalId: '1', title: 'One', updatedAt: '2026-01-01T00:00:00Z' },
+        { externalId: '2', title: 'Two', updatedAt: '2026-01-02T00:00:00Z' }
+      ]
+    })
+
+    const items = await drain(
+      makeConn({
+        pollTool: 'poll_thing',
+        itemsPath: 'items',
+        idField: 'externalId',
+        timestampField: 'updatedAt'
+      })
+    )
+
+    expect(items).toHaveLength(2)
+    expect(callTool).toHaveBeenCalledTimes(1)
+  })
+
+  it('carries the fields backfill upserts on', async () => {
+    toolReturns({
+      items: [
+        {
+          externalId: 'ADO-7',
+          title: 'Disk full',
+          url: 'https://dev.azure.com/x/_workitems/edit/7',
+          description: 'It is full.',
+          status: 'Active',
+          updatedAt: '2026-07-01T00:00:00Z'
+        }
+      ]
+    })
+
+    const [item] = await drain(
+      makeConn({
+        pollTool: 'poll_workItem',
+        itemsPath: 'items',
+        idField: 'externalId',
+        titleField: 'title',
+        urlField: 'url',
+        timestampField: 'updatedAt'
+      })
+    )
+
+    expect(item).toMatchObject({
+      externalId: 'ADO-7',
+      title: 'Disk full',
+      url: 'https://dev.azure.com/x/_workitems/edit/7',
+      description: 'It is full.',
+      // Mapped through the connection's statusMapping by the caller, so the
+      // raw upstream value has to survive this far.
+      status: 'Active',
+      updatedAt: '2026-07-01T00:00:00Z'
+    })
+  })
+
+  it('keeps the whole item, so nothing a workflow templates is lost', async () => {
+    toolReturns({
+      items: [{ externalId: '1', severity: 3, updatedAt: '2026-01-01T00:00:00Z' }]
+    })
+
+    const [item] = await drain(
+      makeConn({ pollTool: 'p', itemsPath: 'items', idField: 'externalId' })
+    )
+
+    expect(item.metadata).toMatchObject({ severity: 3 })
+  })
+
+  it('reports a failing tool rather than importing nothing quietly', async () => {
+    callTool.mockResolvedValueOnce({ isError: true, content: [{ type: 'text', text: 'boom' }] })
+    await expect(backfillMcpConnection(makeConn(CURSORED), () => {})).rejects.toThrow(/boom/)
+  })
+})

--- a/tests/mcp-backfill.test.ts
+++ b/tests/mcp-backfill.test.ts
@@ -94,7 +94,7 @@ describe('backfillMcpConnection', () => {
     expect(args).toMatchObject({ limit: 10 })
   })
 
-  it('leaves the seed alone once it is following the tool own cursor', async () => {
+  it("leaves the seed alone once it is following the tool's own cursor", async () => {
     toolReturns({
       items: [{ externalId: '1', updatedAt: '2026-01-01T00:00:00Z' }],
       nextCursor: 'p2'

--- a/tests/mcp-backfill.test.ts
+++ b/tests/mcp-backfill.test.ts
@@ -79,6 +79,41 @@ describe('backfillMcpConnection', () => {
     expect(callTool.mock.calls[1][0].arguments).toMatchObject({ cursor: 'page-2' })
   })
 
+  it('starts from the beginning even when the connection seeds a cursor', async () => {
+    // pollMcpConnection treats a cursor already in pollArgs as the seed for
+    // the very first poll, which is right for ordinary polling and wrong here:
+    // honouring it would start the import partway through and silently skip
+    // everything before it, which is the whole thing a backfill is for.
+    toolReturns({ items: [{ externalId: '1', updatedAt: '2026-01-01T00:00:00Z' }] })
+
+    await drain(makeConn({ ...CURSORED, pollArgs: '{"cursor":"2026-06-01","limit":10}' }))
+
+    const args = callTool.mock.calls[0][0].arguments
+    expect(args).not.toHaveProperty('cursor')
+    // Everything else the connection configured still goes through.
+    expect(args).toMatchObject({ limit: 10 })
+  })
+
+  it('leaves the seed alone once it is following the tool own cursor', async () => {
+    toolReturns({
+      items: [{ externalId: '1', updatedAt: '2026-01-01T00:00:00Z' }],
+      nextCursor: 'p2'
+    })
+    toolReturns({ items: [] })
+
+    await drain(makeConn({ ...CURSORED, pollArgs: '{"cursor":"2026-06-01"}' }))
+
+    expect(callTool.mock.calls[1][0].arguments).toMatchObject({ cursor: 'p2' })
+  })
+
+  it('leaves unparseable poll args for the poll itself to report', async () => {
+    // Swallowing it here would replace pollMcpConnection's specific message
+    // with a confusing one about backfill.
+    await expect(
+      backfillMcpConnection(makeConn({ ...CURSORED, pollArgs: '{not json' }), () => {})
+    ).rejects.toThrow(/pollArgs/i)
+  })
+
   it('stops when the tool stops moving its cursor', async () => {
     // Otherwise a tool that answers the same page forever would drain until the
     // page cap, thousands of calls later.

--- a/tests/mcp-connector.test.ts
+++ b/tests/mcp-connector.test.ts
@@ -287,9 +287,13 @@ describe('mcpConnector.describe', () => {
     expect(manifest.auth.find((f) => f.key === 'secretEnv')?.type).toBe('password')
   })
 
-  it('exposes actions and triggers, with an empty static action list', async () => {
+  it('exposes actions, triggers and tasks, with an empty static action list', async () => {
     const { mcpConnector } = await importMcp()
-    expect(mcpConnector.capabilities).toEqual(['actions', 'triggers'])
+    // `tasks` is what lets a packaged connector be backfilled; without it
+    // connection:backfill refuses every one of them. Whether a given
+    // connection can actually be imported from depends on it having a
+    // pollTool, which is per-connection and cannot be answered here.
+    expect(mcpConnector.capabilities).toEqual(['actions', 'triggers', 'tasks'])
     // Actions are per-connection (discovered via tools/list), so the static
     // list stays empty.
     expect(mcpConnector.describe().actions).toEqual([])

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -362,3 +362,75 @@ describe('probeSdkConnector icon handling', () => {
     expect(result.manifest.triggers).toHaveLength(1)
   })
 })
+
+describe('what the probe accepts from a package', () => {
+  const probeWith = async (trigger: Record<string, unknown>) => {
+    const { probeSdkConnector } = await importProbe()
+    callTool.mockResolvedValue({
+      structuredContent: manifest({ triggers: [{ ...baseTrigger, ...trigger }] })
+    })
+    const result = await probeSdkConnector({ command: 'npx', args: [] })
+    if (!result.ok) throw new Error(result.error)
+    return result.manifest.triggers[0]
+  }
+
+  const baseTrigger = {
+    type: 'queryResult',
+    label: 'Query result',
+    setup: { filters: {}, env: [] }
+  }
+
+  it('reads a status mapping the connector suggested', async () => {
+    const trigger = await probeWith({
+      statusMapping: [
+        { upstream: 'open', suggestedLocal: 'todo' },
+        { upstream: 'closed', suggestedLocal: 'done' }
+      ]
+    })
+    expect(trigger.statusMapping).toEqual([
+      { upstream: 'open', suggestedLocal: 'todo' },
+      { upstream: 'closed', suggestedLocal: 'done' }
+    ])
+  })
+
+  it('drops a local status it does not recognise', async () => {
+    // This arrives from a third-party package. An unknown status written onto
+    // a connection would fail a constraint later, far from the connector that
+    // supplied it.
+    const trigger = await probeWith({
+      statusMapping: [
+        { upstream: 'open', suggestedLocal: 'todo' },
+        { upstream: 'weird', suggestedLocal: 'obliterated' }
+      ]
+    })
+    expect(trigger.statusMapping).toEqual([{ upstream: 'open', suggestedLocal: 'todo' }])
+  })
+
+  it('ignores a mapping that is not a list at all', async () => {
+    expect((await probeWith({ statusMapping: 'todo' })).statusMapping).toBeUndefined()
+    expect((await probeWith({ statusMapping: [] })).statusMapping).toBeUndefined()
+  })
+
+  it('reads a polling workflow', async () => {
+    const trigger = await probeWith({
+      defaultWorkflow: { name: 'Kusto: rows', defaultCronFromMinutes: 10 }
+    })
+    expect(trigger.defaultWorkflow).toEqual({ name: 'Kusto: rows', defaultCronFromMinutes: 10 })
+  })
+
+  it('refuses an interval that would never fire or never stop', async () => {
+    // A zero or fractional interval produces a cron that does one or the
+    // other, and neither is worth guessing a correction for.
+    for (const minutes of [0, -5, 1.5, 5000]) {
+      const trigger = await probeWith({
+        defaultWorkflow: { name: 'x', defaultCronFromMinutes: minutes }
+      })
+      expect(trigger.defaultWorkflow).toBeUndefined()
+    }
+  })
+
+  it('refuses a workflow with no name', async () => {
+    const trigger = await probeWith({ defaultWorkflow: { defaultCronFromMinutes: 5 } })
+    expect(trigger.defaultWorkflow).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Groundwork for moving Linear out of the app and into the connectors repository. Every connector the factory produces uses the packaged contract, so its gaps matter — and they were invisible because nothing first-party goes through it.

Three, found by trying to port Linear.

## Backfill has never worked for a packaged connector

`connection:backfill` refuses anything without `listItems`/`listItemsPage`, and the MCP bridge every packaged connector runs through implements neither and does not declare `tasks`. So "Import existing items" returned *"Connector mcp does not support listItems()"* as a string and the row reported nothing imported. **Both published connectors, `ado` and `kusto`, are affected today** — this is a live bug, not just a porting obstacle.

Backfill for one of these is draining its trigger from no cursor, which both sides already support. `backfillMcpConnection` takes the whole `SourceConnection`, because addressing the per-connection stdio client needs more than the flattened filters `listItemsPage` is handed — the same reason the scheduler routes polling through `pollMcpConnection`.

One subtlety a test caught before it shipped: only a tool that *takes* the cursor is paging. A connection deduping client-side still returns a cursor — the newest timestamp it saw — and following that as a paging token re-reads the same window until the page cap. Removing the check fails two tests.

## A packaged connector could not say how to set itself up

`SdkConnectorForm` wrote `statusMapping: {}` and nothing ever filled it, so every item a packaged connector imports lands as `todo` — an issue closed a year ago included. And seeding reads the manifest of the connector the registry resolves, which for a packaged connection is the generic MCP one, declaring no workflows: a connection is made and then sits silent until somebody builds the workflow by hand.

Both are now optional fields on `TriggerDefinition`, so no existing connector changes. The probe validates them, because this is third-party data: an unrecognised local status is dropped rather than written onto a connection where it would fail a constraint far from the connector that supplied it, and an interval that is zero, fractional or a week long is refused rather than turned into a cron that never fires or never stops.

## Agents inherited the session Vorn was started from

Only `CLAUDECODE` was stripped, under a comment about nested session detection that describes a whole family. Five siblings went through untouched: `CHILD_SESSION`, `SESSION_ID`, `MESSAGING_SOCKET`, `WORKER_EPOCH`, `ENTRYPOINT`. Started from an agent session — `yarn dev` typed into one, or the app opened from it — these propagate into every agent Vorn spawns, and each believes it is a nested child.

The visible symptom is transcripts silently not being saved. The worse one is `MESSAGING_SOCKET`, which points a freshly launched agent at another session's socket. Stripped by prefix now rather than by name; this list has been wrong once already.

## Testing

`yarn typecheck` clean. 2839 tests pass; `shell-integration-shells` fails identically on `main` (macOS only).

New coverage where there was none: the backfill drain across pages, refusing a cursor that does not advance, a connection with no poll tool saying so rather than reporting nothing imported, and the probe dropping malformed status mappings and intervals.

## What this unblocks

`packages/linear` is written and waiting on `@vornrun/connector-sdk@0.5.7` — the published 0.5.6 predates these fields by a few hours. It stays off a pull request until it builds and its tests run.