### PR TITLE
Stop the device tools answering confidently and wrongly

### DIFF
--- a/src/main/device-registry.ts
+++ b/src/main/device-registry.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 import { nativeImage } from 'electron'
 import type {
@@ -519,8 +519,7 @@ async function claimLocked(params: {
   const previous = entries.get(params.sessionId)
   if (previous && previous.udid !== params.udid) await release({ sessionId: params.sessionId })
 
-  const wasBooted = device.booted
-  if (!wasBooted) {
+  const boot = async (): Promise<void> => {
     try {
       await exec('xcrun', ['simctl', 'boot', params.udid])
       await exec('xcrun', ['simctl', 'bootstatus', params.udid, '-b'])
@@ -528,6 +527,37 @@ async function claimLocked(params: {
       throw explainSimctl(err)
     }
   }
+
+  /**
+   * Claiming a device you already hold keeps the entry you already have.
+   *
+   * Rebuilding it looks harmless and is not. `bootedByVorn` would be recomputed
+   * against a simulator that is booted *because we booted it*, so it would read
+   * false and nothing would ever shut it down again. The generation counter
+   * would drop back to 1 while the same companion kept serving, so a ref minted
+   * before the re-claim would resolve cleanly against a different element after
+   * it — the exact mis-tap the counter exists to prevent. The measured scale and
+   * the captured logs would go too.
+   *
+   * This is not an exotic path: `openPane` re-claims whenever it is given a
+   * udid, so "claim, read, tap, show the person the pane" walks straight into
+   * it.
+   */
+  if (decision.alreadyMine && previous && previous.udid === params.udid) {
+    // The simulator can have gone down under us — shut down from Simulator.app,
+    // or the machine slept. Booting it again makes it ours again.
+    if (!device.booted) {
+      await boot()
+      previous.bootedByVorn = true
+    }
+    if (!previous.companion) {
+      previous.companion = await startCompanion(params.udid, onCompanionExit)
+    }
+    return { udid: params.udid, name: device.name, booted: true }
+  }
+
+  const wasBooted = device.booted
+  if (!wasBooted) await boot()
 
   const entry = newEntry(params.sessionId, params.udid)
   entry.bootedByVorn = !wasBooted
@@ -583,6 +613,35 @@ export function release(params: { sessionId: string }): Promise<{ released: bool
     }
     return { released: true }
   })
+}
+
+/**
+ * Shuts down every simulator this process booted, on the way out.
+ *
+ * `bootedByVorn` is only honoured by `release`, and quitting does not release —
+ * so closing the app with a device claimed left the simulator running forever,
+ * which is the whole thing that flag exists to prevent. It is the commonest way
+ * to leave, and the one path that never enforced it.
+ *
+ * Detached and unreferenced on purpose. `before-quit` handlers are not awaited
+ * by Electron, so anything that has to finish must outlive the process rather
+ * than hold it up; and `simctl shutdown` takes seconds and can wedge, which
+ * would otherwise be a quit that hangs. The trade is that a shutdown which
+ * fails has nowhere to report it — acceptable for a device nobody is using any
+ * more, and better than an app that will not close.
+ */
+export function shutdownOwnedDevices(): void {
+  for (const entry of entries.values()) {
+    if (!entry.bootedByVorn) continue
+    try {
+      spawn('xcrun', ['simctl', 'shutdown', entry.udid], {
+        detached: true,
+        stdio: 'ignore'
+      }).unref()
+    } catch (err) {
+      log.warn(`[device] could not shut down ${entry.udid.slice(0, 8)} on quit: ${String(err)}`)
+    }
+  }
 }
 
 /** Called when a session closes, so a claim cannot outlive its owner. */
@@ -709,6 +768,35 @@ export function formatRuntime(identifier: string): string {
 }
 
 /** Resolves a target to a point, refusing a stale ref rather than tapping. */
+/**
+ * Refuses a point that is not on the screen.
+ *
+ * The units mistake this catches — a coordinate read off a screenshot and never
+ * divided by the scale — is the same one the swipe guard already refuses, and
+ * it is far likelier on a tap. Delivered as-is the event lands nowhere, the
+ * call returns ok, and the agent reads the unchanged screen as "the button did
+ * not work" and tries again.
+ *
+ * Silent when the screen size is unknown: that case is the swipe guard's to
+ * refuse, and a screenshot now fails closed rather than handing out a scale
+ * nobody measured.
+ */
+function requireOnScreen(
+  point: DevicePoint,
+  screen: { width: number; height: number }
+): DevicePoint {
+  if (screen.width <= 0 || screen.height <= 0) return point
+  const inside = point.x >= 0 && point.y >= 0 && point.x <= screen.width && point.y <= screen.height
+  if (!inside) {
+    throw new Error(
+      `(${point.x}, ${point.y}) is outside the screen, which is ${screen.width}x${screen.height} ` +
+        'points. Coordinates are in points, not image pixels — divide a coordinate read off a ' +
+        'screenshot by the `scale` that screenshot reported.'
+    )
+  }
+  return point
+}
+
 function resolveTarget(target: DeviceTarget | undefined, entry: Entry): DevicePoint {
   if (!target) throw new Error('An interaction needs a target: either a ref or x/y (in points).')
   if ('ref' in target) return tapPointFor(target.ref, entry)
@@ -778,7 +866,7 @@ export async function interact(params: {
   switch (params.action) {
     case 'tap':
     case 'press': {
-      const point = resolveTarget(params.target, entry)
+      const point = requireOnScreen(resolveTarget(params.target, entry), screen)
       const touch = { action: { touch: { point } } }
       events.push({ press: { action: touch.action, direction: 'DOWN' } })
       if (params.action === 'press') {
@@ -894,14 +982,30 @@ export async function screenshot(params: {
 }): Promise<{ data: string; scale: number; screen: { width: number; height: number } }> {
   const entry = deviceFor(params.sessionId)
   if (!entry.screenPoints) await fetchTree(entry)
-  const screen = entry.screenPoints ?? { width: 0, height: 0 }
+  // Fail closed, exactly as the swipe guard does on the same condition. The
+  // scale is the number the caller divides an image coordinate by; without a
+  // screen size it cannot be measured, and what used to be returned was the
+  // constructor's guess of 3 wearing a comment that said "read, never assumed".
+  // A 1.14-ratio image divided by 3 lands a tap a third of the way to where it
+  // was aimed, and reports ok. A read taken mid-transition comes back with no
+  // root frame, so this is reachable whenever a screenshot is the first thing
+  // asked of a screen that is still settling.
+  if (!entry.screenPoints || entry.screenPoints.width <= 0) {
+    throw new Error(
+      'The screen size could not be read, so the scale of the image cannot be ' +
+        'measured — and a coordinate divided by a guessed scale lands somewhere ' +
+        'other than where you aimed. The screen is usually mid-transition; call ' +
+        'device_read_screen once it has settled, then take the screenshot.'
+    )
+  }
+  const screen = entry.screenPoints
 
   const res = await call<{ image_data: Buffer }>(entry.companion.client, 'screenshot', {})
   const image = nativeImage.createFromBuffer(Buffer.from(res.image_data))
   const size = image.getSize()
   // Read, never assumed: the tree's points against the image's pixels is the
   // only honest source for this ratio.
-  if (screen.width > 0) entry.scale = size.width / screen.width
+  entry.scale = size.width / screen.width
 
   const maxEdge = clampMaxEdge(params.maxEdge)
   const longest = Math.max(size.width, size.height)
@@ -918,7 +1022,7 @@ export async function screenshot(params: {
     data: out.toPNG().toString('base64'),
     // The scale of the image *as returned*, not of the raw capture — this is
     // the number that converts a coordinate on the delivered image to points.
-    scale: screen.width > 0 ? shown.width / screen.width : entry.scale,
+    scale: shown.width / screen.width,
     screen
   }
 }

--- a/src/main/device-registry.ts
+++ b/src/main/device-registry.ts
@@ -777,15 +777,23 @@ export function formatRuntime(identifier: string): string {
  * call returns ok, and the agent reads the unchanged screen as "the button did
  * not work" and tries again.
  *
- * Silent when the screen size is unknown: that case is the swipe guard's to
- * refuse, and a screenshot now fails closed rather than handing out a scale
- * nobody measured.
+ * Fails closed when the screen size is unknown, rather than waving the point
+ * through. Letting it past was the same "confidently ok, did nothing" this
+ * guard exists to stop — and the swipe branch refuses on exactly that condition
+ * two cases down, so opting out here only made a tap the one input that could
+ * still be aimed at nothing.
  */
 function requireOnScreen(
   point: DevicePoint,
   screen: { width: number; height: number }
 ): DevicePoint {
-  if (screen.width <= 0 || screen.height <= 0) return point
+  if (screen.width <= 0 || screen.height <= 0) {
+    throw new Error(
+      'The screen size could not be read, so there is nothing to check this point against. ' +
+        'That usually means the screen is mid-transition — call device_read_screen once it has ' +
+        'settled, then interact.'
+    )
+  }
   const inside = point.x >= 0 && point.y >= 0 && point.x <= screen.width && point.y <= screen.height
   if (!inside) {
     throw new Error(
@@ -990,7 +998,7 @@ export async function screenshot(params: {
   // was aimed, and reports ok. A read taken mid-transition comes back with no
   // root frame, so this is reachable whenever a screenshot is the first thing
   // asked of a screen that is still settling.
-  if (!entry.screenPoints || entry.screenPoints.width <= 0) {
+  if (!entry.screenPoints || entry.screenPoints.width <= 0 || entry.screenPoints.height <= 0) {
     throw new Error(
       'The screen size could not be read, so the scale of the image cannot be ' +
         'measured — and a coordinate divided by a guessed scale lands somewhere ' +

--- a/src/main/device-registry.ts
+++ b/src/main/device-registry.ts
@@ -634,10 +634,18 @@ export function shutdownOwnedDevices(): void {
   for (const entry of entries.values()) {
     if (!entry.bootedByVorn) continue
     try {
-      spawn('xcrun', ['simctl', 'shutdown', entry.udid], {
+      const child = spawn('xcrun', ['simctl', 'shutdown', entry.udid], {
         detached: true,
         stdio: 'ignore'
-      }).unref()
+      })
+      // spawn reports a missing binary through an async `error` event, not by
+      // throwing — and an `error` event with no listener is an uncaught
+      // exception. Best-effort cleanup on the way out has no business taking
+      // the process down with it, so the failure is logged and dropped.
+      child.on('error', (err) => {
+        log.warn(`[device] could not shut down ${entry.udid.slice(0, 8)} on quit: ${String(err)}`)
+      })
+      child.unref()
     } catch (err) {
       log.warn(`[device] could not shut down ${entry.udid.slice(0, 8)} on quit: ${String(err)}`)
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -533,6 +533,10 @@ app.on('before-quit', async () => {
   isQuitting = true
   globalShortcut.unregisterAll()
   updateManager.stop()
+  // Killing the companions leaves the simulators Vorn booted running: nothing
+  // releases a claim on the way out, and `bootedByVorn` is only honoured by
+  // release. Detached, so this outlives the process rather than delaying it.
+  deviceRegistry.shutdownOwnedDevices()
   await stopServer()
 })
 

--- a/tests/device-registry.test.ts
+++ b/tests/device-registry.test.ts
@@ -18,7 +18,11 @@ const hidTimeouts: (number | undefined)[] = []
 const slowShutdown = { on: false }
 /** Args of each exec call, in the order it *completed*. */
 const execCompletions: string[][] = []
-/** What `simctl list` returns. A test can swap this to change the fixture. */
+/**
+ * What `simctl list` returns. A test can swap this to change the fixture; it is
+ * restored before each test, because a swap that leaks makes the *next* test
+ * pass or fail for a reason nothing in it mentions.
+ */
 const simctlList = {
   value: JSON.stringify({
     devices: {
@@ -29,7 +33,14 @@ const simctlList = {
     }
   })
 }
+const SIMCTL_LIST_DEFAULT = simctlList.value
+/** Detached `simctl shutdown` calls made on quit. */
+const detachedSpawns: string[][] = []
 vi.mock('node:child_process', () => ({
+  spawn: (cmd: string, args: string[]) => {
+    detachedSpawns.push([cmd, ...args])
+    return { unref: () => {} }
+  },
   execFile: (cmd: string, args: string[], cb: (e: unknown, out: unknown) => void) => {
     execCalls.push([cmd, ...args])
     // `promisify` hands the callback value straight through as the resolved
@@ -104,14 +115,18 @@ import {
   formatRuntime,
   keycodesFor,
   clampMaxEdge,
+  shutdownOwnedDevices,
+  screenshot,
   type AXElement
 } from '../src/main/device-registry'
 
 beforeEach(() => {
   resetForTests()
+  simctlList.value = SIMCTL_LIST_DEFAULT
   execCalls.length = 0
   stopped.length = 0
   spawned.length = 0
+  detachedSpawns.length = 0
   slowShutdown.on = false
   execCompletions.length = 0
 })
@@ -441,6 +456,48 @@ describe('a press pays for its own hold', () => {
   })
 })
 
+describe('a coordinate that cannot be trusted', () => {
+  /** A claimed device whose companion answers, so the driving path runs. */
+  function claimed(): void {
+    const e = newEntry('s1', 'udid-1')
+    e.companion = {} as never
+    setEntryForTests(e)
+  }
+
+  beforeEach(() => {
+    treeJson.value = JSON.stringify([
+      { role: 'AXWindow', frame: { x: 0, y: 0, width: 402, height: 874 } }
+    ])
+  })
+
+  it('refuses a tap outside the screen, and says what the screen is', () => {
+    // The units mistake: a coordinate read straight off a screenshot, never
+    // divided by the scale. Delivered as-is it lands nowhere, the call returns
+    // ok, and the agent reads the unchanged screen as "the button is broken".
+    claimed()
+    return expect(
+      interact({ sessionId: 's1', action: 'tap', target: { x: 1206, y: 2622 } })
+    ).rejects.toThrow(/402x874 points/)
+  })
+
+  it('lets a tap on the screen through, edges included', async () => {
+    claimed()
+    await expect(
+      interact({ sessionId: 's1', action: 'tap', target: { x: 402, y: 874 } })
+    ).resolves.toMatchObject({ ok: true })
+  })
+
+  it('refuses a screenshot whose scale cannot be measured', async () => {
+    // A read taken mid-transition comes back with no root frame. What used to
+    // be returned here was the constructor's guess of 3, and a 1.14-ratio image
+    // divided by 3 lands a tap a third of the way to where it was aimed. The
+    // swipe guard already fails closed on exactly this condition.
+    treeJson.value = JSON.stringify([])
+    claimed()
+    await expect(screenshot({ sessionId: 's1' })).rejects.toThrow(/screen size could not be read/)
+  })
+})
+
 describe('typing keycodes', () => {
   it('maps the characters it claims to support', () => {
     expect(keycodesFor('a')).toEqual([4])
@@ -483,6 +540,83 @@ describe('screenshot edge clamping', () => {
     expect(clampMaxEdge(0)).toBe(1000)
     expect(clampMaxEdge(Number.NaN)).toBe(1000)
     expect(clampMaxEdge(-50)).toBe(1000)
+  })
+})
+
+describe('claiming a device you already hold', () => {
+  /**
+   * `openPane` re-claims whenever it is given a udid, so "claim, read, tap,
+   * show the person the pane" is the ordinary path into this — not an exotic
+   * one. Rebuilding the entry there looks harmless and is not: the flag that
+   * records who booted the simulator is recomputed against a simulator that is
+   * booted *because we booted it*, and the generation counter that keeps a ref
+   * from an old screen off a new one drops back to where it started while the
+   * same companion keeps serving.
+   */
+  it('keeps the entry it already has, rather than building a fresh one', async () => {
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+    const entry = entryForTests('s1')!
+    expect(entry.bootedByVorn).toBe(true)
+
+    // Stand in for a session that has been driving the device for a while.
+    entry.generation = 4
+    entry.scale = 2
+    entry.logs.push('a line worth keeping')
+
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+
+    const after = entryForTests('s1')!
+    expect(after.bootedByVorn).toBe(true)
+    expect(after.generation).toBe(4)
+    expect(after.scale).toBe(2)
+    expect(after.logs).toEqual(['a line worth keeping'])
+  })
+
+  it('does not start a second companion for a device it is already attached to', async () => {
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+    expect(spawned).toHaveLength(1)
+  })
+
+  it('reboots and takes ownership when the simulator went down underneath it', async () => {
+    // udid-2 is listed as already booted, so the first claim does not own it.
+    await claim({ sessionId: 's1', udid: 'udid-2' })
+    expect(entryForTests('s1')?.bootedByVorn).toBe(false)
+
+    // The person shuts it down from elsewhere; the next claim boots it, and
+    // that boot is ours.
+    simctlList.value = JSON.stringify({
+      devices: {
+        'com.apple.CoreSimulator.SimRuntime.iOS-26-2': [
+          { udid: 'udid-1', name: 'iPhone 17', state: 'Shutdown', isAvailable: true },
+          { udid: 'udid-2', name: 'iPad Pro', state: 'Shutdown', isAvailable: true }
+        ]
+      }
+    })
+
+    await claim({ sessionId: 's1', udid: 'udid-2' })
+    expect(entryForTests('s1')?.bootedByVorn).toBe(true)
+    expect(execCalls.some((c) => c.includes('boot') && c.includes('udid-2'))).toBe(true)
+  })
+})
+
+describe('quitting with a device claimed', () => {
+  /**
+   * `bootedByVorn` is only ever honoured by `release`, and quitting does not
+   * release. So the commonest way to leave was the one path that never enforced
+   * it: close the app with a device claimed and the simulator ran on forever.
+   */
+  it('shuts down the simulators it booted', async () => {
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+    shutdownOwnedDevices()
+    expect(detachedSpawns).toEqual([['xcrun', 'simctl', 'shutdown', 'udid-1']])
+  })
+
+  it('leaves a simulator the person booted running', async () => {
+    // udid-2 is already booted in the fixture, so it is not ours to close.
+    await claim({ sessionId: 's1', udid: 'udid-2' })
+    shutdownOwnedDevices()
+    expect(detachedSpawns).toEqual([])
   })
 })
 

--- a/tests/device-registry.test.ts
+++ b/tests/device-registry.test.ts
@@ -36,10 +36,19 @@ const simctlList = {
 const SIMCTL_LIST_DEFAULT = simctlList.value
 /** Detached `simctl shutdown` calls made on quit. */
 const detachedSpawns: string[][] = []
+/** `error` listeners attached to those detached children. */
+const spawnErrorHandlers: ((e: unknown) => void)[] = []
 vi.mock('node:child_process', () => ({
   spawn: (cmd: string, args: string[]) => {
     detachedSpawns.push([cmd, ...args])
-    return { unref: () => {} }
+    const child = {
+      on: (event: string, cb: (e: unknown) => void) => {
+        if (event === 'error') spawnErrorHandlers.push(cb)
+        return child
+      },
+      unref: () => {}
+    }
+    return child
   },
   execFile: (cmd: string, args: string[], cb: (e: unknown, out: unknown) => void) => {
     execCalls.push([cmd, ...args])
@@ -127,6 +136,7 @@ beforeEach(() => {
   stopped.length = 0
   spawned.length = 0
   detachedSpawns.length = 0
+  spawnErrorHandlers.length = 0
   slowShutdown.on = false
   execCompletions.length = 0
 })
@@ -629,6 +639,17 @@ describe('quitting with a device claimed', () => {
     await claim({ sessionId: 's1', udid: 'udid-1' })
     shutdownOwnedDevices()
     expect(detachedSpawns).toEqual([['xcrun', 'simctl', 'shutdown', 'udid-1']])
+  })
+
+  it('survives a shutdown that cannot even start', async () => {
+    // spawn reports a missing binary through an async `error` event rather than
+    // by throwing, and an `error` event with no listener is an uncaught
+    // exception. Best-effort cleanup on the way out must not take the process
+    // down with it.
+    await claim({ sessionId: 's1', udid: 'udid-1' })
+    shutdownOwnedDevices()
+    expect(spawnErrorHandlers).toHaveLength(1)
+    expect(() => spawnErrorHandlers[0](new Error('spawn xcrun ENOENT'))).not.toThrow()
   })
 
   it('leaves a simulator the person booted running', async () => {

--- a/tests/device-registry.test.ts
+++ b/tests/device-registry.test.ts
@@ -487,6 +487,25 @@ describe('a coordinate that cannot be trusted', () => {
     ).resolves.toMatchObject({ ok: true })
   })
 
+  it('refuses a tap when there is no screen size to check it against', async () => {
+    // Waving the point through here made a tap the one input that could still
+    // be aimed at nothing: the swipe branch refuses on exactly this condition.
+    treeJson.value = JSON.stringify([])
+    claimed()
+    await expect(
+      interact({ sessionId: 's1', action: 'tap', target: { x: 10, y: 10 } })
+    ).rejects.toThrow(/screen size could not be read/)
+  })
+
+  it('refuses a screenshot when only the height is unreadable', async () => {
+    // Validity is both dimensions — the swipe guard has always checked both.
+    treeJson.value = JSON.stringify([
+      { role: 'AXWindow', frame: { x: 0, y: 0, width: 402, height: 0 } }
+    ])
+    claimed()
+    await expect(screenshot({ sessionId: 's1' })).rejects.toThrow(/screen size could not be read/)
+  })
+
   it('refuses a screenshot whose scale cannot be measured', async () => {
     // A read taken mid-transition comes back with no root frame. What used to
     // be returned here was the constructor's guess of 3, and a 1.14-ratio image


### PR DESCRIPTION
Items 1–3 of the device plan, plus the re-claim fix. Every one is a case where an agent was told the operation succeeded when it had not — no error, no log line, nothing to notice.

## Re-claiming a device you already hold wiped the entry

`claimFor` already returns `alreadyMine`; the answer was thrown away, so a second claim rebuilt the entry from scratch. Two consequences:

- `bootedByVorn` was recomputed against a simulator that is booted **because we booted it**, so it read `false` and nothing would ever shut it down.
- `generation` reset to 1 while the *same* companion kept serving, so a `g1_el_3` ref minted before the re-claim resolves cleanly against a **different** element after it — precisely the mis-tap the counter exists to prevent.

`openPane` re-claims whenever it is given a udid, so "claim, read, tap, open the pane to show the person" is the ordinary route into this.

## Quitting left simulators running

`before-quit` killed the companions; nothing walked the claims or ran `simctl shutdown`. `bootedByVorn` is only honoured by `release`, and quitting does not release — so the commonest way to leave was the one path that never enforced it.

The shutdowns are **detached and unreferenced**: `before-quit` handlers are not awaited by Electron, and `simctl shutdown` takes seconds and can wedge, so the work has to outlive the process rather than delay it. The trade is that a failed shutdown has nowhere to report — acceptable for a device nobody is using, and better than an app that will not close.

## `device_screenshot` handed out a scale nobody measured

It returned the measured ratio — except when the screen size could not be read, where it returned the constructor's guess of `3`, under a comment reading *"read, never assumed"*. The agent is told "divide by 3", divides a 1.14-ratio image by 3, and taps a third of the way to its target.

It fails closed now, exactly as the swipe guard already does on the same condition. **That asymmetry was the bug** — the same unmeasurable screen failed closed on the rare path and open on the common one.

## A tap was never bounds-checked

`interact` fetches the screen size two lines earlier and only the swipe branch used it. A coordinate read off a screenshot and never divided by the scale was delivered as-is, hit nothing, and returned `ok` — leaving the agent to read the unchanged screen as a broken button and retry.

## Testing

All four guards mutation-tested: reverting each one fails its test.

Also fixes a leak in the test file itself — the `simctl` fixture is shared mutable state that nothing restored, so a test which swapped it silently changed the next test's result. Found by writing a test that swapped it.

`diff-cover` reports no lines: the changes are guards and control flow in files whose coverage comes from the suite that exercises them.