### PR TITLE
chore(release): 0.6.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.5.7",
+  "version": "0.6.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
First beta of the 0.6.x line.

- Per-session browser pane, readable and drivable by that session's agent (#432, #435)
- Embedded iOS simulator pane with 13 agent-facing device tools (#436)

Tagging `v0.6.0-beta.1` after this merges triggers `release.yml`, which cuts a draft **prerelease** and publishes `@vornrun/mcp` and `@vornrun/connector-sdk` under the `beta` dist-tag.