### PR TITLE
chore(release): 0.6.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Second beta of the 0.6.x line.

Three phases of palette work land together — #445 (sessions), #446 (workflows), #447 (tasks):

- **One accent.** Bronzo means work is blocked on you and nothing else. A waiting session, an open approval gate and a task handed back for review are one idea wearing three names, and they now share a tone table rather than five maps that disagreed.
- **One ink ramp** for everything that is not blocked or broken, with separate floors for dots and words — a 1.5px disc reads where a label does not.
- **One surface ladder**, declared once in `theme.css` and imported by both clients. 47 places used to spell a rung literally.

Also in this beta: the workflow canvas reports live run state on its nodes, which it accepted but never received, so a run could park on a gate while the gate's node looked idle.

Version bump only — the six workspace packages are synced by the pre-commit hook.