### PR TITLE
Let a connector report its own readiness, and stop assuming GitHub is built in

### DIFF
--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -5,7 +5,13 @@ export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
 export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
-export { connectionSetup, connectorManifest, pollToolName, MANIFEST_TOOL } from './setup'
+export {
+  connectionSetup,
+  connectorManifest,
+  pollToolName,
+  MANIFEST_TOOL,
+  PREFLIGHT_TOOL
+} from './setup'
 export type { ConnectionSetup, ConnectorManifest } from './setup'
 export { createConnectorServer, serveConnector } from './server'
 export type { ConnectorServerOptions } from './server'
@@ -26,6 +32,7 @@ export type {
   NormalizedItem,
   PollContext,
   PollOutcome,
+  PreflightResult,
   TriggerDefinition,
   StatusSuggestion,
   DefaultWorkflow

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z, type ZodTypeAny } from 'zod'
 import { resolveConfig } from './define'
 import { runAction, runPoll } from './runtime'
-import { MANIFEST_TOOL, connectorManifest, pollToolName } from './setup'
+import { MANIFEST_TOOL, PREFLIGHT_TOOL, connectorManifest, pollToolName } from './setup'
 import type { ActionInputField, ActionOutputField, Connector, ConnectorConfig } from './types'
 
 function json(value: Record<string, unknown>): {
@@ -98,6 +98,34 @@ export function createConnectorServer(
     },
     () => json(connectorManifest(connector) as unknown as Record<string, unknown>)
   )
+
+  // Registered only when declared, so a caller can tell "this connector has
+  // nothing to check" from "the check passed" by whether the tool exists.
+  if (connector.preflight) {
+    const preflight = connector.preflight.bind(connector)
+    server.registerTool(
+      PREFLIGHT_TOOL,
+      {
+        description: `Check whether ${connector.name} can run right now`,
+        inputSchema: {},
+        outputSchema: z.looseObject({})
+      },
+      async () => {
+        // A throw is the connector saying "broken", not "not set up yet", and
+        // it must not read to the user as a passing check. Reporting it as a
+        // failed preflight with the message keeps the distinction the caller
+        // can act on: ok:false is always something a person can fix.
+        try {
+          return json({ ...(await preflight()) })
+        } catch (error) {
+          return json({
+            ok: false,
+            message: error instanceof Error ? error.message : String(error)
+          })
+        }
+      }
+    )
+  }
 
   for (const trigger of connector.triggers) {
     server.registerTool(

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -108,7 +108,13 @@ export function createConnectorServer(
       {
         description: `Check whether ${connector.name} can run right now`,
         inputSchema: {},
-        outputSchema: z.looseObject({})
+        // Declared rather than left open like the manifest's: this shape is
+        // fixed, so a caller can validate against it. Still loose, because a
+        // connector adding a field of its own should not fail the call.
+        outputSchema: z.looseObject({
+          ok: z.boolean().describe('Whether the connector could run right now'),
+          message: z.string().optional().describe('What to do about it, when it could not')
+        })
       },
       async () => {
         // A throw is the connector saying "broken", not "not set up yet", and

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -9,6 +9,13 @@ export function pollToolName(triggerType: string): string {
 /** Tool that reports the connector's manifest and setup hints. */
 export const MANIFEST_TOOL = 'vorn_connector_manifest'
 
+/**
+ * Tool that reports whether the connector can run right now. Present only when
+ * the connector declares a `preflight`, so its absence means "nothing to
+ * check" rather than "check passed".
+ */
+export const PREFLIGHT_TOOL = 'vorn_connector_preflight'
+
 export interface ConnectionSetup {
   connectorId: string
   triggerType: string

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -272,8 +272,14 @@ export interface ConnectorDefinition {
    * missing, so without this the first sign that the tool is absent or signed
    * out is a poll failing some minutes after the connection was saved.
    *
-   * Answer `ok: false` for "correctable by the user"; throw for genuinely
-   * broken. Absent means there is nothing to check.
+   * Answer `ok: false` with a message saying what to do about it. Throwing is
+   * equivalent — the server catches it and reports the same shape with the
+   * error's message — so there is one result for a caller to read and no
+   * behaviour riding on which you choose. Prefer returning when the state is
+   * one you recognise, because then you get to write the sentence.
+   *
+   * Absent means there is nothing to check, which is not the same answer as a
+   * check that passed.
    */
   preflight?(): Promise<PreflightResult> | PreflightResult
 }

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -241,6 +241,17 @@ export interface ConnectorIcon {
   paths: string[]
 }
 
+/**
+ * What a connector reports about its own readiness.
+ *
+ * `message` is shown to the user verbatim, so it should say what to do rather
+ * than what went wrong — "run `gh auth login`" beats "not authenticated".
+ */
+export interface PreflightResult {
+  ok: boolean
+  message?: string
+}
+
 export interface ConnectorDefinition {
   /** Stable connector id, e.g. `azure-devops`. */
   id: string
@@ -251,6 +262,20 @@ export interface ConnectorDefinition {
   config?: ConnectorConfigField[]
   triggers?: TriggerDefinition[]
   actions?: ActionDefinition[]
+  /**
+   * Whether this connector could work right now, asked before anyone waits on
+   * a poll.
+   *
+   * A connector whose credentials come from config fields does not need this:
+   * a missing field is already a visible, nameable error. One that borrows an
+   * external tool's login — `gh auth login`, `az login` — has no field to be
+   * missing, so without this the first sign that the tool is absent or signed
+   * out is a poll failing some minutes after the connection was saved.
+   *
+   * Answer `ok: false` for "correctable by the user"; throw for genuinely
+   * broken. Absent means there is nothing to check.
+   */
+  preflight?(): Promise<PreflightResult> | PreflightResult
 }
 
 /** A validated definition. Every accessor below is guaranteed non-null. */

--- a/packages/server/src/connectors/github.ts
+++ b/packages/server/src/connectors/github.ts
@@ -148,23 +148,6 @@ function runWithStdin(
 }
 
 /** Detect owner/repo from a git repo path using gh CLI */
-export async function detectRepoSlug(
-  projectPath: string
-): Promise<{ owner: string; repo: string } | null> {
-  try {
-    const result = await gh(
-      ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
-      projectPath
-    )
-    const slug = result.trim()
-    if (!slug.includes('/')) return null
-    const [owner, repo] = slug.split('/')
-    return { owner, repo }
-  } catch {
-    return null
-  }
-}
-
 /**
  * Invoke the GitHub REST API via `gh api`. For non-GET requests with a body,
  * the JSON body is piped over stdin using `--input -`, which side-steps shell

--- a/packages/server/src/connectors/index.ts
+++ b/packages/server/src/connectors/index.ts
@@ -1,5 +1,5 @@
 export { connectorRegistry } from './registry'
-export { githubConnector, detectRepoSlug } from './github'
+export { githubConnector } from './github'
 export { mcpConnector, invokeMcpTool, discoverTools, mcpConnectionActions } from './mcp'
 export type { McpDiscoveredTool } from './mcp'
 export { stopClient as stopMcpClient, stopAllClients as stopAllMcpClients } from './mcp-clients'

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -165,6 +165,47 @@ export function mcpConnectionActions(conn: SourceConnection): ConnectorActionDef
   return (tools as McpDiscoveredTool[]).map(mcpToolToConnectorAction)
 }
 
+/** Tool a packaged connector registers when it can report its own readiness. */
+export const PREFLIGHT_TOOL = 'vorn_connector_preflight'
+
+export interface PreflightReport {
+  /** `null` when the connector declares no preflight — nothing to check. */
+  ok: boolean | null
+  message?: string
+}
+
+/**
+ * Ask a packaged connector whether it could run right now.
+ *
+ * Only meaningful per connection, never per catalog entry: answering needs the
+ * connector's own process, and a catalog of twenty would mean twenty of them.
+ * A connection already holds a client, so this costs nothing extra.
+ *
+ * A connector with no `preflight` reports `ok: null` rather than `true`. The
+ * two are different answers — "nothing to check" must not be shown to a user
+ * as "checked, fine" — and only the connectors borrowing an external login
+ * have anything to say here.
+ */
+export async function preflightMcpConnection(conn: SourceConnection): Promise<PreflightReport> {
+  const client = await getOrStartClient(conn)
+  const tools = await client.listTools()
+  if (!(tools.tools ?? []).some((tool) => tool.name === PREFLIGHT_TOOL)) {
+    return { ok: null }
+  }
+
+  const result = await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} })
+  const structured = (result as { structuredContent?: Record<string, unknown> }).structuredContent
+  if (result.isError || !structured) {
+    return {
+      ok: false,
+      message: extractTextError(result.content) ?? `${PREFLIGHT_TOOL} failed`
+    }
+  }
+
+  const message = typeof structured.message === 'string' ? structured.message : undefined
+  return { ok: structured.ok === true, ...(message && { message }) }
+}
+
 /** Invoke a single MCP tool. Separate from `VornConnector.execute` because
  *  we need the `SourceConnection` itself to start/address the per-connection
  *  client, not just the merged args the generic execute path provides. */

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -198,7 +198,11 @@ export async function preflightMcpConnection(conn: SourceConnection): Promise<Pr
   if (result.isError || !structured) {
     return {
       ok: false,
-      message: extractTextError(result.content) ?? `${PREFLIGHT_TOOL} failed`
+      // Falls back to a sentence rather than the tool's name: this reaches a
+      // user, and `vorn_connector_preflight failed` tells them nothing they
+      // can act on while naming something they never chose.
+      message:
+        extractTextError(result.content) ?? 'The connector could not report whether it is ready.'
     }
   }
 

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -68,6 +68,48 @@ export function getGitBranch(projectPath: string, remote?: RemoteHost): string |
   }
 }
 
+/**
+ * Pull `owner/repo` out of a git remote URL, for the forms git actually
+ * stores: `git@host:owner/repo.git`, `https://host/owner/repo.git`,
+ * `ssh://git@host/owner/repo`, and any of them without the `.git`.
+ *
+ * Restricted to github.com on purpose. A GitLab or Bitbucket remote parses
+ * into the same shape, and handing that to a GitHub connection would produce a
+ * connection that looks configured and returns nothing.
+ */
+export function parseGitHubRemote(url: string): { owner: string; repo: string } | null {
+  const trimmed = url.trim()
+  if (!trimmed) return null
+  const match = trimmed.match(
+    /^(?:https?:\/\/|ssh:\/\/)?(?:[^@/]+@)?github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?\/?$/i
+  )
+  if (!match) return null
+  const [, owner, repo] = match
+  // A nested path means this is not a repo URL — `github.com/owner/repo/tree/x`
+  // would otherwise yield a repo of "repo/tree/x".
+  if (!owner || !repo || repo.includes('/')) return null
+  return { owner, repo }
+}
+
+/**
+ * The GitHub repo a project points at, read from its `origin` remote.
+ *
+ * Reads git rather than `gh repo view`, so repo auto-detect works whether or
+ * not the GitHub CLI is installed — the connector that needs `gh` is packaged
+ * and separate, and this is the one place Vorn itself wanted to know.
+ */
+export function detectRepoSlug(projectPath: string): { owner: string; repo: string } | null {
+  try {
+    return parseGitHubRemote(
+      gitExec(['remote', 'get-url', 'origin'], projectPath, { timeout: 3000 })
+    )
+  } catch {
+    // No repo, no origin, or no git. All of them mean "cannot tell", which is
+    // what the caller does something useful with.
+    return null
+  }
+}
+
 export function listBranches(projectPath: string, remote?: RemoteHost): string[] {
   try {
     const output = gitExec(['branch', '--format=%(refname:short)'], projectPath, {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -100,7 +100,12 @@ import {
   mcpConnectionActions,
   stopMcpClient
 } from './connectors'
-import { MCP_CONNECTOR_ID, MCP_POLL_EVENT, backfillMcpConnection } from './connectors/mcp'
+import {
+  MCP_CONNECTOR_ID,
+  MCP_POLL_EVENT,
+  backfillMcpConnection,
+  preflightMcpConnection
+} from './connectors/mcp'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { detectRepoSlug } from './connectors/github'
@@ -899,6 +904,27 @@ export function registerAllMethods(): void {
 
   registerMethod('connection:refreshMcpTools', async (connectionId: string) => {
     return runMcpDiscovery(connectionId)
+  })
+
+  /**
+   * Ask a packaged connection whether it could run right now.
+   *
+   * `ok: null` means the connector declares no preflight, which is most of
+   * them — only the ones borrowing an external tool's login have anything to
+   * check. A connector that authenticates from config fields already fails
+   * visibly when a field is missing.
+   */
+  registerMethod('connection:preflight', async (connectionId: string) => {
+    const conn = dbGetSourceConnection(connectionId)
+    if (!conn || conn.connectorId !== MCP_CONNECTOR_ID) return { ok: null }
+    try {
+      return await preflightMcpConnection(conn)
+    } catch (err) {
+      // Starting the connector at all is itself part of what preflight
+      // answers: a package that will not launch is exactly the state the
+      // caller wants reported, not an exception to handle.
+      return { ok: false, message: err instanceof Error ? err.message : String(err) }
+    }
   })
 
   /**

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -916,7 +916,14 @@ export function registerAllMethods(): void {
    */
   registerMethod('connection:preflight', async (connectionId: string) => {
     const conn = dbGetSourceConnection(connectionId)
-    if (!conn || conn.connectorId !== MCP_CONNECTOR_ID) return { ok: null }
+    // A connection that does not exist is a caller error, not an answer about
+    // readiness. Returning `ok: null` for it would file a stale or mistyped id
+    // under "nothing to check" — the one reading a user is most likely to take
+    // as reassurance.
+    if (!conn) throw new Error(`connection ${connectionId} not found`)
+    // A built-in connector genuinely declares no preflight, so this really is
+    // "nothing to check".
+    if (conn.connectorId !== MCP_CONNECTOR_ID) return { ok: null }
     try {
       return await preflightMcpConnection(conn)
     } catch (err) {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -37,6 +37,7 @@ import type {
 } from '@vornrun/shared/types'
 import { DEFAULT_ARTIFACT_DIRS } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
+import { detectRepoSlug } from './git-utils'
 import {
   scanWorktreeInventory,
   reclaimArtifacts,
@@ -108,7 +109,6 @@ import {
 } from './connectors/mcp'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
-import { detectRepoSlug } from './connectors/github'
 import { forEachConnectorItem } from './connectors/paging'
 import { buildConnectorSeededWorkflow } from './default-workflows'
 import { connectorSeededWorkflowId, connectorSeededWorkflowIdPrefix } from '@vornrun/shared/types'

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -310,7 +310,8 @@ export interface RequestMethods {
   }
   /** Ask a packaged connection whether it could run right now. `ok: null`
    *  means the connector declares no preflight — nothing to check, which is
-   *  not the same answer as "checked, fine". */
+   *  not the same answer as "checked, fine". Throws for a connection that does
+   *  not exist, so a stale id cannot read as "nothing to check". */
   'connection:preflight': {
     params: string
     result: { ok: boolean | null; message?: string }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -308,6 +308,13 @@ export interface RequestMethods {
     params: { workflowId: string; inputs?: Record<string, unknown> }
     result: void
   }
+  /** Ask a packaged connection whether it could run right now. `ok: null`
+   *  means the connector declares no preflight — nothing to check, which is
+   *  not the same answer as "checked, fine". */
+  'connection:preflight': {
+    params: string
+    result: { ok: boolean | null; message?: string }
+  }
   /** Main→server push of decrypted credential fields. Called after main
    *  decrypts values (via Electron safeStorage) on boot and on config
    *  changes. Plaintext lives in server memory only — never persisted. */

--- a/src/renderer/lib/run-presentation.ts
+++ b/src/renderer/lib/run-presentation.ts
@@ -82,14 +82,19 @@ function sourceOf(
  * GitHub numbers issues and pull requests in one sequence, and the connector
  * flattens both into the same item shape — the item URL is the only thing that
  * survives the poll to tell them apart (`/pull/<n>` vs `/issues/<n>`).
+ *
+ * Keyed on that URL and not on the connector id, because a packaged connector
+ * does not have its own id here: those connections are stored as `mcp` with
+ * the real id in `filters.sdkConnectorId`, so an `id === 'github'` test would
+ * quietly stop matching the day GitHub ships as a package and every run would
+ * read `mcp 123`.
  */
 function connectorTitle(execution: WorkflowExecution): string | undefined {
   const item = execution.connectorItem
   if (!item) return undefined
-  if (item.connectorId === 'github') {
-    const kind = item.externalUrl?.includes('/pull/') ? 'PR' : 'Issue'
-    return `${kind} #${item.externalId}`
-  }
+  const url = item.externalUrl
+  if (url?.includes('/pull/')) return `PR #${item.externalId}`
+  if (url?.includes('/issues/')) return `Issue #${item.externalId}`
   return item.externalId ? `${item.connectorId} ${item.externalId}` : undefined
 }
 

--- a/tests/connector-sdk-preflight.test.ts
+++ b/tests/connector-sdk-preflight.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import {
+  createConnectorServer,
+  defineConnector,
+  PREFLIGHT_TOOL
+} from '../packages/connector-sdk/src/index'
+import type { ConnectorDefinition } from '../packages/connector-sdk/src/types'
+
+/**
+ * The preflight tool exists for connectors whose credentials come from an
+ * external login rather than a config field — there is no field to be missing,
+ * so without this the first sign of trouble is a poll failing minutes later.
+ */
+async function connect(definition: ConnectorDefinition): Promise<Client> {
+  const server = createConnectorServer(defineConnector(definition), { config: {} })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+  return client
+}
+
+const base: ConnectorDefinition = {
+  id: 'acme',
+  name: 'Acme',
+  version: '1.0.0',
+  triggers: [{ type: 't', label: 'T', poll: () => ({ items: [] }) }]
+}
+
+async function toolNames(client: Client): Promise<string[]> {
+  return (await client.listTools()).tools.map((t) => t.name)
+}
+
+function structured(result: unknown): Record<string, unknown> {
+  return (result as { structuredContent: Record<string, unknown> }).structuredContent
+}
+
+describe('the preflight tool', () => {
+  // Absence is the signal for "nothing to check". Registering it
+  // unconditionally would make every connector claim to have been verified.
+  it('is absent when the connector declares no preflight', async () => {
+    const client = await connect(base)
+    expect(await toolNames(client)).not.toContain(PREFLIGHT_TOOL)
+  })
+
+  it('is present when the connector declares one', async () => {
+    const client = await connect({ ...base, preflight: () => ({ ok: true }) })
+    expect(await toolNames(client)).toContain(PREFLIGHT_TOOL)
+  })
+
+  it('reports a passing check', async () => {
+    const client = await connect({ ...base, preflight: () => ({ ok: true }) })
+    expect(structured(await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} }))).toEqual({
+      ok: true
+    })
+  })
+
+  it('carries the message back, because it says what to do about it', async () => {
+    const client = await connect({
+      ...base,
+      preflight: () => ({ ok: false, message: 'Sign in by running `gh auth login`.' })
+    })
+    expect(structured(await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} }))).toEqual({
+      ok: false,
+      message: 'Sign in by running `gh auth login`.'
+    })
+  })
+
+  it('awaits an async preflight rather than reporting the promise', async () => {
+    const client = await connect({
+      ...base,
+      preflight: async () => {
+        await Promise.resolve()
+        return { ok: false, message: 'still no' }
+      }
+    })
+    expect(structured(await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} }))).toEqual({
+      ok: false,
+      message: 'still no'
+    })
+  })
+
+  // A throw means "broken", which must not reach the user as a passing check.
+  // Reported as a failed preflight so the caller has one shape to read.
+  it('turns a throw into a failed check carrying its message', async () => {
+    const client = await connect({
+      ...base,
+      preflight: () => {
+        throw new Error('gh not found on PATH')
+      }
+    })
+    const result = await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} })
+    expect(structured(result)).toEqual({ ok: false, message: 'gh not found on PATH' })
+    // Not an MCP error: the call succeeded in reporting a real answer.
+    expect(result.isError).toBeFalsy()
+  })
+
+  it('survives a rejected promise the same way', async () => {
+    const client = await connect({
+      ...base,
+      preflight: () => Promise.reject(new Error('signed out'))
+    })
+    expect(structured(await client.callTool({ name: PREFLIGHT_TOOL, arguments: {} }))).toEqual({
+      ok: false,
+      message: 'signed out'
+    })
+  })
+})

--- a/tests/git-utils-repo-slug.test.ts
+++ b/tests/git-utils-repo-slug.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn()
+}))
+
+vi.mock('node:fs', () => ({
+  default: { mkdirSync: vi.fn(), existsSync: vi.fn(() => true) }
+}))
+
+vi.mock('node:crypto', () => ({
+  default: { randomUUID: vi.fn(() => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee') }
+}))
+
+import { execFileSync } from 'node:child_process'
+import { parseGitHubRemote, detectRepoSlug } from '../packages/server/src/git-utils'
+
+const exec = vi.mocked(execFileSync)
+
+beforeEach(() => {
+  exec.mockReset()
+})
+
+/**
+ * Repo detection reads git rather than `gh repo view`, so it keeps working on
+ * a machine with no GitHub CLI — the connector that needs `gh` is packaged and
+ * separate, and this is the one thing Vorn itself wanted to know.
+ */
+describe('parseGitHubRemote', () => {
+  it('reads the scp-like ssh form git writes by default', () => {
+    expect(parseGitHubRemote('git@github.com:vorn-run/vorn.git')).toEqual({
+      owner: 'vorn-run',
+      repo: 'vorn'
+    })
+  })
+
+  it('reads the https form', () => {
+    expect(parseGitHubRemote('https://github.com/vorn-run/connectors.git')).toEqual({
+      owner: 'vorn-run',
+      repo: 'connectors'
+    })
+  })
+
+  it('reads the ssh:// url form', () => {
+    expect(parseGitHubRemote('ssh://git@github.com/vorn-run/vorn')).toEqual({
+      owner: 'vorn-run',
+      repo: 'vorn'
+    })
+  })
+
+  it('tolerates a missing .git, a trailing slash and surrounding whitespace', () => {
+    expect(parseGitHubRemote('  https://github.com/a/b/  ')).toEqual({ owner: 'a', repo: 'b' })
+  })
+
+  it('keeps a dot inside the repo name rather than treating it as the .git suffix', () => {
+    expect(parseGitHubRemote('git@github.com:owner/my.repo.git')).toEqual({
+      owner: 'owner',
+      repo: 'my.repo'
+    })
+  })
+
+  // A GitLab remote parses into the same shape. Handing that slug to a GitHub
+  // connection would produce a connection that looks configured and returns
+  // nothing, which is worse than refusing to guess.
+  it('refuses a remote that is not github.com', () => {
+    expect(parseGitHubRemote('git@gitlab.com:vorn-run/vorn.git')).toBeNull()
+    expect(parseGitHubRemote('https://bitbucket.org/a/b.git')).toBeNull()
+  })
+
+  it('refuses a url that is not a repo root', () => {
+    expect(parseGitHubRemote('https://github.com/vorn-run/vorn/tree/main')).toBeNull()
+  })
+
+  it('refuses empty and malformed input', () => {
+    expect(parseGitHubRemote('')).toBeNull()
+    expect(parseGitHubRemote('   ')).toBeNull()
+    expect(parseGitHubRemote('github.com')).toBeNull()
+    expect(parseGitHubRemote('https://github.com/onlyowner')).toBeNull()
+  })
+})
+
+describe('detectRepoSlug', () => {
+  it('asks git for the origin url and parses it', () => {
+    // getSafeEnv() shells out for a login-shell PATH first, so the git call is
+    // found by its arguments rather than by being first.
+    exec.mockReturnValue('git@github.com:vorn-run/vorn.git\n' as unknown as string)
+    expect(detectRepoSlug('/repo')).toEqual({ owner: 'vorn-run', repo: 'vorn' })
+    const gitCall = exec.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1][0] === 'remote'
+    )
+    expect(gitCall?.[1]).toEqual(['remote', 'get-url', 'origin'])
+  })
+
+  // No repo, no origin, or no git at all. All mean "cannot tell", which the
+  // caller turns into a manual owner/repo entry rather than an error.
+  it('reports null when git fails rather than throwing at the caller', () => {
+    exec.mockImplementation(() => {
+      throw new Error('not a git repository')
+    })
+    expect(detectRepoSlug('/nowhere')).toBeNull()
+  })
+
+  it('reports null when origin points somewhere that is not GitHub', () => {
+    exec.mockReturnValue('git@gitlab.com:a/b.git\n' as unknown as string)
+    expect(detectRepoSlug('/repo')).toBeNull()
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SourceConnection } from '../packages/shared/src/types'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+const listTools = vi.fn()
+const callTool = vi.fn()
+
+vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  getOrStartClient: vi.fn(async () => ({ listTools, callTool })),
+  stopClient: vi.fn(),
+  stopAllClients: vi.fn()
+}))
+
+const { preflightMcpConnection, PREFLIGHT_TOOL } =
+  await import('../packages/server/src/connectors/mcp')
+
+const conn = { id: 'c1', connectorId: 'mcp', filters: {} } as unknown as SourceConnection
+
+beforeEach(() => {
+  listTools.mockReset()
+  callTool.mockReset()
+})
+
+describe('preflightMcpConnection', () => {
+  /**
+   * "Nothing to check" and "checked, fine" are different answers and only one
+   * of them should ever be shown to a user as reassurance. Most connectors
+   * authenticate from config fields and have nothing to report here.
+   */
+  it('reports null when the connector registers no preflight tool', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: 'poll_issues' }] })
+    expect(await preflightMcpConnection(conn)).toEqual({ ok: null })
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('reports a passing check', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({ structuredContent: { ok: true } })
+    expect(await preflightMcpConnection(conn)).toEqual({ ok: true })
+  })
+
+  it('carries the message, which is the part a user can act on', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({
+      structuredContent: { ok: false, message: 'Run `gh auth login`.' }
+    })
+    expect(await preflightMcpConnection(conn)).toEqual({
+      ok: false,
+      message: 'Run `gh auth login`.'
+    })
+  })
+
+  // A tool that errors is a failed check, not an absent one — reporting null
+  // here would read as "this connector had nothing to verify".
+  it('treats a tool error as a failed check', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({
+      isError: true,
+      content: [{ type: 'text', text: 'connector exploded' }]
+    })
+    expect(await preflightMcpConnection(conn)).toEqual({
+      ok: false,
+      message: 'connector exploded'
+    })
+  })
+
+  it('fails the check when the tool answers with no structured payload', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({ content: [] })
+    expect((await preflightMcpConnection(conn)).ok).toBe(false)
+  })
+
+  // Anything other than a literal `true` is not a pass. A connector answering
+  // `{ok: "yes"}` must not be read as ready.
+  it('does not accept a truthy non-boolean as passing', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({ structuredContent: { ok: 'yes' } })
+    expect(await preflightMcpConnection(conn)).toEqual({ ok: false })
+  })
+
+  it('omits a message that is not a string rather than passing it through', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({ structuredContent: { ok: false, message: { nested: 1 } } })
+    expect(await preflightMcpConnection(conn)).toEqual({ ok: false })
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -97,3 +97,22 @@ describe('preflightMcpConnection', () => {
     expect(await preflightMcpConnection(conn)).toEqual({ ok: false })
   })
 })
+
+/**
+ * The RPC around the probe. Its `ok: null` has one meaning — "this connector
+ * declares no preflight" — and everything else has to stay distinguishable
+ * from it, because that is the reading a user takes as reassurance.
+ */
+describe('the connection:preflight contract', () => {
+  it('reserves ok: null for a connector that declares no preflight', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: 'poll_issues' }] })
+    expect(await preflightMcpConnection(conn)).toEqual({ ok: null })
+  })
+
+  // Regression: a failure to start the connector at all must not be reported
+  // as a passing check, nor as "nothing to check".
+  it('reports a connector that will not launch as a failed check', async () => {
+    listTools.mockRejectedValue(new Error('spawn npx ENOENT'))
+    await expect(preflightMcpConnection(conn)).rejects.toThrow('spawn npx ENOENT')
+  })
+})

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -73,6 +73,16 @@ describe('preflightMcpConnection', () => {
     expect((await preflightMcpConnection(conn)).ok).toBe(false)
   })
 
+  // The fallback reaches a user, so it says something rather than naming an
+  // internal tool they never chose.
+  it('falls back to a sentence, not the tool name', async () => {
+    listTools.mockResolvedValue({ tools: [{ name: PREFLIGHT_TOOL }] })
+    callTool.mockResolvedValue({ content: [] })
+    const { message } = await preflightMcpConnection(conn)
+    expect(message).toBe('The connector could not report whether it is ready.')
+    expect(message).not.toContain(PREFLIGHT_TOOL)
+  })
+
   // Anything other than a literal `true` is not a pass. A connector answering
   // `{ok: "yes"}` must not be read as ready.
   it('does not accept a truthy non-boolean as passing', async () => {

--- a/tests/run-presentation.test.ts
+++ b/tests/run-presentation.test.ts
@@ -69,8 +69,40 @@ describe('describeRun', () => {
     expect(p.title).toBe('Issue #84')
   })
 
-  it('treats a GitHub item with no url as an issue rather than throwing', () => {
+  // Previously this guessed "Issue #84", inferred from the connector id. The
+  // guess is gone with the id test: a packaged connector reports `mcp`, so the
+  // inference would have been wrong precisely when it was invisible. Without a
+  // url there is nothing that distinguishes an issue from a pull request, and
+  // naming it generically is better than naming it confidently wrong.
+  it('falls back to the generic form when a GitHub item carries no url', () => {
     const p = describeRun(run({ connectorItem: githubItem({ externalId: '84' }) }))
+    expect(p.title).toBe('github 84')
+  })
+
+  // The port's whole point: the same GitHub items arriving through a packaged
+  // connector, whose connection is stored as `mcp`. Titles must survive that.
+  it('still names a PR when the item arrives from a packaged connector', () => {
+    const p = describeRun(
+      run({
+        connectorItem: githubItem({
+          connectorId: 'mcp',
+          externalUrl: 'https://github.com/vorn-run/vorn/pull/309'
+        })
+      })
+    )
+    expect(p.title).toBe('PR #309')
+  })
+
+  it('still names an issue when the item arrives from a packaged connector', () => {
+    const p = describeRun(
+      run({
+        connectorItem: githubItem({
+          connectorId: 'mcp',
+          externalId: '84',
+          externalUrl: 'https://github.com/vorn-run/vorn/issues/84'
+        })
+      })
+    )
     expect(p.title).toBe('Issue #84')
   })
 


### PR DESCRIPTION
Two steps toward GitHub shipping as a package
([vorn-run/connectors#3](https://github.com/vorn-run/connectors/pull/3)). Both
are useful on their own, and the built-in still works after this.

## A connector can say whether it could run

A connector that reads credentials from config fields fails visibly: the field
is missing and the error names it. One that borrows an external tool's login —
`gh auth login`, `az login` — has no field to be missing, so the first sign the
tool is absent or signed out is a poll failing minutes after the connection was
saved.

Connectors may now declare `preflight()`, surfaced as a
`vorn_connector_preflight` tool beside `vorn_connector_manifest`.

- **Registered only when declared.** Absence means "nothing to check", and
  `preflightMcpConnection` reports `ok: null` for it rather than `true`. Those
  are different answers and only one is reassurance — a tool registered
  unconditionally would let every connector appear to have been verified.
- **A throw becomes a failed check** carrying its message, not a tool error.
  "Broken" must not reach a user looking like "passed", and the caller should
  have one shape to read.

### Two departures from the plan, both about placement

Exposed as `connection:preflight`, **per connection**, rather than folded into
`connector:status`. Answering needs the connector's own process, and
`connector:status` backs `list_connectors` over the whole catalog — the comment
there already warns that a list of twenty would mean twenty `npx` processes. A
connection already holds a client, so this costs nothing.

The `if (c.id === 'github')` branch in `connector:status` **stays for now**. It
is still the only thing reporting on the built-in, which is still the live
GitHub connector; deleting it here would open a regression window until the
built-in is removed. It goes with `github.ts`.

## Vorn stops reaching into the GitHub connector

**Repo auto-detect** called `detectRepoSlug`, which lived in the connector and
shelled out to `gh repo view`. It now reads `git remote get-url origin` from
`git-utils.ts`, beside the machinery for running git that was already there.
Repo detection consequently works on a machine with **no GitHub CLI**, which
the old implementation could not do. The parse is restricted to `github.com`: a
GitLab remote has the same shape, and handing that slug to a GitHub connection
would produce one that looks configured and returns nothing.

**Run titles** keyed on `connectorItem.connectorId === 'github'`. A packaged
connection is stored as `mcp` with its real id in `filters.sdkConnectorId`, so
that test would have stopped matching the day GitHub shipped as a package — and
the failure is silent: every run would read `mcp 123` instead of `PR #309`,
with nothing in any log. Keyed on the item URL now, which the comment above it
already said was the only thing distinguishing an issue from a pull request.
Two tests pin the packaged case.

### One behaviour changes

A GitHub item with **no** URL used to be titled `Issue #84`, inferred from the
connector id. That inference is gone with the id test, and such an item falls
back to the generic form. The guess was only ever right by luck, and would have
been wrong in exactly the case nobody would notice.

## Not done here

`ConnectorSettings.tsx` still gates repo auto-detect on
`connector.id === 'github'`. That form is not the one a packaged connector uses
— `SdkConnectorForm` is — so the capability moves there, against a real
package, rather than being reshaped blind now.

## Verification

- `yarn typecheck` clean.
- Full suite: **3146 passing**. The one failure, `shell-integration-shells`, is
  the known macOS-only failure and is unrelated.
- 25 new tests: the preflight tool's presence, absence, both verdicts, an async
  hook and a throw; the Vorn-side probe including `ok: null` and a non-boolean
  `ok`; every git remote URL form plus the non-GitHub refusal; and run titles
  surviving a packaged connector.