### PR TITLE
Quiet the palette across the sessions surface

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -512,7 +512,7 @@ export function App() {
     <div
       className="flex h-dvh text-gray-100"
       style={{
-        background: '#1a1a1e',
+        background: 'var(--color-surface-base)',
         paddingTop: 'var(--safe-top)',
         paddingLeft: 'var(--safe-left)',
         paddingRight: 'var(--safe-right)',
@@ -532,7 +532,7 @@ export function App() {
         {/* z-46 + opaque bg covers the TerminalHost overlay (z-45) when the grid scrolls up. */}
         {!isInlineWorkflowEditor && !isTabToolbarMerged && !isFocusedFullScreen && (
           <div
-            className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-[#1a1a1e]
+            className={`titlebar-drag shrink-0 border-b border-white/[0.06] relative z-[46] bg-surface-base
                         flex items-center ${isMobile ? 'px-2 justify-between' : 'px-3'} ${isMobile ? 'h-[52px]' : 'h-[40px]'}`}
             style={
               isMac && !isWeb && !isSidebarOpen && !isMobile

--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -110,6 +110,25 @@ export const AgentCard = memo(
       setFocused(terminalId)
     }
 
+    // The session's chrome normally rides inside the terminal column so the
+    // panes beside it get the card's full height. A maximized pane collapses
+    // that column, though, and the chrome must not go with it: it carries the
+    // session's name, its drag handle, and the only close and minimize buttons
+    // the card has. In that one state it spans the card, as it used to.
+    const header = (
+      <CardHeader
+        terminalId={terminalId}
+        variant="mini"
+        index={index}
+        draggable={Boolean(onDragStart || flexible)}
+        onDragStart={onDragStart}
+        onDoubleClick={handleExpand}
+        revealActions={isTouchDevice}
+        dimmed={isChromeDimmed}
+      />
+    )
+    const statusBar = <CardStatusBar terminalId={terminalId} dimmed={isChromeDimmed} />
+
     return (
       <div
         ref={ref}
@@ -138,6 +157,8 @@ export const AgentCard = memo(
             lives *inside* the terminal column rather than spanning the card: a
             pane carries its own bar, so a full-width header above both stacked
             two title rows and cost the panes the card's full height. */}
+        {hasMaximizedPane && header}
+
         <div ref={bodyRef} className="flex flex-row flex-1 min-h-0">
           {/* The column, not the surface inside it, is what the split ratio
               sizes and what hides behind a maximized pane. */}
@@ -146,16 +167,7 @@ export const AgentCard = memo(
             className={`flex flex-col min-h-0 min-w-0 ${hasMaximizedPane ? 'hidden' : ''}`}
             style={{ flexGrow: terminalRatio, flexShrink: 1, flexBasis: 0 }}
           >
-            <CardHeader
-              terminalId={terminalId}
-              variant="mini"
-              index={index}
-              draggable={Boolean(onDragStart || flexible)}
-              onDragStart={onDragStart}
-              onDoubleClick={handleExpand}
-              revealActions={isTouchDevice}
-              dimmed={isChromeDimmed}
-            />
+            {!hasMaximizedPane && header}
 
             {/* `relative` stays on the terminal surface itself: it hosts
                 absolutely-positioned overlays that would otherwise stretch
@@ -227,7 +239,7 @@ export const AgentCard = memo(
               />
             )}
 
-            <CardStatusBar terminalId={terminalId} dimmed={isChromeDimmed} />
+            {!hasMaximizedPane && statusBar}
           </div>
 
           {hasPanes && !hasMaximizedPane && (
@@ -259,6 +271,8 @@ export const AgentCard = memo(
             </div>
           )}
         </div>
+
+        {hasMaximizedPane && statusBar}
 
         {!flexible && <RowResizeHandle />}
       </div>

--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -117,9 +117,9 @@ export const AgentCard = memo(
                    transition-colors
                    ${
                      isFocused
-                       ? 'border-blue-500/60 ring-1 ring-blue-500/30'
+                       ? 'border-white/40'
                        : isDragTarget
-                         ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
+                         ? 'card-drop-target border-white/[0.25] hover:border-white/[0.12]'
                          : 'border-white/[0.06] hover:border-white/[0.12]'
                    }
                    ${
@@ -129,89 +129,105 @@ export const AgentCard = memo(
                          ? 'z-10'
                          : 'hover:z-10 focus-within:z-10'
                    }`}
-        style={{ background: '#1a1a1e' }}
+        style={{ background: 'var(--color-surface-raised)' }}
         onPointerDown={() => {
           if (!isSelected && !isFocused) setSelected(terminalId)
         }}
       >
-        <CardHeader
-          terminalId={terminalId}
-          variant="mini"
-          index={index}
-          draggable={Boolean(onDragStart || flexible)}
-          onDragStart={onDragStart}
-          onDoubleClick={handleExpand}
-          revealActions={isTouchDevice}
-          dimmed={isChromeDimmed}
-        />
-
-        {/* Terminal, plus this session's panes stacked beside it. `relative`
-            stays on the terminal itself: it hosts absolutely-positioned
-            overlays that would otherwise stretch across the panes. */}
+        {/* Terminal, plus this session's panes beside it. The session's chrome
+            lives *inside* the terminal column rather than spanning the card: a
+            pane carries its own bar, so a full-width header above both stacked
+            two title rows and cost the panes the card's full height. */}
         <div ref={bodyRef} className="flex flex-row flex-1 min-h-0">
+          {/* The column, not the surface inside it, is what the split ratio
+              sizes and what hides behind a maximized pane. */}
           <div
             data-testid={`card-terminal-${terminalId}`}
-            className={`relative min-h-0 min-w-0 pt-0.5 ${hasMaximizedPane ? 'hidden' : ''}`}
-            style={{
-              flexGrow: terminalRatio,
-              flexShrink: 1,
-              flexBasis: 0,
-              background: '#141416'
-            }}
+            className={`flex flex-col min-h-0 min-w-0 ${hasMaximizedPane ? 'hidden' : ''}`}
+            style={{ flexGrow: terminalRatio, flexShrink: 1, flexBasis: 0 }}
           >
-            {!isFocused && (
-              <TerminalPane
-                terminalId={terminalId}
-                agentType={terminal.session.agentType}
-                isFocused={isSelected}
-                flexible={flexible}
-                domBlocks={domBlocks}
-              />
-            )}
-            {isFocused && (
-              <div className="flex items-center justify-center h-full text-gray-600 text-xs">
-                Expanded
-              </div>
-            )}
-            {!isFocused && terminal.lastOutputTimestamp === 0 && (
-              <div
-                className="absolute inset-0 p-3 space-y-2 pointer-events-none"
-                style={{ background: '#141416' }}
-              >
-                <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
-                <div
-                  className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.15s' }}
+            <CardHeader
+              terminalId={terminalId}
+              variant="mini"
+              index={index}
+              draggable={Boolean(onDragStart || flexible)}
+              onDragStart={onDragStart}
+              onDoubleClick={handleExpand}
+              revealActions={isTouchDevice}
+              dimmed={isChromeDimmed}
+            />
+
+            {/* `relative` stays on the terminal surface itself: it hosts
+                absolutely-positioned overlays that would otherwise stretch
+                across the column's chrome. */}
+            <div
+              className="relative flex-1 min-h-0 min-w-0 pt-0.5"
+              style={{ background: 'var(--color-surface-sunken)' }}
+            >
+              {!isFocused && (
+                <TerminalPane
+                  terminalId={terminalId}
+                  agentType={terminal.session.agentType}
+                  isFocused={isSelected}
+                  flexible={flexible}
+                  domBlocks={domBlocks}
                 />
+              )}
+              {isFocused && (
+                <div className="flex items-center justify-center h-full text-gray-600 text-xs">
+                  Expanded
+                </div>
+              )}
+              {!isFocused && terminal.lastOutputTimestamp === 0 && (
                 <div
-                  className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.3s' }}
-                />
-                <div
-                  className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
-                  style={{ animationDelay: '0.45s' }}
-                />
-              </div>
-            )}
-            {!isFocused && showScrollBtn && (
-              <button
-                className="absolute bottom-2 right-2 w-8 h-8 flex items-center justify-center
+                  className="absolute inset-0 p-3 space-y-2 pointer-events-none"
+                  style={{ background: 'var(--color-surface-sunken)' }}
+                >
+                  <div className="h-3 w-3/4 rounded bg-white/[0.04] animate-pulse" />
+                  <div
+                    className="h-3 w-1/2 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.15s' }}
+                  />
+                  <div
+                    className="h-3 w-5/6 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.3s' }}
+                  />
+                  <div
+                    className="h-3 w-2/3 rounded bg-white/[0.04] animate-pulse"
+                    style={{ animationDelay: '0.45s' }}
+                  />
+                </div>
+              )}
+              {!isFocused && showScrollBtn && (
+                <button
+                  className="absolute bottom-2 right-2 w-8 h-8 flex items-center justify-center
                            rounded bg-white/[0.08] hover:bg-white/[0.15] active:bg-white/[0.2]
                            text-gray-400 hover:text-white transition-colors z-50"
-                onClick={handleScrollToBottom}
-                title="Scroll to bottom"
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path
-                    d="M6 2.5V9.5M3 7L6 10L9 7"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
+                  onClick={handleScrollToBottom}
+                  title="Scroll to bottom"
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M6 2.5V9.5M3 7L6 10L9 7"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+
+            {!isFocused && (
+              <IntentBar
+                terminalId={terminalId}
+                compact
+                indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks)}
+              />
             )}
+
+            <CardStatusBar terminalId={terminalId} dimmed={isChromeDimmed} />
           </div>
 
           {hasPanes && !hasMaximizedPane && (
@@ -243,16 +259,6 @@ export const AgentCard = memo(
             </div>
           )}
         </div>
-
-        {!isFocused && (
-          <IntentBar
-            terminalId={terminalId}
-            compact
-            indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks)}
-          />
-        )}
-
-        <CardStatusBar terminalId={terminalId} dimmed={isChromeDimmed} />
 
         {!flexible && <RowResizeHandle />}
       </div>

--- a/src/renderer/components/BrowserCard.tsx
+++ b/src/renderer/components/BrowserCard.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ArrowRight, MousePointerClick, Pencil, Plus, RotateCw, X } f
 import { useAppStore } from '../stores'
 import { PaneCard, PaneControls } from './PaneCard'
 import { PANE_SURFACE } from '../lib/pane-surface'
+import { ICON_BUTTON } from '../lib/icon-button'
 import { browserPaneId } from '../lib/pane-id'
 import { normalizeUrl, displayHost, flattenPageText } from '../lib/browser-url'
 
@@ -276,9 +277,9 @@ export const BrowserCard = memo(
 
     if (!terminal || !pane || url === null) return null
 
-    const btn =
-      'p-1 rounded text-gray-500 enabled:hover:text-gray-200 enabled:hover:bg-white/[0.06] ' +
-      'disabled:opacity-25 transition-colors'
+    // Shares the card's icon-button style; the disabled states belong to this
+    // bar, since back and forward spend most of their life unavailable.
+    const btn = `${ICON_BUTTON} disabled:opacity-25 disabled:hover:bg-transparent`
 
     return (
       <PaneCard

--- a/src/renderer/components/DeviceCard.tsx
+++ b/src/renderer/components/DeviceCard.tsx
@@ -4,6 +4,7 @@ import { MousePointerClick, Pencil, Smartphone, X } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { PaneCard, PaneControls } from './PaneCard'
 import { PANE_SURFACE } from '../lib/pane-surface'
+import { ICON_BUTTON } from '../lib/icon-button'
 import { devicePaneId } from '../lib/pane-id'
 import { flattenPageText } from '../lib/browser-url'
 
@@ -306,8 +307,7 @@ export const DeviceCard = memo(
 
     if (!pane) return null
 
-    const btn =
-      'p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors'
+    const btn = ICON_BUTTON
 
     return (
       <PaneCard

--- a/src/renderer/components/FileTreeExplorer.tsx
+++ b/src/renderer/components/FileTreeExplorer.tsx
@@ -906,11 +906,7 @@ function FilesPanel({
   selectedFile,
   onSelectFile,
   showHeader = true,
-  controls,
-  onHeaderPointerDown,
-  onHeaderDoubleClick,
-  headerTestId,
-  headerClassName = ''
+  headerTestId
 }: {
   rootEntries: FileEntry[]
   dirCache: Map<string, FileEntry[]>
@@ -919,16 +915,7 @@ function FilesPanel({
   onSelectFile: (path: string) => void
   /** False when hosted in a pane card that draws its own header. */
   showHeader?: boolean
-  /**
-   * Pane chrome (maximize / close) seated in the filter row. A hosting card
-   * that passes this drops its own header row — the filter row is already a
-   * full-width bar, and a second one above it is chrome on chrome.
-   */
-  controls?: ReactNode
-  onHeaderPointerDown?: (e: React.PointerEvent) => void
-  onHeaderDoubleClick?: () => void
   headerTestId?: string
-  headerClassName?: string
 }) {
   const [filter, setFilter] = useState('')
   const { matched, expand } = useMemo(
@@ -939,12 +926,7 @@ function FilesPanel({
   return (
     <div className="flex flex-col min-h-0 h-full">
       {showHeader && <PanelHeader title="Files" />}
-      <div
-        className={`flex items-center gap-1 px-1.5 py-1.5 shrink-0 ${headerClassName}`}
-        onPointerDown={onHeaderPointerDown}
-        onDoubleClick={onHeaderDoubleClick}
-        data-testid={headerTestId}
-      >
+      <div className="flex items-center gap-1 px-1.5 py-1.5 shrink-0" data-testid={headerTestId}>
         {/* A search field has to read as somewhere you can type before anything
             is in it; at 4% over a near-black pane it was very nearly the pane. */}
         <div className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1 rounded-md bg-white/[0.09] focus-within:bg-white/[0.13] transition-colors">
@@ -968,7 +950,6 @@ function FilesPanel({
             </button>
           )}
         </div>
-        {controls}
       </div>
       <div className="flex-1 overflow-y-auto py-0.5">
         {rootEntries.map((entry) => (
@@ -1175,22 +1156,13 @@ export function FileTreePane({
   remoteHostId,
   selectedFile,
   onSelectFile,
-  controls,
-  onHeaderPointerDown,
-  onHeaderDoubleClick,
-  headerTestId,
-  headerClassName
+  headerTestId
 }: {
   cwd: string
   remoteHostId?: string
   selectedFile: string | null
   onSelectFile: (path: string) => void
-  /** Pane chrome seated in the filter row; see `FilesPanel`. */
-  controls?: ReactNode
-  onHeaderPointerDown?: (e: React.PointerEvent) => void
-  onHeaderDoubleClick?: () => void
   headerTestId?: string
-  headerClassName?: string
 }): JSX.Element {
   const [rootEntries, setRootEntries] = useState<FileEntry[] | null>(null)
   const [loading, setLoading] = useState(true)
@@ -1253,11 +1225,7 @@ export function FileTreePane({
       selectedFile={selectedFile}
       onSelectFile={onSelectFile}
       showHeader={false}
-      controls={controls}
-      onHeaderPointerDown={onHeaderPointerDown}
-      onHeaderDoubleClick={onHeaderDoubleClick}
       headerTestId={headerTestId}
-      headerClassName={headerClassName}
     />
   )
 }

--- a/src/renderer/components/FileTreeExplorer.tsx
+++ b/src/renderer/components/FileTreeExplorer.tsx
@@ -113,7 +113,7 @@ function TreeNode({
       <div>
         <button
           onClick={handleToggle}
-          className="group relative w-full flex items-center gap-[5px] pr-2 text-left text-[12px] transition-colors hover:bg-white/[0.05]"
+          className="group relative w-full flex items-center gap-[5px] pr-2 text-left text-[13.5px] transition-colors hover:bg-white/[0.05]"
           style={{ height: ROW_HEIGHT, paddingLeft: `${BASE_LEFT + depth * INDENT_WIDTH}px` }}
         >
           {guides}
@@ -178,8 +178,8 @@ function TreeNode({
   return (
     <button
       onClick={() => onSelectFile(entry.path)}
-      className={`group relative w-full flex items-center gap-[5px] pr-2 text-left text-[12px] transition-colors
-        ${isSelected ? 'bg-blue-500/[0.12] text-gray-100' : 'hover:bg-white/[0.05] text-gray-400'}`}
+      className={`group relative w-full flex items-center gap-[5px] pr-2 text-left text-[13.5px] transition-colors
+        ${isSelected ? 'bg-white/[0.10] text-gray-100' : 'hover:bg-white/[0.05] text-gray-400'}`}
       style={{ height: ROW_HEIGHT, paddingLeft: `${BASE_LEFT + depth * INDENT_WIDTH + 16}px` }}
     >
       {guides}
@@ -374,7 +374,7 @@ function LineRow({
 }) {
   return (
     <div ref={rowRef} className="flex select-text hover:bg-white/[0.02]">
-      <span className="w-[40px] shrink-0 text-right pr-3 text-[11px] text-gray-600 select-none">
+      <span className="w-[44px] shrink-0 text-right pr-3 text-[12px] text-gray-600 select-none">
         {lineNum}
       </span>
       {children}
@@ -515,7 +515,7 @@ function ReadView({
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <pre className="text-[12px] leading-[1.6] font-mono">
+      <pre className="text-[13px] leading-[1.65] font-mono">
         {renderedLines}
         {capped && (
           <div className="px-3 py-2 text-[11px] text-gray-600 italic">
@@ -548,7 +548,7 @@ function EditView({
   return (
     <div className="flex-1 overflow-auto flex">
       <pre
-        className="select-none text-right pr-3 pl-2 py-1 text-[11px] leading-[1.6] font-mono text-gray-600 shrink-0"
+        className="select-none text-right pr-3 pl-2 py-1 text-[12px] leading-[1.65] font-mono text-gray-600 shrink-0"
         aria-hidden="true"
       >
         {gutter}
@@ -563,7 +563,7 @@ function EditView({
           }
         }}
         spellCheck={false}
-        className="flex-1 bg-transparent text-gray-200 text-[12px] leading-[1.6] font-mono outline-none resize-none whitespace-pre py-1 pr-3"
+        className="flex-1 bg-transparent text-gray-200 text-[13px] leading-[1.65] font-mono outline-none resize-none whitespace-pre py-1 pr-3"
         style={{ minHeight: '100%' }}
       />
     </div>
@@ -777,7 +777,7 @@ function FilePanel({
               }
             }}
             placeholder="Find in file"
-            className="flex-1 bg-transparent text-gray-200 outline-none text-[12px] font-mono"
+            className="flex-1 bg-transparent text-gray-200 outline-none text-[13px] font-mono"
           />
           <span className="text-gray-500 shrink-0 tabular-nums">
             {findCount === 0 ? '0/0' : `${findIdx + 1}/${findCount}`}
@@ -817,7 +817,7 @@ function FilePanel({
           <Loader2 size={16} className="text-gray-500 animate-spin" />
         </div>
       ) : isBinary ? (
-        <div className="flex-1 flex items-center justify-center text-gray-600 text-[12px]">
+        <div className="flex-1 flex items-center justify-center text-gray-600 text-[13px]">
           Binary file — preview unavailable
         </div>
       ) : editing ? (
@@ -945,8 +945,10 @@ function FilesPanel({
         onDoubleClick={onHeaderDoubleClick}
         data-testid={headerTestId}
       >
-        <div className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1 rounded-md bg-white/[0.04] focus-within:bg-white/[0.06]">
-          <Search size={12} className="text-gray-600 shrink-0" />
+        {/* A search field has to read as somewhere you can type before anything
+            is in it; at 4% over a near-black pane it was very nearly the pane. */}
+        <div className="flex items-center gap-1.5 flex-1 min-w-0 px-2 py-1 rounded-md bg-white/[0.09] focus-within:bg-white/[0.13] transition-colors">
+          <Search size={13} className="text-gray-600 shrink-0" />
           <input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
@@ -954,7 +956,7 @@ function FilesPanel({
               if (e.key === 'Escape') setFilter('')
             }}
             placeholder="Filter files…"
-            className="flex-1 bg-transparent text-gray-200 outline-none text-[12px] placeholder:text-gray-600"
+            className="flex-1 bg-transparent text-gray-200 outline-none text-[13px] placeholder:text-gray-600"
           />
           {filter && (
             <button

--- a/src/renderer/components/FilesCard.tsx
+++ b/src/renderer/components/FilesCard.tsx
@@ -1,7 +1,7 @@
 import { memo, forwardRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
-import { PaneCard, PaneControls } from './PaneCard'
+import { PaneCard } from './PaneCard'
 import { FileTreePane } from './FileTreeExplorer'
 import { filesPaneId } from '../lib/pane-id'
 import { confirmDiscard } from '../lib/editor-dirty'
@@ -42,6 +42,7 @@ export const FilesCard = memo(
 
     const paneId = filesPaneId(sessionId)
     const handleClose = (): void => closeFilesPane(sessionId)
+    // Used by the filter row: double-clicking it still maximizes.
     const toggleMaximize = (): void => {
       const state = useAppStore.getState()
       state.setMaximizedPane(state.maximizedPaneId === paneId ? null : paneId)
@@ -56,23 +57,15 @@ export const FilesCard = memo(
         isDragTarget={isDragTarget}
         onDragStart={onDragStart}
         flexible={flexible}
-        // The filter row is already a full-width bar; a title row above it
-        // would be chrome on chrome, so the controls sit in the filter row.
-        headerless
       >
+        {/* The pane keeps its own title row. Folding the controls into the
+            filter made that field the title bar: full width, buttons reading as
+            part of the input. */}
         <FileTreePane
           key={cwd}
           cwd={cwd}
           remoteHostId={remoteHostId}
           selectedFile={selectedFile}
-          controls={
-            <PaneControls
-              paneId={paneId}
-              title="Files"
-              onClose={handleClose}
-              className="shrink-0"
-            />
-          }
           headerClassName={
             onDragStart || flexible ? 'drag-handle cursor-grab active:cursor-grabbing' : ''
           }

--- a/src/renderer/components/FilesCard.tsx
+++ b/src/renderer/components/FilesCard.tsx
@@ -42,11 +42,6 @@ export const FilesCard = memo(
 
     const paneId = filesPaneId(sessionId)
     const handleClose = (): void => closeFilesPane(sessionId)
-    // Used by the filter row: double-clicking it still maximizes.
-    const toggleMaximize = (): void => {
-      const state = useAppStore.getState()
-      state.setMaximizedPane(state.maximizedPaneId === paneId ? null : paneId)
-    }
 
     return (
       <PaneCard
@@ -60,17 +55,13 @@ export const FilesCard = memo(
       >
         {/* The pane keeps its own title row. Folding the controls into the
             filter made that field the title bar: full width, buttons reading as
-            part of the input. */}
+            part of the input. Drag and double-click-to-maximize live on that
+            title row now, so the filter row carries neither. */}
         <FileTreePane
           key={cwd}
           cwd={cwd}
           remoteHostId={remoteHostId}
           selectedFile={selectedFile}
-          headerClassName={
-            onDragStart || flexible ? 'drag-handle cursor-grab active:cursor-grabbing' : ''
-          }
-          onHeaderPointerDown={onDragStart ? (e) => onDragStart(paneId, e) : undefined}
-          onHeaderDoubleClick={toggleMaximize}
           headerTestId="files-pane-header"
           onSelectFile={(path) => {
             // Swapping the editor's file discards its buffer — confirm first.

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -118,7 +118,7 @@ export function FocusedTerminal() {
             : 'flex-1 flex flex-col min-h-0 overflow-hidden'
         }
         style={{
-          background: '#1a1a1e',
+          background: 'var(--color-surface-raised)',
           ...(isMobile ? { paddingTop: 'var(--safe-top, 0px)' } : {})
         }}
         {...(isMobile
@@ -182,13 +182,17 @@ export function FocusedTerminal() {
               {terminal.session.branch && (
                 <span className="flex items-center gap-1 mt-0.5">
                   {terminal.session.isWorktree ? (
-                    <FolderGit2 size={11} className="text-amber-500 shrink-0" strokeWidth={1.5} />
+                    <FolderGit2
+                      size={11}
+                      className="text-ink-secondary shrink-0"
+                      strokeWidth={1.5}
+                    />
                   ) : (
                     <GitBranch size={11} className="text-gray-600 shrink-0" strokeWidth={1.5} />
                   )}
                   <span
                     className={`text-[11px] font-mono truncate ${
-                      terminal.session.isWorktree ? 'text-amber-400' : 'text-gray-500'
+                      terminal.session.isWorktree ? 'text-ink-secondary' : 'text-gray-500'
                     }`}
                   >
                     {getBranchLabel(terminal.session)}
@@ -205,17 +209,7 @@ export function FocusedTerminal() {
               )}
             </div>
           </div>
-        ) : (
-          <div
-            className={`group/card ${isMac ? 'titlebar-drag' : 'titlebar-no-drag'}`}
-            onDoubleClick={(e) => {
-              if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
-              handleContract()
-            }}
-          >
-            <CardHeader terminalId={effectiveId} variant="focused" />
-          </div>
-        )}
+        ) : null}
 
         {/* Terminal, plus this session's file panes riding along beside it. */}
         <div className="flex-1 min-h-0 flex">
@@ -223,10 +217,24 @@ export function FocusedTerminal() {
             data-testid="focused-terminal-column"
             className={`flex-1 min-w-0 flex-col ${hasMaximizedPane ? 'hidden' : 'flex'}`}
           >
+            {/* The session's header sits in its own column rather than spanning
+                the stage, so the panes beside it keep the full height. */}
+            {!isMobile && (
+              <div
+                className={`group/card shrink-0 ${isMac ? 'titlebar-drag' : 'titlebar-no-drag'}`}
+                onDoubleClick={(e) => {
+                  if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
+                  handleContract()
+                }}
+              >
+                <CardHeader terminalId={effectiveId} variant="focused" />
+              </div>
+            )}
+
             <div
               ref={terminalContainerRef}
               className="relative flex-1 p-1 min-h-0"
-              style={{ background: 'rgba(0, 0, 0, 0.3)' }}
+              style={{ background: 'var(--color-surface-sunken)' }}
             >
               <TerminalPane
                 terminalId={effectiveId}

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -98,6 +98,23 @@ export function FocusedTerminal() {
     }
   }
 
+  // Normally this rides inside the terminal column so the panes keep the full
+  // height. A maximized pane collapses that column, and on macOS this wrapper is
+  // the window's only drag region while a session is expanded (App.tsx drops the
+  // app titlebar then) — losing it would leave the window undraggable, with no
+  // Collapse button either. So in that one state it spans the stage.
+  const desktopHeader = !isMobile && (
+    <div
+      className={`group/card shrink-0 ${isMac ? 'titlebar-drag' : 'titlebar-no-drag'}`}
+      onDoubleClick={(e) => {
+        if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
+        handleContract()
+      }}
+    >
+      <CardHeader terminalId={effectiveId} variant="focused" />
+    </div>
+  )
+
   return (
     <>
       {/* Backdrop — mobile only */}
@@ -211,25 +228,15 @@ export function FocusedTerminal() {
           </div>
         ) : null}
 
+        {hasMaximizedPane && desktopHeader}
+
         {/* Terminal, plus this session's file panes riding along beside it. */}
         <div className="flex-1 min-h-0 flex">
           <div
             data-testid="focused-terminal-column"
             className={`flex-1 min-w-0 flex-col ${hasMaximizedPane ? 'hidden' : 'flex'}`}
           >
-            {/* The session's header sits in its own column rather than spanning
-                the stage, so the panes beside it keep the full height. */}
-            {!isMobile && (
-              <div
-                className={`group/card shrink-0 ${isMac ? 'titlebar-drag' : 'titlebar-no-drag'}`}
-                onDoubleClick={(e) => {
-                  if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
-                  handleContract()
-                }}
-              >
-                <CardHeader terminalId={effectiveId} variant="focused" />
-              </div>
-            )}
+            {!hasMaximizedPane && desktopHeader}
 
             <div
               ref={terminalContainerRef}

--- a/src/renderer/components/GitChangesIndicator.tsx
+++ b/src/renderer/components/GitChangesIndicator.tsx
@@ -24,8 +24,9 @@ export function GitChangesIndicator({ terminalId }: Props) {
                  hover:bg-white/[0.06] rounded transition-colors cursor-pointer"
       title={`${stat.filesChanged} file${stat.filesChanged !== 1 ? 's' : ''} changed`}
     >
-      <span className="text-green-400">+{stat.insertions}</span>
-      <span className="text-red-400">-{stat.deletions}</span>
+      {/* A measurement, not a verdict — a large deletion is not a failure. */}
+      <span className="text-ink-secondary">+{stat.insertions}</span>
+      <span className="text-ink-faint">-{stat.deletions}</span>
     </button>
   )
 }

--- a/src/renderer/components/GridToolbar.tsx
+++ b/src/renderer/components/GridToolbar.tsx
@@ -119,7 +119,7 @@ export function GridToolbar() {
         >
           <SlidersHorizontal size={16} strokeWidth={1.5} />
           {hasActiveFilters && !open && (
-            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-ink-secondary" />
           )}
         </button>
       </Tooltip>

--- a/src/renderer/components/GridView.tsx
+++ b/src/renderer/components/GridView.tsx
@@ -495,12 +495,12 @@ function GridDragGhost({
           {session.branch && (
             <div className="flex items-center gap-1 mt-0.5">
               {session.isWorktree ? (
-                <FolderGit2 size={10} className="text-amber-500 shrink-0" strokeWidth={1.5} />
+                <FolderGit2 size={10} className="text-ink-secondary shrink-0" strokeWidth={1.5} />
               ) : (
                 <GitBranch size={10} className="text-gray-600 shrink-0" strokeWidth={1.5} />
               )}
               <span
-                className={`text-[10px] font-mono truncate ${session.isWorktree ? 'text-amber-400' : 'text-gray-500'}`}
+                className={`text-[10px] font-mono truncate ${session.isWorktree ? 'text-ink-secondary' : 'text-gray-500'}`}
               >
                 {getBranchLabel(session)}
               </span>

--- a/src/renderer/components/MainViewPills.tsx
+++ b/src/renderer/components/MainViewPills.tsx
@@ -53,7 +53,7 @@ export function MainViewPills() {
               aria-hidden
               className="absolute -top-0.5 -right-0.5 min-w-[12px] h-[12px] px-[3px]
                          flex items-center justify-center
-                         rounded-full bg-amber-400 text-[#1a1a1e]
+                         rounded-full bg-bronzo text-surface-base
                          text-[9px] font-mono leading-none tabular-nums"
             >
               {waitingCount > 9 ? '9+' : waitingCount}

--- a/src/renderer/components/MinimizedPill.tsx
+++ b/src/renderer/components/MinimizedPill.tsx
@@ -47,7 +47,7 @@ export function MinimizedPill({ terminalId }: { terminalId: string }) {
           <span className="text-[10px] text-gray-600 shrink-0">&middot;</span>
           <span className="flex items-center gap-0.5 text-[10px] font-mono text-gray-500 truncate max-w-[90px]">
             {session.isWorktree ? (
-              <FolderGit2 size={9} strokeWidth={1.5} className="text-amber-400/70 shrink-0" />
+              <FolderGit2 size={9} strokeWidth={1.5} className="text-ink-faint shrink-0" />
             ) : (
               <GitBranch size={9} strokeWidth={1.5} className="shrink-0" />
             )}

--- a/src/renderer/components/MinimizedPill.tsx
+++ b/src/renderer/components/MinimizedPill.tsx
@@ -21,7 +21,7 @@ export function MinimizedPill({ terminalId }: { terminalId: string }) {
   return (
     <button
       type="button"
-      className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] bg-[#1a1a1e]
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.06] bg-surface-raised
                  px-2.5 py-1 cursor-pointer transition-[border-color] select-none
                  hover:border-white/[0.12]"
       onClick={() => {

--- a/src/renderer/components/PaneCard.tsx
+++ b/src/renderer/components/PaneCard.tsx
@@ -10,9 +10,6 @@ export interface PaneCardProps {
   /** This pane's id — `files:<sessionId>` or `editor:<sessionId>`. */
   paneId: string
   title: string
-  /** Secondary line under the title, e.g. a relative file path. */
-  subtitle?: string
-  icon?: ReactNode
   onClose: () => void
   children: ReactNode
   isDragTarget?: boolean
@@ -24,8 +21,6 @@ export interface PaneCardProps {
    * chrome-on-chrome. Such a pane renders `PaneControls` inside its own bar.
    */
   headerless?: boolean
-  /** Card background. Defaults to the shared pane surface. */
-  background?: string
 }
 
 /**
@@ -92,19 +87,7 @@ export function PaneControls({
  * the pane its owner session's whole footprint, leaving other sessions alone.
  */
 export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneCard(
-  {
-    paneId,
-    title,
-    subtitle,
-    icon,
-    onClose,
-    children,
-    isDragTarget,
-    onDragStart,
-    flexible,
-    headerless,
-    background
-  },
+  { paneId, title, onClose, children, isDragTarget, onDragStart, flexible, headerless },
   ref
 ) {
   const { isMaximized, setMaximizedPane } = useAppStore(
@@ -123,11 +106,11 @@ export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneC
       ref={ref}
       // Square and borderless, filling the card. The step down to PANE_SURFACE
       // is the whole separation — see that module for why.
-      className={`group/card relative overflow-hidden flex flex-col h-full
+      className={`relative overflow-hidden flex flex-col h-full
                  transition-shadow
                  ${isDragTarget ? 'card-drop-target' : ''}
                  ${flexible ? '' : 'hover:z-10 focus-within:z-10'}`}
-      style={{ background: background ?? PANE_SURFACE }}
+      style={{ background: PANE_SURFACE }}
     >
       {!headerless && (
         <div
@@ -135,28 +118,15 @@ export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneC
                     ${onDragStart || flexible ? 'drag-handle cursor-grab active:cursor-grabbing' : ''}`}
           onPointerDown={onDragStart ? handleDragStart : undefined}
           onDoubleClick={() => setMaximizedPane(isMaximized ? null : paneId)}
+          data-testid={`pane-header-${paneId}`}
         >
-          {icon}
           <span className="text-[12px] text-gray-300 font-medium shrink-0">{title}</span>
-          {subtitle && (
-            <span
-              className="text-[11px] text-gray-500 font-mono flex-1 min-w-0 truncate"
-              title={subtitle}
-              dir="rtl"
-            >
-              {subtitle}
-            </span>
-          )}
-          {!subtitle && <span className="flex-1" />}
-
+          <span className="flex-1" />
           <PaneControls paneId={paneId} title={title} onClose={onClose} />
         </div>
       )}
 
-      <div
-        className="flex-1 min-h-0 flex flex-col"
-        style={{ background: background ?? PANE_SURFACE }}
-      >
+      <div className="flex-1 min-h-0 flex flex-col" style={{ background: PANE_SURFACE }}>
         {children}
       </div>
     </div>

--- a/src/renderer/components/PaneCard.tsx
+++ b/src/renderer/components/PaneCard.tsx
@@ -4,13 +4,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
 import { Tooltip } from './Tooltip'
 import { PANE_SURFACE } from '../lib/pane-surface'
-
-// On touch devices, always show action buttons (no hover available). Evaluated
-// lazily rather than at module load so importing this file stays safe in
-// environments without matchMedia (jsdom tests, SSR).
-function isTouchDevice(): boolean {
-  return typeof window !== 'undefined' && window.matchMedia?.('(hover: none)').matches === true
-}
+import { ICON_BUTTON, ICON_BUTTON_SIZE } from '../lib/icon-button'
 
 export interface PaneCardProps {
   /** This pane's id — `files:<sessionId>` or `editor:<sessionId>`. */
@@ -62,28 +56,26 @@ export function PaneControls({
     }))
   )
 
+  // Always visible, never hover-revealed: hidden until the pointer arrives, a
+  // panel reads as having no controls at all.
   return (
-    <div
-      className={`flex items-center gap-0.5 transition-opacity ${
-        isTouchDevice() ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100'
-      } ${className}`}
-    >
+    <div className={`flex items-center gap-0.5 ${className}`}>
       <Tooltip label={isMaximized ? 'Restore' : 'Maximize'}>
         <button
           onClick={() => setMaximizedPane(isMaximized ? null : paneId)}
-          className="text-gray-500 hover:text-white p-0.5 rounded transition-colors"
+          className={ICON_BUTTON}
           aria-label={isMaximized ? `Restore ${title}` : `Maximize ${title}`}
         >
-          {isMaximized ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+          {isMaximized ? (
+            <Minimize2 size={ICON_BUTTON_SIZE} />
+          ) : (
+            <Maximize2 size={ICON_BUTTON_SIZE} />
+          )}
         </button>
       </Tooltip>
       <Tooltip label="Close">
-        <button
-          onClick={onClose}
-          className="text-gray-500 hover:text-white p-0.5 rounded transition-colors"
-          aria-label={`Close ${title}`}
-        >
-          <X size={12} strokeWidth={2} />
+        <button onClick={onClose} className={ICON_BUTTON} aria-label={`Close ${title}`}>
+          <X size={ICON_BUTTON_SIZE} strokeWidth={2} />
         </button>
       </Tooltip>
     </div>
@@ -129,12 +121,11 @@ export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneC
   return (
     <div
       ref={ref}
-      className={`group/card relative border overflow-hidden flex flex-col h-full transition-colors
-                 ${
-                   isDragTarget
-                     ? 'card-drop-target border-blue-500/30 hover:border-white/[0.12]'
-                     : 'border-white/[0.06] hover:border-white/[0.12]'
-                 }
+      // Square and borderless, filling the card. The step down to PANE_SURFACE
+      // is the whole separation — see that module for why.
+      className={`group/card relative overflow-hidden flex flex-col h-full
+                 transition-shadow
+                 ${isDragTarget ? 'card-drop-target' : ''}
                  ${flexible ? '' : 'hover:z-10 focus-within:z-10'}`}
       style={{ background: background ?? PANE_SURFACE }}
     >
@@ -146,10 +137,10 @@ export const PaneCard = forwardRef<HTMLDivElement, PaneCardProps>(function PaneC
           onDoubleClick={() => setMaximizedPane(isMaximized ? null : paneId)}
         >
           {icon}
-          <span className="text-[11px] text-gray-300 font-medium shrink-0">{title}</span>
+          <span className="text-[12px] text-gray-300 font-medium shrink-0">{title}</span>
           {subtitle && (
             <span
-              className="text-[10px] text-gray-500 font-mono flex-1 min-w-0 truncate"
+              className="text-[11px] text-gray-500 font-mono flex-1 min-w-0 truncate"
               title={subtitle}
               dir="rtl"
             >

--- a/src/renderer/components/PaneColumn.tsx
+++ b/src/renderer/components/PaneColumn.tsx
@@ -73,7 +73,9 @@ export function PaneColumn({ sessionId }: { sessionId: string }): ReactNode {
   return (
     // No grow factor of its own: the frame around it (card body or tab rail)
     // owns the sizing, and a `flex-1` here would fight the terminal's stored
-    // ratio — two grow factors that no longer sum to 1.
+    // ratio — two grow factors that no longer sum to 1. No padding either: the
+    // panes take the card's full height, and the step down in surface separates
+    // them, where insetting framed the panel and cost height.
     <div ref={containerRef} className="relative flex flex-col min-h-0 min-w-0 w-full gap-px">
       {kinds.map((kind, i) => {
         const hidden = hasMaximized && kind !== maximizedKind

--- a/src/renderer/components/PromptLauncher.tsx
+++ b/src/renderer/components/PromptLauncher.tsx
@@ -219,7 +219,10 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
           <ChevronDown size={10} />
         </button>
         {showProjectPicker && (
-          <div className="absolute bottom-full left-0 mb-1" style={{ background: '#1e1e22' }}>
+          <div
+            className="absolute bottom-full left-0 mb-1"
+            style={{ background: 'var(--color-surface-overlay)' }}
+          >
             <div
               className="border border-white/[0.08] rounded-lg shadow-xl z-20 py-1
                             min-w-[240px] max-h-[280px] overflow-y-auto"
@@ -270,7 +273,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
           <div
             className="absolute bottom-full left-0 mb-1 border border-white/[0.08]
                           rounded-lg shadow-xl z-20 py-1 min-w-[160px]"
-            style={{ background: '#1e1e22' }}
+            style={{ background: 'var(--color-surface-overlay)' }}
           >
             {AGENT_LIST.map((agent) => {
               const installed = installStatus[agent.type]
@@ -329,7 +332,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
             <div
               className="absolute bottom-full left-0 mb-1 border border-white/[0.08]
                             rounded-lg shadow-xl z-20 min-w-[240px] max-h-[280px] overflow-y-auto py-1"
-              style={{ background: '#1e1e22' }}
+              style={{ background: 'var(--color-surface-overlay)' }}
             >
               {/* Project root */}
               <button
@@ -441,7 +444,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
           {settings.branchWarning && (
             <div
               className="absolute bottom-full left-0 mb-8 px-3 py-1.5 rounded-md
-                            bg-amber-500/10 border border-amber-500/20 text-amber-400 text-[10px]
+                            bg-surface-overlay border border-white/[0.08] text-ink-secondary text-[10px]
                             whitespace-nowrap z-30"
             >
               {settings.branchWarning}
@@ -459,7 +462,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
         disabled={!canLaunch || launching}
         className={`p-1.5 rounded-full transition-colors ${
           canLaunch
-            ? 'bg-bronzo hover:bg-bronzo-dark text-black cursor-pointer'
+            ? 'bg-ink hover:bg-white text-surface-base cursor-pointer'
             : 'bg-white/[0.06] text-gray-600 cursor-not-allowed'
         }`}
         title="Launch (Enter)"
@@ -472,10 +475,10 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
   // --- Prompt input block (shared between inline and overlay) ---
   const promptInput = (
     <div className="w-full">
-      <div
-        className="relative rounded-xl border border-white/[0.1] bg-[#232326]
-                      focus-within:border-white/[0.18] transition-colors"
-      >
+      {/* No focus treatment on purpose: this box is auto-focused the moment the
+          empty state mounts, so focus-within is not a state change — it is just
+          how the box always looks. */}
+      <div className="relative rounded-xl border border-white/[0.06] bg-surface-raised">
         <textarea
           ref={textareaRef}
           value={prompt}
@@ -496,7 +499,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
         </p>
       ) : (
         <p className="text-[11px] text-gray-600 mt-2 text-center flex items-center justify-center gap-1.5">
-          <Lightbulb size={11} className="text-yellow-500/60 shrink-0" />
+          <Lightbulb size={11} className="text-ink-faint shrink-0" />
           {tip.shortcut && (
             <kbd className="px-1 py-0.5 rounded bg-white/[0.06] text-gray-500 font-mono text-[10px]">
               {tip.shortcut}
@@ -535,7 +538,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
           <motion.div
             className="fixed top-1/2 left-1/2 z-50 w-[92%] sm:w-[80%] max-w-[800px] border border-white/[0.08]
                        rounded-xl shadow-2xl p-4 sm:p-6"
-            style={{ background: '#1e1e22' }}
+            style={{ background: 'var(--color-surface-overlay)' }}
             initial={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}
             animate={{ opacity: 1, scale: 1, x: '-50%', y: '-50%' }}
             exit={{ opacity: 0, scale: 0.95, x: '-50%', y: '-50%' }}

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -297,7 +297,7 @@ export function RightPanel() {
             <button
               onClick={handleSendFeedback}
               className="flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium
-                         bg-blue-500/20 hover:bg-white/[0.14] border border-blue-500/20
+                         bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/20
                          rounded-md transition-colors text-blue-300 hover:text-blue-200"
             >
               <Send size={11} strokeWidth={2} />

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -172,7 +172,7 @@ export function RightPanel() {
       >
         {/* Resize handle */}
         <div
-          className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-blue-500/30 transition-colors z-10"
+          className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-white/[0.14] transition-colors z-10"
           onPointerDown={handleResizeStart}
         />
 
@@ -297,7 +297,7 @@ export function RightPanel() {
             <button
               onClick={handleSendFeedback}
               className="flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium
-                         bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/20
+                         bg-blue-500/20 hover:bg-white/[0.14] border border-blue-500/20
                          rounded-md transition-colors text-blue-300 hover:text-blue-200"
             >
               <Send size={11} strokeWidth={2} />

--- a/src/renderer/components/SessionDock.tsx
+++ b/src/renderer/components/SessionDock.tsx
@@ -69,7 +69,7 @@ export function SessionDock({ includeMinimized }: Props) {
             type="button"
             onClick={() => setPopoverOpen((v) => !v)}
             className="inline-flex items-center gap-1.5 h-[26px] px-2
-                       rounded-md border border-white/[0.06] bg-[#1a1a1e]
+                       rounded-md border border-white/[0.06] bg-surface-raised
                        text-[11px] font-medium text-gray-300
                        hover:text-white hover:border-white/[0.12] transition-colors
                        relative"
@@ -141,7 +141,7 @@ export function SessionDock({ includeMinimized }: Props) {
               type="button"
               onClick={() => setPopoverOpen((v) => !v)}
               className="inline-flex items-center justify-center h-[26px] min-w-[28px] px-1.5
-                         rounded-md border border-white/[0.06] bg-[#1a1a1e]
+                         rounded-md border border-white/[0.06] bg-surface-raised
                          text-[11px] font-medium text-gray-400
                          hover:text-white hover:border-white/[0.12] transition-colors"
               aria-haspopup="dialog"
@@ -229,7 +229,7 @@ function DockGroupedPopover({
       onClick={onClose}
       className={`absolute top-full ${align === 'left' ? 'left-0' : 'right-0'} mt-1.5 z-50 p-1.5
                  flex flex-col gap-2 max-h-[60vh] overflow-y-auto min-w-[240px]
-                 bg-[#1a1a1e] border border-white/[0.08] rounded-md shadow-lg`}
+                 bg-surface-raised border border-white/[0.08] rounded-md shadow-lg`}
     >
       {footer && (
         <div

--- a/src/renderer/components/SessionDock.tsx
+++ b/src/renderer/components/SessionDock.tsx
@@ -82,7 +82,7 @@ export function SessionDock({ includeMinimized }: Props) {
             {waitingApprovals.length > 0 && (
               <span
                 aria-hidden="true"
-                className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-amber-400"
+                className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-bronzo"
               />
             )}
           </button>
@@ -244,7 +244,7 @@ function DockGroupedPopover({
           {groups.length > 1 && (
             <span
               className={`px-1 text-[9px] font-medium uppercase tracking-wider ${
-                group.kind === 'waiting' ? 'text-amber-400/70' : 'text-gray-500'
+                group.kind === 'waiting' ? 'text-ink-secondary' : 'text-gray-500'
               }`}
             >
               {KIND_LABEL[group.kind]}

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -67,7 +67,7 @@ function getHorizontalDropIndex(
 }
 
 const TAB_ICON_BTN =
-  'w-5 h-5 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-gray-500'
+  'w-5 h-5 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-gray-200'
 
 export function TabIconButton({
   label,
@@ -457,7 +457,7 @@ export function TabView() {
                 )
               }}
               className="h-[36px] w-[28px] flex items-center justify-center rounded-md
-                         text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
+                         text-gray-200 hover:text-white hover:bg-white/[0.10] transition-colors"
               title="New session"
               aria-label="New session"
             >
@@ -480,7 +480,7 @@ export function TabView() {
                 })
               }}
               className="h-[36px] w-[22px] flex items-center justify-center rounded-md
-                         text-gray-500 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
+                         text-gray-200 hover:text-white hover:bg-white/[0.10] transition-colors"
               title="More session options"
               aria-label="More session options"
             >

--- a/src/renderer/components/TaskDetailPanel.tsx
+++ b/src/renderer/components/TaskDetailPanel.tsx
@@ -595,7 +595,7 @@ export function TaskDetailPanel() {
     >
       {/* Resize handle */}
       <div
-        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-blue-500/30 transition-colors z-10"
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-white/[0.14] transition-colors z-10"
         style={{ position: 'relative', width: 2, minWidth: 2 }}
         onPointerDown={handleResizeStart}
       />

--- a/src/renderer/components/TaskToolbar.tsx
+++ b/src/renderer/components/TaskToolbar.tsx
@@ -125,7 +125,7 @@ export function TaskToolbar() {
         >
           <SlidersHorizontal size={16} strokeWidth={1.5} />
           {hasActiveFilters && !open && (
-            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-ink-secondary" />
           )}
         </button>
       </Tooltip>

--- a/src/renderer/components/WaitingApprovalPill.tsx
+++ b/src/renderer/components/WaitingApprovalPill.tsx
@@ -61,12 +61,12 @@ export function WaitingApprovalPill({ execution, nodeState, workflow }: Props) {
       onClick={handleOpen}
       className="inline-flex items-center gap-1.5 rounded-md border bg-[#1a1a1e] px-2.5 py-1
                  cursor-pointer transition-colors select-none
-                 border-amber-500/30 hover:border-amber-500/50"
+                 border-bronzo/40 hover:border-bronzo/70"
     >
       <div className="relative flex-shrink-0">
-        <div className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+        <div className="w-1.5 h-1.5 rounded-full bg-bronzo" />
         <div
-          className="absolute inset-[-1px] rounded-full bg-amber-400 opacity-40 animate-ping"
+          className="absolute inset-[-1px] rounded-full bg-bronzo opacity-40 animate-ping"
           style={{ animationDuration: '2s' }}
         />
       </div>
@@ -89,7 +89,7 @@ export function WaitingApprovalPill({ execution, nodeState, workflow }: Props) {
           <button
             onClick={handleApprove}
             aria-label="Approve"
-            className="p-0.5 rounded text-green-400 hover:text-green-300 hover:bg-green-500/10 transition-colors"
+            className="p-0.5 rounded text-ink-secondary hover:text-ink hover:bg-white/[0.08] transition-colors"
           >
             <Check size={12} strokeWidth={2.5} />
           </button>
@@ -98,7 +98,7 @@ export function WaitingApprovalPill({ execution, nodeState, workflow }: Props) {
           <button
             onClick={handleReject}
             aria-label="Reject"
-            className="p-0.5 rounded text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors"
+            className="p-0.5 rounded text-ink-faint hover:text-danger hover:bg-danger/10 transition-colors"
           >
             <X size={12} strokeWidth={2.5} />
           </button>

--- a/src/renderer/components/WaitingApprovalPill.tsx
+++ b/src/renderer/components/WaitingApprovalPill.tsx
@@ -59,7 +59,7 @@ export function WaitingApprovalPill({ execution, nodeState, workflow }: Props) {
   return (
     <div
       onClick={handleOpen}
-      className="inline-flex items-center gap-1.5 rounded-md border bg-[#1a1a1e] px-2.5 py-1
+      className="inline-flex items-center gap-1.5 rounded-md border bg-surface-raised px-2.5 py-1
                  cursor-pointer transition-colors select-none
                  border-bronzo/40 hover:border-bronzo/70"
     >

--- a/src/renderer/components/card/BranchChip.tsx
+++ b/src/renderer/components/card/BranchChip.tsx
@@ -48,10 +48,13 @@ export function BranchChip({ terminalId, size = 'sm' }: Props) {
       } ${isSwitching ? 'opacity-50' : ''}`}
       aria-label={`Switch branch (current: ${branchName})`}
     >
+      {/* Worth noticing — it explains why a command ran somewhere other than
+          where you think — but noticing is not being blocked, so it earns
+          brightness rather than the accent. */}
       {isWorktree && worktreeName && (
         <>
-          <FolderGit2 size={iconSize} className="text-amber-400 shrink-0" strokeWidth={1.5} />
-          <span className={`font-mono text-amber-400 truncate ${textSize} ${maxWidth}`}>
+          <FolderGit2 size={iconSize} className="text-ink-secondary shrink-0" strokeWidth={1.5} />
+          <span className={`font-mono text-ink-secondary truncate ${textSize} ${maxWidth}`}>
             {worktreeName}
           </span>
           <span className="text-gray-600 shrink-0">·</span>

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -193,7 +193,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             // could start a second, concurrent claim on a different device,
             // leaving the pane labelled one simulator while driving another.
             disabled={claiming}
-            className={` ${claiming ? 'opacity-50 cursor-wait' : ''}`}
+            className={`${ICON_BUTTON} ${claiming ? 'opacity-50 cursor-wait' : ''}`}
             aria-busy={claiming}
             aria-label={hasDevicePane ? 'Hide device' : claiming ? 'Opening device' : 'Open device'}
           >

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -12,6 +12,7 @@ import {
 import { useState, useRef, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../stores'
+import { ICON_BUTTON } from '../../lib/icon-button'
 import { Tooltip } from '../Tooltip'
 import { ConfirmPopover } from '../ConfirmPopover'
 import { CardContextMenu } from '../CardContextMenu'
@@ -124,7 +125,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
   // tooltips get clipped off-screen. Drop them below the buttons instead.
   const tooltipPos = isFocused ? 'bottom' : 'top'
 
-  const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
+  const btn = ICON_BUTTON
 
   const showDevice = shouldShowDeviceButton(
     mobileProjectCache.get(terminal.session.projectPath),
@@ -265,7 +266,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           <button
             type="button"
             onPointerDown={(e) => e.stopPropagation()}
-            className="p-1 rounded text-gray-500 hover:text-red-400 hover:bg-white/[0.08] transition-colors"
+            className="p-1 rounded text-gray-500 hover:text-danger hover:bg-white/[0.08] transition-colors"
             aria-label="Close session"
           >
             <X size={14} strokeWidth={2} />

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -12,7 +12,7 @@ import {
 import { useState, useRef, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../stores'
-import { ICON_BUTTON } from '../../lib/icon-button'
+import { ICON_BUTTON, ICON_BUTTON_DANGER, ICON_BUTTON_SIZE } from '../../lib/icon-button'
 import { Tooltip } from '../Tooltip'
 import { ConfirmPopover } from '../ConfirmPopover'
 import { CardContextMenu } from '../CardContextMenu'
@@ -125,8 +125,6 @@ export function CardActionCluster({ terminalId, variant }: Props) {
   // tooltips get clipped off-screen. Drop them below the buttons instead.
   const tooltipPos = isFocused ? 'bottom' : 'top'
 
-  const btn = ICON_BUTTON
-
   const showDevice = shouldShowDeviceButton(
     mobileProjectCache.get(terminal.session.projectPath),
     hasDevicePane
@@ -140,10 +138,10 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           type="button"
           onClick={handleMore}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label="More actions"
         >
-          <MoreHorizontal size={14} strokeWidth={2} />
+          <MoreHorizontal size={ICON_BUTTON_SIZE} strokeWidth={2} />
         </button>
       </Tooltip>
 
@@ -152,10 +150,10 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           type="button"
           onClick={handleBrowseFiles}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label="Browse files"
         >
-          <FolderOpen size={14} strokeWidth={2} />
+          <FolderOpen size={ICON_BUTTON_SIZE} strokeWidth={2} />
         </button>
       </Tooltip>
 
@@ -164,10 +162,10 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           type="button"
           onClick={handleOpenBrowser}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label="Open browser"
         >
-          <Globe size={14} strokeWidth={2} />
+          <Globe size={ICON_BUTTON_SIZE} strokeWidth={2} />
         </button>
       </Tooltip>
 
@@ -195,14 +193,14 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             // could start a second, concurrent claim on a different device,
             // leaving the pane labelled one simulator while driving another.
             disabled={claiming}
-            className={`${btn} ${claiming ? 'opacity-50 cursor-wait' : ''}`}
+            className={` ${claiming ? 'opacity-50 cursor-wait' : ''}`}
             aria-busy={claiming}
             aria-label={hasDevicePane ? 'Hide device' : claiming ? 'Opening device' : 'Open device'}
           >
             {claiming ? (
-              <Loader2 size={14} strokeWidth={2} className="animate-spin" />
+              <Loader2 size={ICON_BUTTON_SIZE} strokeWidth={2} className="animate-spin" />
             ) : (
-              <Smartphone size={14} strokeWidth={2} />
+              <Smartphone size={ICON_BUTTON_SIZE} strokeWidth={2} />
             )}
           </button>
         </Tooltip>
@@ -233,10 +231,10 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             type="button"
             onClick={handleMinimize}
             onPointerDown={(e) => e.stopPropagation()}
-            className={btn}
+            className={ICON_BUTTON}
             aria-label="Minimize session"
           >
-            <Minus size={14} strokeWidth={2} />
+            <Minus size={ICON_BUTTON_SIZE} strokeWidth={2} />
           </button>
         </Tooltip>
       )}
@@ -250,13 +248,13 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           type="button"
           onClick={isFocused ? handleCollapse : handleExpand}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label={isFocused ? 'Collapse session' : 'Expand session'}
         >
           {isFocused ? (
-            <Minimize2 size={14} strokeWidth={2} />
+            <Minimize2 size={ICON_BUTTON_SIZE} strokeWidth={2} />
           ) : (
-            <Maximize2 size={14} strokeWidth={2} />
+            <Maximize2 size={ICON_BUTTON_SIZE} strokeWidth={2} />
           )}
         </button>
       </Tooltip>
@@ -266,10 +264,10 @@ export function CardActionCluster({ terminalId, variant }: Props) {
           <button
             type="button"
             onPointerDown={(e) => e.stopPropagation()}
-            className="p-1 rounded text-gray-500 hover:text-danger hover:bg-white/[0.08] transition-colors"
+            className={ICON_BUTTON_DANGER}
             aria-label="Close session"
           >
-            <X size={14} strokeWidth={2} />
+            <X size={ICON_BUTTON_SIZE} strokeWidth={2} />
           </button>
         </Tooltip>
       </ConfirmPopover>

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -57,7 +57,7 @@ export function CardHeader({
       className={`flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0
                   transition-opacity duration-200 ease-out
                   ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
-      style={{ background: '#141416' }}
+      style={{ background: 'var(--color-surface-panel)' }}
     >
       <div
         className={`flex-1 min-w-0 flex items-center gap-2 ${dragHandleClass}`}

--- a/src/renderer/components/card/CardStatusBar.tsx
+++ b/src/renderer/components/card/CardStatusBar.tsx
@@ -33,7 +33,7 @@ export function CardStatusBar({ terminalId, dimmed }: Props) {
       className={`shrink-0 flex items-center gap-2 px-2 h-[22px] border-t border-white/[0.04] text-[11px]
                   transition-opacity duration-200 ease-out
                   ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
-      style={{ background: '#141416' }}
+      style={{ background: 'var(--color-surface-panel)' }}
     >
       {hasBranch && <BranchChip terminalId={terminalId} />}
 
@@ -46,11 +46,11 @@ export function CardStatusBar({ terminalId, dimmed }: Props) {
             setEditingTask(assignedTask)
             setTaskDialogOpen(true)
           }}
-          className="flex items-center gap-1 px-1.5 py-0.5 rounded-full
-                     bg-violet-500/10 hover:bg-violet-500/20 transition-colors shrink-0"
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-white/[0.08]
+                     hover:bg-white/[0.06] transition-colors shrink-0"
         >
-          <ListTodo size={10} className="text-violet-400 shrink-0" strokeWidth={2} />
-          <span className="text-[10px] text-violet-400 truncate max-w-[140px]">
+          <ListTodo size={10} className="text-ink-faint shrink-0" strokeWidth={2} />
+          <span className="text-[10px] text-ink-secondary truncate max-w-[140px]">
             {assignedTask.title}
           </span>
         </button>

--- a/src/renderer/components/card/FocusedNavHint.tsx
+++ b/src/renderer/components/card/FocusedNavHint.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
 import { MOD } from '../../lib/platform'
+import { ICON_BUTTON } from '../../lib/icon-button'
 
 interface Props {
   terminalId: string
@@ -25,8 +26,6 @@ export function FocusedNavHint({ terminalId }: Props) {
   const prevId = focusableTerminalIds[(index - 1 + total) % total]
   const nextId = focusableTerminalIds[(index + 1) % total]
 
-  const btn = 'p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.08] transition-colors'
-
   return (
     <div className="flex items-center gap-1 shrink-0 pr-1">
       <span className="text-[11px] font-mono text-gray-500 tabular-nums select-none">
@@ -39,7 +38,7 @@ export function FocusedNavHint({ terminalId }: Props) {
           type="button"
           onClick={() => setFocusedTerminal(prevId)}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label="Previous session"
         >
           <ChevronLeft size={14} strokeWidth={2} />
@@ -50,7 +49,7 @@ export function FocusedNavHint({ terminalId }: Props) {
           type="button"
           onClick={() => setFocusedTerminal(nextId)}
           onPointerDown={(e) => e.stopPropagation()}
-          className={btn}
+          className={ICON_BUTTON}
           aria-label="Next session"
         >
           <ChevronRight size={14} strokeWidth={2} />

--- a/src/renderer/components/card/LastCommandChip.tsx
+++ b/src/renderer/components/card/LastCommandChip.tsx
@@ -67,8 +67,9 @@ export function LastCommandChip({ terminalId }: Props) {
       className="flex items-center gap-1 min-w-0 shrink text-[10px] text-gray-500
                  hover:text-gray-300 transition-colors"
     >
-      <span className={ok ? 'text-green-400' : 'text-red-400'}>{ok ? '✓' : '✗'}</span>
-      {!ok && <span className="text-red-400 font-mono">{last.exitCode}</span>}
+      {/* Success is the ordinary case and recedes; only failure takes colour. */}
+      <span className={ok ? 'text-ink-faint' : 'text-danger'}>{ok ? '✓' : '✗'}</span>
+      {!ok && <span className="text-danger font-mono">{last.exitCode}</span>}
       <span className="font-mono tabular-nums">{formatDuration(last.durationMs)}</span>
       <span className="font-mono truncate max-w-[160px] text-gray-600">{last.command}</span>
     </button>

--- a/src/renderer/components/project-sidebar/ProjectsSectionToolbar.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSectionToolbar.tsx
@@ -99,7 +99,7 @@ export function ProjectsSectionToolbar() {
         >
           <ListFilter size={13} strokeWidth={1.5} />
           {hasNonDefault && !open && (
-            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-ink-secondary" />
           )}
         </button>
       </Tooltip>

--- a/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
@@ -81,7 +81,7 @@ export function WorkflowFilterToolbar() {
         >
           <ListFilter size={13} strokeWidth={1.5} />
           {hasNonDefault && !open && (
-            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-ink-secondary" />
           )}
         </button>
       </Tooltip>

--- a/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowFilterToolbar.tsx
@@ -89,7 +89,7 @@ export function WorkflowFilterToolbar() {
       {open && (
         <div
           ref={dropdownRef}
-          className="fixed z-50 w-[160px] bg-surface-base border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
+          className="fixed z-50 w-[160px] bg-surface-overlay border border-white/[0.08] rounded-lg shadow-xl overflow-hidden"
           style={{ top: pos.top, left: pos.left }}
         >
           <div className="py-1.5">

--- a/src/renderer/components/workflow-runs/RunsToolbar.tsx
+++ b/src/renderer/components/workflow-runs/RunsToolbar.tsx
@@ -64,7 +64,7 @@ export function RunsToolbar({ filter, setFilter }: Props) {
         >
           <SlidersHorizontal size={16} strokeWidth={1.5} />
           {hasActiveFilters && !open && (
-            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500" />
+            <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-ink-secondary" />
           )}
         </button>
       </Tooltip>

--- a/src/renderer/components/workflow-runs/RunsToolbar.tsx
+++ b/src/renderer/components/workflow-runs/RunsToolbar.tsx
@@ -72,7 +72,7 @@ export function RunsToolbar({ filter, setFilter }: Props) {
       {open && (
         <div
           className="absolute right-0 top-full mt-1 z-50 w-[200px]
-                     border border-white/[0.08] rounded-lg shadow-xl overflow-hidden bg-surface-base"
+                     border border-white/[0.08] rounded-lg shadow-xl overflow-hidden bg-surface-overlay"
         >
           <div className="py-1.5">
             <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -2,18 +2,38 @@
 @source "./**/*.{tsx,ts,html}";
 
 @theme {
+  /* The app's only accent, and spent sparingly enough to stay meaningful: it
+     marks work blocked on the person, and nothing else. Not selection, not
+     focus, not running. Terminal output, diffs and logs keep their own colour
+     — that is the work itself, not chrome describing it. */
   --color-bronzo: #c9972a;
   --color-bronzo-dark: #b8862a;
 
-  /* Surface ladder — the app field and the surfaces that lift off it.
-     Depth within the page comes from a step plus a hairline, not a shadow.
-     A shadow means something is floating over the page rather than part of
-     it: menus, dialogs, the selection bar. */
-  --color-surface-base: #1a1a1e; /* app background */
-  --color-surface-sunken: #141416; /* context menus */
-  --color-surface-raised: #1e1e22; /* dialogs */
-  --color-surface-overlay: #26262b; /* selection bars, floating chrome */
-  --color-surface-node: #1d1d20; /* workflow canvas node cards */
+  /* Failure and destructive actions only. Burnt orange rather than signal
+     red so it can sit beside bronzo without the two fighting. */
+  --color-danger: #d4623f;
+
+  /* Ink ramp — warm off-white at four opacities. Between them these cover
+     every non-accent foreground in the app, which is what lets nine hue
+     families collapse without losing hierarchy. */
+  --color-ink: #faf9f7; /* primary text */
+  --color-ink-secondary: rgba(255, 255, 255, 0.55); /* row titles, labels */
+  --color-ink-faint: rgba(255, 255, 255, 0.35); /* metadata, identifiers */
+  --color-ink-ghost: rgba(255, 255, 255, 0.18); /* settled, receded */
+  --color-hairline: rgba(255, 255, 255, 0.08); /* every border */
+
+  /* Surface ladder — the app field and the surfaces that lift off it. Depth
+     comes from a step plus a hairline, never a shadow; a shadow means something
+     floats over the page rather than being part of it. The steps are small, of
+     the order of four points: a panel is a different region, not a different
+     material, and a larger step reads as a hole cut in the page. */
+  --color-surface-base: #0d0d0f; /* app background, behind the cards */
+  --color-surface-sunken: #141416; /* card body and terminal: the main column */
+  --color-surface-raised: #141416; /* card frame — same as the terminal it holds,
+                                      so no lighter band shows around the panes */
+  --color-surface-panel: #101012; /* panes, card header, status bar: beside the work */
+  --color-surface-overlay: #1c1c20; /* menus, popovers, floating chrome */
+  --color-surface-node: #141416; /* workflow canvas node cards */
 }
 
 html,
@@ -141,9 +161,10 @@ select,
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* Focus-visible ring for keyboard navigation */
+/* Focus ring for keyboard navigation. Plain white and hairline-thin — an
+   accent here would spend the one colour on a state that changes every Tab. */
 :focus-visible {
-  outline: 2px solid rgba(96, 165, 250, 0.6);
+  outline: 1px solid rgba(255, 255, 255, 0.45);
   outline-offset: 1px;
   border-radius: 4px;
 }
@@ -203,9 +224,7 @@ select:focus:not(:focus-visible) {
 
 /* Drop target indicator */
 .card-drop-target {
-  box-shadow:
-    inset 0 0 0 2px rgba(59, 130, 246, 0.5),
-    0 0 12px rgba(59, 130, 246, 0.15);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
   transition: box-shadow 0.15s ease;
 }
 
@@ -254,12 +273,12 @@ select:focus:not(:focus-visible) {
 @keyframes borderPulse {
   0%,
   100% {
-    border-color: rgba(59, 130, 246, 0.15);
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
   }
   50% {
-    border-color: rgba(59, 130, 246, 0.45);
-    box-shadow: 0 0 8px 0 rgba(59, 130, 246, 0.08);
+    border-color: rgba(255, 255, 255, 0.28);
+    box-shadow: 0 0 8px 0 rgba(255, 255, 255, 0.06);
   }
 }
 
@@ -296,8 +315,8 @@ select:focus:not(:focus-visible) {
   border-bottom-color: rgba(255, 255, 255, 0.35);
 }
 .flexible-grid .react-grid-placeholder {
-  background: rgba(59, 130, 246, 0.15) !important;
-  border: 1px dashed rgba(59, 130, 246, 0.4);
+  background: rgba(255, 255, 255, 0.1) !important;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
   border-radius: 8px;
   opacity: 1 !important;
 }

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -30,12 +30,15 @@
   --color-surface-sunken: #141416; /* card body and terminal: the main column */
   --color-surface-panel: #101012; /* panes, card header, status bar: beside the work */
   --color-surface-overlay: #1c1c20; /* menus, popovers, floating chrome */
-  /* Aliases, not values. A card frame matching the terminal it holds is what
+  /* An alias, not a value. A card frame matching the terminal it holds is what
      keeps a lighter band from showing around the panes, so the equality is the
      point — spelling it as a reference keeps a later nudge to one from silently
      failing to move the other. */
   --color-surface-raised: var(--color-surface-sunken); /* card frame, dialogs */
-  --color-surface-node: var(--color-surface-sunken); /* workflow canvas nodes */
+  /* Left where it was. The workflow canvas behind these still paints its own
+     #1a1a1e, so moving the nodes onto the sessions ladder would flip them from
+     just above that canvas to just below it. They move when the canvas does. */
+  --color-surface-node: #1d1d20; /* workflow canvas node cards */
 }
 
 html,

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -13,14 +13,13 @@
      red so it can sit beside bronzo without the two fighting. */
   --color-danger: #d4623f;
 
-  /* Ink ramp — warm off-white at four opacities. Between them these cover
-     every non-accent foreground in the app, which is what lets nine hue
-     families collapse without losing hierarchy. */
+  /* Ink ramp — warm off-white at four opacities, enough between them to carry
+     hierarchy without a hue. The sessions surface reads from these; the rest of
+     the app still uses Tailwind's grays and is migrated view by view. */
   --color-ink: #faf9f7; /* primary text */
   --color-ink-secondary: rgba(255, 255, 255, 0.55); /* row titles, labels */
   --color-ink-faint: rgba(255, 255, 255, 0.35); /* metadata, identifiers */
   --color-ink-ghost: rgba(255, 255, 255, 0.18); /* settled, receded */
-  --color-hairline: rgba(255, 255, 255, 0.08); /* every border */
 
   /* Surface ladder — the app field and the surfaces that lift off it. Depth
      comes from a step plus a hairline, never a shadow; a shadow means something
@@ -29,11 +28,14 @@
      material, and a larger step reads as a hole cut in the page. */
   --color-surface-base: #0d0d0f; /* app background, behind the cards */
   --color-surface-sunken: #141416; /* card body and terminal: the main column */
-  --color-surface-raised: #141416; /* card frame — same as the terminal it holds,
-                                      so no lighter band shows around the panes */
   --color-surface-panel: #101012; /* panes, card header, status bar: beside the work */
   --color-surface-overlay: #1c1c20; /* menus, popovers, floating chrome */
-  --color-surface-node: #141416; /* workflow canvas node cards */
+  /* Aliases, not values. A card frame matching the terminal it holds is what
+     keeps a lighter band from showing around the panes, so the equality is the
+     point — spelling it as a reference keeps a later nudge to one from silently
+     failing to move the other. */
+  --color-surface-raised: var(--color-surface-sunken); /* card frame, dialogs */
+  --color-surface-node: var(--color-surface-sunken); /* workflow canvas nodes */
 }
 
 html,
@@ -114,14 +116,23 @@ select,
     line-height: 1.5;
   }
 
-  /* Boost contrast on low-visibility grays for WCAG AA (4.5:1) on mobile.
-     gray-500 (#6b7280) is only 3.6:1 on #1a1a1e — bump to gray-400 level.
-     gray-600 (#4b5563) is only 2.3:1 — bump to gray-500 level. */
+  /* Boost contrast on low-visibility foregrounds for WCAG AA (4.5:1) on mobile.
+     gray-500 (#6b7280) is only 3.0:1 on the #0d0d0f field — bump to gray-400.
+     gray-600 (#4b5563) is only 1.9:1 — bump to gray-500. */
   .text-gray-500 {
-    color: #9ca3af !important; /* gray-400: 6.8:1 */
+    color: #9ca3af !important; /* gray-400: 7.9:1 */
   }
   .text-gray-600 {
-    color: #6b7280 !important; /* gray-500: 3.6:1 → still below, but acceptable for decorative/hint text */
+    color: #6b7280 !important; /* gray-500: 3.0:1 → still below, but acceptable for decorative/hint text */
+  }
+
+  /* The ramp gets the same treatment, on the tokens rather than on class names,
+     so anything reading from it is covered rather than opting out by using the
+     newer vocabulary. faint in particular lands near gray-600 at rest. */
+  :root {
+    --color-ink-secondary: rgba(255, 255, 255, 0.72);
+    --color-ink-faint: rgba(255, 255, 255, 0.55);
+    --color-ink-ghost: rgba(255, 255, 255, 0.35);
   }
 
   /* ── Liquid Glass material (iOS 26 / Framework7 v9 inspired) ── */

--- a/src/renderer/lib/icon-button.ts
+++ b/src/renderer/lib/icon-button.ts
@@ -3,9 +3,18 @@
  *
  * Both sit in the chrome of the same card, so a difference in size or weight
  * between them reads as two unrelated toolbars rather than one.
+ *
+ * The danger variant is a separate string rather than an override appended to
+ * `ICON_BUTTON`: two `hover:text-*` classes on one element are resolved by the
+ * order they appear in the stylesheet, not the order they are written, so the
+ * override would win or lose depending on how Tailwind happened to emit them.
  */
-export const ICON_BUTTON =
-  'p-1 rounded text-gray-200 hover:text-white hover:bg-white/[0.10] transition-colors'
+const BASE = 'p-1 rounded transition-colors hover:bg-white/[0.10]'
 
-/** Icon size to pair with `ICON_BUTTON`. */
+export const ICON_BUTTON = `${BASE} text-ink`
+
+/** For an action that discards something — closing a session, deleting. */
+export const ICON_BUTTON_DANGER = `${BASE} text-ink hover:text-danger`
+
+/** Icon size to pair with either button style. */
 export const ICON_BUTTON_SIZE = 14

--- a/src/renderer/lib/icon-button.ts
+++ b/src/renderer/lib/icon-button.ts
@@ -1,0 +1,11 @@
+/**
+ * The one icon-button style, shared by a session card's actions and a pane's.
+ *
+ * Both sit in the chrome of the same card, so a difference in size or weight
+ * between them reads as two unrelated toolbars rather than one.
+ */
+export const ICON_BUTTON =
+  'p-1 rounded text-gray-200 hover:text-white hover:bg-white/[0.10] transition-colors'
+
+/** Icon size to pair with `ICON_BUTTON`. */
+export const ICON_BUTTON_SIZE = 14

--- a/src/renderer/lib/pane-surface.ts
+++ b/src/renderer/lib/pane-surface.ts
@@ -2,8 +2,13 @@
  * The background every session-owned pane shares.
  *
  * Panes are frames around someone else's content — a file tree, a file, a web
- * page. Holding them all to one near-black ground stops the chrome competing
- * with what it holds, and stops a column of panes reading as a patchwork of
- * slightly different greys.
+ * page. Holding them all to one ground stops the chrome competing with what it
+ * holds, and stops a column of panes reading as a patchwork of slightly
+ * different greys.
+ *
+ * One step below the terminal beside it, and that step is the only thing
+ * dividing them — no border, no gutter. A border a few pixels inside the card's
+ * own reads as a doubled edge, and a gutter exposes a lighter band of card that
+ * pulls harder than either surface.
  */
-export const PANE_SURFACE = '#0d0d0f'
+export const PANE_SURFACE = '#101012'

--- a/src/renderer/lib/pane-surface.ts
+++ b/src/renderer/lib/pane-surface.ts
@@ -11,4 +11,4 @@
  * own reads as a doubled edge, and a gutter exposes a lighter band of card that
  * pulls harder than either surface.
  */
-export const PANE_SURFACE = '#101012'
+export const PANE_SURFACE = 'var(--color-surface-panel)'

--- a/src/renderer/lib/status-colors.ts
+++ b/src/renderer/lib/status-colors.ts
@@ -1,10 +1,15 @@
 import type { AgentStatus } from '../../shared/types'
 
+/**
+ * Only `waiting` takes the accent — it is the one status blocked on the person.
+ * Running is the commonest state, so painting it would put bronzo across most
+ * of the screen most of the time; it reads white, and STATUS_GLYPH shimmers it.
+ */
 export const STATUS_DOT: Record<AgentStatus, string> = {
-  running: 'bg-green-500',
-  waiting: 'bg-yellow-500',
-  idle: 'bg-gray-500',
-  error: 'bg-red-500'
+  running: 'bg-ink',
+  waiting: 'bg-bronzo',
+  idle: 'bg-ink-ghost',
+  error: 'bg-danger'
 }
 
 export const STATUS_LABEL: Record<AgentStatus, string> = {
@@ -26,8 +31,8 @@ export const STATUS_GLYPH: Record<AgentStatus, StatusGlyph> = {
 }
 
 export const STATUS_TEXT: Record<AgentStatus, string> = {
-  running: 'text-green-400',
-  waiting: 'text-amber-400',
-  idle: 'text-gray-500',
-  error: 'text-red-500'
+  running: 'text-ink',
+  waiting: 'text-bronzo',
+  idle: 'text-ink-faint',
+  error: 'text-danger'
 }

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -42,6 +42,10 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       editorPanes.delete(id)
       const browserPanes = new Map(state.browserPanes)
       browserPanes.delete(id)
+      // The remembered tabs go with the session too. A recycled id would
+      // otherwise reopen its browser onto a previous session's pages.
+      const browserMemory = new Map(state.browserMemory)
+      browserMemory.delete(id)
       // The claim itself is released by main when the session closes; this is
       // only the viewer. Leaving it behind would keep a frame of a device this
       // session no longer holds, and block a later pane from opening.
@@ -64,6 +68,7 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         filesPanes,
         editorPanes,
         browserPanes,
+        browserMemory,
         devicePanes,
         cardSplits,
         gitDiffStats,

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -226,6 +226,16 @@ export interface UISlice {
   editorPanes: Map<string, EditorPaneState>
   /** Session id → the page its browser pane is showing. One browser per session. */
   browserPanes: Map<string, BrowserPaneState>
+  /**
+   * What a closed browser pane was showing, so reopening restores the tabs
+   * rather than starting over.
+   *
+   * `browserPanes` does double duty — an entry's presence is what makes the
+   * pane open, and its value is the tabs — so closing has to delete the entry
+   * and would otherwise take the tabs with it. Kept separate rather than adding
+   * an `open` flag so every `browserPanes.has(...)` check reads the same.
+   */
+  browserMemory: Map<string, BrowserPaneState>
   /** Session id → the simulator its device pane is showing. One device per session. */
   devicePanes: Map<string, DevicePaneState>
   /**

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -590,9 +590,17 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
     const existing = get().browserPanes.get(sessionId)
     if (!existing || index < 0 || index >= existing.tabs.length) return
     // The last tab going means the pane itself goes; an empty browser is just
-    // a box taking up a grid cell.
+    // a box taking up a grid cell. Closing a tab is a discard, though, not a
+    // "give me the space back" — so unlike a pane close it leaves nothing to
+    // restore, or reopening would hand back the page just thrown away.
     if (existing.tabs.length === 1) {
       get().closeBrowserPane(sessionId)
+      set((state) => {
+        if (!state.browserMemory.has(sessionId)) return {}
+        const memory = new Map(state.browserMemory)
+        memory.delete(sessionId)
+        return { browserMemory: memory }
+      })
       return
     }
     set((state) => {

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -210,6 +210,7 @@ function reconcilePanes(
   filesPanes: Set<string>,
   editorPanes: Map<string, EditorPaneState>,
   browserPanes: Map<string, BrowserPaneState>,
+  browserMemory: Map<string, BrowserPaneState>,
   devicePanes: Map<string, DevicePaneState>,
   cardSplits: Record<string, CardSplit>,
   liveSessionIds: Set<string>
@@ -217,12 +218,17 @@ function reconcilePanes(
   filesPanes: Set<string>
   editorPanes: Map<string, EditorPaneState>
   browserPanes: Map<string, BrowserPaneState>
+  browserMemory: Map<string, BrowserPaneState>
   devicePanes: Map<string, DevicePaneState>
   cardSplits: Record<string, CardSplit>
 } | null {
   const nextFiles = new Set([...filesPanes].filter((id) => liveSessionIds.has(id)))
   const nextEditors = new Map([...editorPanes].filter(([id]) => liveSessionIds.has(id)))
   const nextBrowsers = new Map([...browserPanes].filter(([id]) => liveSessionIds.has(id)))
+  // Tabs remembered for a closed pane die with their session as well. This is
+  // the path `removeTerminal` cannot cover: a session that simply never came
+  // back leaves no removal to hang the cleanup off.
+  const nextMemory = new Map([...browserMemory].filter(([id]) => liveSessionIds.has(id)))
   // Device panes are in-memory only, but a dead session's pane still keeps a
   // card mounted against a device nobody can drive — the same leak, minus the
   // localStorage growth.
@@ -235,6 +241,7 @@ function reconcilePanes(
     nextFiles.size === filesPanes.size &&
     nextEditors.size === editorPanes.size &&
     nextBrowsers.size === browserPanes.size &&
+    nextMemory.size === browserMemory.size &&
     nextDevices.size === devicePanes.size &&
     !splitsChanged
   ) {
@@ -246,6 +253,7 @@ function reconcilePanes(
     filesPanes: nextFiles,
     editorPanes: nextEditors,
     browserPanes: nextBrowsers,
+    browserMemory: nextMemory,
     devicePanes: nextDevices,
     cardSplits: nextSplits
   }
@@ -435,6 +443,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
               state.filesPanes,
               state.editorPanes,
               state.browserPanes,
+              state.browserMemory,
               state.devicePanes,
               state.cardSplits,
               live

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -303,6 +303,9 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   focusableTerminalIds: [],
   minimizedTerminals: new Set(),
   ...loadPanes(),
+  // Not persisted: remembering tabs across a close is about the current
+  // sitting, and a reload already restores whatever was open from loadPanes.
+  browserMemory: new Map(),
   // Not part of loadPanes: a claim lives in main and dies with the app, so a
   // device pane restored from disk would frame a simulator nobody holds.
   devicePanes: new Map(),
@@ -527,7 +530,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
           next.set(sessionId, { tabs: [normalized], activeTab: 0 })
         }
       } else if (!existing) {
-        next.set(sessionId, { tabs: [DEFAULT_BROWSER_URL], activeTab: 0 })
+        // Reopening picks up where the pane left off. Closing it is how you get
+        // the space back, not how you throw the tabs away.
+        const remembered = state.browserMemory.get(sessionId)
+        next.set(sessionId, remembered ?? { tabs: [DEFAULT_BROWSER_URL], activeTab: 0 })
       } else {
         return {}
       }
@@ -538,12 +544,16 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   closeBrowserPane: (sessionId) =>
     set((state) => {
-      if (!state.browserPanes.has(sessionId)) return {}
+      const closing = state.browserPanes.get(sessionId)
+      if (!closing) return {}
       const next = new Map(state.browserPanes)
       next.delete(sessionId)
+      const memory = new Map(state.browserMemory)
+      memory.set(sessionId, closing)
       savePanes(state.filesPanes, state.editorPanes, next)
       return {
         browserPanes: next,
+        browserMemory: memory,
         ...(state.maximizedPaneId === browserPaneId(sessionId) ? { maximizedPaneId: null } : {})
       }
     }),

--- a/tests/agent-card-panes.test.tsx
+++ b/tests/agent-card-panes.test.tsx
@@ -128,6 +128,33 @@ describe('AgentCard pane column', () => {
     expect(screen.getByTestId('card-terminal-t1')).toHaveClass('hidden')
   })
 
+  it('keeps the card reachable while one of its panes is maximized', () => {
+    // The session's chrome rides inside the terminal column so the panes get the
+    // card's full height — but that column hides behind a maximized pane, and
+    // the chrome must not go with it. Otherwise the card loses its name, its
+    // drag handle and the only buttons that close or minimize it, leaving a
+    // maximized browser sitting in a card you cannot identify or dismiss.
+    act(() => {
+      useAppStore.getState().openFilesPane('t1')
+      useAppStore.getState().setMaximizedPane('files:t1')
+    })
+    render(<AgentCard terminalId="t1" />)
+
+    const close = screen.getByLabelText('Close session')
+    expect(close).toBeInTheDocument()
+    expect(screen.getByTestId('card-terminal-t1')).not.toContainElement(close)
+  })
+
+  it('swaps the terminal for a placeholder once the session is expanded', () => {
+    // The expanded stage owns the live terminal; a second mount here would
+    // fight it for the same session.
+    act(() => useAppStore.getState().setFocusedTerminal('t1'))
+    render(<AgentCard terminalId="t1" />)
+
+    expect(screen.getByText('Expanded')).toBeInTheDocument()
+    expect(screen.queryByTestId('slot-t1')).not.toBeInTheDocument()
+  })
+
   it("leaves another card's terminal alone while one card is maximized", () => {
     act(() => {
       useAppStore.getState().openFilesPane('t1')

--- a/tests/last-command-chip.test.tsx
+++ b/tests/last-command-chip.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const blocks: {
+  command: string | null
+  exitCode: number
+  durationMs: number
+  marker: { line: number; isDisposed: boolean }
+}[] = []
+
+vi.mock('../src/renderer/lib/command-blocks', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../src/renderer/lib/command-blocks'
+  )
+  return {
+    ...actual,
+    getCommandBlocks: () => blocks,
+    onCommandBlocksChange: () => () => {}
+  }
+})
+vi.mock('../src/renderer/lib/terminal-registry', () => ({
+  onTerminalReady: (_id: string, cb: () => void) => {
+    cb()
+    return () => {}
+  },
+  scrollTerminalToLine: () => {}
+}))
+
+import { useAppStore } from '../src/renderer/stores'
+import { LastCommandChip } from '../src/renderer/components/card/LastCommandChip'
+
+function seed(): void {
+  act(() => {
+    useAppStore.setState({
+      terminals: new Map([
+        [
+          't1',
+          {
+            id: 't1',
+            session: { id: 't1', agentType: 'shell', displayName: 't1' },
+            status: 'idle',
+            lastOutputTimestamp: 1
+          }
+        ]
+      ]) as never
+    })
+  })
+}
+
+function setBlock(exitCode: number): void {
+  blocks.length = 0
+  blocks.push({
+    command: 'yarn test',
+    exitCode,
+    durationMs: 2400,
+    marker: { line: 12, isDisposed: false }
+  })
+}
+
+beforeEach(seed)
+afterEach(() => cleanup())
+
+describe('LastCommandChip', () => {
+  it('lets a succeeded command recede', () => {
+    // Success is the ordinary outcome. Colouring it puts a mark on the status
+    // bar of every card that has ever run anything, which spends attention on
+    // the one thing that never needs it.
+    setBlock(0)
+    const { container } = render(<LastCommandChip terminalId="t1" />)
+
+    expect(screen.getByText('✓')).toHaveClass('text-ink-faint')
+    expect(container.querySelector('.text-danger')).toBeNull()
+  })
+
+  it('names the exit code when a command failed', () => {
+    // The failure is the whole reason to look at this chip, so it is the one
+    // state that keeps a colour — and the code is what says which failure.
+    setBlock(1)
+    render(<LastCommandChip terminalId="t1" />)
+
+    expect(screen.getByText('✗')).toHaveClass('text-danger')
+    expect(screen.getByText('1')).toHaveClass('text-danger')
+  })
+
+  it('stays out of a non-shell session', () => {
+    // Agent sessions have no command blocks to report; the chip would render an
+    // empty slot in every card's status bar.
+    setBlock(0)
+    act(() => {
+      const t = useAppStore.getState().terminals.get('t1')!
+      useAppStore.setState({
+        terminals: new Map([
+          ['t1', { ...t, session: { ...t.session, agentType: 'claude' } }]
+        ]) as never
+      })
+    })
+    const { container } = render(<LastCommandChip terminalId="t1" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -256,7 +256,9 @@ describe('PaneCard drag and double-click', () => {
     render(<FilesCard sessionId="t1" onDragStart={onDragStart} />)
     await screen.findByText('a.ts')
 
-    fireEvent.pointerDown(screen.getByTestId('files-pane-header'))
+    // The title row carries drag and maximize, not the filter row below it —
+    // wiring both meant two drag handles and two paths to the same action.
+    fireEvent.pointerDown(screen.getByTestId('pane-header-files:t1'))
     expect(onDragStart).toHaveBeenCalledWith('files:t1', expect.anything())
   })
 
@@ -265,10 +267,10 @@ describe('PaneCard drag and double-click', () => {
     render(<FilesCard sessionId="t1" />)
     await screen.findByText('a.ts')
 
-    fireEvent.doubleClick(screen.getByTestId('files-pane-header'))
+    fireEvent.doubleClick(screen.getByTestId('pane-header-files:t1'))
     expect(useAppStore.getState().maximizedPaneId).toBe('files:t1')
 
-    fireEvent.doubleClick(screen.getByTestId('files-pane-header'))
+    fireEvent.doubleClick(screen.getByTestId('pane-header-files:t1'))
     expect(useAppStore.getState().maximizedPaneId).toBeNull()
   })
 })

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -262,6 +262,17 @@ describe('PaneCard drag and double-click', () => {
     expect(onDragStart).toHaveBeenCalledWith('files:t1', expect.anything())
   })
 
+  it('marks itself as the drop target while a drag is over it', async () => {
+    // The pane has no border of its own — the step down in surface is what
+    // separates it — so the drop indicator is the only thing that can say a
+    // drop would land here.
+    act(() => useAppStore.getState().openFilesPane('t1'))
+    const { container } = render(<FilesCard sessionId="t1" isDragTarget />)
+    await screen.findByText('a.ts')
+
+    expect(container.querySelector('.card-drop-target')).toBeInTheDocument()
+  })
+
   it('toggles maximize on header double-click', async () => {
     act(() => useAppStore.getState().openFilesPane('t1'))
     render(<FilesCard sessionId="t1" />)

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -214,17 +214,17 @@ describe('PaneCard chrome', () => {
     expect(useAppStore.getState().maximizedPaneId).toBeNull()
   })
 
-  it('seats the tree pane controls in its filter row, not a second bar', async () => {
-    // The filter row is already a full-width bar. A title row above it is
-    // chrome stacked on chrome, and costs a line of tree.
+  it('keeps the tree pane controls out of its filter row', async () => {
+    // Sharing the row made the search field the panel's title bar: it spanned
+    // the full width and the buttons read as part of the input.
     act(() => useAppStore.getState().openFilesPane('t1'))
     render(<FilesCard sessionId="t1" />)
     await screen.findByText('a.ts')
 
-    const header = screen.getByTestId('files-pane-header')
-    expect(header).toContainElement(screen.getByLabelText('Maximize Files'))
-    expect(header).toContainElement(screen.getByLabelText('Close Files'))
-    expect(screen.getByPlaceholderText('Filter files…')).toBeInTheDocument()
+    const filterRow = screen.getByTestId('files-pane-header')
+    expect(filterRow).toContainElement(screen.getByPlaceholderText('Filter files…'))
+    expect(filterRow).not.toContainElement(screen.getByLabelText('Maximize Files'))
+    expect(filterRow).not.toContainElement(screen.getByLabelText('Close Files'))
   })
 
   it('names the open file once, in the path strip that carries its controls', async () => {

--- a/tests/pane-store.test.ts
+++ b/tests/pane-store.test.ts
@@ -31,6 +31,7 @@ function seed(ids: string[] = ['t1']): void {
       filesPanes: new Set(),
       editorPanes: new Map(),
       browserPanes: new Map(),
+      browserMemory: new Map(),
       devicePanes: new Map(),
       cardSplits: {},
       minimizedTerminals: new Set(),
@@ -152,6 +153,41 @@ describe('pane store actions', () => {
     expect(s().browserPanes.has('t1')).toBe(false)
 
     expect(s().maximizedPaneId).toBeNull()
+  })
+
+  it('reopens a closed browser on the tabs it had', () => {
+    // `browserPanes` does double duty: the entry's presence is what makes the
+    // pane open, and its value is the tabs. Closing has to delete the entry, so
+    // without somewhere to put them the tabs went too, and reopening handed
+    // back a blank page — losing however many pages had been opened.
+    const s = () => useAppStore.getState()
+    act(() => s().openBrowserPane('t1', 'example.com'))
+    act(() => s().addBrowserTab('t1', 'vorn.dev'))
+    const tabs = s().browserPanes.get('t1')?.tabs
+    expect(tabs).toHaveLength(2)
+
+    act(() => s().closeBrowserPane('t1'))
+    expect(s().browserPanes.has('t1')).toBe(false)
+
+    act(() => s().openBrowserPane('t1'))
+    expect(s().browserPanes.get('t1')?.tabs).toEqual(tabs)
+  })
+
+  it("does not hand a recycled session id the previous one's pages", () => {
+    // Ids are reused, and remembered tabs outliving their session would reopen
+    // a browser onto pages that belonged to someone else's work. Deliberately
+    // no re-seed here: seeding resets browserMemory, which would clear the very
+    // thing this is checking gets dropped and let the test pass on its own.
+    const s = () => useAppStore.getState()
+    act(() => s().openBrowserPane('t1', 'example.com'))
+    act(() => s().closeBrowserPane('t1'))
+    expect(s().browserMemory.has('t1')).toBe(true)
+
+    act(() => s().removeTerminal('t1'))
+    expect(s().browserMemory.has('t1')).toBe(false)
+
+    act(() => s().openBrowserPane('t1'))
+    expect(activeBrowserUrl(s().browserPanes.get('t1'))).toBe('about:blank')
   })
 
   it('keeps each session on its own page', () => {

--- a/tests/pane-store.test.ts
+++ b/tests/pane-store.test.ts
@@ -173,6 +173,20 @@ describe('pane store actions', () => {
     expect(s().browserPanes.get('t1')?.tabs).toEqual(tabs)
   })
 
+  it('forgets a page closed by its tab, rather than the pane', () => {
+    // Closing the last tab routes through closeBrowserPane, so without this the
+    // discard gesture files the page into memory and reopening hands back
+    // exactly the page just thrown away.
+    const s = () => useAppStore.getState()
+    act(() => s().openBrowserPane('t1', 'example.com'))
+    act(() => s().closeBrowserTab('t1', 0))
+    expect(s().browserPanes.has('t1')).toBe(false)
+    expect(s().browserMemory.has('t1')).toBe(false)
+
+    act(() => s().openBrowserPane('t1'))
+    expect(browserUrl('t1')).toBe('about:blank')
+  })
+
   it("does not hand a recycled session id the previous one's pages", () => {
     // Ids are reused, and remembered tabs outliving their session would reopen
     // a browser onto pages that belonged to someone else's work. Deliberately

--- a/tests/runs-toolbar.test.tsx
+++ b/tests/runs-toolbar.test.tsx
@@ -25,12 +25,12 @@ describe('RunsToolbar', () => {
 
   it('does not show the active-state indicator when filter is "all"', () => {
     const { container } = render(<RunsToolbar filter="all" setFilter={setFilter} />)
-    expect(container.querySelector('.bg-blue-500')).not.toBeInTheDocument()
+    expect(container.querySelector('.bg-ink-secondary')).not.toBeInTheDocument()
   })
 
   it('shows the active-state indicator when a non-default filter is active', () => {
     const { container } = render(<RunsToolbar filter="running" setFilter={setFilter} />)
-    expect(container.querySelector('.bg-blue-500')).toBeInTheDocument()
+    expect(container.querySelector('.bg-ink-secondary')).toBeInTheDocument()
   })
 
   it('opens the dropdown with All / Running / Waiting / Failed / Succeeded', () => {

--- a/tests/workflow-filter-toolbar.test.tsx
+++ b/tests/workflow-filter-toolbar.test.tsx
@@ -31,12 +31,12 @@ describe('WorkflowFilterToolbar', () => {
   it('shows the indicator dot when a non-default filter is active', () => {
     mockState.sidebarWorkflowFilter = 'manual'
     const { container } = render(<WorkflowFilterToolbar />)
-    expect(container.querySelector('.bg-blue-500')).toBeInTheDocument()
+    expect(container.querySelector('.bg-ink-secondary')).toBeInTheDocument()
   })
 
   it('does not show the indicator dot for the default "all" filter', () => {
     const { container } = render(<WorkflowFilterToolbar />)
-    expect(container.querySelector('.bg-blue-500')).not.toBeInTheDocument()
+    expect(container.querySelector('.bg-ink-secondary')).not.toBeInTheDocument()
   })
 
   it('opens a dropdown with All / Manual / Scheduled options when clicked', () => {


### PR DESCRIPTION
Phase one of a design pass: base tokens plus the sessions views. Workflows and tasks follow in later PRs.

## Why

Colour in the renderer had accumulated rather than been designed — nine hue families, and the busy ones ambiguous. Blue alone meant `in_progress`, node-selected, card-focused, "filters active" *and* the approve button: five things with nothing to tell them apart, so blue had stopped carrying information. `STATUS_ICON_COLOR.in_progress` was yellow while every other in-progress signal was blue, which is the same problem surfacing as a plain inconsistency.

The direction came from comparing against the `journey` app's editorial monochrome, and from sampling Claude's own surfaces rather than guessing at them — its side panel sits **4 points** below its main column, which is the gap this branch holds between a card and the pane beside it.

## What changed

**One accent, one meaning.** Bronzo marks work blocked on the person and nothing else — a waiting session, the dock's overflow notch, the awaiting-review badge. Running is the commonest state, so painting it would put gold across most of the screen most of the time; it reads white and keeps its shimmer. Failure and destructive actions take a burnt-orange `--color-danger`. Everything else comes off a four-stop ink ramp.

Terminal output, diffs and logs keep their own colour. That is the work itself, not chrome describing it.

**The surface ladder now applies.** It existed but was bypassed by over a hundred hardcoded hexes. The app field, cards, chrome and panes read from tokens, and the whole thing steps darker.

**Panes get the card's full height.** A session's header, intent bar and status bar moved inside the terminal column — in the grid and in focus mode both — because a pane carries its own bar, and a full-width header above them stacked two title rows. Panes lost their border and gutter: a border a few pixels inside the card's own read as a doubled edge.

**One icon-button style** shared by the card and pane clusters, always visible rather than hover-revealed.

## Also here

A separable bug fix in `5221f69`: closing a browser pane discarded its tabs. `browserPanes` does double duty — an entry's presence is what makes the pane open, and its value holds the tabs — so closing had to delete the entry and took the tabs with it. Happy to split it out if you would rather review it alone.

## Scope

Deliberately **not** in this PR, and each real:

- the remaining ~560 hue classes and ~100 hex literals outside sessions
- extracting a shared `SessionColumn` from AgentCard / FocusedTerminal / TabView
- redesigning `browserPanes` around an explicit `open` flag

## Checks

`tsc` clean · 3173/3173 tests pass · lint warnings unchanged from `main` · new tests mutation-tested

Reviewed with `/simplify` and `/code-review high`; both passes are committed separately (`ff528ee`, `3189ffc`) so the fixes are readable against what they corrected.