### PR TITLE
Give the terminal back the width it was already being handed

### DIFF
--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -133,7 +133,11 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
   }
 
   return (
-    <div className="flex h-full w-full pr-2">
+    // No right padding: the terminal already ends short of the card. xterm
+    // reserves a scrollbar gutter and the fit addon drops the partial column
+    // that will not fit, so a pane's worth of width was going unused at the
+    // edge before anything was added on top of it.
+    <div className="flex h-full w-full">
       <CommandSpine terminalId={terminalId} className="relative mr-2 h-full" />
       <TerminalSlot
         terminalId={terminalId}

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -126,6 +126,31 @@ select,
   }
 }
 
+/* The terminal's scrollbar overlays instead of reserving a gutter.
+   xterm sets `overflow-y: scroll` on its viewport, so Chromium holds ~6px open
+   down the right edge of every terminal — but only draws a bar once there is
+   something to scroll. That is why an empty session reached the card's edge and
+   a busy one stopped short of it: the same code, two different widths, for a
+   reason nothing on screen explained. The command spine down the left already
+   shows where you are in the scrollback, so the bar itself is not what was
+   carrying that information. */
+.xterm .xterm-viewport {
+  scrollbar-width: none;
+}
+
+/* The column that will not fit is dead space — a terminal draws whole cells or
+   nothing, so up to one character's width is always left over. Centring the
+   screen splits that between the two edges instead of banking it all against
+   the right one, which is the difference between symmetric padding and a ragged
+   margin. Never more than half a character either side. */
+.xterm .xterm-screen {
+  margin-inline: auto;
+}
+.xterm .xterm-viewport::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -208,6 +208,14 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     term.loadAddon(addon)
     e._gpuAddon = addon
     term.refresh(0, term.rows - 1)
+    // The first fit ran against the DOM renderer's idea of a cell. A GPU
+    // renderer measures the font itself and usually lands on a slightly
+    // narrower cell, so the column count chosen a moment ago is now too low —
+    // and nothing else recomputes it, because the wrapper's size has not
+    // changed. That is the whole reason a terminal sat with a band of unused
+    // width down its right edge until the window was resized: resizing was the
+    // only thing that ever asked it to fit again.
+    refit(terminalId)
   }
   // Terminal fallback — if even canvas fails to load, there's no further
   // fallback, so swallow the error here instead of propagating an unhandled
@@ -285,6 +293,29 @@ function notifyRegistryChange(): void {
   }
 }
 
+/**
+ * Fit the terminal to the space it already has, and tell the pty.
+ *
+ * `syncTerminalOverlay` only fits when the wrapper's rect changes, which is the
+ * right trigger for a moved or resized card and the wrong one for anything that
+ * changes the size of a *cell* — a renderer swap, a font arriving, a font-size
+ * change. Those leave the wrapper identical and the column count stale.
+ */
+export function refit(terminalId: string): void {
+  const entry = registry.get(terminalId)
+  if (!entry || !entry.term.element) return
+  try {
+    entry.fitAddon.fit()
+  } catch {
+    return
+  }
+  const { cols, rows } = entry.term
+  if (cols === entry.lastSyncedCols && rows === entry.lastSyncedRows) return
+  entry.lastSyncedCols = cols
+  entry.lastSyncedRows = rows
+  window.api.resizeTerminal({ id: terminalId, cols, rows })
+}
+
 function ensurePersistentWrapper(entry: TerminalEntry, terminalId: string): HTMLDivElement {
   if (entry.persistentWrapper) return entry.persistentWrapper
   const wrapper = document.createElement('div')
@@ -299,17 +330,22 @@ function ensurePersistentWrapper(entry: TerminalEntry, terminalId: string): HTML
   entry.persistentWrapper = wrapper
   if (hostRoot) {
     hostRoot.appendChild(wrapper)
-    openIntoPersistentWrapper(entry)
+    openIntoPersistentWrapper(entry, terminalId)
   }
   return wrapper
 }
 
-function openIntoPersistentWrapper(entry: TerminalEntry): void {
+function openIntoPersistentWrapper(entry: TerminalEntry, terminalId: string): void {
   if (entry.term.element) return
   const wrapper = entry.persistentWrapper
   if (!wrapper || !wrapper.parentElement) return
   entry.term.open(wrapper)
   entry._loadRenderer?.()
+  // A font that arrives after the terminal opened changes the cell width under
+  // a column count already chosen, the same way a renderer swap does. Resolved
+  // immediately when nothing is pending, so this costs a microtask in the
+  // common case.
+  void document.fonts?.ready.then(() => refit(terminalId))
 }
 
 /**
@@ -323,7 +359,7 @@ export function setHostRoot(root: HTMLElement | null): void {
     const wrapper = entry.persistentWrapper
     if (wrapper && wrapper.parentElement !== root) {
       root.appendChild(wrapper)
-      openIntoPersistentWrapper(entry)
+      openIntoPersistentWrapper(entry, id)
       // Re-sync after adoption — registerSlot may have run before the host
       // mounted, setting geometry on a detached wrapper. Now that it's in the
       // DOM and xterm has opened, position + fit correctly.
@@ -342,7 +378,7 @@ export function registerSlot(terminalId: string, slotEl: HTMLElement): void {
   if (!entry) entry = createTerminalEntry(terminalId)
   entry.activeSlot = slotEl
   ensurePersistentWrapper(entry, terminalId)
-  openIntoPersistentWrapper(entry)
+  openIntoPersistentWrapper(entry, terminalId)
   syncTerminalOverlay(terminalId)
 }
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -215,7 +215,7 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     // changed. That is the whole reason a terminal sat with a band of unused
     // width down its right edge until the window was resized: resizing was the
     // only thing that ever asked it to fit again.
-    refit(terminalId)
+    fitTerminal(terminalId)
   }
   // Terminal fallback — if even canvas fails to load, there's no further
   // fallback, so swallow the error here instead of propagating an unhandled
@@ -293,29 +293,6 @@ function notifyRegistryChange(): void {
   }
 }
 
-/**
- * Fit the terminal to the space it already has, and tell the pty.
- *
- * `syncTerminalOverlay` only fits when the wrapper's rect changes, which is the
- * right trigger for a moved or resized card and the wrong one for anything that
- * changes the size of a *cell* — a renderer swap, a font arriving, a font-size
- * change. Those leave the wrapper identical and the column count stale.
- */
-export function refit(terminalId: string): void {
-  const entry = registry.get(terminalId)
-  if (!entry || !entry.term.element) return
-  try {
-    entry.fitAddon.fit()
-  } catch {
-    return
-  }
-  const { cols, rows } = entry.term
-  if (cols === entry.lastSyncedCols && rows === entry.lastSyncedRows) return
-  entry.lastSyncedCols = cols
-  entry.lastSyncedRows = rows
-  window.api.resizeTerminal({ id: terminalId, cols, rows })
-}
-
 function ensurePersistentWrapper(entry: TerminalEntry, terminalId: string): HTMLDivElement {
   if (entry.persistentWrapper) return entry.persistentWrapper
   const wrapper = document.createElement('div')
@@ -345,7 +322,7 @@ function openIntoPersistentWrapper(entry: TerminalEntry, terminalId: string): vo
   // a column count already chosen, the same way a renderer swap does. Resolved
   // immediately when nothing is pending, so this costs a microtask in the
   // common case.
-  void document.fonts?.ready.then(() => refit(terminalId))
+  void document.fonts?.ready.then(() => fitTerminal(terminalId))
 }
 
 /**
@@ -484,6 +461,13 @@ export function getRegisteredTerminalIds(): string[] {
 
 /**
  * Fit the terminal to its persistent wrapper and notify the pty of new size.
+ *
+ * Called for anything that changes the size of a *cell* as well as anything
+ * that changes the size of the box. `syncTerminalOverlay` only fits when the
+ * wrapper's rect moves, which is the right trigger for a resized card and the
+ * wrong one for a renderer swap or a font arriving — both leave the box
+ * identical and the column count stale, and the terminal then sat with a band
+ * of unused width until something resized it.
  */
 export function fitTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)


### PR DESCRIPTION
A session card had a band of unused width down its right edge. Measured rather than guessed at:

```
slot=1422   wrapper=1422   viewport=1422   xterm-screen=1343   →  79px
```

79px is **ten columns**, not padding — which ruled out the two things that looked like the cause.

## The terminal fits once, too early

It fits when it opens, against the DOM renderer's idea of how wide a cell is. The GPU renderer then mounts **asynchronously**, measures the font itself, and lands on a narrower cell — so the column count chosen a moment earlier is now too low.

Nothing recomputed it. The only thing that triggers a fit is the wrapper's rect changing, and a renderer swap leaves the box exactly where it was. **Resizing the window was the one thing that ever asked the terminal to fit again**, which is how this was spotted.

`refit()` fits against the space a terminal already has, and is called for the two cases that change the size of a *cell* rather than the size of the box:

- the GPU renderer mounting
- `document.fonts.ready` settling, since a font arriving does the same thing

## Two smaller reclaims

- xterm sets `overflow-y: scroll` on its viewport, so Chromium held ~6px open on every terminal but only drew a bar once there was something to scroll. That is why an **empty session reached the card's edge and a busy one stopped short of it** — the same code at two different widths, for a reason nothing on screen explained. The command spine already shows position in the scrollback, so the bar was not carrying information that was otherwise unavailable.
- The terminal wrapper carried right padding it did not need.

## What is left is irreducible

A terminal draws whole cells, so up to one character's width never fits. Centring the screen splits that between both edges instead of banking it against the right one — symmetric padding rather than a ragged margin, and never more than half a character either side.

## Verification

Instrumented the live app to log slot/wrapper/viewport/screen widths, confirmed the 79px, applied the fix, and confirmed the gap collapsed. The instrumentation is not in this diff.

Unrelated, found while reading: xterm is configured with `JetBrains Mono` first but there is no `@font-face` for it anywhere, so it silently falls back to Menlo. Worth either bundling the font or having the stack say what it actually uses.
