### PR TITLE
Draw every node card in one shell

### DIFF
--- a/src/renderer/components/workflow-editor/node-visuals.ts
+++ b/src/renderer/components/workflow-editor/node-visuals.ts
@@ -233,3 +233,13 @@ export const NODE_UNSELECTED = 'border-white/[0.08]'
  */
 export const TASK_CHIP =
   'text-[10px] px-1.5 py-0.5 border border-white/[0.08] rounded text-ink-secondary truncate cursor-pointer hover:bg-white/[0.06] transition-colors'
+
+/**
+ * What a preview line on a node card is cut to.
+ *
+ * Every card that previews its own content wrote this by hand, with the cut
+ * length as a bare number a few lines from the string it applied to.
+ */
+export function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '...' : text
+}

--- a/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
@@ -1,7 +1,7 @@
 import { Hand } from 'lucide-react'
 import type { ApprovalConfig, NodeExecutionStatus } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH, truncate } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -17,32 +17,15 @@ export function ApprovalNode({ label, config, selected, executionStatus, onClick
     : 'Waits for approval'
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
+    <NodeShell
+      icon={<Hand size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
+      label={label}
+      subtitle={subtitle}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
     >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        <Hand size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
-        </div>
-      </div>
-      {config.message && (
-        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2">
-          {config.message.length > 60 ? config.message.slice(0, 60) + '...' : config.message}
-        </div>
-      )}
-    </div>
+      {config.message && <NodeFooter>{truncate(config.message, 60)}</NodeFooter>}
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
@@ -1,9 +1,9 @@
 import { Zap } from 'lucide-react'
 import type { CallConnectorActionConfig, NodeExecutionStatus } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
 import { ConnectorIcon } from '../../ConnectorIcon'
 import { useConnectorIdFor, useConnectionIconFor } from '../../../lib/use-connections'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH } from '../node-visuals'
+import { NodeShell } from './NodeShell'
 
 interface Props {
   label: string
@@ -25,22 +25,9 @@ export function CallConnectorActionNode({
   const icon = useConnectionIconFor(config.connectionId)
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
-    >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        {connectorId ? (
+    <NodeShell
+      icon={
+        connectorId ? (
           <ConnectorIcon
             connectorId={connectorId}
             icon={icon}
@@ -49,14 +36,13 @@ export function CallConnectorActionNode({
           />
         ) : (
           <Zap size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
-        )}
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">
-            {config.action || 'Select action'}
-          </div>
-        </div>
-      </div>
-    </div>
+        )
+      }
+      label={label}
+      subtitle={config.action || 'Select action'}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
+    />
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
@@ -4,8 +4,8 @@ import type {
   ConditionOperator,
   NodeExecutionStatus
 } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH, truncate } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -36,34 +36,15 @@ export function ConditionNode({ label, config, selected, executionStatus, onClic
     : undefined
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
+    <NodeShell
+      icon={<GitFork size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
+      label={label}
+      subtitle={hasConfig ? OPERATOR_LABELS[config.operator] : 'Not configured'}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
     >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        <GitFork size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">
-            {hasConfig ? OPERATOR_LABELS[config.operator] : 'Not configured'}
-          </div>
-        </div>
-      </div>
-      {preview && (
-        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2 font-mono">
-          {preview.length > 60 ? preview.slice(0, 60) + '...' : preview}
-        </div>
-      )}
-    </div>
+      {preview && <NodeFooter mono>{truncate(preview, 60)}</NodeFooter>}
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
@@ -1,7 +1,7 @@
 import { ListPlus } from 'lucide-react'
 import type { CreateTaskFromItemConfig, NodeExecutionStatus } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH } from '../node-visuals'
+import { NodeShell } from './NodeShell'
 
 interface Props {
   label: string
@@ -22,29 +22,13 @@ export function CreateTaskFromItemNode({
     config.project === 'fromConnection' ? 'Project from connection' : config.project
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
-    >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        <ListPlus size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">
-            {projectLabel} · initial: {config.initialStatus}
-          </div>
-        </div>
-      </div>
-    </div>
+    <NodeShell
+      icon={<ListPlus size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />}
+      label={label}
+      subtitle={`${projectLabel} · initial: ${config.initialStatus}`}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
+    />
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
@@ -2,8 +2,8 @@ import { AgentIcon } from '../../AgentIcon'
 import type { LaunchAgentConfig, AiAgentType, NodeExecutionStatus } from '../../../../shared/types'
 import { useAppStore } from '../../../stores'
 import { ClipboardList, Server } from 'lucide-react'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH, truncate } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -21,9 +21,7 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
     : undefined
 
   const promptPreview = config.prompt
-    ? config.prompt.length > 60
-      ? config.prompt.slice(0, 60) + '...'
-      : config.prompt
+    ? truncate(config.prompt, 60)
     : config.taskFromQueue
       ? 'Next task from queue'
       : config.taskId
@@ -31,21 +29,8 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
         : undefined
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
-    >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
+    <NodeShell
+      icon={
         <span className="shrink-0">
           {isFromTask ? (
             <ClipboardList size={14} className={NODE_GLYPH} />
@@ -53,25 +38,27 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
             <AgentIcon agentType={config.agentType as AiAgentType} size={14} />
           )}
         </span>
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">
-            {config.projectName || 'No project'}
-            {!remoteHost && config.branch && ` · ${config.branch}`}
+      }
+      label={label}
+      subtitle={
+        <>
+          {config.projectName || 'No project'}
+          {!remoteHost && config.branch && ` · ${config.branch}`}
+        </>
+      }
+      meta={
+        remoteHost && (
+          <div className="flex items-center gap-1 mt-0.5">
+            <Server size={9} className="text-ink-faint" strokeWidth={1.5} />
+            <span className="text-[10px] text-ink-faint truncate">{remoteHost.label}</span>
           </div>
-          {remoteHost && (
-            <div className="flex items-center gap-1 mt-0.5">
-              <Server size={9} className="text-ink-faint" strokeWidth={1.5} />
-              <span className="text-[10px] text-ink-faint truncate">{remoteHost.label}</span>
-            </div>
-          )}
-        </div>
-      </div>
-      {promptPreview && (
-        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2">
-          {promptPreview}
-        </div>
-      )}
-    </div>
+        )
+      }
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
+    >
+      {promptPreview && <NodeFooter>{promptPreview}</NodeFooter>}
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
@@ -1,7 +1,7 @@
 import { Repeat } from 'lucide-react'
 import type { LoopConfig, NodeExecutionStatus, WorkflowNode } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -38,49 +38,38 @@ export function LoopNode({
       : `Repeats ${body.length} step${body.length === 1 ? '' : 's'} · up to ${max}×`
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  ${body.length === 0 ? 'border-dashed' : ''}
-                  bg-surface-node hover:bg-white/[0.02]`}
-    >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        <Repeat size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
-        </div>
-        {iteration !== undefined && iteration > 0 && (
+    <NodeShell
+      icon={<Repeat size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
+      label={label}
+      subtitle={subtitle}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
+      dashed={body.length === 0}
+      trailing={
+        iteration !== undefined &&
+        iteration > 0 && (
           <span className="shrink-0 text-[10px] text-gray-400 bg-white/[0.06] rounded px-1.5 py-0.5">
             {iteration}×
           </span>
-        )}
-      </div>
-
+        )
+      }
+    >
       {body.length > 0 && (
-        <div className="mt-2 border-t border-white/[0.06] pt-2 space-y-0.5">
+        <NodeFooter rows>
           {body.map((n, i) => (
             <div key={n.id} className="text-[11px] text-gray-500 truncate">
               <span className="text-gray-600 tabular-nums">{i + 1}.</span> {n.label}
             </div>
           ))}
-        </div>
+        </NodeFooter>
       )}
 
       {config.until?.variable && (
-        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2">
+        <NodeFooter>
           until {config.until.variable} {config.until.operator} {config.until.value}
-        </div>
+        </NodeFooter>
       )}
-    </div>
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from 'react'
+import type { NodeExecutionStatus } from '../../../../shared/types'
+import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
+import { NODE_SELECTED, NODE_UNSELECTED } from '../node-visuals'
+
+/**
+ * The card every step on the canvas is drawn in.
+ *
+ * Eight components repeated this shell almost exactly: the same root classes,
+ * the same click handling, the same status dot, the same icon-then-two-lines
+ * header. "Almost" is the problem — two had drifted to `rounded-sm` and sat
+ * visibly smaller beside the rest on one canvas, and a status dot added to
+ * seven of them was missed by the eighth. Each card now says only what makes it
+ * that kind of step.
+ *
+ * The root classes are written here literally rather than composed, for two
+ * reasons that point the same way: Tailwind scans source text, so a name built
+ * at runtime is never generated; and `node-selection.test.tsx` reads
+ * `container.firstChild` as the card root and checks the shape is shared, which
+ * only holds while this element is the outermost one.
+ */
+export function NodeShell({
+  icon,
+  label,
+  subtitle,
+  selected,
+  executionStatus,
+  onClick,
+  dashed,
+  meta,
+  trailing,
+  children
+}: {
+  icon: ReactNode
+  label: string
+  /** The one line under the label: what this step is pointed at. */
+  subtitle: ReactNode
+  selected?: boolean
+  /**
+   * What this node is doing in a live run. Absent on a canvas showing a
+   * definition, which is most of the time.
+   */
+  executionStatus?: NodeExecutionStatus
+  onClick: () => void
+  /** A loop with no body is an outline of a step rather than a step. */
+  dashed?: boolean
+  /** Extra rows below the subtitle, inside the text column. */
+  meta?: ReactNode
+  /** A chip pinned to the right of the header row. */
+  trailing?: ReactNode
+  /** Footer sections, each its own `NodeFooter`. */
+  children?: ReactNode
+}) {
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
+                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
+                  ${dashed ? 'border-dashed' : ''}
+                  bg-surface-node hover:bg-white/[0.02]`}
+    >
+      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
+        <span
+          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
+        />
+      )}
+      <div className="flex items-center gap-2">
+        {icon}
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-medium text-white truncate">{label}</div>
+          <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>
+          {meta}
+        </div>
+        {trailing}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * A section below the header, divided from it by a hairline.
+ *
+ * Every card that previews its own content — a script's first real line, an
+ * approval's message, a loop's body — drew the same rule and the same spacing
+ * by hand. `rows` is the one real variation: a list styles its own lines, so it
+ * takes the divider and the spacing without the single-line preview treatment.
+ */
+export function NodeFooter({
+  mono,
+  rows,
+  children
+}: {
+  mono?: boolean
+  rows?: boolean
+  children: ReactNode
+}) {
+  const inner = rows
+    ? 'space-y-0.5'
+    : `text-[11px] text-gray-600 truncate ${mono ? 'font-mono' : ''}`
+  return <div className={`mt-2 border-t border-white/[0.06] pt-2 ${inner}`}>{children}</div>
+}

--- a/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
@@ -1,7 +1,7 @@
 import { Terminal, Code2 } from 'lucide-react'
 import type { ScriptConfig, NodeExecutionStatus } from '../../../../shared/types'
-import { WORKFLOW_STATUS_DOT_PULSE } from '../../../lib/workflow-status'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH, truncate } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -29,35 +29,20 @@ export function ScriptNode({ label, config, selected, executionStatus, onClick }
     : undefined
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
+    <NodeShell
+      icon={<Icon size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
+      label={label}
+      subtitle={
+        <>
+          {config.scriptType}
+          {config.projectName && ` · ${config.projectName}`}
+        </>
+      }
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
     >
-      {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
-        <span
-          className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
-        />
-      )}
-      <div className="flex items-center gap-2">
-        <Icon size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">
-            {config.scriptType}
-            {config.projectName && ` · ${config.projectName}`}
-          </div>
-        </div>
-      </div>
-      {preview && (
-        <div className="mt-2 text-[11px] text-gray-600 truncate border-t border-white/[0.06] pt-2 font-mono">
-          {preview.length > 50 ? preview.slice(0, 50) + '...' : preview}
-        </div>
-      )}
-    </div>
+      {preview && <NodeFooter mono>{truncate(preview, 50)}</NodeFooter>}
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -6,7 +6,8 @@ import type {
 } from '../../../../shared/types'
 import { useConnectorIdFor, useConnectionIconFor } from '../../../lib/use-connections'
 import { ConnectorIcon } from '../../ConnectorIcon'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from '../node-visuals'
+import { NODE_GLYPH } from '../node-visuals'
+import { NodeShell } from './NodeShell'
 
 interface Props {
   label: string
@@ -69,17 +70,9 @@ export function TriggerNode({ label, config, selected, onClick }: Props) {
   const { connectorId, icon: connectorGlyph } = useConnectorGlyph(config)
 
   return (
-    <div
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className={`px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node hover:bg-white/[0.02]`}
-    >
-      <div className="flex items-center gap-2">
-        {connectorId ? (
+    <NodeShell
+      icon={
+        connectorId ? (
           <ConnectorIcon
             connectorId={connectorId}
             icon={connectorGlyph}
@@ -88,12 +81,12 @@ export function TriggerNode({ label, config, selected, onClick }: Props) {
           />
         ) : (
           <Icon size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
-        )}
-        <div className="min-w-0">
-          <div className="text-[13px] font-medium text-white truncate">{label}</div>
-          <div className="text-[11px] text-gray-500 truncate">{getSubtitle(config)}</div>
-        </div>
-      </div>
-    </div>
+        )
+      }
+      label={label}
+      subtitle={getSubtitle(config)}
+      selected={selected}
+      onClick={onClick}
+    />
   )
 }

--- a/tests/node-cards.test.tsx
+++ b/tests/node-cards.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (sel?: (s: unknown) => unknown) => {
+    const state = { config: { remoteHosts: [{ id: 'h1', label: 'build-box' }] } }
+    return sel ? sel(state) : state
+  }
+}))
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnectorIdFor: (id: string | null) => (id ? 'github' : null),
+  useConnectionIconFor: () => undefined
+}))
+vi.mock('../src/renderer/components/ConnectorIcon', () => ({
+  ConnectorIcon: () => <span data-testid="connector-icon" />
+}))
+vi.mock('../src/renderer/components/AgentIcon', () => ({
+  AgentIcon: () => <span data-testid="agent-icon" />
+}))
+
+import { ScriptNode } from '../src/renderer/components/workflow-editor/nodes/ScriptNode'
+import { ConditionNode } from '../src/renderer/components/workflow-editor/nodes/ConditionNode'
+import { LaunchAgentNode } from '../src/renderer/components/workflow-editor/nodes/LaunchAgentNode'
+import { CallConnectorActionNode } from '../src/renderer/components/workflow-editor/nodes/CallConnectorActionNode'
+import { TriggerNode } from '../src/renderer/components/workflow-editor/nodes/TriggerNode'
+import type {
+  ScriptConfig,
+  ConditionConfig,
+  LaunchAgentConfig,
+  CallConnectorActionConfig,
+  TriggerConfig
+} from '../src/shared/types'
+
+const noop = (): void => {}
+
+afterEach(cleanup)
+
+describe('ScriptNode', () => {
+  it('names the runtime, and the project when it has one', () => {
+    render(
+      <ScriptNode
+        label="Build"
+        config={{ scriptType: 'bash', projectName: 'vorn' } as ScriptConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText(/bash/)).toBeInTheDocument()
+    expect(screen.getByText(/vorn/)).toBeInTheDocument()
+  })
+
+  it('previews the first line that is neither blank nor a comment', () => {
+    // A script's opening comment is the least informative line in it.
+    render(
+      <ScriptNode
+        label="Build"
+        config={
+          { scriptType: 'bash', scriptContent: '# set up\n\n  yarn build\nmore' } as ScriptConfig
+        }
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('yarn build')).toBeInTheDocument()
+  })
+
+  it('cuts a long preview rather than letting one card run taller', () => {
+    render(
+      <ScriptNode
+        label="Build"
+        config={{ scriptType: 'node', scriptContent: 'x'.repeat(80) } as ScriptConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText(`${'x'.repeat(50)}...`)).toBeInTheDocument()
+  })
+})
+
+describe('ConditionNode', () => {
+  it('says so plainly when it has nothing to compare', () => {
+    render(<ConditionNode label="If" config={{} as ConditionConfig} onClick={noop} />)
+    expect(screen.getByText('Not configured')).toBeInTheDocument()
+  })
+
+  it('spells the comparison out, quoting the value it tests against', () => {
+    render(
+      <ConditionNode
+        label="If"
+        config={{ variable: 'status', operator: 'equals', value: 'ok' } as ConditionConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('status = "ok"')).toBeInTheDocument()
+  })
+
+  it('leaves the value off an operator that does not take one', () => {
+    render(
+      <ConditionNode
+        label="If"
+        config={{ variable: 'out', operator: 'isEmpty', value: 'ignored' } as ConditionConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('out is empty')).toBeInTheDocument()
+  })
+})
+
+describe('LaunchAgentNode', () => {
+  it('names the project and branch it will work in', () => {
+    render(
+      <LaunchAgentNode
+        label="Fix it"
+        config={{ agentType: 'claude', projectName: 'vorn', branch: 'main' } as LaunchAgentConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText(/vorn/)).toBeInTheDocument()
+    expect(screen.getByText(/main/)).toBeInTheDocument()
+  })
+
+  it('names the host instead of the branch when the work runs elsewhere', () => {
+    // Where it runs is the more surprising fact of the two, and both do not fit.
+    render(
+      <LaunchAgentNode
+        label="Fix it"
+        config={
+          {
+            agentType: 'claude',
+            projectName: 'vorn',
+            branch: 'main',
+            remoteHostId: 'h1'
+          } as LaunchAgentConfig
+        }
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('build-box')).toBeInTheDocument()
+    expect(screen.queryByText(/main/)).not.toBeInTheDocument()
+  })
+
+  it('says where its work comes from when there is no prompt to show', () => {
+    render(
+      <LaunchAgentNode
+        label="Next"
+        config={{ agentType: 'claude', taskFromQueue: true } as LaunchAgentConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('Next task from queue')).toBeInTheDocument()
+    cleanup()
+
+    render(
+      <LaunchAgentNode
+        label="Task"
+        config={{ agentType: 'claude', taskId: 't1' } as LaunchAgentConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('From task')).toBeInTheDocument()
+  })
+
+  it('falls back to saying it has no project rather than showing nothing', () => {
+    render(
+      <LaunchAgentNode
+        label="Fix it"
+        config={{ agentType: 'claude' } as LaunchAgentConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('No project')).toBeInTheDocument()
+  })
+})
+
+describe('CallConnectorActionNode', () => {
+  it('prompts for an action until one is chosen', () => {
+    render(
+      <CallConnectorActionNode
+        label="Call"
+        config={{} as CallConnectorActionConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('Select action')).toBeInTheDocument()
+  })
+
+  it('shows the connector it will call once it has a connection', () => {
+    render(
+      <CallConnectorActionNode
+        label="Call"
+        config={{ connectionId: 'c1', action: 'createIssue' } as CallConnectorActionConfig}
+        onClick={noop}
+      />
+    )
+    expect(screen.getByText('createIssue')).toBeInTheDocument()
+    expect(screen.getByTestId('connector-icon')).toBeInTheDocument()
+  })
+})
+
+describe('TriggerNode', () => {
+  it('says what starts the run, in the terms of the trigger', () => {
+    const cases: [TriggerConfig, string | RegExp][] = [
+      [{ triggerType: 'manual' } as TriggerConfig, 'Click to run'],
+      [{ triggerType: 'recurring', cron: '0 9 * * *' } as TriggerConfig, 'Cron: 0 9 * * *'],
+      [{ triggerType: 'taskCreated' } as TriggerConfig, 'Any project'],
+      [{ triggerType: 'taskCreated', projectFilter: 'vorn' } as TriggerConfig, 'Project: vorn'],
+      [{ triggerType: 'taskStatusChanged' } as TriggerConfig, 'Any change'],
+      [
+        {
+          triggerType: 'taskStatusChanged',
+          fromStatus: 'todo',
+          toStatus: 'done',
+          projectFilter: 'vorn'
+        } as TriggerConfig,
+        /todo → done · vorn/
+      ]
+    ]
+
+    for (const [config, expected] of cases) {
+      render(<TriggerNode label="Start" config={config} onClick={noop} />)
+      expect(screen.getByText(expected)).toBeInTheDocument()
+      cleanup()
+    }
+  })
+
+  it("wears the connector's own mark when a connector starts it", () => {
+    render(
+      <TriggerNode
+        label="Start"
+        config={
+          {
+            triggerType: 'connectorPoll',
+            connectionId: 'c1',
+            event: 'issues.opened',
+            cron: '*/5 * * * *'
+          } as TriggerConfig
+        }
+        onClick={noop}
+      />
+    )
+    expect(screen.getByTestId('connector-icon')).toBeInTheDocument()
+    expect(screen.getByText(/issues.opened/)).toBeInTheDocument()
+  })
+})

--- a/tests/node-shell.test.tsx
+++ b/tests/node-shell.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import { NodeShell, NodeFooter } from '../src/renderer/components/workflow-editor/nodes/NodeShell'
+import {
+  NODE_SELECTED,
+  NODE_UNSELECTED,
+  truncate
+} from '../src/renderer/components/workflow-editor/node-visuals'
+import { WORKFLOW_STATUS_DOT_PULSE } from '../src/renderer/lib/workflow-status'
+
+const noop = (): void => {}
+const base = { icon: <span data-testid="icon" />, label: 'A step', subtitle: 'does a thing' }
+
+afterEach(cleanup)
+
+describe('NodeShell', () => {
+  it('is the outermost element, carrying the shape every card shares', () => {
+    // node-selection.test.tsx reads container.firstChild as the card root and
+    // checks the shape there, so a wrapper element here would silently defeat
+    // it. The classes are also written literally because Tailwind scans source
+    // text — a name composed at runtime is never generated.
+    const { container } = render(<NodeShell {...base} onClick={noop} />)
+    const root = container.firstElementChild as HTMLElement
+    for (const cls of ['rounded-md', 'px-3', 'py-2.5', 'w-[280px]', 'relative']) {
+      expect(root.className).toContain(cls)
+    }
+  })
+
+  it('marks selection with the shared border and never the accent', () => {
+    // Bronzo says work is blocked on the person. Selecting a node is neither.
+    const on = render(<NodeShell {...base} selected onClick={noop} />)
+    const selected = on.container.firstElementChild as HTMLElement
+    expect(selected.className).toContain(NODE_SELECTED)
+    expect(selected.className).not.toContain('bronzo')
+    cleanup()
+
+    const off = render(<NodeShell {...base} onClick={noop} />)
+    expect((off.container.firstElementChild as HTMLElement).className).toContain(NODE_UNSELECTED)
+  })
+
+  it('shows the state a live run put this node in', () => {
+    for (const status of ['running', 'waiting', 'error', 'success'] as const) {
+      const { container } = render(<NodeShell {...base} executionStatus={status} onClick={noop} />)
+      expect(
+        container.querySelector(`.${WORKFLOW_STATUS_DOT_PULSE[status].split(' ')[0]}`)
+      ).toBeInTheDocument()
+      cleanup()
+    }
+  })
+
+  it('draws no dot on a canvas that is only showing a definition', () => {
+    const { container } = render(<NodeShell {...base} onClick={noop} />)
+    expect(container.querySelector('span.absolute.rounded-full')).toBeNull()
+  })
+
+  it('outlines a card that stands for nothing yet', () => {
+    // A loop with no body is the shape of a step rather than a step.
+    const { container } = render(<NodeShell {...base} dashed onClick={noop} />)
+    expect((container.firstElementChild as HTMLElement).className).toContain('border-dashed')
+  })
+
+  it('carries the three things a card may add to the header', () => {
+    render(
+      <NodeShell
+        {...base}
+        onClick={noop}
+        meta={<span data-testid="meta" />}
+        trailing={<span data-testid="trailing" />}
+      >
+        <NodeFooter>a preview</NodeFooter>
+      </NodeShell>
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByTestId('meta')).toBeInTheDocument()
+    expect(screen.getByTestId('trailing')).toBeInTheDocument()
+    expect(screen.getByText('a preview')).toBeInTheDocument()
+  })
+
+  it('opens the node without letting the canvas take the click too', () => {
+    // The canvas clears selection on its own background click, so a card that
+    // let the event through would select and immediately deselect.
+    const onClick = vi.fn()
+    const onCanvas = vi.fn()
+    render(
+      <div onClick={onCanvas}>
+        <NodeShell {...base} onClick={onClick} />
+      </div>
+    )
+    fireEvent.click(screen.getByText('A step'))
+    expect(onClick).toHaveBeenCalled()
+    expect(onCanvas).not.toHaveBeenCalled()
+  })
+})
+
+describe('NodeFooter', () => {
+  it('divides itself from the header the same way every card did by hand', () => {
+    const { container } = render(<NodeFooter>text</NodeFooter>)
+    const el = container.firstElementChild as HTMLElement
+    expect(el.className).toContain('border-t')
+    expect(el.className).toContain('truncate')
+    expect(el.className).not.toContain('font-mono')
+  })
+
+  it('sets a preview of the work itself in mono', () => {
+    const { container } = render(<NodeFooter mono>ls -la</NodeFooter>)
+    expect((container.firstElementChild as HTMLElement).className).toContain('font-mono')
+  })
+
+  it('leaves a list to style its own rows', () => {
+    // A loop body brings its own numbering and truncation per line, so the
+    // single-line preview treatment would fight it.
+    const { container } = render(
+      <NodeFooter rows>
+        <div>one</div>
+      </NodeFooter>
+    )
+    const el = container.firstElementChild as HTMLElement
+    expect(el.className).toContain('space-y-0.5')
+    expect(el.className).not.toContain('truncate')
+  })
+})
+
+describe('truncate', () => {
+  it('leaves a line that fits alone', () => {
+    expect(truncate('short', 10)).toBe('short')
+    expect(truncate('exactly10!', 10)).toBe('exactly10!')
+  })
+
+  it('cuts a longer line and says it was cut', () => {
+    expect(truncate('abcdefghijk', 10)).toBe('abcdefghij...')
+  })
+})


### PR DESCRIPTION
The deferred follow-up from #447.

Eight components repeated the same card almost exactly — the same root classes, click handling, status dot, and icon-then-two-lines header. *Almost* is the problem: two had drifted to a smaller radius and sat visibly different beside the rest on one canvas, and the status dot added to seven of them was missed by the eighth. Each card now says only what makes it that kind of step.

## The three real variations

They survive as slots rather than being flattened away — a remote host row under the subtitle, a chip pinned right of the header, and footers, of which a loop has two. `NodeFooter` carries the one genuine difference between them: a list styles its own rows, so it takes the divider without the single-line preview treatment.

`TriggerNode` gains `relative` and `flex-1` by joining the shell. Neither is visible — it has no status dot to position and nothing to its right. It still gets no dot: passing one is a behaviour change, not a refactor, so it stays out of this PR.

## Why the root classes are still written out

Two reasons that agree. Tailwind scans source text, so a class name assembled at runtime is never generated. And `node-selection.test.tsx` reads `container.firstChild` as the card root, which only holds while the shell renders that element itself — no wrapper, no indirection hiding the literals.

## Verification

Every card rendered old and new across each config variant × five execution statuses × both selection states, diffing the DOM: **145 comparisons, all identical**.

That harness paid for itself immediately. It caught `2×` rendering literally as an escape sequence on every loop card showing an iteration count — a unicode escape resolves in a template literal and not in JSX text, and no existing test covered that chip.

The harness was scaffolding and is gone. What remains is a test for the shell's own contract and the first real tests these eight cards have had — patch coverage went from 30% to 100%, since the branch otherwise reads as almost pure deletion.

**232 lines out, 120 back.** No visual change.