### PR TITLE
Let a card be one surface, and take the last cold greys out of workflows

### DIFF
--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -53,11 +53,14 @@ export function CardHeader({
   const dragHandleClass = draggable ? `drag-handle${onDragStart ? ' cursor-grab' : ''}` : ''
 
   return (
+    // The card is one object, so its header, body and status bar share a ground
+    // and the hairline below does the dividing. Two fills made the header read
+    // as a separate band stuck to the top of the card rather than part of it.
     <div
       className={`flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0
                   transition-opacity duration-200 ease-out
                   ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
-      style={{ background: 'var(--color-surface-panel)' }}
+      style={{ background: 'var(--color-surface-raised)' }}
     >
       <div
         className={`flex-1 min-w-0 flex items-center gap-2 ${dragHandleClass}`}

--- a/src/renderer/components/card/CardStatusBar.tsx
+++ b/src/renderer/components/card/CardStatusBar.tsx
@@ -33,7 +33,7 @@ export function CardStatusBar({ terminalId, dimmed }: Props) {
       className={`shrink-0 flex items-center gap-2 px-2 h-[22px] border-t border-white/[0.04] text-[11px]
                   transition-opacity duration-200 ease-out
                   ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
-      style={{ background: 'var(--color-surface-panel)' }}
+      style={{ background: 'var(--color-surface-raised)' }}
     >
       {hasBranch && <BranchChip terminalId={terminalId} />}
 

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -226,11 +226,12 @@ export function RunStepsList({
           return (
             <div key={ns.nodeId}>
               {/* Line linking the previous step to this one so the cards read
-                  as one continuous flow. Deliberately neutral: the status dots
+                  as one continuous flow. Neutral on purpose: the status dots
                   carry the colour, and tinting the connectors too turns the
-                  trace into a rainbow that competes with them. */}
+                  trace into a rainbow that competes with them. It read
+                  gray-700, which is blue-tinted rather than neutral. */}
               {i > 0 && (
-                <div aria-hidden className="flex justify-center text-gray-700">
+                <div aria-hidden className="flex justify-center text-ink-ghost">
                   <div className="flex flex-col items-center">
                     <div className="w-px h-3.5 bg-current" />
                     <ChevronDown size={10} strokeWidth={2} className="-mt-[3px]" />

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -80,7 +80,7 @@ export function NodeConfigPanel({
   const headerConnectorIcon = useConnectionIconFor(connectorConfig?.connectionId)
 
   return (
-    <div className="w-[420px] border-l border-white/[0.08] bg-surface-overlay flex flex-col h-full overflow-hidden titlebar-no-drag">
+    <div className="w-[420px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag">
       <div className="flex items-center gap-2 px-5 py-3 border-b border-white/[0.08]">
         {headerConnectorId ? (
           <ConnectorIcon
@@ -224,18 +224,22 @@ export function NodeConfigPanel({
 
         {/* A trigger has nothing downstream of its own failure to govern. */}
         {node.type !== 'trigger' && onErrorChange && (
-          <div className="pt-4 border-t border-gray-800">
+          <div className="pt-4 border-t border-white/[0.08]">
             <label
               htmlFor={`onError-${node.id}`}
               className="block text-[11px] text-gray-500 mb-1.5"
             >
               If this step fails
             </label>
+            {/* Tailwind's gray-900 and gray-700 are blue-tinted (#111827,
+                #374151), so this control read as the one blue thing in the
+                editor. Every other select in these panels uses this wash. */}
             <select
               id={`onError-${node.id}`}
               value={node.onError ?? 'stop'}
               onChange={(e) => onErrorChange(node.id, e.target.value as WorkflowNodeErrorPolicy)}
-              className="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1.5 text-xs text-gray-200"
+              className="w-full px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-md
+                         text-[13px] text-gray-200 focus:outline-none focus:border-white/[0.2]"
             >
               <option value="stop">Stop the run</option>
               <option value="continue">Carry on anyway</option>

--- a/src/renderer/components/workflow-editor/panels/NodePalette.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodePalette.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export function NodePalette({ onAddTrigger, onAddLaunchAgent, onAddScript, hasTrigger }: Props) {
   return (
-    <div className="w-[180px] border-r border-white/[0.08] bg-surface-overlay flex flex-col h-full overflow-hidden titlebar-no-drag">
+    <div className="w-[180px] border-r border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag">
       <div className="px-3 py-3 border-b border-white/[0.08]">
         <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
           Add Nodes

--- a/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
@@ -38,7 +38,7 @@ export function RunHistoryPanel({
 
   return (
     <>
-      <div className="w-[340px] border-l border-white/[0.08] bg-surface-overlay flex flex-col h-full overflow-hidden titlebar-no-drag">
+      <div className="w-[340px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag">
         <div className="flex items-center justify-between px-4 py-3 border-b border-white/[0.08]">
           <span className="text-[13px] font-medium text-white">Run History</span>
           <button

--- a/src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel.tsx
@@ -54,7 +54,7 @@ export function WorkflowPropertiesPanel({
   onClose
 }: Props) {
   return (
-    <div className="w-[340px] border-l border-white/[0.08] bg-surface-overlay flex flex-col h-full overflow-hidden titlebar-no-drag">
+    <div className="w-[340px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag">
       <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.08]">
         <span className="text-[13px] font-medium text-white">Properties</span>
         <button

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -48,7 +48,7 @@
      read as a different band or the card loses its top edge. */
   --color-surface-base: #0d0d0f; /* app background, behind the cards */
   --color-surface-sunken: #141416; /* card body and terminal: the main column */
-  --color-surface-panel: #101012; /* panes, card header, status bar: beside the work */
+  --color-surface-panel: #101012; /* panes and the sidebar: chrome beside the work */
   --color-surface-overlay: #1c1c20; /* menus, popovers, floating chrome */
   /* Aliases, not values. A card frame matching the terminal it holds is what
      keeps a lighter band from showing around the panes, so the equality is the

--- a/src/shared/surface.ts
+++ b/src/shared/surface.ts
@@ -27,7 +27,7 @@ export const SURFACE = {
   base: '#0d0d0f',
   /** Card body and the terminal canvas inside it. */
   sunken: '#141416',
-  /** Panes, card header, status bar: beside the work. */
+  /** Panes and the sidebar: chrome beside the work. */
   panel: '#101012',
   /** Menus, popovers, floating chrome. */
   overlay: '#1c1c20'

--- a/tests/card-header.test.tsx
+++ b/tests/card-header.test.tsx
@@ -151,6 +151,16 @@ describe('CardHeader', () => {
     expect(setRenamingTerminalId).not.toHaveBeenCalled()
   })
 
+  it('sits on the same ground as the rest of the card', () => {
+    // A card is one object. The header used to take the pane rung while the
+    // body took the card rung, so it read as a separate band stuck to the top
+    // rather than part of the card — the hairline is what divides them.
+    const { container } = render(<CardHeader terminalId="term-1" variant="mini" />)
+    const header = container.firstElementChild as HTMLElement
+    expect(header.style.background).toBe('var(--color-surface-raised)')
+    expect(header.className).toContain('border-b')
+  })
+
   it('focused variant shows the action cluster without needing hover', () => {
     render(<CardHeader terminalId="term-1" variant="focused" />)
     expect(screen.getByRole('button', { name: /Collapse/ })).toBeInTheDocument()

--- a/tests/card-status-bar.test.tsx
+++ b/tests/card-status-bar.test.tsx
@@ -709,4 +709,12 @@ describe('TabView merged toolbar controls', () => {
     fireEvent.click(moreBtn)
     expect(moreBtn).toBeInTheDocument()
   })
+
+  it('sits on the same ground as the rest of the card', () => {
+    // Same rule as the header: one card, one ground, divided by a hairline.
+    const { container } = render(<CardStatusBar terminalId="term-1" />)
+    const bar = container.firstElementChild as HTMLElement
+    expect(bar.style.background).toBe('var(--color-surface-raised)')
+    expect(bar.className).toContain('border-t')
+  })
 })

--- a/tests/workflow-panel-surface.test.ts
+++ b/tests/workflow-panel-surface.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = join(__dirname, '..')
+const panels = join(root, 'src/renderer/components/workflow-editor/panels')
+const read = (name: string): string => readFileSync(join(panels, name), 'utf8')
+
+/** The panels docked to an edge of the editor, each a permanent region of it. */
+const DOCKED = [
+  'NodeConfigPanel.tsx',
+  'WorkflowPropertiesPanel.tsx',
+  'RunHistoryPanel.tsx',
+  'NodePalette.tsx'
+] as const
+
+/** The one panel element in each file: the root, which carries the edge border. */
+const rootClasses = (source: string): string =>
+  source.match(/className="([^"]*border-[lr] [^"]*)"/)?.[1] ?? ''
+
+describe('the workflow editor panels', () => {
+  it('sits on the same ground as the nodes it inspects', () => {
+    // These are docked regions of the editor, not floating chrome. On the
+    // overlay rung they were the lightest thing on screen and read pale beside
+    // a canvas of nodes; the node rung ties a config panel to the node it is
+    // describing.
+    const wrong = DOCKED.filter((name) => !rootClasses(read(name)).includes('bg-surface-node'))
+    expect(wrong).toEqual([])
+  })
+
+  it('leaves the overlay rung to the things that actually float', () => {
+    // A dropdown opened from inside a panel does float over it, and has to stay
+    // distinguishable from the panel it covers — so the rung is not wrong
+    // everywhere, only on the panels themselves.
+    const onOverlay = DOCKED.filter((name) =>
+      rootClasses(read(name)).includes('bg-surface-overlay')
+    )
+    expect(onOverlay).toEqual([])
+
+    const menu = read('NodeConfigPanel.tsx')
+    expect(menu).toContain("background: 'var(--color-surface-overlay)'")
+  })
+})


### PR DESCRIPTION
Three things reported from the running app, all the same kind of defect.

## A session card was two materials

The header and status bar sat on the pane rung (`#101012`) while the body sat on the card rung (`#141416`), so the header read as a separate band stuck to the top rather than part of the card. All three share a ground now, and the hairline each already carried does the dividing.

Panes keep their own rung — a pane frames someone else's content, and sitting a step below the terminal beside it is deliberate.

## The workflow side panels were floating chrome

Node config, workflow properties, run history and the palette were all on `surface-overlay` — the rung meant for menus and popovers. That made them the lightest surfaces on screen and pale beside a canvas of nodes. They take `surface-node`, so a config panel sits on the same ground as the node it describes.

The dropdown that opens *inside* a panel keeps overlay, because it genuinely floats and has to stay distinct from the panel under it. A test pins that split rather than banning the rung outright.

## The blue in "If this step fails"

That select used Tailwind's `gray-900` and `gray-700` — `#111827` and `#374151`, which are **blue-tinted, not neutral**. It was the one blue control in the editor. Every other select in these panels already used the neutral wash, so it now matches them.

The run trace's connector line had the same problem, sitting under a comment that claimed it was deliberately neutral.

## Testing

The card's shared ground and the docked-versus-floating split are pinned by tests, both mutation-tested. `diff-cover` reports no lines — the changes are class and token strings.