### PR TITLE
chore(release): 0.6.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Fixes the palette in `beta.2`.

The theme import sat after `@source` in both entry stylesheets. PostCSS drops an `@import` that anything precedes — with a **warning rather than an error**, so the build stayed green while every token resolved to nothing. In the shipped `beta.2` that meant cards painting the same colour as the background, dialogs transparent, and the task statuses losing their colour entirely.

Also in this beta:

- **Surface levels back where they were.** They had been moved down twice; every step survived arithmetically, but that close to black a display has no room to show it.
- **The widget joins the palette.** It is its own window with its own stylesheet and never imported the tokens, so it was the last surface painting a waiting agent yellow rather than the accent — on the window most likely to be the only thing on screen when an agent stops for you.

Verified before tagging: a real `electron-vite build` from `main` emits no import warning, and the built stylesheets carry the surface, status and accent tokens plus the utilities that read them. The widget's own sheet resolves `waiting` to `var(--color-bronzo)`.

Version bump only — the six workspace packages are synced by the pre-commit hook.