### PR TITLE
Put the surface levels back where they were

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -17,7 +17,7 @@
       /* Loading state before React mounts */
       body {
         margin: 0;
-        background: #0a0a0c;
+        background: #0d0d0f;
         color: #9ca3af;
       }
       #root:empty {

--- a/packages/web/public/offline.html
+++ b/packages/web/public/offline.html
@@ -12,7 +12,7 @@
       }
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background: #0a0a0c;
+        background: #0d0d0f;
         color: #d4d4d8;
         display: flex;
         align-items: center;

--- a/packages/web/src/global.css
+++ b/packages/web/src/global.css
@@ -1,14 +1,16 @@
+/* The renderer's custom styles (scrollbar, animations, etc.) are re-declared
+   below rather than imported, to avoid path resolution issues. The palette is
+   not: it is imported, because a second copy of the tokens is exactly how this
+   client ended up rendering every tokenised background as transparent.
+
+   Every @import has to precede everything else in the file, @source included,
+   or PostCSS drops it and takes the whole palette with it. */
 @import 'tailwindcss';
+@import '../../../src/renderer/theme.css';
 @source "../**/*.{ts,tsx}";
 @source "../index.html";
 @source "../../../src/renderer/**/*.{ts,tsx}";
 @variant dark (&:where(.dark, .dark *));
-
-/* The renderer's custom styles (scrollbar, animations, etc.) are re-declared
-   below rather than imported, to avoid path resolution issues. The palette is
-   not: it is imported, because a second copy of the tokens is exactly how this
-   client ended up rendering every tokenised background as transparent. */
-@import '../../../src/renderer/theme.css';
 
 html,
 body {

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -1,9 +1,12 @@
-@import 'tailwindcss';
-@source "./**/*.{tsx,ts,html}";
+/* The palette lives in theme.css so the web client can share it verbatim — it
+   has its own Tailwind entry and would otherwise define no tokens at all.
 
-/* The palette lives in theme.css so the web client can share it verbatim —
-   it has its own Tailwind entry and would otherwise define no tokens at all. */
+   Every @import has to precede everything else in the file, including @source
+   and the comment above it, or PostCSS drops it and takes the whole palette
+   with it. */
+@import 'tailwindcss';
 @import './theme.css';
+@source "./**/*.{tsx,ts,html}";
 
 html,
 body {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,7 +9,7 @@
     />
     <title>Vorn</title>
   </head>
-  <body class="text-gray-100 overflow-hidden" style="background: #0a0a0c">
+  <body class="text-gray-100 overflow-hidden" style="background: #0d0d0f">
     <div id="root"></div>
     <script type="module" src="./main.tsx"></script>
   </body>

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -35,17 +35,21 @@
      the order of four points: a panel is a different region, not a different
      material, and a larger step reads as a hole cut in the page.
 
-     The set sits three points below where it started, and the card body sits
-     two points above its own header rather than four. A card is one object —
-     header, frame and the terminal inside it — so that step only has to
-     separate them, not announce a new region; the step that still has work to
-     do is the one from the field up to the card. Five points down for the
-     whole set was tried first and read as too flat, since a display has less
-     room to separate rungs the closer they all get to black. */
-  --color-surface-base: #0a0a0c; /* app background, behind the cards */
-  --color-surface-sunken: #0f0f11; /* card body and terminal: the main column */
-  --color-surface-panel: #0d0d0f; /* panes, card header, status bar: beside the work */
-  --color-surface-overlay: #19191d; /* menus, popovers, floating chrome */
+     These values were moved down — first five points, then three, with the
+     card body dropped a further two so it sat closer to its own header. Each
+     step survived the move arithmetically and the set still failed in the
+     built app: the rungs stopped resolving as distinct surfaces, and a board
+     of cards read as one flat field. A ladder this tight needs the headroom,
+     so the level is back where it started and should stay there. Judge any
+     future move in the packaged app on a real display, not in dev.
+
+     The card body is four points above its header, not two. Two was tried on
+     the theory that a card is one object; it is, but the header still has to
+     read as a different band or the card loses its top edge. */
+  --color-surface-base: #0d0d0f; /* app background, behind the cards */
+  --color-surface-sunken: #141416; /* card body and terminal: the main column */
+  --color-surface-panel: #101012; /* panes, card header, status bar: beside the work */
+  --color-surface-overlay: #1c1c20; /* menus, popovers, floating chrome */
   /* Aliases, not values. A card frame matching the terminal it holds is what
      keeps a lighter band from showing around the panes, so the equality is the
      point — spelling it as a reference keeps a later nudge to one from silently

--- a/src/shared/surface.ts
+++ b/src/shared/surface.ts
@@ -24,13 +24,13 @@
  */
 export const SURFACE = {
   /** App field, the window ground, and the document before the app mounts. */
-  base: '#0a0a0c',
+  base: '#0d0d0f',
   /** Card body and the terminal canvas inside it. */
-  sunken: '#0f0f11',
+  sunken: '#141416',
   /** Panes, card header, status bar: beside the work. */
-  panel: '#0d0d0f',
+  panel: '#101012',
   /** Menus, popovers, floating chrome. */
-  overlay: '#19191d'
+  overlay: '#1c1c20'
 } as const
 
 /** The terminal canvas sits on the same rung as the card holding it. */

--- a/tests/surface-token.test.ts
+++ b/tests/surface-token.test.ts
@@ -45,7 +45,7 @@ describe('the surface ladder', () => {
     expect(wrong).toEqual([])
   })
 
-  it('gives every client the palette, not just the one that owns it', () => {
+  it('gives every client the palette, not just the one that owns it', async () => {
     // Both clients mount the same renderer, but each has its own Tailwind entry
     // and only one of them defined the tokens. Utilities silently stopped being
     // generated for the other, and an inline var() that resolves to nothing is
@@ -59,6 +59,28 @@ describe('the surface ladder', () => {
       read(p).includes('--color-surface-base:')
     )
     expect(declaring).toEqual(['src/renderer/theme.css'])
+  })
+
+  it('keeps every @import ahead of the statements that would drop it', () => {
+    // PostCSS silently discards an @import that does not precede every other
+    // statement — @source counts — and it warns rather than errors, so the
+    // build stays green while every token resolves to nothing: cards and
+    // dialogs paint transparent and the status hues vanish. Compiling the sheet
+    // in isolation does not reproduce it, because the bundler's pipeline is
+    // what enforces the rule, so the ordering itself is what has to be pinned.
+    const outOfOrder = ENTRY_SHEETS.filter((p) => {
+      const statements = read(p)
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+      const lastImport = statements.map((l) => l.startsWith('@import')).lastIndexOf(true)
+      const firstOther = statements.findIndex(
+        (l) => !l.startsWith('@import') && !l.startsWith('@charset')
+      )
+      return firstOther !== -1 && lastImport > firstOther
+    })
+    expect(outOfOrder).toEqual([])
   })
 
   it('steps in small, even increments from the field up to floating chrome', () => {


### PR DESCRIPTION
The surface set was moved down twice — five points, then three, with the card body dropped a further two — and it is wrong in the packaged app. Every step survived the move arithmetically, so the rungs are nominally still apart, but this close to black a display has no room left to show it: the task board reads as one flat field with no cards on it, which is the opposite of what the ladder exists for.

All four values return to what shipped before the darkening:

| | reverted to |
|---|---|
| `base` | `#0d0d0f` |
| `panel` | `#101012` |
| `sunken` | `#141416` |
| `overlay` | `#1c1c20` |

The three pre-mount grounds and the JS mirror the terminal canvas reads come back with them, so nothing is left behind on the old level.

The card body also goes back to four points above its header rather than two. Two came from treating a card as one object — it is, but the header still has to read as its own band or the card loses its top edge.

**Nothing else about the palette work is touched.** The tokens, the shared tone table, the single theme declaration both clients import, and the guard tests all stay; only the four values move. That separation is exactly what made this a five-file revert instead of a 47-file one.

Worth recording for whoever tries this again: dev is not where to judge it. Both moves looked defensible there and only failed in the built app.