### PR TITLE
chore(release): 0.6.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0-beta.3",
+  "version": "0.6.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Two agent-facing bugs that had been shipping since `beta.1`.

**`device_launch` hung for the life of the process.** The call is bidirectional in the proto and was sent through a helper that waits on a callback grpc-js never generates for those — so no error, no log line, just an agent waiting out its turn.

**The device tools had four ways of reporting success without having done anything:** a re-claim that wiped the entry (losing which simulator Vorn booted, and resetting the ref generation while the same companion kept serving), a quit that left simulators running, a screenshot handing back a scale nobody measured, and a tap nobody bounds-checked.

Also in this beta:

- A session card is one surface rather than two, and the workflow panels sit on the same ground as the nodes they describe.
- The last blue-tinted greys are out of the editor — Tailwind's `gray-900`/`gray-700` are `#111827`/`#374151`, which is why one dropdown read blue.
- The terminal fills the width it was already being given. It fit once against the wrong cell size and nothing ever asked it to try again except a window resize.

Version bump only — the six workspace packages are synced by the pre-commit hook.
