### PR TITLE
feat(panes): give each session its own Files and File panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/renderer/components/EditorCard.tsx
+++ b/src/renderer/components/EditorCard.tsx
@@ -5,6 +5,7 @@ import { PaneCard } from './PaneCard'
 import { FileEditorPane } from './FileTreeExplorer'
 import { FileTypeIcon } from './file-icons'
 import { editorPaneId } from '../lib/pane-id'
+import { dirtyRefFor, confirmDiscard, clearDirty } from '../lib/editor-dirty'
 
 interface Props {
   /** Session that owns this editor. */
@@ -39,6 +40,14 @@ export const EditorCard = memo(
     const remoteHostId = terminal.session.remoteHostId
     const fileName = filePath.split(/[/\\]/).pop() ?? filePath
 
+    // Closing discards the buffer, so confirm first. The editor's own state is
+    // out of reach from here — it reports dirtiness through the shared ref.
+    const handleClose = (): void => {
+      if (!confirmDiscard(sessionId)) return
+      clearDirty(sessionId)
+      closeEditorPane(sessionId)
+    }
+
     return (
       <PaneCard
         ref={ref}
@@ -47,7 +56,7 @@ export const EditorCard = memo(
         // relative path, alongside the dirty dot and the find/edit toolbar.
         title={fileName}
         icon={<FileTypeIcon name={fileName} size={12} />}
-        onClose={() => closeEditorPane(sessionId)}
+        onClose={handleClose}
         isDragTarget={isDragTarget}
         onDragStart={onDragStart}
         flexible={flexible}
@@ -57,7 +66,8 @@ export const EditorCard = memo(
           cwd={cwd}
           filePath={filePath}
           remoteHostId={remoteHostId}
-          onClose={() => closeEditorPane(sessionId)}
+          dirtyRef={dirtyRefFor(sessionId)}
+          onClose={handleClose}
         />
       </PaneCard>
     )

--- a/src/renderer/components/EditorCard.tsx
+++ b/src/renderer/components/EditorCard.tsx
@@ -1,0 +1,65 @@
+import { memo, forwardRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '../stores'
+import { PaneCard } from './PaneCard'
+import { FileEditorPane } from './FileTreeExplorer'
+import { FileTypeIcon } from './file-icons'
+import { editorPaneId } from '../lib/pane-id'
+
+interface Props {
+  /** Session that owns this editor. */
+  sessionId: string
+  isDragTarget?: boolean
+  onDragStart?: (paneId: string, e: React.PointerEvent) => void
+  flexible?: boolean
+}
+
+/**
+ * A session's open file, as its own grid pane.
+ *
+ * Independent of that session's tree pane — it renders whatever path the store
+ * holds, whether or not a tree is open, and can be maximized on its own.
+ */
+export const EditorCard = memo(
+  forwardRef<HTMLDivElement, Props>(function EditorCard(
+    { sessionId, isDragTarget, onDragStart, flexible },
+    ref
+  ) {
+    const { terminal, filePath, closeEditorPane } = useAppStore(
+      useShallow((s) => ({
+        terminal: s.terminals.get(sessionId),
+        filePath: s.editorPanes.get(sessionId)?.filePath ?? null,
+        closeEditorPane: s.closeEditorPane
+      }))
+    )
+
+    if (!terminal || !filePath) return null
+
+    const cwd = terminal.session.worktreePath || terminal.session.projectPath
+    const remoteHostId = terminal.session.remoteHostId
+    const fileName = filePath.split(/[/\\]/).pop() ?? filePath
+
+    return (
+      <PaneCard
+        ref={ref}
+        paneId={editorPaneId(sessionId)}
+        // No subtitle: the editor's own path strip below already shows the
+        // relative path, alongside the dirty dot and the find/edit toolbar.
+        title={fileName}
+        icon={<FileTypeIcon name={fileName} size={12} />}
+        onClose={() => closeEditorPane(sessionId)}
+        isDragTarget={isDragTarget}
+        onDragStart={onDragStart}
+        flexible={flexible}
+      >
+        <FileEditorPane
+          key={filePath}
+          cwd={cwd}
+          filePath={filePath}
+          remoteHostId={remoteHostId}
+          onClose={() => closeEditorPane(sessionId)}
+        />
+      </PaneCard>
+    )
+  })
+)

--- a/src/renderer/components/FileTreeExplorer.tsx
+++ b/src/renderer/components/FileTreeExplorer.tsx
@@ -1254,18 +1254,26 @@ export function FileEditorPane({
   cwd,
   filePath,
   remoteHostId,
-  onClose
+  onClose,
+  dirtyRef: externalDirtyRef
 }: {
   cwd: string
   filePath: string
   remoteHostId?: string
   onClose?: () => void
+  /**
+   * Set while the buffer has unsaved edits. The hosting pane reads it to
+   * confirm before swapping files or closing — in the split-pane layout those
+   * actions are driven from the tree and the card header, not from here.
+   */
+  dirtyRef?: React.MutableRefObject<boolean>
 }): JSX.Element {
   const [content, setContent] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [isBinary, setIsBinary] = useState(false)
   const activeRequestRef = useRef<string | null>(null)
-  const dirtyRef = useRef(false)
+  const localDirtyRef = useRef(false)
+  const dirtyRef = externalDirtyRef ?? localDirtyRef
 
   useEffect(() => {
     let stale = false

--- a/src/renderer/components/FileTreeExplorer.tsx
+++ b/src/renderer/components/FileTreeExplorer.tsx
@@ -582,7 +582,8 @@ function FilePanel({
   onClose,
   onContentSaved,
   remoteHostId,
-  dirtyRef
+  dirtyRef,
+  showHeader = true
 }: {
   cwd: string
   filePath: string
@@ -593,6 +594,8 @@ function FilePanel({
   onContentSaved: (next: string) => void
   remoteHostId?: string
   dirtyRef: React.MutableRefObject<boolean>
+  /** False when hosted in a pane card that draws its own header. */
+  showHeader?: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState('')
@@ -607,6 +610,7 @@ function FilePanel({
 
   // Reset transient state when file changes
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: clear per-file edit/find state when the file changes
     setEditing(false)
     setDraft('')
     setSaveError(null)
@@ -689,7 +693,7 @@ function FilePanel({
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
-      <PanelHeader title="File" onClose={onClose} />
+      {showHeader && <PanelHeader title="File" onClose={onClose} />}
 
       {/* Path strip + toolbar */}
       <div
@@ -880,13 +884,16 @@ function FilesPanel({
   dirCache,
   loadDir,
   selectedFile,
-  onSelectFile
+  onSelectFile,
+  showHeader = true
 }: {
   rootEntries: FileEntry[]
   dirCache: Map<string, FileEntry[]>
   loadDir: (path: string) => Promise<void>
   selectedFile: string | null
   onSelectFile: (path: string) => void
+  /** False when hosted in a pane card that draws its own header. */
+  showHeader?: boolean
 }) {
   const [filter, setFilter] = useState('')
   const { matched, expand } = useMemo(
@@ -896,7 +903,7 @@ function FilesPanel({
 
   return (
     <div className="flex flex-col min-h-0 h-full">
-      <PanelHeader title="Files" />
+      {showHeader && <PanelHeader title="Files" />}
       <div className="px-2 py-1.5 border-b border-white/[0.06] shrink-0">
         <div className="flex items-center gap-1.5 px-2 py-1 rounded bg-white/[0.04] focus-within:bg-white/[0.06]">
           <Search size={12} className="text-gray-600 shrink-0" />
@@ -1150,5 +1157,160 @@ export function FileTreeExplorer({ cwd, remoteHostId }: { cwd: string; remoteHos
         </>
       )}
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Standalone panes
+//
+// `FileTreeExplorer` above stacks the tree and the editor in one component with
+// an internal divider. When each lives in its own grid pane, the grid provides
+// the split instead, so these two exports own their state independently — a
+// session can have either open, maximized, or closed without the other.
+// ---------------------------------------------------------------------------
+
+/** The file tree on its own. Selecting a file is reported via `onSelectFile`. */
+export function FileTreePane({
+  cwd,
+  remoteHostId,
+  selectedFile,
+  onSelectFile
+}: {
+  cwd: string
+  remoteHostId?: string
+  selectedFile: string | null
+  onSelectFile: (path: string) => void
+}): JSX.Element {
+  const [rootEntries, setRootEntries] = useState<FileEntry[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [dirCache, setDirCache] = useState(() => new Map<string, FileEntry[]>())
+
+  useEffect(() => {
+    let stale = false
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset cache when cwd/host changes
+    setDirCache(new Map())
+    setLoading(true)
+    window.api
+      .listDir(cwd, remoteHostId)
+      .then((entries) => {
+        if (stale) return
+        setRootEntries(entries)
+        setLoading(false)
+      })
+      .catch(() => {
+        if (!stale) setLoading(false)
+      })
+    return () => {
+      stale = true
+    }
+  }, [cwd, remoteHostId])
+
+  const loadDir = useCallback(
+    async (dirPath: string) => {
+      const entries = await window.api.listDir(dirPath, remoteHostId)
+      setDirCache((prev) => {
+        if (prev.has(dirPath)) return prev
+        const next = new Map(prev)
+        next.set(dirPath, entries)
+        return next
+      })
+    },
+    [remoteHostId]
+  )
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 size={20} className="text-gray-500 animate-spin" />
+      </div>
+    )
+  }
+
+  if (!rootEntries || rootEntries.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">
+        Empty directory
+      </div>
+    )
+  }
+
+  return (
+    <FilesPanel
+      rootEntries={rootEntries}
+      dirCache={dirCache}
+      loadDir={loadDir}
+      selectedFile={selectedFile}
+      onSelectFile={onSelectFile}
+      showHeader={false}
+    />
+  )
+}
+
+/**
+ * The file editor on its own, owning the load of `filePath`. Independent of the
+ * tree: it renders whatever path it is given, whether or not a tree is open.
+ */
+export function FileEditorPane({
+  cwd,
+  filePath,
+  remoteHostId,
+  onClose
+}: {
+  cwd: string
+  filePath: string
+  remoteHostId?: string
+  onClose?: () => void
+}): JSX.Element {
+  const [content, setContent] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [isBinary, setIsBinary] = useState(false)
+  const activeRequestRef = useRef<string | null>(null)
+  const dirtyRef = useRef(false)
+
+  useEffect(() => {
+    let stale = false
+    activeRequestRef.current = filePath
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset to a loading state when the file changes
+    setLoading(true)
+    setContent(null)
+    setIsBinary(false)
+    window.api
+      .readFileContent(filePath, undefined, remoteHostId)
+      .then((next) => {
+        if (stale || activeRequestRef.current !== filePath) return
+        if (next === null) {
+          setIsBinary(true)
+          setContent(null)
+        } else {
+          setIsBinary(false)
+          setContent(next)
+        }
+        setLoading(false)
+      })
+      .catch(() => {
+        if (!stale) setLoading(false)
+      })
+    return () => {
+      stale = true
+    }
+  }, [filePath, remoteHostId])
+
+  const handleContentSaved = useCallback((next: string) => {
+    setContent(next)
+  }, [])
+
+  return (
+    <FilePanel
+      cwd={cwd}
+      filePath={filePath}
+      content={content}
+      loading={loading}
+      isBinary={isBinary}
+      onClose={onClose ?? (() => {})}
+      onContentSaved={handleContentSaved}
+      remoteHostId={remoteHostId}
+      dirtyRef={dirtyRef}
+      showHeader={false}
+    />
   )
 }

--- a/src/renderer/components/FilesCard.tsx
+++ b/src/renderer/components/FilesCard.tsx
@@ -1,0 +1,64 @@
+import { memo, forwardRef } from 'react'
+import { FolderTree } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '../stores'
+import { PaneCard } from './PaneCard'
+import { FileTreePane } from './FileTreeExplorer'
+import { filesPaneId } from '../lib/pane-id'
+
+interface Props {
+  /** Session that owns this tree. */
+  sessionId: string
+  isDragTarget?: boolean
+  onDragStart?: (paneId: string, e: React.PointerEvent) => void
+  flexible?: boolean
+}
+
+/**
+ * A session's file tree, as its own grid pane.
+ *
+ * Independent of that session's editor pane: closing this leaves an open file
+ * open. Selecting a file here routes through the store (`openEditorPane`) rather
+ * than a prop, so the two panes have no parent/child relationship.
+ */
+export const FilesCard = memo(
+  forwardRef<HTMLDivElement, Props>(function FilesCard(
+    { sessionId, isDragTarget, onDragStart, flexible },
+    ref
+  ) {
+    const { terminal, selectedFile, openEditorPane, closeFilesPane } = useAppStore(
+      useShallow((s) => ({
+        terminal: s.terminals.get(sessionId),
+        selectedFile: s.editorPanes.get(sessionId)?.filePath ?? null,
+        openEditorPane: s.openEditorPane,
+        closeFilesPane: s.closeFilesPane
+      }))
+    )
+
+    if (!terminal) return null
+
+    const cwd = terminal.session.worktreePath || terminal.session.projectPath
+    const remoteHostId = terminal.session.remoteHostId
+
+    return (
+      <PaneCard
+        ref={ref}
+        paneId={filesPaneId(sessionId)}
+        title="Files"
+        icon={<FolderTree size={12} className="text-gray-500 shrink-0" />}
+        onClose={() => closeFilesPane(sessionId)}
+        isDragTarget={isDragTarget}
+        onDragStart={onDragStart}
+        flexible={flexible}
+      >
+        <FileTreePane
+          key={cwd}
+          cwd={cwd}
+          remoteHostId={remoteHostId}
+          selectedFile={selectedFile}
+          onSelectFile={(path) => openEditorPane(sessionId, path)}
+        />
+      </PaneCard>
+    )
+  })
+)

--- a/src/renderer/components/FilesCard.tsx
+++ b/src/renderer/components/FilesCard.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../stores'
 import { PaneCard } from './PaneCard'
 import { FileTreePane } from './FileTreeExplorer'
 import { filesPaneId } from '../lib/pane-id'
+import { confirmDiscard } from '../lib/editor-dirty'
 
 interface Props {
   /** Session that owns this tree. */
@@ -56,7 +57,11 @@ export const FilesCard = memo(
           cwd={cwd}
           remoteHostId={remoteHostId}
           selectedFile={selectedFile}
-          onSelectFile={(path) => openEditorPane(sessionId, path)}
+          onSelectFile={(path) => {
+            // Swapping the editor's file discards its buffer — confirm first.
+            if (path !== selectedFile && !confirmDiscard(sessionId)) return
+            openEditorPane(sessionId, path)
+          }}
         />
       </PaneCard>
     )

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -14,6 +14,8 @@ import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { useTerminalScrollButton } from '../hooks/useTerminalScrollButton'
 import { useTerminalPinchZoom } from '../hooks/useTerminalPinchZoom'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { FilesCard } from './FilesCard'
+import { EditorCard } from './EditorCard'
 import { isMac } from '../lib/platform'
 import { ArrowDown, FolderGit2, GitBranch, Minimize2, Pencil } from 'lucide-react'
 
@@ -32,6 +34,10 @@ export function FocusedTerminal() {
   const terminalContainerRef = useRef<HTMLDivElement>(null)
   const isMobile = useIsMobile()
   const domBlocks = useAppStore((s) => s.config?.defaults.domBlockRendering ?? true)
+  // The expanded session's own panes come with it, so maximizing a card doesn't
+  // hide the tree or file you had open next to it.
+  const hasFilesPane = useAppStore((s) => (effectiveId ? s.filesPanes.has(effectiveId) : false))
+  const hasEditorPane = useAppStore((s) => (effectiveId ? s.editorPanes.has(effectiveId) : false))
   useTerminalPinchZoom(terminalContainerRef)
 
   if (!effectiveId || !terminal) return null
@@ -163,45 +169,65 @@ export function FocusedTerminal() {
           </div>
         )}
 
-        {/* Terminal */}
-        <div
-          ref={terminalContainerRef}
-          className="relative flex-1 p-1 min-h-0"
-          style={{ background: 'rgba(0, 0, 0, 0.3)' }}
-        >
-          <TerminalPane
-            terminalId={effectiveId}
-            agentType={terminal.session.agentType}
-            isFocused={!isRenaming && !isPreview}
-            domBlocks={domBlocks}
-          />
-          {/* Mobile: floating controls (font size + scroll) */}
-          <div className="absolute bottom-4 right-4 flex flex-col items-end gap-2 z-50">
-            {isMobile && <MobileFontSizeControl />}
-            {showScrollBtn && (
-              <button
-                className="w-8 h-8 flex items-center justify-center
+        {/* Terminal, plus this session's file panes riding along beside it. */}
+        <div className="flex-1 min-h-0 flex">
+          <div className="flex-1 min-w-0 flex flex-col">
+            <div
+              ref={terminalContainerRef}
+              className="relative flex-1 p-1 min-h-0"
+              style={{ background: 'rgba(0, 0, 0, 0.3)' }}
+            >
+              <TerminalPane
+                terminalId={effectiveId}
+                agentType={terminal.session.agentType}
+                isFocused={!isRenaming && !isPreview}
+                domBlocks={domBlocks}
+              />
+              {/* Mobile: floating controls (font size + scroll) */}
+              <div className="absolute bottom-4 right-4 flex flex-col items-end gap-2 z-50">
+                {isMobile && <MobileFontSizeControl />}
+                {showScrollBtn && (
+                  <button
+                    className="w-8 h-8 flex items-center justify-center
                            rounded bg-white/[0.08] hover:bg-white/[0.15] text-gray-400 hover:text-white
                            transition-colors"
-                onClick={handleScrollToBottom}
-                title="Scroll to bottom"
-              >
-                <ArrowDown size={14} />
-              </button>
-            )}
-          </div>
-        </div>
+                    onClick={handleScrollToBottom}
+                    title="Scroll to bottom"
+                  >
+                    <ArrowDown size={14} />
+                  </button>
+                )}
+              </div>
+            </div>
 
-        {/* +4 for this pane's own container padding, so the caret lands in
+            {/* +4 for this pane's own container padding, so the caret lands in
             the terminal's text column. */}
-        {!isMobile && (
-          <IntentBar
-            terminalId={effectiveId}
-            indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks) + 4}
-          />
-        )}
+            {!isMobile && (
+              <IntentBar
+                terminalId={effectiveId}
+                indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks) + 4}
+              />
+            )}
 
-        {!isMobile && <CardStatusBar terminalId={effectiveId} />}
+            {!isMobile && <CardStatusBar terminalId={effectiveId} />}
+          </div>
+
+          {/* The expanded session keeps its own Files / File panes. */}
+          {!isMobile && (hasFilesPane || hasEditorPane) && (
+            <div className="w-[420px] shrink-0 flex flex-col gap-px border-l border-white/[0.06]">
+              {hasFilesPane && (
+                <div className="flex-1 min-h-0">
+                  <FilesCard sessionId={effectiveId} />
+                </div>
+              )}
+              {hasEditorPane && (
+                <div className="flex-1 min-h-0">
+                  <EditorCard sessionId={effectiveId} />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
 
         {isMobile && <MobileTerminalKeybar terminalId={effectiveId} />}
       </motion.div>

--- a/src/renderer/components/GitChangesIndicator.tsx
+++ b/src/renderer/components/GitChangesIndicator.tsx
@@ -31,11 +31,11 @@ export function GitChangesIndicator({ terminalId }: Props) {
 }
 
 export function BrowseFilesButton({ terminalId }: Props) {
-  const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
+  const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
 
   const handleClick = (e: React.MouseEvent): void => {
     e.stopPropagation()
-    setDiffSidebar(terminalId, 'all-files')
+    toggleFilesPane(terminalId)
   }
 
   return (

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -6,7 +6,8 @@ import { GridLayout, noCompactor, type EventCallback, type Layout } from 'react-
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { useAppStore } from '../stores'
-import { AgentCard } from './AgentCard'
+import { PaneRenderer } from './PaneRenderer'
+import { parsePaneId } from '../lib/pane-id'
 import { PromptLauncher } from './PromptLauncher'
 import { GridContextMenu } from './GridContextMenu'
 import { AgentIcon } from './AgentIcon'
@@ -88,7 +89,26 @@ export const GridView = memo(function GridView() {
   const { size: wrapperSize, setNode: setGridWrapperNode } = useContainerSize()
 
   const terminals = useAppStore((s) => s.terminals)
-  const { orderedIds } = useVisibleTerminals()
+  const { orderedIds: allOrderedIds } = useVisibleTerminals()
+  const maximizedPaneId = useAppStore((s) => s.maximizedPaneId)
+
+  // Session-scoped maximize: the maximized pane takes over its *owner session's*
+  // footprint, so only that session's sibling panes drop out. Other sessions keep
+  // rendering, which is what makes maximize usable for side-by-side comparison.
+  const orderedIds = useMemo(() => {
+    if (!maximizedPaneId || !allOrderedIds.includes(maximizedPaneId)) return allOrderedIds
+    const owner = parsePaneId(maximizedPaneId).sessionId
+    return allOrderedIds.filter(
+      (id) => id === maximizedPaneId || parsePaneId(id).sessionId !== owner
+    )
+  }, [allOrderedIds, maximizedPaneId])
+
+  // How many grid cells the maximized pane absorbs, so it can span them.
+  const maximizedSpan = useMemo(() => {
+    if (!maximizedPaneId || !allOrderedIds.includes(maximizedPaneId)) return 1
+    const owner = parsePaneId(maximizedPaneId).sessionId
+    return allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner).length
+  }, [allOrderedIds, maximizedPaneId])
 
   const isMobile = useIsMobile()
 
@@ -276,6 +296,8 @@ export const GridView = memo(function GridView() {
       ) : gridColumns === -1 ? (
         <FlexibleGrid
           orderedIds={orderedIds}
+          allOrderedIds={allOrderedIds}
+          maximizedPaneId={maximizedPaneId}
           onCreateSession={createNewSession}
           onShowContextMenu={setGridContextMenu}
         />
@@ -288,17 +310,26 @@ export const GridView = memo(function GridView() {
           onContextMenu={handleGridContextMenu}
         >
           {orderedIds.map((id, index) => (
-            <AgentCard
+            <div
               key={id}
-              ref={(el) => {
-                if (el) cardRefs.current.set(id, el)
-                else cardRefs.current.delete(id)
-              }}
-              terminalId={id}
-              index={index}
-              isDragTarget={dragState?.isDragging === true && dropTargetIndex === index}
-              onDragStart={sortMode === 'manual' ? handleDragStart : undefined}
-            />
+              className="min-w-0 min-h-0"
+              style={
+                id === maximizedPaneId && maximizedSpan > 1
+                  ? { gridColumn: `span ${maximizedSpan}` }
+                  : undefined
+              }
+            >
+              <PaneRenderer
+                ref={(el) => {
+                  if (el) cardRefs.current.set(id, el)
+                  else cardRefs.current.delete(id)
+                }}
+                paneId={id}
+                index={index}
+                isDragTarget={dragState?.isDragging === true && dropTargetIndex === index}
+                onDragStart={sortMode === 'manual' ? handleDragStart : undefined}
+              />
+            </div>
           ))}
         </div>
       )}
@@ -326,23 +357,34 @@ function getStableKey(session: TerminalState['session']): string {
 
 function FlexibleGrid({
   orderedIds,
+  allOrderedIds,
+  maximizedPaneId,
   onCreateSession,
   onShowContextMenu
 }: {
   orderedIds: string[]
+  /** Includes panes hidden by maximize — needed to compute the group's footprint. */
+  allOrderedIds: string[]
+  maximizedPaneId: string | null
   onCreateSession: () => void
   onShowContextMenu: (pos: { x: number; y: number } | null) => void
 }) {
   const { size: containerSize, setNode: setContainerNode } = useContainerSize()
   const containerWidth = containerSize?.width ?? 0
 
-  // Narrow selector: only extract the stable keys we need, not the full terminals Map
+  // Narrow selector: only extract the stable keys we need, not the full terminals Map.
+  // Child panes key off their owner session's stable key, prefixed by kind, so a
+  // session's tree and file keep independent saved rects that survive restarts
+  // alongside the terminal's.
   const stableKeys = useAppStore(
     useShallow((s) => {
       const keys: Record<string, string> = {}
-      for (const id of orderedIds) {
-        const t = s.terminals.get(id)
-        if (t) keys[id] = getStableKey(t.session) || id
+      for (const id of allOrderedIds) {
+        const { kind, sessionId } = parsePaneId(id)
+        const t = s.terminals.get(sessionId)
+        if (!t) continue
+        const base = getStableKey(t.session) || sessionId
+        keys[id] = kind === 'terminal' ? base : `${kind}:${base}`
       }
       return keys
     })
@@ -361,7 +403,7 @@ function FlexibleGrid({
     }
 
     let autoIndex = 0
-    return orderedIds.map((id) => {
+    const items = orderedIds.map((id) => {
       const key = stableKeys[id]
       if (!key) return { i: id, x: 0, y: 0, w: FLEX_DEFAULT_W, h: FLEX_DEFAULT_H }
       const saved = flexibleLayouts[key]
@@ -374,19 +416,50 @@ function FlexibleGrid({
       autoIndex++
       return { i: id, x, y, w: FLEX_DEFAULT_W, h: FLEX_DEFAULT_H }
     })
-  }, [orderedIds, stableKeys, flexibleLayouts])
+
+    // Maximized pane takes the bounding box of its owner session's rects. This is
+    // computed for render only and never written back to `flexibleLayouts`, so
+    // restoring returns every sibling to its own saved position.
+    if (maximizedPaneId) {
+      const owner = parsePaneId(maximizedPaneId).sessionId
+      const group = allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner)
+      if (group.length > 1) {
+        const rects = group
+          .map((id) => flexibleLayouts[stableKeys[id]])
+          .filter((r): r is FlexibleLayoutRect => Boolean(r))
+        if (rects.length > 0) {
+          const x = Math.min(...rects.map((r) => r.x))
+          const y = Math.min(...rects.map((r) => r.y))
+          const right = Math.max(...rects.map((r) => r.x + r.w))
+          const bottom = Math.max(...rects.map((r) => r.y + r.h))
+          const target = items.find((it) => it.i === maximizedPaneId)
+          if (target) {
+            target.x = x
+            target.y = y
+            target.w = right - x
+            target.h = bottom - y
+          }
+        }
+      }
+    }
+
+    return items
+  }, [orderedIds, allOrderedIds, stableKeys, flexibleLayouts, maximizedPaneId])
 
   const persistLayout = useCallback(
     (updatedLayout: Layout) => {
       const merged: Record<string, FlexibleLayoutRect> = { ...flexibleLayouts }
       for (const item of updatedLayout) {
+        // While maximized, the pane's rect is a computed bounding box over its
+        // siblings — persisting it would destroy their saved positions.
+        if (item.i === maximizedPaneId) continue
         const key = stableKeys[item.i]
         if (!key) continue
         merged[key] = { x: item.x, y: item.y, w: item.w, h: item.h }
       }
       setFlexibleLayouts(merged)
     },
-    [stableKeys, flexibleLayouts, setFlexibleLayouts]
+    [stableKeys, flexibleLayouts, setFlexibleLayouts, maximizedPaneId]
   )
 
   const handleDragStop: EventCallback = useCallback(
@@ -445,7 +518,7 @@ function FlexibleGrid({
       >
         {orderedIds.map((id, index) => (
           <div key={id} className="h-full">
-            <AgentCard terminalId={id} index={index} flexible />
+            <PaneRenderer paneId={id} index={index} flexible />
           </div>
         ))}
       </GridLayout>

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -7,7 +7,8 @@ import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { useAppStore } from '../stores'
 import { PaneRenderer } from './PaneRenderer'
-import { parsePaneId } from '../lib/pane-id'
+import { parsePaneId, isTerminalPane } from '../lib/pane-id'
+import { sessionPositionForGridIndex } from '../lib/pane-order'
 import { PromptLauncher } from './PromptLauncher'
 import { GridContextMenu } from './GridContextMenu'
 import { AgentIcon } from './AgentIcon'
@@ -175,6 +176,9 @@ export const GridView = memo(function GridView() {
   const handleDragStart = useCallback(
     (terminalId: string, e: React.PointerEvent) => {
       if (sortMode !== 'manual') return
+      // Manual sort reorders sessions, so only session cards start a drag —
+      // a child pane travels with its owner rather than moving on its own.
+      if (!isTerminalPane(terminalId)) return
       if (e.button !== 0) return
       const el = cardRefs.current.get(terminalId)
       const rect = el?.getBoundingClientRect()
@@ -220,9 +224,15 @@ export const GridView = memo(function GridView() {
 
   const handlePointerUp = useCallback(() => {
     if (dragState?.isDragging && dropTargetIndex !== null) {
-      const fromIndex = orderedIds.indexOf(dragState.draggingId)
-      if (fromIndex !== -1 && fromIndex !== dropTargetIndex) {
-        reorderTerminals(fromIndex, dropTargetIndex)
+      // `orderedIds` interleaves each session's child panes, but `terminalOrder`
+      // holds sessions only — so grid positions must be translated into
+      // session positions before reordering, or the splice targets the wrong
+      // element (or none at all) and corrupts the persisted order.
+      const sessionIds = orderedIds.filter(isTerminalPane)
+      const fromIndex = sessionIds.indexOf(dragState.draggingId)
+      const toIndex = sessionPositionForGridIndex(orderedIds, dropTargetIndex)
+      if (fromIndex !== -1 && toIndex !== -1 && fromIndex !== toIndex) {
+        reorderTerminals(fromIndex, toIndex)
       }
     }
     setDragState(null)
@@ -315,7 +325,11 @@ export const GridView = memo(function GridView() {
               className="min-w-0 min-h-0"
               style={
                 id === maximizedPaneId && maximizedSpan > 1
-                  ? { gridColumn: `span ${maximizedSpan}` }
+                  ? {
+                      // Clamp to the track count: spanning past it makes CSS
+                      // Grid add an implicit column and skews every row.
+                      gridColumn: `span ${gridColumns > 0 ? Math.min(maximizedSpan, gridColumns) : maximizedSpan}`
+                    }
                   : undefined
               }
             >
@@ -446,20 +460,31 @@ function FlexibleGrid({
     return items
   }, [orderedIds, allOrderedIds, stableKeys, flexibleLayouts, maximizedPaneId])
 
+  // A maximized pane only renders as a computed bounding box when its owner
+  // actually has siblings to span. Deriving the skip from that condition (rather
+  // than from `maximizedPaneId` alone) means a stale id can never permanently
+  // stop a pane's rect from being saved.
+  const boundingBoxPaneId = useMemo(() => {
+    if (!maximizedPaneId || !orderedIds.includes(maximizedPaneId)) return null
+    const owner = parsePaneId(maximizedPaneId).sessionId
+    const siblings = allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner)
+    return siblings.length > 1 ? maximizedPaneId : null
+  }, [maximizedPaneId, orderedIds, allOrderedIds])
+
   const persistLayout = useCallback(
     (updatedLayout: Layout) => {
       const merged: Record<string, FlexibleLayoutRect> = { ...flexibleLayouts }
       for (const item of updatedLayout) {
         // While maximized, the pane's rect is a computed bounding box over its
         // siblings — persisting it would destroy their saved positions.
-        if (item.i === maximizedPaneId) continue
+        if (item.i === boundingBoxPaneId) continue
         const key = stableKeys[item.i]
         if (!key) continue
         merged[key] = { x: item.x, y: item.y, w: item.w, h: item.h }
       }
       setFlexibleLayouts(merged)
     },
-    [stableKeys, flexibleLayouts, setFlexibleLayouts, maximizedPaneId]
+    [stableKeys, flexibleLayouts, setFlexibleLayouts, boundingBoxPaneId]
   )
 
   const handleDragStop: EventCallback = useCallback(

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -8,7 +8,14 @@ import 'react-resizable/css/styles.css'
 import { useAppStore } from '../stores'
 import { PaneRenderer } from './PaneRenderer'
 import { parsePaneId, isTerminalPane } from '../lib/pane-id'
-import { sessionPositionForGridIndex } from '../lib/pane-order'
+import {
+  sessionPositionForGridIndex,
+  visiblePanesWhileMaximized,
+  maximizedCellSpan,
+  maximizedBoundingRect,
+  paneLayoutKey,
+  boundingBoxPaneFor
+} from '../lib/pane-order'
 import { PromptLauncher } from './PromptLauncher'
 import { GridContextMenu } from './GridContextMenu'
 import { AgentIcon } from './AgentIcon'
@@ -96,20 +103,16 @@ export const GridView = memo(function GridView() {
   // Session-scoped maximize: the maximized pane takes over its *owner session's*
   // footprint, so only that session's sibling panes drop out. Other sessions keep
   // rendering, which is what makes maximize usable for side-by-side comparison.
-  const orderedIds = useMemo(() => {
-    if (!maximizedPaneId || !allOrderedIds.includes(maximizedPaneId)) return allOrderedIds
-    const owner = parsePaneId(maximizedPaneId).sessionId
-    return allOrderedIds.filter(
-      (id) => id === maximizedPaneId || parsePaneId(id).sessionId !== owner
-    )
-  }, [allOrderedIds, maximizedPaneId])
+  const orderedIds = useMemo(
+    () => visiblePanesWhileMaximized(allOrderedIds, maximizedPaneId),
+    [allOrderedIds, maximizedPaneId]
+  )
 
   // How many grid cells the maximized pane absorbs, so it can span them.
-  const maximizedSpan = useMemo(() => {
-    if (!maximizedPaneId || !allOrderedIds.includes(maximizedPaneId)) return 1
-    const owner = parsePaneId(maximizedPaneId).sessionId
-    return allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner).length
-  }, [allOrderedIds, maximizedPaneId])
+  const maximizedSpan = useMemo(
+    () => maximizedCellSpan(allOrderedIds, maximizedPaneId),
+    [allOrderedIds, maximizedPaneId]
+  )
 
   const isMobile = useIsMobile()
 
@@ -394,11 +397,11 @@ function FlexibleGrid({
     useShallow((s) => {
       const keys: Record<string, string> = {}
       for (const id of allOrderedIds) {
-        const { kind, sessionId } = parsePaneId(id)
+        const { sessionId } = parsePaneId(id)
         const t = s.terminals.get(sessionId)
         if (!t) continue
         const base = getStableKey(t.session) || sessionId
-        keys[id] = kind === 'terminal' ? base : `${kind}:${base}`
+        keys[id] = paneLayoutKey(id, base)
       }
       return keys
     })
@@ -435,25 +438,17 @@ function FlexibleGrid({
     // computed for render only and never written back to `flexibleLayouts`, so
     // restoring returns every sibling to its own saved position.
     if (maximizedPaneId) {
-      const owner = parsePaneId(maximizedPaneId).sessionId
-      const group = allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner)
-      if (group.length > 1) {
-        const rects = group
-          .map((id) => flexibleLayouts[stableKeys[id]])
-          .filter((r): r is FlexibleLayoutRect => Boolean(r))
-        if (rects.length > 0) {
-          const x = Math.min(...rects.map((r) => r.x))
-          const y = Math.min(...rects.map((r) => r.y))
-          const right = Math.max(...rects.map((r) => r.x + r.w))
-          const bottom = Math.max(...rects.map((r) => r.y + r.h))
-          const target = items.find((it) => it.i === maximizedPaneId)
-          if (target) {
-            target.x = x
-            target.y = y
-            target.w = right - x
-            target.h = bottom - y
-          }
-        }
+      const box = maximizedBoundingRect(
+        allOrderedIds,
+        maximizedPaneId,
+        (id) => flexibleLayouts[stableKeys[id]]
+      )
+      const target = box ? items.find((it) => it.i === maximizedPaneId) : undefined
+      if (box && target) {
+        target.x = box.x
+        target.y = box.y
+        target.w = box.w
+        target.h = box.h
       }
     }
 
@@ -464,12 +459,10 @@ function FlexibleGrid({
   // actually has siblings to span. Deriving the skip from that condition (rather
   // than from `maximizedPaneId` alone) means a stale id can never permanently
   // stop a pane's rect from being saved.
-  const boundingBoxPaneId = useMemo(() => {
-    if (!maximizedPaneId || !orderedIds.includes(maximizedPaneId)) return null
-    const owner = parsePaneId(maximizedPaneId).sessionId
-    const siblings = allOrderedIds.filter((id) => parsePaneId(id).sessionId === owner)
-    return siblings.length > 1 ? maximizedPaneId : null
-  }, [maximizedPaneId, orderedIds, allOrderedIds])
+  const boundingBoxPaneId = useMemo(
+    () => boundingBoxPaneFor(orderedIds, allOrderedIds, maximizedPaneId),
+    [maximizedPaneId, orderedIds, allOrderedIds]
+  )
 
   const persistLayout = useCallback(
     (updatedLayout: Layout) => {

--- a/src/renderer/components/MinimizedPill.tsx
+++ b/src/renderer/components/MinimizedPill.tsx
@@ -3,9 +3,52 @@ import { useShallow } from 'zustand/react/shallow'
 import { AgentIcon } from './AgentIcon'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { STATUS_DOT } from '../lib/status-colors'
-import { GitBranch, FolderGit2 } from 'lucide-react'
+import { GitBranch, FolderGit2, FolderTree, FileCode } from 'lucide-react'
+import { parsePaneId } from '../lib/pane-id'
+
+/**
+ * Dock pill for a minimized file-tree or editor pane. Labelled with its owner
+ * session so several sessions' panes stay tellable apart in the dock.
+ */
+function ChildPanePill({ paneId }: { paneId: string }) {
+  const { kind, sessionId } = parsePaneId(paneId)
+  const { terminal, filePath, toggleMinimized } = useAppStore(
+    useShallow((s) => ({
+      terminal: s.terminals.get(sessionId),
+      filePath: s.editorPanes.get(sessionId)?.filePath ?? null,
+      toggleMinimized: s.toggleMinimized
+    }))
+  )
+
+  if (!terminal) return null
+
+  const owner = getDisplayName(terminal.session)
+  const label = kind === 'editor' && filePath ? (filePath.split(/[/\\]/).pop() ?? 'File') : 'Files'
+
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] bg-[#1a1a1e]
+                 px-2.5 py-1 cursor-pointer transition-[border-color] select-none
+                 hover:border-white/[0.12]"
+      onClick={() => toggleMinimized(paneId)}
+      title={`Click to restore — ${owner}`}
+    >
+      {kind === 'editor' ? (
+        <FileCode size={13} strokeWidth={1.5} className="text-gray-400 shrink-0" />
+      ) : (
+        <FolderTree size={13} strokeWidth={1.5} className="text-gray-400 shrink-0" />
+      )}
+      <span className="text-[11px] font-medium text-gray-200 truncate max-w-[120px]">{label}</span>
+      <span className="text-[10px] text-gray-600 shrink-0">&middot;</span>
+      <span className="text-[10px] text-gray-500 truncate max-w-[90px]">{owner}</span>
+    </button>
+  )
+}
 
 export function MinimizedPill({ terminalId }: { terminalId: string }) {
+  const isChildPane = parsePaneId(terminalId).kind !== 'terminal'
+
   const { terminal, toggleMinimized, setActiveTabId } = useAppStore(
     useShallow((s) => ({
       terminal: s.terminals.get(terminalId),
@@ -13,6 +56,8 @@ export function MinimizedPill({ terminalId }: { terminalId: string }) {
       setActiveTabId: s.setActiveTabId
     }))
   )
+
+  if (isChildPane) return <ChildPanePill paneId={terminalId} />
 
   if (!terminal) return null
 

--- a/src/renderer/components/PaneCard.tsx
+++ b/src/renderer/components/PaneCard.tsx
@@ -1,0 +1,125 @@
+import { forwardRef, type ReactNode } from 'react'
+import { Maximize2, Minimize2, Minus, X } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '../stores'
+import { Tooltip } from './Tooltip'
+
+// On touch devices, always show action buttons (no hover available). Evaluated
+// lazily rather than at module load so importing this file stays safe in
+// environments without matchMedia (jsdom tests, SSR).
+function isTouchDevice(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia?.('(hover: none)').matches === true
+}
+
+export interface PaneCardProps {
+  /** This pane's id — `files:<sessionId>` or `editor:<sessionId>`. */
+  paneId: string
+  title: string
+  /** Secondary line under the title, e.g. a relative file path. */
+  subtitle?: string
+  icon?: ReactNode
+  onClose: () => void
+  children: ReactNode
+  isDragTarget?: boolean
+  onDragStart?: (paneId: string, e: React.PointerEvent) => void
+  flexible?: boolean
+}
+
+/**
+ * Chrome shared by the non-terminal panes a session owns (its file tree and its
+ * open file). Mirrors `AgentCard`'s outer shape so grid drag/resize and the
+ * flexible layout treat every pane the same, but carries its own header with
+ * maximize / minimize / close.
+ *
+ * Maximize here is session-scoped: `GridView` reads `maximizedPaneId` and gives
+ * the pane its owner session's whole footprint, leaving other sessions alone.
+ */
+export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneCard(
+  { paneId, title, subtitle, icon, onClose, children, isDragTarget, onDragStart, flexible },
+  ref
+) {
+  const { isMaximized, setMaximizedPane, toggleMinimized } = useAppStore(
+    useShallow((s) => ({
+      isMaximized: s.maximizedPaneId === paneId,
+      setMaximizedPane: s.setMaximizedPane,
+      toggleMinimized: s.toggleMinimized
+    }))
+  )
+
+  const handleDragStart = (e: React.PointerEvent): void => {
+    onDragStart?.(paneId, e)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={`group/card relative border overflow-hidden flex flex-col h-full transition-colors
+                 ${
+                   isDragTarget
+                     ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
+                     : 'border-white/[0.06] hover:border-white/[0.12]'
+                 }
+                 ${flexible ? '' : 'hover:z-10 focus-within:z-10'}`}
+      style={{ background: '#1a1a1e' }}
+    >
+      <div
+        className={`flex items-center gap-1.5 px-2 py-1 shrink-0 border-b border-white/[0.06]
+                    ${onDragStart || flexible ? 'drag-handle cursor-grab active:cursor-grabbing' : ''}`}
+        style={{ background: '#1e1e22' }}
+        onPointerDown={onDragStart ? handleDragStart : undefined}
+        onDoubleClick={() => setMaximizedPane(isMaximized ? null : paneId)}
+      >
+        {icon}
+        <span className="text-[11px] text-gray-300 font-medium shrink-0">{title}</span>
+        {subtitle && (
+          <span
+            className="text-[10px] text-gray-500 font-mono flex-1 min-w-0 truncate"
+            title={subtitle}
+            dir="rtl"
+          >
+            {subtitle}
+          </span>
+        )}
+        {!subtitle && <span className="flex-1" />}
+
+        <div
+          className={`flex items-center gap-0.5 transition-opacity ${
+            isTouchDevice() ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100'
+          }`}
+        >
+          <Tooltip label="Minimize">
+            <button
+              onClick={() => toggleMinimized(paneId)}
+              className="text-gray-500 hover:text-white p-0.5 rounded transition-colors"
+              aria-label={`Minimize ${title}`}
+            >
+              <Minus size={12} strokeWidth={2} />
+            </button>
+          </Tooltip>
+          <Tooltip label={isMaximized ? 'Restore' : 'Maximize'}>
+            <button
+              onClick={() => setMaximizedPane(isMaximized ? null : paneId)}
+              className="text-gray-500 hover:text-white p-0.5 rounded transition-colors"
+              aria-label={isMaximized ? `Restore ${title}` : `Maximize ${title}`}
+            >
+              {isMaximized ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+            </button>
+          </Tooltip>
+          <Tooltip label="Close">
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-white p-0.5 rounded transition-colors"
+              aria-label={`Close ${title}`}
+            >
+              <X size={12} strokeWidth={2} />
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 flex flex-col" style={{ background: '#141416' }}>
+        {children}
+      </div>
+    </div>
+  )
+})

--- a/src/renderer/components/PaneRenderer.tsx
+++ b/src/renderer/components/PaneRenderer.tsx
@@ -1,0 +1,62 @@
+import { forwardRef } from 'react'
+import { AgentCard } from './AgentCard'
+import { FilesCard } from './FilesCard'
+import { EditorCard } from './EditorCard'
+import { parsePaneId } from '../lib/pane-id'
+
+interface Props {
+  /** Pane id: a terminal id, or `files:<sessionId>` / `editor:<sessionId>`. */
+  paneId: string
+  index?: number
+  isDragTarget?: boolean
+  onDragStart?: (paneId: string, e: React.PointerEvent) => void
+  flexible?: boolean
+}
+
+/**
+ * Renders whichever card a pane id names.
+ *
+ * Every grid render path goes through here so the kind branch lives in exactly
+ * one place; the paths themselves stay a flat map over opaque id strings.
+ */
+export const PaneRenderer = forwardRef<HTMLDivElement, Props>(function PaneRenderer(
+  { paneId, index, isDragTarget, onDragStart, flexible },
+  ref
+) {
+  const { kind, sessionId } = parsePaneId(paneId)
+
+  if (kind === 'files') {
+    return (
+      <FilesCard
+        ref={ref}
+        sessionId={sessionId}
+        isDragTarget={isDragTarget}
+        onDragStart={onDragStart}
+        flexible={flexible}
+      />
+    )
+  }
+
+  if (kind === 'editor') {
+    return (
+      <EditorCard
+        ref={ref}
+        sessionId={sessionId}
+        isDragTarget={isDragTarget}
+        onDragStart={onDragStart}
+        flexible={flexible}
+      />
+    )
+  }
+
+  return (
+    <AgentCard
+      ref={ref}
+      terminalId={paneId}
+      index={index}
+      isDragTarget={isDragTarget}
+      onDragStart={onDragStart}
+      flexible={flexible}
+    />
+  )
+})

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -17,11 +17,11 @@ import {
   FolderGit2
 } from 'lucide-react'
 import { ProjectIcon } from './project-sidebar/ProjectIcon'
-import { FileTreeExplorer } from './FileTreeExplorer'
 
-const TABS: PanelTab[] = ['all-files', 'changes']
+// The rail is diff review only. Browsing files happens in a session's own Files
+// pane, where several sessions' trees can be open side by side.
+const TABS: PanelTab[] = ['changes']
 const TAB_LABELS: Record<PanelTab, string> = {
-  'all-files': 'All files',
   changes: 'Changes'
 }
 
@@ -71,6 +71,7 @@ export function RightPanel() {
 
   useEffect(() => {
     if (terminalId && cwd) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: load the diff for the newly selected session
       fetchDiff()
     } else {
       setDiffResult(null)
@@ -319,10 +320,6 @@ export function RightPanel() {
             onCancelComment={() => setCommentingLine(null)}
             onRemoveComment={handleRemoveComment}
           />
-        )}
-
-        {activeTab === 'all-files' && (
-          <FileTreeExplorer key={cwd} cwd={cwd} remoteHostId={terminal?.session.remoteHostId} />
         )}
       </div>
 

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -3,6 +3,9 @@ import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
 import { useVisibleTerminals, compareTerminalIds } from '../hooks/useVisibleTerminals'
+import { isTerminalPane } from '../lib/pane-id'
+import { FilesCard } from './FilesCard'
+import { EditorCard } from './EditorCard'
 import { AgentStatusIcon } from './AgentStatusIcon'
 import { TerminalPane } from './TerminalPane'
 import { terminalTextIndentPx } from '../lib/terminal-indent'
@@ -120,7 +123,11 @@ export function TabView() {
   // minimizedTerminals set is preserved so switching back to grid restores
   // the dock pills.
   const allTabIds = useMemo(() => {
-    const merged = [...orderedIds, ...minimizedIds]
+    // Tab mode shows one pane at a time, and its strip/context menu are built
+    // around sessions (rename, status, assigned task). A session's file panes
+    // ride along with it here rather than claiming tabs of their own — they get
+    // their own cells in grid mode, where side-by-side actually means something.
+    const merged = [...orderedIds, ...minimizedIds].filter(isTerminalPane)
     return merged.sort((a, b) => compareTerminalIds(a, b, terminals, sortMode, terminalOrder))
   }, [orderedIds, minimizedIds, terminalOrder, terminals, sortMode])
   const activeTabId = useAppStore((s) => s.activeTabId)
@@ -131,7 +138,7 @@ export function TabView() {
   const setRenamingTerminalId = useAppStore((s) => s.setRenamingTerminalId)
   const renameTerminal = useAppStore((s) => s.renameTerminal)
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
-  const setDiffSidebar = useAppStore((s) => s.setDiffSidebarTerminalId)
+  const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
   const tasks = useAppStore((s) => s.config?.tasks)
   const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
   const domBlocks = useAppStore((s) => s.config?.defaults.domBlockRendering ?? true)
@@ -256,6 +263,8 @@ export function TabView() {
 
   const hasTabs = allTabIds.length > 0
   const activeTerminal = activeTabId ? terminals.get(activeTabId) : null
+  const activeHasFiles = useAppStore((s) => (activeTabId ? s.filesPanes.has(activeTabId) : false))
+  const activeHasEditor = useAppStore((s) => (activeTabId ? s.editorPanes.has(activeTabId) : false))
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -392,7 +401,7 @@ export function TabView() {
                       <TabIconButton
                         label="Browse files"
                         icon={<FolderOpen size={13} />}
-                        onClick={() => setDiffSidebar(id, 'all-files')}
+                        onClick={() => toggleFilesPane(id)}
                       />
                       <TabIconButton
                         label="Rename session"
@@ -512,45 +521,63 @@ export function TabView() {
           )}
         </div>
       ) : (
-        <div className="flex-1 min-h-0 flex flex-col" style={{ background: '#141416' }}>
-          <div className="relative flex-1 min-h-0">
+        <div className="flex-1 min-h-0 flex" style={{ background: '#141416' }}>
+          <div className="flex-1 min-w-0 flex flex-col">
+            <div className="relative flex-1 min-h-0">
+              {activeTabId && activeTerminal && (
+                <TerminalPane
+                  key={activeTabId}
+                  terminalId={activeTabId}
+                  agentType={activeTerminal.session.agentType}
+                  isFocused={true}
+                  domBlocks={domBlocks}
+                />
+              )}
+              {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
+                <div
+                  className="absolute inset-0 p-3 space-y-2 pointer-events-none"
+                  style={{ background: '#141416' }}
+                >
+                  <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
+                  <div
+                    className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.15s' }}
+                  />
+                  <div
+                    className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.3s' }}
+                  />
+                  <div
+                    className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.45s' }}
+                  />
+                </div>
+              )}
+            </div>
             {activeTabId && activeTerminal && (
-              <TerminalPane
-                key={activeTabId}
+              <IntentBar
                 terminalId={activeTabId}
-                agentType={activeTerminal.session.agentType}
-                isFocused={true}
-                domBlocks={domBlocks}
+                indentPx={terminalTextIndentPx(activeTerminal.session.agentType, domBlocks)}
               />
             )}
-            {activeTabId && activeTerminal && activeTerminal.lastOutputTimestamp === 0 && (
-              <div
-                className="absolute inset-0 p-3 space-y-2 pointer-events-none"
-                style={{ background: '#141416' }}
-              >
-                <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
-                <div
-                  className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.15s' }}
-                />
-                <div
-                  className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.3s' }}
-                />
-                <div
-                  className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.45s' }}
-                />
-              </div>
-            )}
+            {activeTabId && activeTerminal && <CardStatusBar terminalId={activeTabId} />}
           </div>
-          {activeTabId && activeTerminal && (
-            <IntentBar
-              terminalId={activeTabId}
-              indentPx={terminalTextIndentPx(activeTerminal.session.agentType, domBlocks)}
-            />
+
+          {/* The active session's file panes, alongside its terminal. */}
+          {activeTabId && activeTerminal && (activeHasFiles || activeHasEditor) && (
+            <div className="w-[380px] shrink-0 flex flex-col gap-px border-l border-white/[0.06]">
+              {activeHasFiles && (
+                <div className="flex-1 min-h-0">
+                  <FilesCard sessionId={activeTabId} />
+                </div>
+              )}
+              {activeHasEditor && (
+                <div className="flex-1 min-h-0">
+                  <EditorCard sessionId={activeTabId} />
+                </div>
+              )}
+            </div>
           )}
-          {activeTabId && activeTerminal && <CardStatusBar terminalId={activeTabId} />}
         </div>
       )}
 

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -18,12 +18,12 @@ interface Props {
 }
 
 export function CardActionCluster({ terminalId, variant }: Props) {
-  const { terminal, setDiffSidebar, setFocused, toggleMinimized } = useAppStore(
+  const { terminal, setFocused, toggleMinimized, toggleFilesPane } = useAppStore(
     useShallow((s) => ({
       terminal: s.terminals.get(terminalId),
-      setDiffSidebar: s.setDiffSidebarTerminalId,
       setFocused: s.setFocusedTerminal,
-      toggleMinimized: s.toggleMinimized
+      toggleMinimized: s.toggleMinimized,
+      toggleFilesPane: s.toggleFilesPane
     }))
   )
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
@@ -33,7 +33,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
 
   const handleBrowseFiles = (e: React.MouseEvent): void => {
     e.stopPropagation()
-    setDiffSidebar(terminalId, 'all-files')
+    toggleFilesPane(terminalId)
   }
 
   const handleMinimize = (e: React.MouseEvent): void => {

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useEffect } from 'react'
-import { X } from 'lucide-react'
+import { X, FolderTree } from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { AgentStatusIcon } from '../AgentStatusIcon'
 import { closeTerminalSession } from '../../lib/terminal-close'
@@ -24,6 +24,8 @@ export function SessionItem({
   const previewTerminalId = useAppStore((s) => s.previewTerminalId)
   const layoutMode = useAppStore((s) => s.config?.defaults?.layoutMode ?? 'grid')
   const enableHoverPreview = useAppStore((s) => s.config?.defaults?.enableHoverPreview ?? false)
+  const hasFilesPane = useAppStore((s) => s.filesPanes.has(session.id))
+  const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
   const isActive =
     layoutMode === 'tabs' ? activeTabId === session.id : focusedTerminalId === session.id
   const isPreviewing = previewTerminalId === session.id
@@ -88,6 +90,22 @@ export function SessionItem({
           <div className="text-[10px] text-gray-600 truncate">{session.branch}</div>
         )}
       </div>
+      <button
+        type="button"
+        aria-label={`${hasFilesPane ? 'Hide' : 'Show'} files for ${session.name}`}
+        title={hasFilesPane ? 'Hide files' : 'Show files'}
+        onClick={(e) => {
+          e.stopPropagation()
+          toggleFilesPane(session.id)
+        }}
+        className={`${
+          hasFilesPane
+            ? 'opacity-100 text-amber-400/80'
+            : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
+        } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
+      >
+        <FolderTree size={12} strokeWidth={2} />
+      </button>
       <button
         type="button"
         aria-label={`Close session ${session.name}`}

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -52,6 +52,10 @@ export function useKeyboardShortcuts() {
           state.setSettingsOpen(false)
           return
         }
+        if (state.maximizedPaneId) {
+          state.setMaximizedPane(null)
+          return
+        }
         if (state.diffSidebarTerminalId) {
           state.setDiffSidebarTerminalId(null)
           return

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -2,7 +2,7 @@ import { useMemo, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL, type SortMode, type TerminalState } from '../stores/types'
-import { filesPaneId, editorPaneId } from '../lib/pane-id'
+import { filesPaneId, editorPaneId, isTerminalPane } from '../lib/pane-id'
 
 /**
  * Stable comparator for terminal ids under the active sortMode. Manual mode
@@ -139,7 +139,10 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
   ])
 
   useEffect(() => {
-    setVisibleTerminalIds(orderedIds)
+    // `visibleTerminalIds` drives session navigation (Cmd+], Cmd+[, Cmd+1-9),
+    // so it stays sessions-only — a pane id here would send those shortcuts to
+    // a tab that no `terminals.get()` can resolve.
+    setVisibleTerminalIds(orderedIds.filter(isTerminalPane))
     const sel = useAppStore.getState().selectedTerminalId
     if (sel && !orderedIds.includes(sel)) {
       useAppStore.getState().setSelectedTerminal(null)

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -2,6 +2,7 @@ import { useMemo, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL, type SortMode, type TerminalState } from '../stores/types'
+import { filesPaneId, editorPaneId } from '../lib/pane-id'
 
 /**
  * Stable comparator for terminal ids under the active sortMode. Manual mode
@@ -49,6 +50,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     statusFilter,
     terminalOrder,
     minimizedTerminals,
+    filesPanes,
+    editorPanes,
     setVisibleTerminalIds,
     setFocusableTerminalIds
   } = useAppStore(
@@ -62,6 +65,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
       statusFilter: s.statusFilter,
       terminalOrder: s.terminalOrder,
       minimizedTerminals: s.minimizedTerminals,
+      filesPanes: s.filesPanes,
+      editorPanes: s.editorPanes,
       setVisibleTerminalIds: s.setVisibleTerminalIds,
       setFocusableTerminalIds: s.setFocusableTerminalIds
     }))
@@ -97,14 +102,19 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
       })
       .sort(sortFn)
 
+    // Expand each visible session into its pane group: the terminal followed by
+    // whichever child panes it owns. Keeping children adjacent to their owner is
+    // what lets session-scoped maximize span a contiguous run of grid cells.
     const ordered: string[] = []
     const minimized: string[] = []
+    const pushPane = (paneId: string): void => {
+      if (minimizedTerminals.has(paneId)) minimized.push(paneId)
+      else ordered.push(paneId)
+    }
     for (const [id] of filtered) {
-      if (minimizedTerminals.has(id)) {
-        minimized.push(id)
-      } else {
-        ordered.push(id)
-      }
+      pushPane(id)
+      if (filesPanes.has(id)) pushPane(filesPaneId(id))
+      if (editorPanes.has(id)) pushPane(editorPaneId(id))
     }
 
     // Focused-mode nav spans the active project (or workspace) regardless of
@@ -123,7 +133,9 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     statusFilter,
     sortMode,
     terminalOrder,
-    minimizedTerminals
+    minimizedTerminals,
+    filesPanes,
+    editorPanes
   ])
 
   useEffect(() => {

--- a/src/renderer/lib/editor-dirty.ts
+++ b/src/renderer/lib/editor-dirty.ts
@@ -1,0 +1,40 @@
+/**
+ * Unsaved-edit tracking for session-owned editor panes.
+ *
+ * The editor lives in one pane while the actions that would discard its buffer
+ * live elsewhere — picking another file happens in the tree pane, closing
+ * happens in the card header. Neither can reach the editor's internal state
+ * through props, so each editor registers a dirty flag here under its session
+ * id and the other panes consult it before throwing work away.
+ */
+
+const dirtyBySession = new Map<string, { current: boolean }>()
+
+/** Ref the editor pane keeps in sync with its unsaved-changes state. */
+export function dirtyRefFor(sessionId: string): { current: boolean } {
+  let ref = dirtyBySession.get(sessionId)
+  if (!ref) {
+    ref = { current: false }
+    dirtyBySession.set(sessionId, ref)
+  }
+  return ref
+}
+
+export function isEditorDirty(sessionId: string): boolean {
+  return dirtyBySession.get(sessionId)?.current === true
+}
+
+export function clearDirty(sessionId: string): void {
+  dirtyBySession.delete(sessionId)
+}
+
+/**
+ * Ask before discarding an editor's unsaved changes. Returns true when the
+ * caller should proceed — either the buffer was clean or the user confirmed.
+ */
+export function confirmDiscard(sessionId: string): boolean {
+  if (!isEditorDirty(sessionId)) return true
+  const ok = window.confirm('Discard unsaved changes?')
+  if (ok) clearDirty(sessionId)
+  return ok
+}

--- a/src/renderer/lib/pane-id.ts
+++ b/src/renderer/lib/pane-id.ts
@@ -1,0 +1,61 @@
+/**
+ * Pane identity.
+ *
+ * The grid, tab strip, dock and layout persistence all address panes by opaque
+ * string id. Historically that id was always a terminal id, and every consumer
+ * did `terminals.get(id)` and bailed on a miss. To let a session own additional
+ * panes (its file tree, its open file) without rewriting that machinery, child
+ * panes get a prefixed id derived from their owner session's id.
+ *
+ * Ids stay opaque strings, so ordering, drag/resize and minimize keep working
+ * untouched — only the components that *render* a pane need to branch on kind.
+ */
+
+export type PaneKind = 'terminal' | 'files' | 'editor'
+
+const FILES_PREFIX = 'files:'
+const EDITOR_PREFIX = 'editor:'
+
+/** Id of the file-tree pane owned by `sessionId`. */
+export function filesPaneId(sessionId: string): string {
+  return `${FILES_PREFIX}${sessionId}`
+}
+
+/** Id of the file-editor pane owned by `sessionId`. */
+export function editorPaneId(sessionId: string): string {
+  return `${EDITOR_PREFIX}${sessionId}`
+}
+
+/**
+ * Resolve a pane id to its kind and owner session.
+ *
+ * Terminal panes are their own owner, so `parsePaneId(termId)` yields
+ * `{ kind: 'terminal', sessionId: termId }`. That makes "which session does this
+ * pane belong to" a single call regardless of kind.
+ */
+export function parsePaneId(paneId: string): { kind: PaneKind; sessionId: string } {
+  if (paneId.startsWith(FILES_PREFIX)) {
+    return { kind: 'files', sessionId: paneId.slice(FILES_PREFIX.length) }
+  }
+  if (paneId.startsWith(EDITOR_PREFIX)) {
+    return { kind: 'editor', sessionId: paneId.slice(EDITOR_PREFIX.length) }
+  }
+  return { kind: 'terminal', sessionId: paneId }
+}
+
+/** Kind of a pane id, without allocating the owner string. */
+export function paneKind(paneId: string): PaneKind {
+  if (paneId.startsWith(FILES_PREFIX)) return 'files'
+  if (paneId.startsWith(EDITOR_PREFIX)) return 'editor'
+  return 'terminal'
+}
+
+/** The session a pane belongs to. For a terminal pane, the pane id itself. */
+export function paneOwnerId(paneId: string): string {
+  return parsePaneId(paneId).sessionId
+}
+
+/** True when the pane is a session's terminal rather than one of its children. */
+export function isTerminalPane(paneId: string): boolean {
+  return paneKind(paneId) === 'terminal'
+}

--- a/src/renderer/lib/pane-order.ts
+++ b/src/renderer/lib/pane-order.ts
@@ -1,0 +1,21 @@
+import { isTerminalPane } from './pane-id'
+
+/**
+ * Translate a drop position in the rendered grid into an index in
+ * `terminalOrder`, which holds sessions only.
+ *
+ * The grid interleaves each session's child panes (`t1`, `files:t1`, `t2`), so
+ * the two index spaces diverge as soon as any pane is open. Splicing a raw grid
+ * index into `terminalOrder` targets the wrong element — or, past the end, an
+ * undefined one that then gets persisted.
+ *
+ * The session position is the number of session panes appearing before the drop
+ * point; dropping past the last session yields the end of the list.
+ */
+export function sessionPositionForGridIndex(orderedIds: string[], gridIndex: number): number {
+  let sessions = 0
+  for (let i = 0; i < orderedIds.length && i < gridIndex; i++) {
+    if (isTerminalPane(orderedIds[i])) sessions++
+  }
+  return sessions
+}

--- a/src/renderer/lib/pane-order.ts
+++ b/src/renderer/lib/pane-order.ts
@@ -1,4 +1,11 @@
-import { isTerminalPane } from './pane-id'
+import { isTerminalPane, parsePaneId } from './pane-id'
+
+export interface Rect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
 
 /**
  * Translate a drop position in the rendered grid into an index in
@@ -18,4 +25,85 @@ export function sessionPositionForGridIndex(orderedIds: string[], gridIndex: num
     if (isTerminalPane(orderedIds[i])) sessions++
   }
   return sessions
+}
+
+/**
+ * Panes still rendered while `maximizedPaneId` is maximized.
+ *
+ * Maximize is session-scoped: the pane takes over its *owner's* footprint, so
+ * only that session's siblings drop out. Every other session keeps rendering,
+ * which is what makes maximize usable for comparing two worktrees side by side.
+ */
+export function visiblePanesWhileMaximized(
+  orderedIds: string[],
+  maximizedPaneId: string | null
+): string[] {
+  if (!maximizedPaneId || !orderedIds.includes(maximizedPaneId)) return orderedIds
+  const owner = parsePaneId(maximizedPaneId).sessionId
+  return orderedIds.filter((id) => id === maximizedPaneId || parsePaneId(id).sessionId !== owner)
+}
+
+/** How many grid cells a maximized pane absorbs — its owner's pane count. */
+export function maximizedCellSpan(orderedIds: string[], maximizedPaneId: string | null): number {
+  if (!maximizedPaneId || !orderedIds.includes(maximizedPaneId)) return 1
+  const owner = parsePaneId(maximizedPaneId).sessionId
+  return orderedIds.filter((id) => parsePaneId(id).sessionId === owner).length
+}
+
+/**
+ * Persisted-layout key for a pane.
+ *
+ * Rects are keyed by the owner session's *stable* key (which survives restarts)
+ * rather than its id, and child panes namespace that key by kind so a session's
+ * tree and file keep independent saved positions alongside its terminal.
+ */
+export function paneLayoutKey(paneId: string, ownerStableKey: string): string {
+  const { kind } = parsePaneId(paneId)
+  return kind === 'terminal' ? ownerStableKey : `${kind}:${ownerStableKey}`
+}
+
+/**
+ * The pane whose rect is currently a computed bounding box, if any.
+ *
+ * Only a maximized pane that is on screen *and* has siblings to span renders as
+ * a box. Deriving the persist-skip from that condition — rather than from
+ * `maximizedPaneId` alone — means a stale id can never permanently stop a
+ * pane's rect from being saved.
+ */
+export function boundingBoxPaneFor(
+  visibleIds: string[],
+  allIds: string[],
+  maximizedPaneId: string | null
+): string | null {
+  if (!maximizedPaneId || !visibleIds.includes(maximizedPaneId)) return null
+  const owner = parsePaneId(maximizedPaneId).sessionId
+  const siblings = allIds.filter((id) => parsePaneId(id).sessionId === owner)
+  return siblings.length > 1 ? maximizedPaneId : null
+}
+
+/**
+ * Bounding box of an owner session's saved rects, for a maximized pane in the
+ * flexible layout.
+ *
+ * Returns null when there is nothing to span — one pane, or no saved rects. The
+ * caller must never persist this box: it is a render-time union, and writing it
+ * back would overwrite each sibling's own saved position.
+ */
+export function maximizedBoundingRect(
+  orderedIds: string[],
+  maximizedPaneId: string,
+  rectFor: (paneId: string) => Rect | undefined
+): Rect | null {
+  const owner = parsePaneId(maximizedPaneId).sessionId
+  const group = orderedIds.filter((id) => parsePaneId(id).sessionId === owner)
+  if (group.length <= 1) return null
+
+  const rects = group.map(rectFor).filter((r): r is Rect => Boolean(r))
+  if (rects.length === 0) return null
+
+  const x = Math.min(...rects.map((r) => r.x))
+  const y = Math.min(...rects.map((r) => r.y))
+  const right = Math.max(...rects.map((r) => r.x + r.w))
+  const bottom = Math.max(...rects.map((r) => r.y + r.h))
+  return { x, y, w: right - x, h: bottom - y }
 }

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -1,6 +1,7 @@
 import { StateCreator } from 'zustand'
 import { AppStore, TerminalsSlice, TerminalState } from './types'
 import { filesPaneId, editorPaneId } from '../lib/pane-id'
+import { clearDirty } from '../lib/editor-dirty'
 
 export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice> = (set) => ({
   terminals: new Map(),
@@ -29,6 +30,10 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       // A session owns its file-tree and editor panes: they die with it, and so
       // does any minimized or maximized state pointing at them.
       const childIds = [filesPaneId(id), editorPaneId(id)]
+      // The dirty registry lives outside the store, so it needs explicit
+      // teardown — otherwise a session closed with unsaved edits leaves a flag
+      // that a recycled id would inherit.
+      clearDirty(id)
       const minimized = new Set(state.minimizedTerminals)
       minimized.delete(id)
       for (const child of childIds) minimized.delete(child)

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -1,5 +1,6 @@
 import { StateCreator } from 'zustand'
 import { AppStore, TerminalsSlice, TerminalState } from './types'
+import { filesPaneId, editorPaneId } from '../lib/pane-id'
 
 export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice> = (set) => ({
   terminals: new Map(),
@@ -25,17 +26,30 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       const next = new Map(state.terminals)
       next.delete(id)
       const order = state.terminalOrder.filter((tid) => tid !== id)
+      // A session owns its file-tree and editor panes: they die with it, and so
+      // does any minimized or maximized state pointing at them.
+      const childIds = [filesPaneId(id), editorPaneId(id)]
       const minimized = new Set(state.minimizedTerminals)
       minimized.delete(id)
+      for (const child of childIds) minimized.delete(child)
+      const filesPanes = new Set(state.filesPanes)
+      filesPanes.delete(id)
+      const editorPanes = new Map(state.editorPanes)
+      editorPanes.delete(id)
       const gitDiffStats = new Map(state.gitDiffStats)
       gitDiffStats.delete(id)
       window.api.notifyWidgetStatus()
       const extra = state.diffSidebarTerminalId === id ? { diffSidebarTerminalId: null } : {}
+      const maxOwned =
+        state.maximizedPaneId === id || childIds.includes(state.maximizedPaneId ?? '')
       return {
         terminals: next,
         terminalOrder: order,
         minimizedTerminals: minimized,
+        filesPanes,
+        editorPanes,
         gitDiffStats,
+        ...(maxOwned ? { maximizedPaneId: null } : {}),
         ...extra
       }
     }),

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -41,13 +41,22 @@ export type RunBucket = 'all' | 'running' | 'waiting' | 'success' | 'error'
 export type WorktreeSortMode = 'name' | 'recent'
 export type WorktreeFilter = 'all' | 'active'
 export type SidebarViewMode = 'worktrees' | 'worktrees-sessions' | 'sessions' | 'sessions-flat'
-export type PanelTab = 'changes' | 'all-files'
+export type PanelTab = 'changes'
 
 export interface FlexibleLayoutRect {
   x: number
   y: number
   w: number
   h: number
+}
+
+/**
+ * State of a session's file-editor pane. Independent of that session's tree
+ * pane — the editor can be open, maximized, and closed on its own.
+ */
+export interface EditorPaneState {
+  /** Absolute path of the open file. */
+  filePath: string
 }
 
 export interface TerminalState {
@@ -161,6 +170,16 @@ export interface UISlice {
   visibleTerminalIds: string[]
   focusableTerminalIds: string[]
   minimizedTerminals: Set<string>
+  /** Session ids whose file-tree pane is open. Keyed by owner, one per session. */
+  filesPanes: Set<string>
+  /** Session id → the file its editor pane is showing. One editor per session. */
+  editorPanes: Map<string, EditorPaneState>
+  /**
+   * Pane id currently maximized, or null. At most one app-wide. A maximized
+   * pane covers only its owner session's footprint — other sessions are
+   * unaffected, which is what makes it usable for side-by-side comparison.
+   */
+  maximizedPaneId: string | null
   sessionDockCollapsed: boolean
   isOnboardingOpen: boolean
   diffSidebarTerminalId: string | null
@@ -213,6 +232,18 @@ export interface UISlice {
   setFocusableTerminalIds: (ids: string[]) => void
   reorderTerminals: (fromIndex: number, toIndex: number) => void
   toggleMinimized: (id: string) => void
+  /** Open (or focus) the file-tree pane owned by `sessionId`. */
+  openFilesPane: (sessionId: string) => void
+  closeFilesPane: (sessionId: string) => void
+  toggleFilesPane: (sessionId: string) => void
+  /**
+   * Show `filePath` in the session's editor pane, creating it if needed.
+   * Independent of the tree pane — the editor works with Files closed.
+   */
+  openEditorPane: (sessionId: string, filePath: string) => void
+  closeEditorPane: (sessionId: string) => void
+  /** Maximize a pane over its owner session's footprint, or null to restore. */
+  setMaximizedPane: (paneId: string | null) => void
   toggleSessionDockCollapsed: () => void
   setOnboardingOpen: (open: boolean) => void
   setDiffSidebarTerminalId: (id: string | null, tab?: PanelTab) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -297,7 +297,15 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   openFilesPane: (sessionId) =>
     set((state) => {
-      if (state.filesPanes.has(sessionId)) return {}
+      const paneId = filesPaneId(sessionId)
+      // Opening an already-open pane focuses it, which for a minimized pane
+      // means bringing it back rather than doing nothing.
+      if (state.filesPanes.has(sessionId)) {
+        if (!state.minimizedTerminals.has(paneId)) return {}
+        const minimized = new Set(state.minimizedTerminals)
+        minimized.delete(paneId)
+        return { minimizedTerminals: minimized }
+      }
       const next = new Set(state.filesPanes)
       next.add(sessionId)
       savePanes(next, state.editorPanes)
@@ -321,8 +329,11 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
     }),
 
   toggleFilesPane: (sessionId) => {
-    const { filesPanes, openFilesPane, closeFilesPane } = get()
-    if (filesPanes.has(sessionId)) closeFilesPane(sessionId)
+    const { filesPanes, minimizedTerminals, openFilesPane, closeFilesPane } = get()
+    // A minimized pane is open but out of sight, so the toggle restores it
+    // instead of closing something the user cannot currently see.
+    const isHidden = minimizedTerminals.has(filesPaneId(sessionId))
+    if (filesPanes.has(sessionId) && !isHidden) closeFilesPane(sessionId)
     else openFilesPane(sessionId)
   },
 

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -91,6 +91,26 @@ function savePanes(filesPanes: Set<string>, editorPanes: Map<string, EditorPaneS
   }
 }
 
+/**
+ * Drop persisted pane entries whose session no longer exists.
+ *
+ * `removeTerminal` prunes sessions closed during a run, but a session that
+ * simply never came back after a restart leaves its entry behind. Reconciling
+ * against the live set keeps localStorage from growing without bound and stops
+ * a recycled id from inheriting a stale pane.
+ */
+function reconcilePanes(
+  filesPanes: Set<string>,
+  editorPanes: Map<string, EditorPaneState>,
+  liveSessionIds: Set<string>
+): { filesPanes: Set<string>; editorPanes: Map<string, EditorPaneState> } | null {
+  const nextFiles = new Set([...filesPanes].filter((id) => liveSessionIds.has(id)))
+  const nextEditors = new Map([...editorPanes].filter(([id]) => liveSessionIds.has(id)))
+  if (nextFiles.size === filesPanes.size && nextEditors.size === editorPanes.size) return null
+  savePanes(nextFiles, nextEditors)
+  return { filesPanes: nextFiles, editorPanes: nextEditors }
+}
+
 function loadSidebarSettings(): Record<string, string> {
   try {
     const raw = localStorage.getItem(SIDEBAR_STORAGE_KEY)
@@ -243,7 +263,16 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   },
 
   setTerminalOrder: (order) => set({ terminalOrder: order }),
-  setVisibleTerminalIds: (ids) => set({ visibleTerminalIds: ids }),
+  setVisibleTerminalIds: (ids) =>
+    set((state) => {
+      // Sessions restore by their persisted id, so pane entries stay valid across
+      // restarts — but a session that never comes back would leave its entry
+      // behind forever. Reconcile against the live set as it settles.
+      const live = new Set(state.terminals.keys())
+      const reconciled =
+        live.size > 0 ? reconcilePanes(state.filesPanes, state.editorPanes, live) : null
+      return { visibleTerminalIds: ids, ...(reconciled ?? {}) }
+    }),
   setFocusableTerminalIds: (ids) => set({ focusableTerminalIds: ids }),
 
   reorderTerminals: (fromIndex, toIndex) =>

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -1,6 +1,14 @@
 import { StateCreator } from 'zustand'
 import { TerminalSession } from '../../shared/types'
-import { AppStore, UISlice, SidebarViewMode, FlexibleLayoutRect, TaskSourceFilter } from './types'
+import {
+  AppStore,
+  UISlice,
+  SidebarViewMode,
+  FlexibleLayoutRect,
+  TaskSourceFilter,
+  EditorPaneState
+} from './types'
+import { filesPaneId, editorPaneId } from '../lib/pane-id'
 
 const EMPTY_SESSIONS: TerminalSession[] = []
 const WORKTREE_CACHE_TTL = 5_000
@@ -8,6 +16,7 @@ const worktreeCacheTimestamps = new Map<string, number>()
 const GRID_STORAGE_KEY = 'vorn:gridSettings'
 const SIDEBAR_STORAGE_KEY = 'vorn:sidebarSettings'
 const FLEXIBLE_STORAGE_KEY = 'vorn:flexibleLayouts'
+const PANES_STORAGE_KEY = 'vorn:panes'
 
 function loadGridSettings(): { gridColumns?: number; sortMode?: string; statusFilter?: string } {
   try {
@@ -39,6 +48,44 @@ function loadFlexibleLayouts(): Record<string, FlexibleLayoutRect> {
 function saveFlexibleLayouts(layouts: Record<string, FlexibleLayoutRect>): void {
   try {
     localStorage.setItem(FLEXIBLE_STORAGE_KEY, JSON.stringify(layouts))
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Open child panes, persisted so a reload restores the same workspace.
+ * Shape: `{ files: sessionId[], editors: { [sessionId]: filePath } }`.
+ * Entries whose session no longer exists are pruned lazily by `removeTerminal`.
+ */
+function loadPanes(): { filesPanes: Set<string>; editorPanes: Map<string, EditorPaneState> } {
+  try {
+    const raw = localStorage.getItem(PANES_STORAGE_KEY)
+    if (!raw) return { filesPanes: new Set(), editorPanes: new Map() }
+    const parsed = JSON.parse(raw) as {
+      files?: string[]
+      editors?: Record<string, string>
+    }
+    return {
+      filesPanes: new Set(parsed.files ?? []),
+      editorPanes: new Map(
+        Object.entries(parsed.editors ?? {}).map(([id, filePath]) => [id, { filePath }])
+      )
+    }
+  } catch {
+    return { filesPanes: new Set(), editorPanes: new Map() }
+  }
+}
+
+function savePanes(filesPanes: Set<string>, editorPanes: Map<string, EditorPaneState>): void {
+  try {
+    localStorage.setItem(
+      PANES_STORAGE_KEY,
+      JSON.stringify({
+        files: [...filesPanes],
+        editors: Object.fromEntries([...editorPanes].map(([id, s]) => [id, s.filePath]))
+      })
+    )
   } catch {
     /* ignore */
   }
@@ -94,6 +141,8 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   visibleTerminalIds: [],
   focusableTerminalIds: [],
   minimizedTerminals: new Set(),
+  ...loadPanes(),
+  maximizedPaneId: null,
   sessionDockCollapsed: false,
   isOnboardingOpen: false,
   diffSidebarTerminalId: null,
@@ -209,13 +258,75 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   toggleMinimized: (id) =>
     set((state) => {
       const next = new Set(state.minimizedTerminals)
-      if (next.has(id)) {
-        next.delete(id)
-      } else {
-        next.add(id)
-      }
-      return { minimizedTerminals: next }
+      const nowMinimized = !next.has(id)
+      if (nowMinimized) next.add(id)
+      else next.delete(id)
+      // A pane that just got minimized can't stay maximized.
+      const clearMax = nowMinimized && state.maximizedPaneId === id
+      return { minimizedTerminals: next, ...(clearMax ? { maximizedPaneId: null } : {}) }
     }),
+
+  openFilesPane: (sessionId) =>
+    set((state) => {
+      if (state.filesPanes.has(sessionId)) return {}
+      const next = new Set(state.filesPanes)
+      next.add(sessionId)
+      savePanes(next, state.editorPanes)
+      return { filesPanes: next }
+    }),
+
+  closeFilesPane: (sessionId) =>
+    set((state) => {
+      if (!state.filesPanes.has(sessionId)) return {}
+      const next = new Set(state.filesPanes)
+      next.delete(sessionId)
+      savePanes(next, state.editorPanes)
+      const paneId = filesPaneId(sessionId)
+      const minimized = new Set(state.minimizedTerminals)
+      minimized.delete(paneId)
+      return {
+        filesPanes: next,
+        minimizedTerminals: minimized,
+        ...(state.maximizedPaneId === paneId ? { maximizedPaneId: null } : {})
+      }
+    }),
+
+  toggleFilesPane: (sessionId) => {
+    const { filesPanes, openFilesPane, closeFilesPane } = get()
+    if (filesPanes.has(sessionId)) closeFilesPane(sessionId)
+    else openFilesPane(sessionId)
+  },
+
+  openEditorPane: (sessionId, filePath) =>
+    set((state) => {
+      const next = new Map(state.editorPanes)
+      next.set(sessionId, { filePath })
+      savePanes(state.filesPanes, next)
+      // Re-opening into a minimized editor should surface it again.
+      const paneId = editorPaneId(sessionId)
+      const minimized = new Set(state.minimizedTerminals)
+      minimized.delete(paneId)
+      return { editorPanes: next, minimizedTerminals: minimized }
+    }),
+
+  closeEditorPane: (sessionId) =>
+    set((state) => {
+      if (!state.editorPanes.has(sessionId)) return {}
+      const next = new Map(state.editorPanes)
+      next.delete(sessionId)
+      savePanes(state.filesPanes, next)
+      const paneId = editorPaneId(sessionId)
+      const minimized = new Set(state.minimizedTerminals)
+      minimized.delete(paneId)
+      return {
+        editorPanes: next,
+        minimizedTerminals: minimized,
+        ...(state.maximizedPaneId === paneId ? { maximizedPaneId: null } : {})
+      }
+    }),
+
+  setMaximizedPane: (paneId) =>
+    set((state) => (state.maximizedPaneId === paneId ? {} : { maximizedPaneId: paneId })),
 
   toggleSessionDockCollapsed: () =>
     set((state) => ({ sessionDockCollapsed: !state.sessionDockCollapsed })),

--- a/tests/card-action-cluster.test.tsx
+++ b/tests/card-action-cluster.test.tsx
@@ -56,13 +56,13 @@ const mockTerminal = {
 
 const initialState = useAppStore.getState()
 
-let setDiffSidebar: ReturnType<typeof vi.fn>
+let toggleFilesPane: ReturnType<typeof vi.fn>
 let setFocused: ReturnType<typeof vi.fn>
 let toggleMinimized: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   vi.clearAllMocks()
-  setDiffSidebar = vi.fn()
+  toggleFilesPane = vi.fn()
   setFocused = vi.fn()
   toggleMinimized = vi.fn()
   const terminals = new Map()
@@ -71,7 +71,7 @@ beforeEach(() => {
     useAppStore.setState({
       terminals,
       focusedTerminalId: null,
-      setDiffSidebarTerminalId: setDiffSidebar,
+      toggleFilesPane,
       setFocusedTerminal: setFocused,
       toggleMinimized
     })
@@ -93,10 +93,10 @@ describe('CardActionCluster — mini variant (grid, hover-revealed)', () => {
     expect(screen.getByRole('button', { name: /Close/ })).toBeInTheDocument()
   })
 
-  it('Browse files opens the diff sidebar in all-files mode', () => {
+  it("Browse files toggles the session's own Files pane", () => {
     render(<CardActionCluster terminalId="term-1" variant="mini" />)
     fireEvent.click(screen.getByRole('button', { name: /Browse files/ }))
-    expect(setDiffSidebar).toHaveBeenCalledWith('term-1', 'all-files')
+    expect(toggleFilesPane).toHaveBeenCalledWith('term-1')
   })
 
   it('Minimize toggles the minimized state for this terminal', () => {
@@ -150,7 +150,7 @@ describe('CardActionCluster guards', () => {
     fireEvent.pointerDown(screen.getByRole('button', { name: /Expand/ }))
     fireEvent.pointerDown(screen.getByRole('button', { name: /Close/ }))
     // onPointerDown calls stopPropagation only — none of the click-triggered store actions fire.
-    expect(setDiffSidebar).not.toHaveBeenCalled()
+    expect(toggleFilesPane).not.toHaveBeenCalled()
     expect(toggleMinimized).not.toHaveBeenCalled()
     expect(setFocused).not.toHaveBeenCalled()
   })

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -629,13 +629,13 @@ describe('TabView merged toolbar controls', () => {
   })
 
   it('clicks browse files button on a tab', () => {
-    const setDiffSidebar = vi.fn()
+    const toggleFilesPane = vi.fn()
     act(() => {
-      useAppStore.setState({ setDiffSidebarTerminalId: setDiffSidebar })
+      useAppStore.setState({ toggleFilesPane })
     })
     render(<TabView />)
     fireEvent.click(screen.getByRole('button', { name: 'Browse files' }))
-    expect(setDiffSidebar).toHaveBeenCalledWith('term-1', 'all-files')
+    expect(toggleFilesPane).toHaveBeenCalledWith('term-1')
   })
 
   it('clicks rename button on a tab', () => {

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { forwardRef } from 'react'
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 Object.defineProperty(window, 'api', {
@@ -140,6 +140,10 @@ beforeEach(() => {
     focusedTerminalId: null,
     previewTerminalId: null,
     minimizedTerminals: new Set<string>(),
+    filesPanes: new Set<string>(),
+    editorPanes: new Map(),
+    maximizedPaneId: null,
+    flexibleLayouts: {},
     rowHeight: 208,
     terminalOrder: ['term-a', 'term-b']
   })
@@ -339,5 +343,60 @@ describe('fitMaxRows', () => {
 
   it('caps at the hard max (4) on very tall viewports', () => {
     expect(fitMaxRows(5000)).toBe(4)
+  })
+})
+
+describe('GridView — session-owned panes', () => {
+  it("renders a session's panes next to it", () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('term-a')
+      useAppStore.getState().openEditorPane('term-a', '/repo/a.ts')
+    })
+    render(<GridView />)
+
+    expect(screen.getByTestId('card-term-a')).toBeInTheDocument()
+    expect(screen.getByTestId('card-files:term-a')).toBeInTheDocument()
+    expect(screen.getByTestId('card-editor:term-a')).toBeInTheDocument()
+    expect(screen.getByTestId('card-term-b')).toBeInTheDocument()
+  })
+
+  it('collapses only the owner session while one of its panes is maximized', () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('term-a')
+      useAppStore.getState().setMaximizedPane('files:term-a')
+    })
+    render(<GridView />)
+
+    // term-a's terminal yields its cell to the maximized tree...
+    expect(screen.queryByTestId('card-term-a')).not.toBeInTheDocument()
+    expect(screen.getByTestId('card-files:term-a')).toBeInTheDocument()
+    // ...while the other session keeps rendering, which is the compare case.
+    expect(screen.getByTestId('card-term-b')).toBeInTheDocument()
+  })
+
+  it('clamps the maximized span to the configured column count', () => {
+    act(() => {
+      useAppStore.setState({ gridColumns: 2 })
+      useAppStore.getState().openFilesPane('term-a')
+      useAppStore.getState().openEditorPane('term-a', '/repo/a.ts')
+      useAppStore.getState().setMaximizedPane('files:term-a')
+    })
+    render(<GridView />)
+
+    // The owner has 3 panes but only 2 tracks exist; spanning 3 would make CSS
+    // Grid add an implicit column and skew every row.
+    const cell = screen.getByTestId('card-files:term-a').parentElement
+    expect(cell?.style.gridColumn).toBe('span 2')
+  })
+
+  it('renders panes in the flexible layout too', () => {
+    act(() => {
+      useAppStore.setState({ gridColumns: -1 })
+      useAppStore.getState().openFilesPane('term-a')
+    })
+    render(<GridView />)
+
+    expect(screen.getByTestId('card-term-a')).toBeInTheDocument()
+    expect(screen.getByTestId('card-files:term-a')).toBeInTheDocument()
   })
 })

--- a/tests/grid-view.test.tsx
+++ b/tests/grid-view.test.tsx
@@ -50,17 +50,18 @@ afterAll(() => {
   Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
 })
 
-// Stub AgentCard with forwardRef so GridView's ref callback (which calls
-// cardRefs.current.set(id, el)) actually fires.
-vi.mock('../src/renderer/components/AgentCard', () => ({
-  AgentCard: forwardRef<
+// Stub PaneRenderer with forwardRef so GridView's ref callback (which calls
+// cardRefs.current.set(id, el)) actually fires. GridView renders every pane —
+// terminal, files, editor — through this one seam.
+vi.mock('../src/renderer/components/PaneRenderer', () => ({
+  PaneRenderer: forwardRef<
     HTMLDivElement,
-    { terminalId: string; index: number; isDragTarget: boolean }
-  >(function MockAgentCard({ terminalId, index, isDragTarget }, ref) {
+    { paneId: string; index: number; isDragTarget: boolean }
+  >(function MockPaneRenderer({ paneId, index, isDragTarget }, ref) {
     return (
       <div
         ref={ref}
-        data-testid={`card-${terminalId}`}
+        data-testid={`card-${paneId}`}
         data-index={index}
         data-drag-target={isDragTarget ? 'yes' : 'no'}
       />

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -1,0 +1,328 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import type { FileEntry } from '../src/shared/types'
+
+// AgentCard (pulled in by PaneRenderer) reads matchMedia at module load, so it
+// must exist before the dynamic imports below.
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  writable: true,
+  configurable: true
+})
+
+const mockListDir = vi.fn<(path: string) => Promise<FileEntry[]>>()
+const mockReadFileContent = vi.fn<(path: string) => Promise<string | null>>()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    listDir: (...args: unknown[]) => mockListDir(...(args as [string])),
+    readFileContent: (...args: unknown[]) => mockReadFileContent(...(args as [string])),
+    writeFileContent: vi.fn().mockResolvedValue({ success: true }),
+    notifyWidgetStatus: vi.fn(),
+    // FocusedTerminal pulls in the full card header, which probes the host.
+    detectInstalledAgents: vi.fn().mockResolvedValue([]),
+    detectIDEs: vi.fn().mockResolvedValue([]),
+    getGitDiffStat: vi.fn().mockResolvedValue(null),
+    onTerminalData: vi.fn(() => () => {}),
+    onTerminalExit: vi.fn(() => () => {})
+  },
+  writable: true,
+  configurable: true
+})
+
+const { useAppStore } = await import('../src/renderer/stores')
+const { FilesCard } = await import('../src/renderer/components/FilesCard')
+const { EditorCard } = await import('../src/renderer/components/EditorCard')
+const { PaneRenderer } = await import('../src/renderer/components/PaneRenderer')
+const { MinimizedPill } = await import('../src/renderer/components/MinimizedPill')
+const { FocusedTerminal } = await import('../src/renderer/components/FocusedTerminal')
+const { dirtyRefFor, clearDirty } = await import('../src/renderer/lib/editor-dirty')
+
+const ENTRIES: FileEntry[] = [
+  { name: 'src', path: '/repo/src', isDirectory: true },
+  { name: 'a.ts', path: '/repo/a.ts', isDirectory: false },
+  { name: 'b.ts', path: '/repo/b.ts', isDirectory: false }
+]
+
+const session = (id: string, over: Record<string, unknown> = {}) =>
+  ({
+    id,
+    projectName: 'repo',
+    projectPath: '/repo',
+    agentType: 'claude',
+    createdAt: 0,
+    displayName: id,
+    ...over
+  }) as never
+
+function seed(ids = ['t1']): void {
+  const terminals = new Map()
+  for (const id of ids) {
+    terminals.set(id, { id, session: session(id), status: 'idle', lastOutputTimestamp: 1 })
+  }
+  act(() => {
+    useAppStore.setState({
+      terminals,
+      filesPanes: new Set(),
+      editorPanes: new Map(),
+      minimizedTerminals: new Set(),
+      maximizedPaneId: null,
+      terminalOrder: ids
+    })
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  clearDirty('t1')
+  mockListDir.mockResolvedValue(ENTRIES)
+  mockReadFileContent.mockResolvedValue('hello')
+  seed()
+})
+
+describe('FilesCard', () => {
+  it('lists the owner session’s worktree and opens a clicked file in its editor', async () => {
+    render(<FilesCard sessionId="t1" />)
+    await screen.findByText('a.ts')
+
+    // cwd comes from the owner session, not a global — this is what lets two
+    // sessions show different trees.
+    expect(mockListDir).toHaveBeenCalledWith('/repo', undefined)
+
+    fireEvent.click(screen.getByText('a.ts'))
+    expect(useAppStore.getState().editorPanes.get('t1')?.filePath).toBe('/repo/a.ts')
+  })
+
+  it('prefers the worktree path when the session has one', async () => {
+    const terminals = new Map()
+    terminals.set('t1', {
+      id: 't1',
+      session: session('t1', { worktreePath: '/repo-wt' }),
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    act(() => useAppStore.setState({ terminals }))
+
+    render(<FilesCard sessionId="t1" />)
+    await waitFor(() => expect(mockListDir).toHaveBeenCalledWith('/repo-wt', undefined))
+  })
+
+  it('confirms before replacing a dirty editor, and keeps the old file on cancel', async () => {
+    act(() => useAppStore.getState().openEditorPane('t1', '/repo/a.ts'))
+    dirtyRefFor('t1').current = true
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<FilesCard sessionId="t1" />)
+    await screen.findByText('b.ts')
+    fireEvent.click(screen.getByText('b.ts'))
+
+    expect(confirm).toHaveBeenCalled()
+    // Cancelling must not throw the unsaved buffer away.
+    expect(useAppStore.getState().editorPanes.get('t1')?.filePath).toBe('/repo/a.ts')
+  })
+
+  it('closes its own pane without touching the editor', async () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openEditorPane('t1', '/repo/a.ts')
+    })
+    render(<FilesCard sessionId="t1" />)
+    await screen.findByText('a.ts')
+
+    fireEvent.click(screen.getByRole('button', { name: /Close Files/ }))
+    expect(useAppStore.getState().filesPanes.has('t1')).toBe(false)
+    // The panes are independent — the open file survives.
+    expect(useAppStore.getState().editorPanes.has('t1')).toBe(true)
+  })
+
+  it('renders nothing when its owner session is gone', () => {
+    const { container } = render(<FilesCard sessionId="ghost" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('EditorCard', () => {
+  beforeEach(() => {
+    act(() => useAppStore.getState().openEditorPane('t1', '/repo/a.ts'))
+  })
+
+  it('titles the pane with the filename and loads its content', async () => {
+    render(<EditorCard sessionId="t1" />)
+    await waitFor(() =>
+      expect(mockReadFileContent).toHaveBeenCalledWith('/repo/a.ts', undefined, undefined)
+    )
+    // The filename lives in the header; the path strip below shows the rest, so
+    // the two must not duplicate it.
+    expect(screen.getAllByText('a.ts').length).toBeGreaterThan(0)
+  })
+
+  it('confirms before closing a dirty buffer and stays open on cancel', async () => {
+    render(<EditorCard sessionId="t1" />)
+    await waitFor(() => expect(mockReadFileContent).toHaveBeenCalled())
+    dirtyRefFor('t1').current = true
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    fireEvent.click(screen.getByRole('button', { name: /Close a\.ts/ }))
+    expect(useAppStore.getState().editorPanes.has('t1')).toBe(true)
+  })
+
+  it('closes when the discard is confirmed', async () => {
+    render(<EditorCard sessionId="t1" />)
+    await waitFor(() => expect(mockReadFileContent).toHaveBeenCalled())
+    dirtyRefFor('t1').current = true
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    fireEvent.click(screen.getByRole('button', { name: /Close a\.ts/ }))
+    expect(useAppStore.getState().editorPanes.has('t1')).toBe(false)
+  })
+
+  it('renders nothing when no file is open', () => {
+    act(() => useAppStore.getState().closeEditorPane('t1'))
+    const { container } = render(<EditorCard sessionId="t1" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('PaneCard chrome', () => {
+  it('maximizes, restores and minimizes through the store', async () => {
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    render(<FilesCard sessionId="t1" />)
+    await screen.findByText('a.ts')
+
+    fireEvent.click(screen.getByRole('button', { name: /Maximize Files/ }))
+    expect(useAppStore.getState().maximizedPaneId).toBe('files:t1')
+
+    fireEvent.click(screen.getByRole('button', { name: /Restore Files/ }))
+    expect(useAppStore.getState().maximizedPaneId).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Minimize Files/ }))
+    expect(useAppStore.getState().minimizedTerminals.has('files:t1')).toBe(true)
+  })
+})
+
+describe('PaneCard drag and double-click', () => {
+  it("reports drags with its own pane id, not its owner's", async () => {
+    const onDragStart = vi.fn()
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    render(<FilesCard sessionId="t1" onDragStart={onDragStart} />)
+    await screen.findByText('a.ts')
+
+    fireEvent.pointerDown(screen.getByText('Files'))
+    expect(onDragStart).toHaveBeenCalledWith('files:t1', expect.anything())
+  })
+
+  it('toggles maximize on header double-click', async () => {
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    render(<FilesCard sessionId="t1" />)
+    await screen.findByText('a.ts')
+
+    fireEvent.doubleClick(screen.getByText('Files'))
+    expect(useAppStore.getState().maximizedPaneId).toBe('files:t1')
+
+    fireEvent.doubleClick(screen.getByText('Files'))
+    expect(useAppStore.getState().maximizedPaneId).toBeNull()
+  })
+})
+
+describe('BrowseFilesButton', () => {
+  it("toggles the session's files pane", async () => {
+    const { BrowseFilesButton } = await import('../src/renderer/components/GitChangesIndicator')
+    render(<BrowseFilesButton terminalId="t1" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse files' }))
+    expect(useAppStore.getState().filesPanes.has('t1')).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse files' }))
+    expect(useAppStore.getState().filesPanes.has('t1')).toBe(false)
+  })
+})
+
+describe('PaneRenderer', () => {
+  it('dispatches on pane kind', async () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openEditorPane('t1', '/repo/a.ts')
+    })
+
+    const files = render(<PaneRenderer paneId="files:t1" />)
+    expect(await files.findByText('Files')).toBeInTheDocument()
+    files.unmount()
+
+    const editor = render(<PaneRenderer paneId="editor:t1" />)
+    await waitFor(() => expect(mockReadFileContent).toHaveBeenCalled())
+    editor.unmount()
+  })
+})
+
+describe('MinimizedPill for child panes', () => {
+  it('labels a minimized tree with its owner and restores on click', () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().toggleMinimized('files:t1')
+    })
+
+    render(<MinimizedPill terminalId="files:t1" />)
+    // Without the kind branch this pill renders nothing and the pane is lost.
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('t1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(useAppStore.getState().minimizedTerminals.has('files:t1')).toBe(false)
+  })
+
+  it('labels a minimized editor with its filename', () => {
+    act(() => {
+      useAppStore.getState().openEditorPane('t1', '/repo/a.ts')
+      useAppStore.getState().toggleMinimized('editor:t1')
+    })
+
+    render(<MinimizedPill terminalId="editor:t1" />)
+    expect(screen.getByText('a.ts')).toBeInTheDocument()
+  })
+
+  it('renders nothing for a pane whose session is gone', () => {
+    const { container } = render(<MinimizedPill terminalId="files:ghost" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('panes travel with their session into focus mode', () => {
+  beforeEach(() => {
+    act(() =>
+      useAppStore.setState({
+        focusedTerminalId: 't1',
+        previewTerminalId: null,
+        config: { defaults: { domBlockRendering: false } } as never
+      })
+    )
+  })
+
+  it("renders the session's tree and file beside the expanded terminal", async () => {
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openEditorPane('t1', '/repo/a.ts')
+    })
+
+    render(<FocusedTerminal />)
+
+    // Expanding a card used to hide whatever the session had open next to it.
+    expect(await screen.findByText('Files')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(mockReadFileContent).toHaveBeenCalledWith('/repo/a.ts', undefined, undefined)
+    )
+  })
+
+  it('shows no pane column when the session has none open', () => {
+    render(<FocusedTerminal />)
+    expect(screen.queryByText('Files')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when no session is focused', () => {
+    act(() => useAppStore.setState({ focusedTerminalId: null }))
+    const { container } = render(<FocusedTerminal />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/tests/pane-lib.test.ts
+++ b/tests/pane-lib.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  filesPaneId,
+  editorPaneId,
+  parsePaneId,
+  paneKind,
+  paneOwnerId,
+  isTerminalPane
+} from '../src/renderer/lib/pane-id'
+import {
+  dirtyRefFor,
+  isEditorDirty,
+  clearDirty,
+  confirmDiscard
+} from '../src/renderer/lib/editor-dirty'
+
+/**
+ * Pane ids are opaque strings everywhere except here — the grid, dock, tab strip
+ * and layout persistence all just pass them around. That only holds if the
+ * prefix scheme round-trips exactly, so these assertions pin it down.
+ */
+describe('pane-id', () => {
+  it('builds and parses child pane ids', () => {
+    expect(filesPaneId('abc')).toBe('files:abc')
+    expect(editorPaneId('abc')).toBe('editor:abc')
+    expect(parsePaneId('files:abc')).toEqual({ kind: 'files', sessionId: 'abc' })
+    expect(parsePaneId('editor:abc')).toEqual({ kind: 'editor', sessionId: 'abc' })
+  })
+
+  it('treats a bare terminal id as its own owner', () => {
+    // Callers ask "which session owns this pane" without knowing the kind, so a
+    // terminal has to answer with itself rather than null.
+    expect(parsePaneId('abc')).toEqual({ kind: 'terminal', sessionId: 'abc' })
+    expect(paneOwnerId('abc')).toBe('abc')
+    expect(paneOwnerId('files:abc')).toBe('abc')
+    expect(paneOwnerId('editor:abc')).toBe('abc')
+  })
+
+  it('reports kind without allocating the owner string', () => {
+    expect(paneKind('files:abc')).toBe('files')
+    expect(paneKind('editor:abc')).toBe('editor')
+    expect(paneKind('abc')).toBe('terminal')
+  })
+
+  it('distinguishes session panes from child panes', () => {
+    expect(isTerminalPane('abc')).toBe(true)
+    expect(isTerminalPane('files:abc')).toBe(false)
+    expect(isTerminalPane('editor:abc')).toBe(false)
+  })
+
+  it('survives session ids that themselves contain a colon', () => {
+    // Session ids come from the server; a colon in one must not be mistaken for
+    // a pane prefix, or a session would silently render as somebody's file tree.
+    const weird = 'host:1234'
+    expect(parsePaneId(weird)).toEqual({ kind: 'terminal', sessionId: weird })
+    expect(parsePaneId(filesPaneId(weird))).toEqual({ kind: 'files', sessionId: weird })
+    expect(paneOwnerId(editorPaneId(weird))).toBe(weird)
+  })
+})
+
+/**
+ * The editor lives in one pane while the actions that discard its buffer live in
+ * others (picking a file in the tree, closing from the card header). This
+ * registry is the only channel between them, so losing it means losing edits.
+ */
+describe('editor-dirty', () => {
+  beforeEach(() => {
+    clearDirty('s1')
+    clearDirty('s2')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts clean and tracks a session-scoped dirty flag', () => {
+    expect(isEditorDirty('s1')).toBe(false)
+    dirtyRefFor('s1').current = true
+    expect(isEditorDirty('s1')).toBe(true)
+    // Sessions are independent: one dirty editor must not block another's.
+    expect(isEditorDirty('s2')).toBe(false)
+  })
+
+  it('returns the same ref for a session so the editor can keep it in sync', () => {
+    expect(dirtyRefFor('s1')).toBe(dirtyRefFor('s1'))
+    expect(dirtyRefFor('s1')).not.toBe(dirtyRefFor('s2'))
+  })
+
+  it('clears a flag', () => {
+    dirtyRefFor('s1').current = true
+    clearDirty('s1')
+    expect(isEditorDirty('s1')).toBe(false)
+  })
+
+  it('proceeds without prompting when the buffer is clean', () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    expect(confirmDiscard('s1')).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+
+  it('prompts when dirty and proceeds only on confirmation', () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    dirtyRefFor('s1').current = true
+
+    expect(confirmDiscard('s1')).toBe(true)
+    expect(confirm).toHaveBeenCalledOnce()
+    // Confirming discards the buffer, so the flag must not linger and prompt
+    // again on the next action.
+    expect(isEditorDirty('s1')).toBe(false)
+  })
+
+  it('blocks and keeps the buffer when the user cancels', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    dirtyRefFor('s1').current = true
+
+    expect(confirmDiscard('s1')).toBe(false)
+    expect(isEditorDirty('s1')).toBe(true)
+  })
+})

--- a/tests/pane-store.test.ts
+++ b/tests/pane-store.test.ts
@@ -93,6 +93,47 @@ describe('pane store actions', () => {
     expect(s().minimizedTerminals.has('editor:t1')).toBe(false)
   })
 
+  it('restores a minimized tree instead of leaving it hidden', () => {
+    const s = () => useAppStore.getState()
+    act(() => s().openFilesPane('t1'))
+    act(() => s().toggleMinimized('files:t1'))
+    expect(s().minimizedTerminals.has('files:t1')).toBe(true)
+
+    // "Browse files" on a session whose tree is minimized must bring it back —
+    // returning early here made the button look dead.
+    act(() => s().openFilesPane('t1'))
+    expect(s().minimizedTerminals.has('files:t1')).toBe(false)
+    expect(s().filesPanes.has('t1')).toBe(true)
+  })
+
+  it('toggling a minimized tree restores it rather than closing it', () => {
+    const s = () => useAppStore.getState()
+    act(() => s().openFilesPane('t1'))
+    act(() => s().toggleMinimized('files:t1'))
+
+    // Closing something the user cannot see is never the intent.
+    act(() => s().toggleFilesPane('t1'))
+    expect(s().filesPanes.has('t1')).toBe(true)
+    expect(s().minimizedTerminals.has('files:t1')).toBe(false)
+
+    // Once visible, the toggle closes as usual.
+    act(() => s().toggleFilesPane('t1'))
+    expect(s().filesPanes.has('t1')).toBe(false)
+  })
+
+  it('clears the editor dirty flag when its session closes', async () => {
+    const { dirtyRefFor, isEditorDirty } = await import('../src/renderer/lib/editor-dirty')
+    const s = () => useAppStore.getState()
+    act(() => s().openEditorPane('t1', '/p/a.ts'))
+    dirtyRefFor('t1').current = true
+
+    act(() => s().removeTerminal('t1'))
+
+    // The registry lives outside the store; a leaked flag would make a recycled
+    // session id prompt about edits that no longer exist.
+    expect(isEditorDirty('t1')).toBe(false)
+  })
+
   it('closing a pane clears its minimized and maximized state', () => {
     const s = () => useAppStore.getState()
     act(() => {

--- a/tests/pane-store.test.ts
+++ b/tests/pane-store.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from '@testing-library/react'
+import { useAppStore } from '../src/renderer/stores'
+
+const session = (id: string) =>
+  ({
+    id,
+    projectName: 'p',
+    projectPath: '/p',
+    agentType: 'claude',
+    createdAt: 0,
+    displayName: id
+  }) as never
+
+function seed(ids: string[] = ['t1']): void {
+  const terminals = new Map()
+  for (const id of ids) {
+    terminals.set(id, { id, session: session(id), status: 'idle', lastOutputTimestamp: 1 })
+  }
+  act(() => {
+    useAppStore.setState({
+      terminals,
+      filesPanes: new Set(),
+      editorPanes: new Map(),
+      minimizedTerminals: new Set(),
+      maximizedPaneId: null,
+      terminalOrder: ids,
+      visibleTerminalIds: []
+    })
+  })
+}
+
+describe('pane store actions', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      ...(window as unknown as { api?: Record<string, unknown> }).api,
+      notifyWidgetStatus: vi.fn(),
+      reorderSessions: vi.fn()
+    }
+    seed(['t1', 't2'])
+  })
+
+  it('opens, toggles and closes a session tree', () => {
+    const s = () => useAppStore.getState()
+
+    act(() => s().openFilesPane('t1'))
+    expect(s().filesPanes.has('t1')).toBe(true)
+
+    // Opening twice is a no-op rather than a duplicate.
+    act(() => s().openFilesPane('t1'))
+    expect(s().filesPanes.size).toBe(1)
+
+    act(() => s().toggleFilesPane('t1'))
+    expect(s().filesPanes.has('t1')).toBe(false)
+
+    act(() => s().toggleFilesPane('t1'))
+    expect(s().filesPanes.has('t1')).toBe(true)
+  })
+
+  it("keeps each session's panes separate", () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().openEditorPane('t1', '/p/a.ts')
+      s().openEditorPane('t2', '/p/b.ts')
+    })
+
+    // Two sessions on the same worktree hold independent state — this is the
+    // whole point of session ownership.
+    expect(s().editorPanes.get('t1')?.filePath).toBe('/p/a.ts')
+    expect(s().editorPanes.get('t2')?.filePath).toBe('/p/b.ts')
+    expect(s().filesPanes.has('t2')).toBe(false)
+  })
+
+  it('swaps the file inside one editor rather than stacking editors', () => {
+    const s = () => useAppStore.getState()
+    act(() => s().openEditorPane('t1', '/p/a.ts'))
+    act(() => s().openEditorPane('t1', '/p/b.ts'))
+
+    expect(s().editorPanes.size).toBe(1)
+    expect(s().editorPanes.get('t1')?.filePath).toBe('/p/b.ts')
+  })
+
+  it('re-opening a file un-minimizes the editor instead of updating it unseen', () => {
+    const s = () => useAppStore.getState()
+    act(() => s().openEditorPane('t1', '/p/a.ts'))
+    act(() => s().toggleMinimized('editor:t1'))
+    expect(s().minimizedTerminals.has('editor:t1')).toBe(true)
+
+    act(() => s().openEditorPane('t1', '/p/b.ts'))
+    expect(s().minimizedTerminals.has('editor:t1')).toBe(false)
+  })
+
+  it('closing a pane clears its minimized and maximized state', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().setMaximizedPane('files:t1')
+      s().toggleMinimized('files:t1')
+    })
+    // Minimizing a maximized pane already drops the maximize.
+    expect(s().maximizedPaneId).toBeNull()
+
+    act(() => s().closeFilesPane('t1'))
+    expect(s().minimizedTerminals.has('files:t1')).toBe(false)
+  })
+
+  it('minimizing a maximized pane clears the maximize', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().setMaximizedPane('files:t1')
+    })
+    expect(s().maximizedPaneId).toBe('files:t1')
+
+    act(() => s().toggleMinimized('files:t1'))
+    expect(s().maximizedPaneId).toBeNull()
+
+    // Restoring does not silently re-maximize it.
+    act(() => s().toggleMinimized('files:t1'))
+    expect(s().maximizedPaneId).toBeNull()
+  })
+
+  it('holds at most one maximized pane app-wide', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().openFilesPane('t2')
+      s().setMaximizedPane('files:t1')
+      s().setMaximizedPane('files:t2')
+    })
+    expect(s().maximizedPaneId).toBe('files:t2')
+
+    act(() => s().setMaximizedPane(null))
+    expect(s().maximizedPaneId).toBeNull()
+  })
+
+  it('closing an editor clears a maximize that pointed at it', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openEditorPane('t1', '/p/a.ts')
+      s().setMaximizedPane('editor:t1')
+    })
+    act(() => s().closeEditorPane('t1'))
+
+    // A stale id here would leave the grid maximizing a pane that is gone.
+    expect(s().maximizedPaneId).toBeNull()
+    expect(s().editorPanes.has('t1')).toBe(false)
+  })
+
+  it('persists open panes so a reload restores the workspace', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().openEditorPane('t1', '/p/a.ts')
+    })
+
+    const raw = localStorage.getItem('vorn:panes')
+    expect(raw).toBeTruthy()
+    expect(JSON.parse(raw as string)).toEqual({
+      files: ['t1'],
+      editors: { t1: '/p/a.ts' }
+    })
+
+    act(() => s().closeFilesPane('t1'))
+    expect(JSON.parse(localStorage.getItem('vorn:panes') as string).files).toEqual([])
+  })
+
+  it('drops persisted panes for sessions that never came back', () => {
+    const s = () => useAppStore.getState()
+    act(() => {
+      s().openFilesPane('t1')
+      s().openEditorPane('t2', '/p/b.ts')
+    })
+
+    // t2 does not return after a restart; its pane entry would otherwise sit in
+    // localStorage forever and could attach to a recycled id.
+    const terminals = new Map(s().terminals)
+    terminals.delete('t2')
+    act(() => useAppStore.setState({ terminals }))
+    act(() => s().setVisibleTerminalIds(['t1']))
+
+    expect(s().filesPanes.has('t1')).toBe(true)
+    expect(s().editorPanes.has('t2')).toBe(false)
+    expect(JSON.parse(localStorage.getItem('vorn:panes') as string).editors).toEqual({})
+  })
+
+  it('does not prune while the session list is still empty', () => {
+    const s = () => useAppStore.getState()
+    act(() => s().openFilesPane('t1'))
+
+    // During startup terminals is empty; pruning then would wipe every restored
+    // pane before the sessions arrive.
+    act(() => useAppStore.setState({ terminals: new Map() }))
+    act(() => s().setVisibleTerminalIds([]))
+
+    expect(s().filesPanes.has('t1')).toBe(true)
+  })
+})

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { useAppStore } from '../src/renderer/stores'
 import { SessionItem } from '../src/renderer/components/project-sidebar/SessionItem'
@@ -93,5 +93,27 @@ describe('SessionItem', () => {
     const { container } = render(<SessionItem session={session} />)
     const closeBtn = container.querySelector('button[type="button"]')
     expect(closeBtn).toBeInTheDocument()
+  })
+
+  it("toggles this session's files pane without selecting the session", () => {
+    const setActiveTabId = vi.fn()
+    act(() => useAppStore.setState({ setActiveTabId }))
+
+    render(<SessionItem session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: /Show files for/ }))
+
+    expect(useAppStore.getState().filesPanes.has(session.id)).toBe(true)
+    // The row is itself a button; the toggle must stop propagation or opening
+    // files would also switch the active session.
+    expect(setActiveTabId).not.toHaveBeenCalled()
+  })
+
+  it('reflects and clears an open files pane', () => {
+    act(() => useAppStore.getState().openFilesPane(session.id))
+    render(<SessionItem session={session} />)
+
+    const btn = screen.getByRole('button', { name: /Hide files for/ })
+    fireEvent.click(btn)
+    expect(useAppStore.getState().filesPanes.has(session.id)).toBe(false)
   })
 })

--- a/tests/session-panes.test.tsx
+++ b/tests/session-panes.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useAppStore } from '../src/renderer/stores'
 import { useVisibleTerminals } from '../src/renderer/hooks/useVisibleTerminals'
+import { sessionPositionForGridIndex } from '../src/renderer/lib/pane-order'
 
 const session = (id: string) =>
   ({
@@ -95,6 +96,19 @@ describe('useVisibleTerminals — session-owned panes', () => {
     expect(result.current.minimizedIds).toEqual(['files:t1'])
   })
 
+  it('keeps visibleTerminalIds sessions-only, so Cmd+N navigation stays valid', () => {
+    renderHook(() => useVisibleTerminals())
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openEditorPane('t1', '/p/a.ts')
+    })
+
+    // Cmd+], Cmd+[ and Cmd+1-9 index into this list and hand the result to
+    // setActiveTabId / setSelectedTerminal — a pane id there lands on a tab no
+    // terminals.get() can resolve.
+    expect(useAppStore.getState().visibleTerminalIds).toEqual(['t1'])
+  })
+
   it('drops a session-owned pane when the session closes', () => {
     const { result } = renderHook(() => useVisibleTerminals())
     act(() => {
@@ -107,5 +121,32 @@ describe('useVisibleTerminals — session-owned panes', () => {
     expect(result.current.orderedIds).toEqual([])
     expect(useAppStore.getState().filesPanes.has('t1')).toBe(false)
     expect(useAppStore.getState().editorPanes.has('t1')).toBe(false)
+  })
+})
+
+describe('sessionPositionForGridIndex', () => {
+  // The grid interleaves each session's panes; terminalOrder holds sessions
+  // only. Reordering with a raw grid index splices the wrong element — or an
+  // undefined one — and corrupts the persisted session order.
+  const grid = ['t1', 'files:t1', 'editor:t1', 't2', 't3', 'files:t3']
+
+  it('maps a grid drop position to a session position', () => {
+    expect(sessionPositionForGridIndex(grid, 0)).toBe(0) // before t1
+    expect(sessionPositionForGridIndex(grid, 3)).toBe(1) // before t2
+    expect(sessionPositionForGridIndex(grid, 4)).toBe(2) // before t3
+    expect(sessionPositionForGridIndex(grid, 6)).toBe(3) // past the end
+  })
+
+  it('never exceeds the session count, whatever the grid index', () => {
+    const sessions = grid.filter((id) => !id.includes(':')).length
+    for (let i = 0; i <= grid.length + 2; i++) {
+      expect(sessionPositionForGridIndex(grid, i)).toBeLessThanOrEqual(sessions)
+    }
+  })
+
+  it('is an identity when no panes are open', () => {
+    const plain = ['t1', 't2', 't3']
+    expect(sessionPositionForGridIndex(plain, 0)).toBe(0)
+    expect(sessionPositionForGridIndex(plain, 2)).toBe(2)
   })
 })

--- a/tests/session-panes.test.tsx
+++ b/tests/session-panes.test.tsx
@@ -3,7 +3,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useAppStore } from '../src/renderer/stores'
 import { useVisibleTerminals } from '../src/renderer/hooks/useVisibleTerminals'
-import { sessionPositionForGridIndex } from '../src/renderer/lib/pane-order'
+import {
+  sessionPositionForGridIndex,
+  visiblePanesWhileMaximized,
+  maximizedCellSpan,
+  maximizedBoundingRect,
+  paneLayoutKey,
+  boundingBoxPaneFor
+} from '../src/renderer/lib/pane-order'
 
 const session = (id: string) =>
   ({
@@ -148,5 +155,79 @@ describe('sessionPositionForGridIndex', () => {
     const plain = ['t1', 't2', 't3']
     expect(sessionPositionForGridIndex(plain, 0)).toBe(0)
     expect(sessionPositionForGridIndex(plain, 2)).toBe(2)
+  })
+})
+
+describe('session-scoped maximize', () => {
+  // t1 owns a tree and a file; t2 is a plain session. Maximizing must collapse
+  // only t1's group — t2 keeps rendering, which is the entire point.
+  const grid = ['t1', 'files:t1', 'editor:t1', 't2']
+
+  it("hides the maximized pane's siblings and nothing else", () => {
+    expect(visiblePanesWhileMaximized(grid, 'editor:t1')).toEqual(['editor:t1', 't2'])
+    expect(visiblePanesWhileMaximized(grid, 't1')).toEqual(['t1', 't2'])
+  })
+
+  it('is a no-op with nothing maximized, or a pane not on screen', () => {
+    expect(visiblePanesWhileMaximized(grid, null)).toEqual(grid)
+    expect(visiblePanesWhileMaximized(grid, 'files:ghost')).toEqual(grid)
+  })
+
+  it('spans exactly the cells its owner gave up', () => {
+    expect(maximizedCellSpan(grid, 'editor:t1')).toBe(3)
+    expect(maximizedCellSpan(grid, 't2')).toBe(1)
+    expect(maximizedCellSpan(grid, null)).toBe(1)
+    expect(maximizedCellSpan(grid, 'files:ghost')).toBe(1)
+  })
+
+  it("unions the owner group's rects in flexible mode", () => {
+    const rects: Record<string, { x: number; y: number; w: number; h: number }> = {
+      t1: { x: 0, y: 0, w: 4, h: 3 },
+      'files:t1': { x: 4, y: 0, w: 2, h: 3 },
+      'editor:t1': { x: 0, y: 3, w: 6, h: 2 },
+      t2: { x: 8, y: 0, w: 4, h: 3 }
+    }
+    expect(maximizedBoundingRect(grid, 'editor:t1', (id) => rects[id])).toEqual({
+      x: 0,
+      y: 0,
+      w: 6,
+      h: 5
+    })
+    // t2's rect sits outside the group and must not widen the box.
+    expect(maximizedBoundingRect(grid, 't2', (id) => rects[id])).toBeNull()
+  })
+
+  it('returns null when there is nothing to span', () => {
+    // A lone session has no siblings to absorb, and a group with no saved rects
+    // has no box — in both cases the pane keeps its own rect.
+    expect(maximizedBoundingRect(['t2'], 't2', () => undefined)).toBeNull()
+    expect(maximizedBoundingRect(grid, 'editor:t1', () => undefined)).toBeNull()
+  })
+})
+
+describe('flexible-layout keys and the persist guard', () => {
+  const grid = ['t1', 'files:t1', 'editor:t1', 't2']
+
+  it('namespaces child pane keys so siblings keep independent rects', () => {
+    // All three share one owner stable key; without the kind prefix they would
+    // overwrite each other's saved position.
+    expect(paneLayoutKey('t1', 'stable-1')).toBe('stable-1')
+    expect(paneLayoutKey('files:t1', 'stable-1')).toBe('files:stable-1')
+    expect(paneLayoutKey('editor:t1', 'stable-1')).toBe('editor:stable-1')
+  })
+
+  it('flags a pane only while it actually renders as a bounding box', () => {
+    expect(boundingBoxPaneFor(['editor:t1', 't2'], grid, 'editor:t1')).toBe('editor:t1')
+    // Nothing maximized.
+    expect(boundingBoxPaneFor(grid, grid, null)).toBeNull()
+    // A lone session spans nothing, so its own rect is still the real one.
+    expect(boundingBoxPaneFor(grid, grid, 't2')).toBeNull()
+  })
+
+  it('never flags a stale id, so a pane cannot be frozen out of persistence', () => {
+    // If a stale `maximizedPaneId` suppressed persistence forever, that pane's
+    // position would silently stop being saved.
+    expect(boundingBoxPaneFor(grid, grid, 'files:ghost')).toBeNull()
+    expect(boundingBoxPaneFor(['t2'], grid, 'editor:t1')).toBeNull()
   })
 })

--- a/tests/session-panes.test.tsx
+++ b/tests/session-panes.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAppStore } from '../src/renderer/stores'
+import { useVisibleTerminals } from '../src/renderer/hooks/useVisibleTerminals'
+
+const session = (id: string) =>
+  ({
+    id,
+    projectName: 'p',
+    projectPath: '/p',
+    agentType: 'claude',
+    createdAt: 0,
+    displayName: id
+  }) as never
+
+/**
+ * A session's file panes are derived inside `useVisibleTerminals`'s memo. The
+ * memo must depend on `filesPanes`/`editorPanes` or opening a pane updates the
+ * store while the grid keeps rendering a stale id list — the pane silently never
+ * appears. These assertions fail if those deps are dropped again.
+ */
+describe('useVisibleTerminals — session-owned panes', () => {
+  beforeEach(() => {
+    // removeTerminal pings the widget; stub it so the store call works headless.
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      ...(window as unknown as { api?: Record<string, unknown> }).api,
+      notifyWidgetStatus: vi.fn()
+    }
+    const terminals = new Map()
+    terminals.set('t1', {
+      id: 't1',
+      session: session('t1'),
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    act(() => {
+      useAppStore.setState({
+        terminals,
+        activeProject: null,
+        activeWorktreePath: null,
+        filesPanes: new Set(),
+        editorPanes: new Map(),
+        minimizedTerminals: new Set(),
+        terminalOrder: ['t1'],
+        statusFilter: 'all'
+      })
+    })
+  })
+
+  it('adds and removes child pane ids as panes open and close', () => {
+    const { result } = renderHook(() => useVisibleTerminals())
+    expect(result.current.orderedIds).toEqual(['t1'])
+
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    expect(result.current.orderedIds).toEqual(['t1', 'files:t1'])
+
+    act(() => useAppStore.getState().openEditorPane('t1', '/p/a.ts'))
+    expect(result.current.orderedIds).toEqual(['t1', 'files:t1', 'editor:t1'])
+
+    // Panes are independent: closing the tree leaves the open file alone.
+    act(() => useAppStore.getState().closeFilesPane('t1'))
+    expect(result.current.orderedIds).toEqual(['t1', 'editor:t1'])
+
+    act(() => useAppStore.getState().closeEditorPane('t1'))
+    expect(result.current.orderedIds).toEqual(['t1'])
+  })
+
+  it('keeps a session and its panes adjacent, so maximize can span them', () => {
+    const terminals = useAppStore.getState().terminals
+    const next = new Map(terminals)
+    next.set('t2', {
+      id: 't2',
+      session: session('t2'),
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    act(() => useAppStore.setState({ terminals: next, terminalOrder: ['t1', 't2'] }))
+
+    const { result } = renderHook(() => useVisibleTerminals())
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openFilesPane('t2')
+    })
+
+    expect(result.current.orderedIds).toEqual(['t1', 'files:t1', 't2', 'files:t2'])
+  })
+
+  it('routes a minimized child pane to the dock, not the grid', () => {
+    const { result } = renderHook(() => useVisibleTerminals())
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    act(() => useAppStore.getState().toggleMinimized('files:t1'))
+
+    expect(result.current.orderedIds).toEqual(['t1'])
+    expect(result.current.minimizedIds).toEqual(['files:t1'])
+  })
+
+  it('drops a session-owned pane when the session closes', () => {
+    const { result } = renderHook(() => useVisibleTerminals())
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().openEditorPane('t1', '/p/a.ts')
+    })
+    expect(result.current.orderedIds).toHaveLength(3)
+
+    act(() => useAppStore.getState().removeTerminal('t1'))
+    expect(result.current.orderedIds).toEqual([])
+    expect(useAppStore.getState().filesPanes.has('t1')).toBe(false)
+    expect(useAppStore.getState().editorPanes.has('t1')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why

The file tree and the diff shared one fixed right rail bound to a single terminal. Only one tree could be open app-wide, and you could never put a file beside the agent editing it.

## What

**Files and File are now separate panes owned by a session.** Two sessions on the same worktree get two independent trees — separate scroll, expanded folders and selection — and either pane can be opened, maximized, closed or minimized without the other.

- **Pane identity** — child panes get prefixed ids (`files:<id>` / `editor:<id>`) so ids stay opaque strings and the existing ordering, drag, layout persistence and minimize machinery keeps working untouched. Only the components that *render* a pane branch on kind, via a single `PaneRenderer` seam.
- **Session-scoped maximize** — a pane covers its owner session's whole footprint while other sessions keep rendering beside it, which is what makes it usable for comparing worktrees. In flexible mode the maximized rect is a computed bounding box that is deliberately never persisted, so restoring returns every sibling to its own saved position.
- **Panes travel into focus mode**, so expanding a card no longer hides them.
- **The right rail becomes diff-only**; every "browse files" entry point now opens the session's own pane instead.

## Review fixes (second commit)

A code review caught two bugs that corrupted state, both from confusing grid indices with session indices:

1. **Manual drag reorder** spliced a grid index into `terminalOrder`. The grid interleaves child panes while `terminalOrder` holds sessions only, so any session with an open pane pushed `undefined` into the persisted order on the first drag.
2. **`visibleTerminalIds` carried pane ids**, so Cmd+], Cmd+[ and Cmd+1-9 could hand `setActiveTabId` an id no `terminals.get()` resolves — landing on a blank tab.

Also fixed: the unsaved-changes guard lost when the editor was split out of the tree (edits were discarded silently on file switch or close), an unclamped maximized grid span that added an implicit column, a stale `maximizedPaneId` that could permanently freeze a pane's saved rect, and persisted pane entries for sessions that never return.

Two review findings were **rejected after checking**: session ids *are* stable across restarts (persisted in SQLite, restored by id), and the dock-overcount case is unreachable since pane ids are only emitted while iterating live sessions.

## Testing

- `tests/session-panes.test.tsx` — 8 new tests covering pane visibility reactivity, pane independence, adjacency (which session-scoped maximize depends on), dock routing, cleanup on session close, and the two corrupting bugs above.
- Both regression tests were **mutation-tested** — each fix was reverted to confirm the test actually fails against the unfixed code.
- Full suite: 2855 passing. Typecheck clean, lint clean at zero warnings, build succeeds.

## Verification

On a project with two sessions on the same worktree: open Files on both and confirm the trees are independent; click a file in each and confirm separate editors; maximize one pane and confirm the other session still renders beside it; drag a session that has panes open and confirm ordering survives a reload; edit a file then switch files and confirm the discard prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)