### PR TITLE
Stop device_launch hanging, and give a diff its colours back

### DIFF
--- a/src/main/device-companion.ts
+++ b/src/main/device-companion.ts
@@ -322,8 +322,17 @@ export function callStreaming<T>(
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     let settled = false
-    // `timer` is declared below and only read from callbacks, which cannot run
-    // before the synchronous body finishes.
+    // The timer is armed before the call is opened, so a client that answers
+    // synchronously — a mock, or a future grpc-js fast path — finds it already
+    // there. Held in an object because cancelling needs the stream, and the
+    // stream does not exist until after the timer.
+    const open: { stream?: grpc.ClientWritableStream<unknown> } = {}
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      open.stream?.cancel()
+      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
+    }, STREAM_TIMEOUT_MS)
     const settle = (fn: () => void): void => {
       if (settled) return
       settled = true
@@ -335,12 +344,7 @@ export function callStreaming<T>(
       if (err) settle(() => reject(new Error(err.details || err.message)))
       else settle(() => resolve(res))
     })
-    const timer = setTimeout(() => {
-      if (settled) return
-      settled = true
-      stream.cancel()
-      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
-    }, STREAM_TIMEOUT_MS)
+    open.stream = stream
 
     for (const m of messages) stream.write(m)
     stream.end()

--- a/src/main/device-companion.ts
+++ b/src/main/device-companion.ts
@@ -270,6 +270,20 @@ export function installCompanionQuitHook(): void {
 }
 
 /**
+ * How long a call may take before we give up on it.
+ *
+ * Without this a call that never answers hangs its caller for the life of the
+ * process, and an agent waiting on a tool result has no way to tell that apart
+ * from a slow simulator. Generous enough that a cold app launch fits.
+ *
+ * A caller that asks the device to *hold* — a long press is a DOWN, a delay and
+ * an UP inside one call — must add that hold to the budget. Left at the bare
+ * default, a 30s press raced this exact number and lost: the press happened and
+ * the call reported failure.
+ */
+export const CALL_TIMEOUT_MS = 30_000
+
+/**
  * Wraps a unary companion call in a promise.
  *
  * gRPC-js is callback-first, and a status error carries the detail that makes
@@ -283,23 +297,33 @@ export function installCompanionQuitHook(): void {
  *  - `screenshot` returns `image_format` as an empty string, so the format has
  *    to be sniffed from the bytes (they are PNG) rather than trusted.
  */
-export function call<T>(client: CompanionClient, method: string, request: unknown): Promise<T> {
+export function call<T>(
+  client: CompanionClient,
+  method: string,
+  request: unknown,
+  timeoutMs: number = CALL_TIMEOUT_MS
+): Promise<T> {
   return new Promise((resolve, reject) => {
+    // A wedged simulator keeps its socket open, so gRPC never errors and a
+    // unary call waits as long as a streaming one would. `screenshot` and
+    // `accessibility_info` come through here — the two calls an agent makes
+    // most, and the two whose silence is least distinguishable from slowness.
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(`The device did not answer ${method} within ${timeoutMs / 1000}s.`))
+    }, timeoutMs)
+
     client[method](request, (err: grpc.ServiceError | null, res: T) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
       if (err) reject(new Error(err.details || err.message))
       else resolve(res)
     })
   })
 }
-
-/**
- * How long any streaming call may take before we give up on it.
- *
- * Without this a call that never answers hangs its caller for the life of the
- * process, and an agent waiting on a tool result has no way to tell that apart
- * from a slow simulator. Generous enough that a cold app launch fits.
- */
-const STREAM_TIMEOUT_MS = 30_000
 
 /**
  * Writes a sequence of messages to a **client-streaming** call — `stream X → Y`
@@ -318,7 +342,8 @@ const STREAM_TIMEOUT_MS = 30_000
 export function callStreaming<T>(
   client: CompanionClient,
   method: string,
-  messages: readonly unknown[]
+  messages: readonly unknown[],
+  timeoutMs: number = CALL_TIMEOUT_MS
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     let settled = false
@@ -331,8 +356,8 @@ export function callStreaming<T>(
       if (settled) return
       settled = true
       open.stream?.cancel()
-      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
-    }, STREAM_TIMEOUT_MS)
+      reject(new Error(`The device did not answer ${method} within ${timeoutMs / 1000}s.`))
+    }, timeoutMs)
     const settle = (fn: () => void): void => {
       if (settled) return
       settled = true
@@ -354,7 +379,8 @@ export function callStreaming<T>(
 export function callBidiStreaming<T>(
   client: CompanionClient,
   method: string,
-  messages: readonly unknown[]
+  messages: readonly unknown[],
+  timeoutMs: number = CALL_TIMEOUT_MS
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     const stream = client[method]() as grpc.ClientDuplexStream<unknown, T>
@@ -370,8 +396,8 @@ export function callBidiStreaming<T>(
       if (settled) return
       settled = true
       stream.cancel()
-      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
-    }, STREAM_TIMEOUT_MS)
+      reject(new Error(`The device did not answer ${method} within ${timeoutMs / 1000}s.`))
+    }, timeoutMs)
 
     stream.on('data', (msg: T) => {
       last = msg

--- a/src/main/device-companion.ts
+++ b/src/main/device-companion.ts
@@ -383,21 +383,29 @@ export function callBidiStreaming<T>(
   timeoutMs: number = CALL_TIMEOUT_MS
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    const stream = client[method]() as grpc.ClientDuplexStream<unknown, T>
     let last: T | undefined
     let settled = false
+    // Same shape as the helper above, and for the same reason: the deadline is
+    // armed before the call exists, so nothing can reach the timer before it is
+    // there. The handlers below happen to be registered after it either way —
+    // keeping both functions identical is what stops a later reordering
+    // reintroducing that.
+    const open: { stream?: grpc.ClientDuplexStream<unknown, T> } = {}
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      open.stream?.cancel()
+      reject(new Error(`The device did not answer ${method} within ${timeoutMs / 1000}s.`))
+    }, timeoutMs)
     const settle = (fn: () => void): void => {
       if (settled) return
       settled = true
       clearTimeout(timer)
       fn()
     }
-    const timer = setTimeout(() => {
-      if (settled) return
-      settled = true
-      stream.cancel()
-      reject(new Error(`The device did not answer ${method} within ${timeoutMs / 1000}s.`))
-    }, timeoutMs)
+
+    const stream = client[method]() as grpc.ClientDuplexStream<unknown, T>
+    open.stream = stream
 
     stream.on('data', (msg: T) => {
       last = msg

--- a/src/main/device-companion.ts
+++ b/src/main/device-companion.ts
@@ -293,14 +293,27 @@ export function call<T>(client: CompanionClient, method: string, request: unknow
 }
 
 /**
- * Writes a sequence of messages to a client-streaming call and waits for the
- * single reply.
+ * How long any streaming call may take before we give up on it.
  *
- * `hid` and `launch` are `stream X → Y`, not unary: a tap is *two* events, a
- * DOWN and an UP, and sending only the first leaves a finger held on the glass
- * — every subsequent gesture then behaves strangely for reasons nothing
- * reports. Keeping both halves inside one call is what makes that impossible to
- * get half-right at a call site.
+ * Without this a call that never answers hangs its caller for the life of the
+ * process, and an agent waiting on a tool result has no way to tell that apart
+ * from a slow simulator. Generous enough that a cold app launch fits.
+ */
+const STREAM_TIMEOUT_MS = 30_000
+
+/**
+ * Writes a sequence of messages to a **client-streaming** call — `stream X → Y`
+ * — and waits for the single reply.
+ *
+ * `hid` is the one that matters: a tap is *two* events, a DOWN and an UP, and
+ * sending only the first leaves a finger held on the glass — every subsequent
+ * gesture then behaves strangely for reasons nothing reports. Keeping both
+ * halves inside one call is what makes that impossible to get half-right at a
+ * call site.
+ *
+ * Only for methods the proto declares as `stream X` returning a bare `Y`. A
+ * method that streams *back* has no callback form at all, and passing one there
+ * is a hang rather than an error — see `callBidiStreaming`.
  */
 export function callStreaming<T>(
   client: CompanionClient,
@@ -308,10 +321,64 @@ export function callStreaming<T>(
   messages: readonly unknown[]
 ): Promise<T> {
   return new Promise((resolve, reject) => {
+    let settled = false
+    // `timer` is declared below and only read from callbacks, which cannot run
+    // before the synchronous body finishes.
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      fn()
+    }
+
     const stream = client[method]((err: grpc.ServiceError | null, res: T) => {
-      if (err) reject(new Error(err.details || err.message))
-      else resolve(res)
+      if (err) settle(() => reject(new Error(err.details || err.message)))
+      else settle(() => resolve(res))
     })
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      stream.cancel()
+      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
+    }, STREAM_TIMEOUT_MS)
+
+    for (const m of messages) stream.write(m)
+    stream.end()
+  })
+}
+
+export function callBidiStreaming<T>(
+  client: CompanionClient,
+  method: string,
+  messages: readonly unknown[]
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const stream = client[method]() as grpc.ClientDuplexStream<unknown, T>
+    let last: T | undefined
+    let settled = false
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      fn()
+    }
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      stream.cancel()
+      reject(new Error(`The device did not answer ${method} within ${STREAM_TIMEOUT_MS / 1000}s.`))
+    }, STREAM_TIMEOUT_MS)
+
+    stream.on('data', (msg: T) => {
+      last = msg
+    })
+    stream.on('error', (err: grpc.ServiceError) => {
+      settle(() => reject(new Error(err.details || err.message)))
+    })
+    stream.on('end', () => {
+      settle(() => resolve((last ?? {}) as T))
+    })
+
     for (const m of messages) stream.write(m)
     stream.end()
   })

--- a/src/main/device-registry.ts
+++ b/src/main/device-registry.ts
@@ -17,6 +17,7 @@ import {
   call,
   callStreaming,
   callBidiStreaming,
+  CALL_TIMEOUT_MS,
   type CompanionHandle
 } from './device-companion'
 import log from './logger'
@@ -834,7 +835,15 @@ export async function interact(params: {
     }
   }
 
-  await callStreaming(entry.companion.client, 'hid', events)
+  // A press asks the device to hold, and that hold is spent inside the call.
+  // Charging it to the same budget as the round trip is how a 30s press came to
+  // fail after succeeding: the deadline fired on the delay it had itself asked
+  // for.
+  const heldSeconds = events.reduce<number>(
+    (total, e) => total + ((e as { delay?: { duration?: number } }).delay?.duration ?? 0),
+    0
+  )
+  await callStreaming(entry.companion.client, 'hid', events, CALL_TIMEOUT_MS + heldSeconds * 1000)
   // Refs describe a screen that this input may have just replaced.
   entry.generation++
   entry.refs.clear()

--- a/src/main/device-registry.ts
+++ b/src/main/device-registry.ts
@@ -16,6 +16,7 @@ import {
   stopCompanion,
   call,
   callStreaming,
+  callBidiStreaming,
   type CompanionHandle
 } from './device-companion'
 import log from './logger'
@@ -923,7 +924,10 @@ export async function launch(params: {
 }): Promise<{ ok: true }> {
   const entry = deviceFor(params.sessionId)
   try {
-    await callStreaming(entry.companion.client, 'launch', [
+    // Bidirectional in the proto — `stream LaunchRequest → stream LaunchResponse`
+    // — so it has no callback form. Sent through the client-streaming helper it
+    // never settled, and device_launch hung for the life of the process.
+    await callBidiStreaming(entry.companion.client, 'launch', [
       { start: { bundle_id: params.bundleId, foreground_if_running: true } }
     ])
   } catch (err) {

--- a/src/renderer/components/DiffSidebar.tsx
+++ b/src/renderer/components/DiffSidebar.tsx
@@ -51,10 +51,8 @@ export function DiffFileList({
             <FileTypeIcon name={fileName} size={15} />
             <span className="flex-1 min-w-0 truncate text-gray-300 font-mono">{file.filePath}</span>
             <span className="shrink-0 flex items-center gap-1.5 text-[11px] font-mono">
-              {file.insertions > 0 && (
-                <span className="text-ink-secondary">+{file.insertions}</span>
-              )}
-              {file.deletions > 0 && <span className="text-ink-faint">-{file.deletions}</span>}
+              {file.insertions > 0 && <span className="text-diff-add">+{file.insertions}</span>}
+              {file.deletions > 0 && <span className="text-diff-remove">-{file.deletions}</span>}
             </span>
             <span className={`shrink-0 text-[10px] font-bold ${STATUS_LETTER_CLASS}`}>
               {letter}

--- a/src/renderer/components/GitChangesIndicator.tsx
+++ b/src/renderer/components/GitChangesIndicator.tsx
@@ -24,9 +24,11 @@ export function GitChangesIndicator({ terminalId }: Props) {
                  hover:bg-white/[0.06] rounded transition-colors cursor-pointer"
       title={`${stat.filesChanged} file${stat.filesChanged !== 1 ? 's' : ''} changed`}
     >
-      {/* A measurement, not a verdict — a large deletion is not a failure. */}
-      <span className="text-ink-secondary">+{stat.insertions}</span>
-      <span className="text-ink-faint">-{stat.deletions}</span>
+      {/* A diff keeps its own colours: green and red here are the work itself,
+          not chrome describing it, and they have meant added and removed for
+          longer than this app has existed. */}
+      <span className="text-diff-add">+{stat.insertions}</span>
+      <span className="text-diff-remove">-{stat.deletions}</span>
     </button>
   )
 }

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -29,6 +29,16 @@
   --color-status-blue: #6f8faf; /* in progress */
   --color-status-sage: #7d9471; /* done */
 
+  /* A diff's own colours, and the one place green and red are allowed.
+     The accent rule carves this out already: terminal output, diffs and logs
+     keep their colour because they are the work itself rather than chrome
+     describing it. Added and removed lines have read green and red for as long
+     as diffs have existed, and neutralising them threw away meaning a reader
+     already had. Held to the same low saturation as the rest of the palette so
+     they sit beside bronzo rather than shouting over it. */
+  --color-diff-add: #7ea96a;
+  --color-diff-remove: #c96f62;
+
   /* Surface ladder — the app field and the surfaces that lift off it. Depth
      comes from a step plus a hairline, never a shadow; a shadow means something
      floats over the page rather than being part of it. The steps are small, of

--- a/tests/device-companion-calls.test.ts
+++ b/tests/device-companion-calls.test.ts
@@ -55,6 +55,22 @@ describe('callStreaming, for stream X → Y', () => {
     expect(call.ended).toBe(true)
   })
 
+  it('survives a client that answers synchronously', async () => {
+    // Real gRPC always answers on a later tick, so the deadline could be armed
+    // after the call was opened and nothing would notice. A mock — or a future
+    // fast path — that calls back inside the same turn would then reach the
+    // timer before it existed and crash instead of resolving.
+    const call = new WritableCall()
+    const client = {
+      hid: (cb: (e: null, r: unknown) => void) => {
+        cb(null, { ok: true })
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callStreaming(client, 'hid', [{ down: 1 }])).resolves.toEqual({ ok: true })
+  })
+
   it('carries the status detail, which is the actionable half of a failure', async () => {
     const client = {
       hid: (cb: (e: unknown) => void) => {

--- a/tests/device-companion-calls.test.ts
+++ b/tests/device-companion-calls.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { callStreaming, callBidiStreaming } from '../src/main/device-companion'
+import { callStreaming, callBidiStreaming, CALL_TIMEOUT_MS } from '../src/main/device-companion'
 import type { CompanionClient } from '../src/main/device-companion'
 
 /**
@@ -81,6 +81,29 @@ describe('callStreaming, for stream X → Y', () => {
 
     await expect(callStreaming(client, 'hid', [{}])).rejects.toThrow('device is not booted')
   })
+})
+
+it('lets a caller buy more time for a hold it asked the device to make', async () => {
+  // A long press is DOWN, a delay, UP — all inside one call. Charged against
+  // the bare round-trip budget, a press held for as long as the deadline
+  // allows loses the race with it: the press happens and the call reports
+  // failure. The caller adds the hold to the budget.
+  vi.useFakeTimers()
+  const call = new WritableCall()
+  const client = { hid: () => call } as unknown as CompanionClient
+
+  const pending = callStreaming(client, 'hid', [{}], CALL_TIMEOUT_MS + 30_000)
+  const nearlyThere = vi.advanceTimersByTimeAsync(CALL_TIMEOUT_MS + 29_000)
+  let settled = false
+  void pending.catch(() => {
+    settled = true
+  })
+  await nearlyThere
+  expect(settled).toBe(false)
+
+  const rest = vi.advanceTimersByTimeAsync(2_000)
+  await expect(pending).rejects.toThrow(/within 60s/)
+  await rest
 })
 
 describe('callBidiStreaming, for stream X → stream Y', () => {

--- a/tests/device-companion-calls.test.ts
+++ b/tests/device-companion-calls.test.ts
@@ -128,6 +128,22 @@ describe('callBidiStreaming, for stream X → stream Y', () => {
     expect(call.ended).toBe(true)
   })
 
+  it('survives a client that answers synchronously', async () => {
+    // Both helpers arm the deadline before opening the call, so neither can
+    // reach the timer before it exists. Unreachable as the handlers are
+    // registered today — pinned so a reordering cannot make it reachable.
+    const call = new DuplexCall()
+    const client = {
+      launch: () => {
+        call.emit('data', { running: true })
+        queueMicrotask(() => call.emit('end'))
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callBidiStreaming(client, 'launch', [{}])).resolves.toBeDefined()
+  })
+
   it('takes the last message when the server sends several', async () => {
     const call = new DuplexCall()
     const client = {

--- a/tests/device-companion-calls.test.ts
+++ b/tests/device-companion-calls.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { callStreaming, callBidiStreaming } from '../src/main/device-companion'
+import type { CompanionClient } from '../src/main/device-companion'
+
+/**
+ * The two streaming shapes the companion proto uses, and why telling them apart
+ * matters more than it looks.
+ *
+ * `hid` is `stream HIDEvent → HIDResponse` and `launch` is
+ * `stream LaunchRequest → stream LaunchResponse`. grpc-js gives the first a
+ * callback overload and the second none at all, so sending a bidi call through
+ * the callback helper produces a stream nobody reads and a promise that never
+ * settles. That is what device_launch did: no error, no log line, just an agent
+ * waiting out its turn — the one failure mode with nothing to report.
+ */
+
+/** A client-streaming call: collects writes, answers through the callback. */
+class WritableCall extends EventEmitter {
+  written: unknown[] = []
+  ended = false
+  cancelled = false
+  write(m: unknown): void {
+    this.written.push(m)
+  }
+  end(): void {
+    this.ended = true
+  }
+  cancel(): void {
+    this.cancelled = true
+  }
+}
+
+/** A bidi call: collects writes, answers by emitting data then end. */
+class DuplexCall extends WritableCall {}
+
+afterEach(() => vi.useRealTimers())
+
+describe('callStreaming, for stream X → Y', () => {
+  it('sends every message before closing, and resolves with the one reply', async () => {
+    // A tap is two events. Sending only the DOWN leaves a finger held on the
+    // glass and every later gesture misbehaves for reasons nothing reports.
+    const call = new WritableCall()
+    const client = {
+      hid: (cb: (e: null, r: unknown) => void) => {
+        queueMicrotask(() => cb(null, { ok: true }))
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callStreaming(client, 'hid', [{ down: 1 }, { up: 1 }])).resolves.toEqual({
+      ok: true
+    })
+    expect(call.written).toEqual([{ down: 1 }, { up: 1 }])
+    expect(call.ended).toBe(true)
+  })
+
+  it('carries the status detail, which is the actionable half of a failure', async () => {
+    const client = {
+      hid: (cb: (e: unknown) => void) => {
+        queueMicrotask(() => cb({ details: 'device is not booted', message: 'call failed' }))
+        return new WritableCall()
+      }
+    } as unknown as CompanionClient
+
+    await expect(callStreaming(client, 'hid', [{}])).rejects.toThrow('device is not booted')
+  })
+})
+
+describe('callBidiStreaming, for stream X → stream Y', () => {
+  it('resolves from the stream rather than a callback that never comes', async () => {
+    // The regression: grpc-js generates no callback overload for a bidi method,
+    // so the reply only ever arrives as stream events.
+    const call = new DuplexCall()
+    const client = {
+      launch: () => {
+        queueMicrotask(() => {
+          call.emit('data', { running: true })
+          call.emit('end')
+        })
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(
+      callBidiStreaming(client, 'launch', [{ start: { bundle_id: 'com.apple.Preferences' } }])
+    ).resolves.toEqual({ running: true })
+    expect(call.written).toEqual([{ start: { bundle_id: 'com.apple.Preferences' } }])
+    expect(call.ended).toBe(true)
+  })
+
+  it('takes the last message when the server sends several', async () => {
+    const call = new DuplexCall()
+    const client = {
+      launch: () => {
+        queueMicrotask(() => {
+          call.emit('data', { stage: 'installing' })
+          call.emit('data', { stage: 'running' })
+          call.emit('end')
+        })
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callBidiStreaming(client, 'launch', [{}])).resolves.toEqual({ stage: 'running' })
+  })
+
+  it('settles even when the server ends without saying anything', async () => {
+    const call = new DuplexCall()
+    const client = {
+      launch: () => {
+        queueMicrotask(() => call.emit('end'))
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callBidiStreaming(client, 'launch', [{}])).resolves.toEqual({})
+  })
+
+  it('reports an error rather than waiting for an end that will not come', async () => {
+    const call = new DuplexCall()
+    const client = {
+      launch: () => {
+        queueMicrotask(() => call.emit('error', { details: 'not installed', message: 'failed' }))
+        return call
+      }
+    } as unknown as CompanionClient
+
+    await expect(callBidiStreaming(client, 'launch', [{}])).rejects.toThrow('not installed')
+  })
+
+  it('gives up on a call that never answers, instead of hanging forever', async () => {
+    // A silent simulator is indistinguishable from a slow one until something
+    // puts a bound on it. Without this the caller waits for the life of the
+    // process and the agent burns its turn.
+    vi.useFakeTimers()
+    const call = new DuplexCall()
+    const client = { launch: () => call } as unknown as CompanionClient
+
+    const pending = callBidiStreaming(client, 'launch', [{}])
+    const advanced = vi.advanceTimersByTimeAsync(30_000)
+    await expect(pending).rejects.toThrow(/did not answer launch/)
+    await advanced
+    // The call is cancelled too — a timed-out request left open holds the
+    // companion's attention for a result nobody is waiting for any more.
+    expect(call.cancelled).toBe(true)
+  })
+})

--- a/tests/device-registry.test.ts
+++ b/tests/device-registry.test.ts
@@ -12,6 +12,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
  */
 
 const execCalls: string[][] = []
+/** The deadline the registry asked for on each `hid` call. */
+const hidTimeouts: (number | undefined)[] = []
 /** Whether `simctl shutdown` should take its real, slow time to answer. */
 const slowShutdown = { on: false }
 /** Args of each exec call, in the order it *completed*. */
@@ -66,7 +68,12 @@ vi.mock('../src/main/device-companion', () => ({
   },
   stopCompanion: (udid: string) => stopped.push(udid),
   call: async () => ({ json: treeJson.value }),
-  callStreaming: async () => ({})
+  callStreaming: async (_c: unknown, _m: string, _msgs: unknown, timeoutMs?: number) => {
+    hidTimeouts.push(timeoutMs)
+    return {}
+  },
+  callBidiStreaming: async () => ({}),
+  CALL_TIMEOUT_MS: 30_000
 }))
 
 vi.mock('electron', () => ({ nativeImage: { createFromBuffer: () => ({}) } }))
@@ -399,6 +406,38 @@ describe('runtime formatting', () => {
 
   it('handles a runtime with no version suffix', () => {
     expect(formatRuntime('com.apple.CoreSimulator.SimRuntime.iOS')).toBe('iOS')
+  })
+})
+
+describe('a press pays for its own hold', () => {
+  /** A claimed device whose companion answers, so `interact` runs for real. */
+  function claimed(): void {
+    const e = newEntry('s1', 'udid-1')
+    e.companion = {} as never
+    setEntryForTests(e)
+  }
+
+  beforeEach(() => {
+    hidTimeouts.length = 0
+    treeJson.value = JSON.stringify([
+      { role: 'AXWindow', frame: { x: 0, y: 0, width: 402, height: 874 } }
+    ])
+  })
+
+  it('adds the hold to the deadline, so the press cannot outlast its own call', async () => {
+    // A long press is DOWN, a delay, UP — all inside one call. Charged against
+    // the bare round-trip budget, a press held for as long as the deadline
+    // allows loses the race with it: the press happens and the call reports
+    // failure. The hold has to be added to the budget it is spent from.
+    claimed()
+    await interact({ sessionId: 's1', action: 'press', target: { x: 200, y: 400 }, duration: 30 })
+    expect(hidTimeouts).toEqual([30_000 + 30 * 1000])
+  })
+
+  it('charges a plain tap nothing extra', async () => {
+    claimed()
+    await interact({ sessionId: 's1', action: 'tap', target: { x: 200, y: 400 } })
+    expect(hidTimeouts).toEqual([30_000])
   })
 })
 

--- a/tests/diff-file-list.test.tsx
+++ b/tests/diff-file-list.test.tsx
@@ -57,6 +57,16 @@ describe('DiffFileList', () => {
     expect(screen.getByText('M')).toBeInTheDocument()
   })
 
+  it('keeps a diff in its own colours, which are green and red', () => {
+    // The accent rule carves diffs out: they are the work itself rather than
+    // chrome describing it, and added/removed have read green/red for as long
+    // as diffs have existed. Neutralising them threw away meaning a reader
+    // already had.
+    render(<DiffFileList {...props} files={[file({ insertions: 4, deletions: 2 })]} />)
+    expect(screen.getByText('+4').className).toContain('text-diff-add')
+    expect(screen.getByText('-2').className).toContain('text-diff-remove')
+  })
+
   it('shows an insertion and deletion count only when there is one', () => {
     render(
       <DiffFileList


### PR DESCRIPTION
## The hang

`launch` is bidirectional in the proto:

```proto
rpc launch(stream LaunchRequest) returns (stream LaunchResponse) {}
```

grpc-js generates **no callback overload** for bidi methods — they take optional metadata and return a duplex stream. Sent through the client-streaming helper, `launch` produced a stream nobody read and a promise that never settled, so **`device_launch` hung for the life of the process**. No error, no log line, just an agent waiting out its turn — the one failure mode with nothing to report.

This has been shipping since `beta.1`.

`callBidiStreaming` reads the reply off the stream where it actually arrives. The docstring that caused this claimed "`hid` and `launch` are `stream X → Y`" — only `hid` is:

| rpc | shape | callback form |
|---|---|---|
| `hid` | `stream → unary` | correct |
| `launch` | `stream → stream` | **hangs** |

Each helper now says which shape it is for and what happens if the two are confused. Both also take a deadline — a silent simulator was indistinguishable from a slow one, and neither could be told from a bug in Vorn.

`install` is also bidi in the proto but goes through `simctl` instead, so it was never affected.

### Testing

The tests drive the real helpers against a fake client of each shape. **Putting the callback form back fails five of them by timing out** — the hang itself rather than a proxy for it. The existing registry test stubs `callStreaming` out entirely (`async () => ({})`), which is why nothing caught this.

## The diff colours

The counts in the status bar and the diff sidebar go back to green and red. The palette rule always carved this out — *"terminal output, diffs and logs keep their own colour, that is the work itself rather than chrome describing it"* — so neutralising them was an over-application that threw away meaning a reader already had.

They get their own tokens at the palette's own saturation, so they read as green and red without shouting over the accent.