### PR TITLE
Give the widget the palette every other surface reads

### DIFF
--- a/src/renderer/widget.css
+++ b/src/renderer/widget.css
@@ -1,3 +1,11 @@
+/* The widget is its own window with its own stylesheet, so it never saw the
+   palette the rest of the app reads. That is how it ended up the one surface
+   where a waiting agent is yellow rather than the accent — the same state the
+   dock, the runs list and the task board all mark with bronzo. Importing the
+   theme is enough: @theme emits the tokens as plain custom properties, no
+   Tailwind entry required. */
+@import './theme.css';
+
 * {
   margin: 0;
   padding: 0;
@@ -23,7 +31,7 @@ body {
 }
 
 .widget-container {
-  background: rgba(26, 26, 30, 0.96);
+  background: color-mix(in srgb, var(--color-surface-overlay) 96%, transparent);
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   overflow: hidden;
@@ -94,10 +102,10 @@ body {
 @keyframes glow-ring {
   0%,
   100% {
-    box-shadow: 0 0 0 0 var(--glow-color, rgba(74, 222, 128, 0.4));
+    box-shadow: 0 0 0 0 var(--glow-color, rgba(255, 255, 255, 0.4));
   }
   50% {
-    box-shadow: 0 0 8px 3px var(--glow-color, rgba(74, 222, 128, 0.3));
+    box-shadow: 0 0 8px 3px var(--glow-color, rgba(255, 255, 255, 0.3));
   }
 }
 
@@ -106,7 +114,9 @@ body {
   border-radius: 50%;
 }
 
-/* Status dot */
+/* Status dot. The four states read exactly as they do everywhere else: only
+   waiting is blocked on the person and takes the accent, running is the
+   commonest state so it stays ink, and idle recedes. */
 .status-dot {
   width: 7px;
   height: 7px;
@@ -115,16 +125,16 @@ body {
 }
 
 .status-running {
-  background: #4ade80;
+  background: var(--color-ink);
 }
 .status-waiting {
-  background: #facc15;
+  background: var(--color-bronzo);
 }
 .status-idle {
-  background: #6b7280;
+  background: var(--color-ink-ghost);
 }
 .status-error {
-  background: #ef4444;
+  background: var(--color-danger);
 }
 
 /* App button (V_ / Vorn label) */
@@ -134,7 +144,7 @@ body {
   border: none;
   font-size: 11px;
   font-weight: 600;
-  color: #c9972a;
+  color: var(--color-bronzo);
   cursor: pointer;
   padding: 0;
   border-radius: 3px;
@@ -251,8 +261,8 @@ body {
 }
 
 .permission-focused {
-  border-color: rgba(99, 102, 241, 0.45);
-  background: rgba(99, 102, 241, 0.06);
+  border-color: rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .permission-header {
@@ -340,9 +350,9 @@ body {
 }
 
 .permission-allow:hover {
-  background: rgba(74, 222, 128, 0.18);
-  border-color: rgba(74, 222, 128, 0.35);
-  color: #4ade80;
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: var(--color-ink);
 }
 
 .permission-deny {
@@ -352,9 +362,9 @@ body {
 }
 
 .permission-deny:hover {
-  background: rgba(239, 68, 68, 0.14);
-  border-color: rgba(239, 68, 68, 0.3);
-  color: #ef4444;
+  background: color-mix(in srgb, var(--color-danger) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-danger) 30%, transparent);
+  color: var(--color-danger);
 }
 
 .permission-suggestions {
@@ -382,8 +392,8 @@ body {
 }
 
 .permission-suggestion-btn:hover {
-  background: rgba(99, 102, 241, 0.12);
-  border-color: rgba(99, 102, 241, 0.3);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
   color: rgba(255, 255, 255, 0.7);
 }
 
@@ -436,7 +446,7 @@ body {
 }
 
 .ask-option-selected {
-  background: rgba(99, 102, 241, 0.15) !important;
-  border-color: rgba(99, 102, 241, 0.45) !important;
+  background: rgba(255, 255, 255, 0.12) !important;
+  border-color: rgba(255, 255, 255, 0.35) !important;
   color: rgba(255, 255, 255, 0.9) !important;
 }

--- a/tests/widget-palette.test.ts
+++ b/tests/widget-palette.test.ts
@@ -15,6 +15,17 @@ describe('the widget reads the same palette as the app', () => {
     // Tailwind entry, no second declaration to drift.
     expect(widget).toMatch(/@import\s+['"]\.\/theme\.css['"]/)
     expect(widget).not.toContain('--color-bronzo:')
+
+    // And it has to be the first statement. PostCSS silently discards an
+    // @import that any rule precedes — it warns rather than errors, so the
+    // build stays green while every token resolves to nothing. Comments are
+    // allowed ahead of it; nothing else is.
+    const firstStatement = widget
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((l) => l.trim())
+      .find(Boolean)
+    expect(firstStatement).toMatch(/^@import/)
   })
 
   it('marks the one state that is blocked on the person with the accent', () => {
@@ -42,8 +53,11 @@ describe('the widget reads the same palette as the app', () => {
     // Four hardcoded status hues, an indigo used for focus and selection, and a
     // second spelling of the accent all lived here. A hue the app does not have
     // a name for is the thing worth catching.
-    const strays = ['#4ade80', '#facc15', '#ef4444', '#6b7280', '#c9972a', '99, 102, 241'].filter(
-      (hex) => widget.toLowerCase().includes(hex.toLowerCase())
+    // Matched loosely on purpose: reformatting `99, 102, 241` to `99,102,241`
+    // would otherwise let the same colour back in unnoticed.
+    const sheet = widget.toLowerCase().replace(/\s+/g, '')
+    const strays = ['#4ade80', '#facc15', '#ef4444', '#6b7280', '#c9972a', '99,102,241'].filter(
+      (hex) => sheet.includes(hex)
     )
     expect(strays).toEqual([])
   })

--- a/tests/widget-palette.test.ts
+++ b/tests/widget-palette.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = join(__dirname, '..')
+const read = (p: string): string => readFileSync(join(root, p), 'utf8')
+
+const widget = read('src/renderer/widget.css')
+
+describe('the widget reads the same palette as the app', () => {
+  it('imports the theme rather than keeping its own copy', () => {
+    // The widget is a separate window with a separate stylesheet, which is how
+    // it became the one surface still painting a waiting agent yellow. @theme
+    // emits plain custom properties, so the import is all it needs — no
+    // Tailwind entry, no second declaration to drift.
+    expect(widget).toMatch(/@import\s+['"]\.\/theme\.css['"]/)
+    expect(widget).not.toContain('--color-bronzo:')
+  })
+
+  it('marks the one state that is blocked on the person with the accent', () => {
+    // Same rule as the session dock, the runs list and the task board: waiting
+    // takes bronzo and nothing else does.
+    const rule = (name: string): string =>
+      widget.match(new RegExp(`\\.status-${name}\\s*\\{([^}]*)\\}`))?.[1].trim() ?? ''
+
+    expect(rule('waiting')).toContain('var(--color-bronzo)')
+    for (const other of ['running', 'idle', 'error']) {
+      expect([other, rule(other).includes('bronzo')]).toEqual([other, false])
+    }
+  })
+
+  it('reads every status off the shared vocabulary, not a literal', () => {
+    const statuses = ['running', 'waiting', 'idle', 'error']
+    const literal = statuses.filter((s) => {
+      const rule = widget.match(new RegExp(`\\.status-${s}\\s*\\{([^}]*)\\}`))?.[1] ?? ''
+      return /#[0-9a-fA-F]{3,8}/.test(rule)
+    })
+    expect(literal).toEqual([])
+  })
+
+  it('keeps no palette of its own beside the shared one', () => {
+    // Four hardcoded status hues, an indigo used for focus and selection, and a
+    // second spelling of the accent all lived here. A hue the app does not have
+    // a name for is the thing worth catching.
+    const strays = ['#4ade80', '#facc15', '#ef4444', '#6b7280', '#c9972a', '99, 102, 241'].filter(
+      (hex) => widget.toLowerCase().includes(hex.toLowerCase())
+    )
+    expect(strays).toEqual([])
+  })
+})


### PR DESCRIPTION
The last surface still outside the rule, and the one where being outside it mattered most.

The widget is its own window with its own stylesheet, and it never imported the tokens — so while sessions, workflows and tasks were being collapsed onto one vocabulary, it kept four hardcoded status hues. It disagreed on exactly the load-bearing case: **waiting was yellow**, the one state that means an agent has stopped and needs you, which the dock, the runs list and the task board all mark with the accent. The always-on-top window is the surface most likely to be the only thing on screen when that happens.

## The fix is one import

`@theme` emits the tokens as plain custom properties, so a stylesheet gets them without a Tailwind entry of its own. That is the same import the web client now uses — one declaration, not a third copy of the values.

With the palette in reach the rest follows: `running` is ink, `idle` recedes to ghost, `error` is danger, `waiting` takes bronzo. A second spelling of the accent on the app button and the old container hex both read tokens now.

## Two things beyond status

- **Permission verdicts** painted allow green and deny red on hover. Allow is a neutral affordance — the same shape the prompt launcher's primary already uses — and only deny is destructive, so only deny keeps a hue.
- **Indigo was a fourth accent**, doing focus and selection in three places. Both are neutral washes now, which is what the rest of the app uses for that job.

## Verification

Compiled `widget.css` through PostCSS and read the resolved rules — the tokens have to survive the build, not merely be referenced. `.status-waiting` resolves to `var(--color-bronzo)` and no yellow, green or indigo survives anywhere in the output.

The test pins the rule rather than the values: the accent belongs to `waiting` alone, no status is a literal, and no palette of the widget's own comes back. Both guards mutation-tested.

CSS-only, so `diff-cover` reports no lines — the gate does not apply.