### PR TITLE
A session's own terminals, and terminals that can leave

### DIFF
--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAppStore } from '../stores'
+import { useClaimedTerminalIds } from '../hooks/usePanelTerminals'
 import { usePromotedCards } from '../hooks/usePromotedCards'
 import { FileTypeIcon } from './file-icons'
 import { getProjectHostIds, getProjectRemoteHostId, type RecentSession } from '../../shared/types'
@@ -119,6 +120,7 @@ function useCommands(
 ): Command[] {
   const config = useAppStore((s) => s.config)
   const terminals = useAppStore((s) => s.terminals)
+  const claimed = useClaimedTerminalIds()
   const promotedCards = usePromotedCards()
   const worktreeCache = useAppStore((s) => s.worktreeCache)
   const addTerminal = useAppStore((s) => s.addTerminal)
@@ -278,6 +280,10 @@ function useCommands(
 
     // --- Terminals ---
     for (const [id, term] of terminals) {
+      // A shell held by a terminals panel is deliberately absent from every
+      // other surface; focusing one from here would open a stage for a session
+      // the grid, the strip and the sidebar all agree is not there.
+      if (claimed.has(id)) continue
       const name = getDisplayName(term.session)
       const agentType = term.session.agentType
       const agentDef = agentType === 'shell' ? null : AGENT_DEFINITIONS[agentType]
@@ -499,6 +505,7 @@ function useCommands(
     return commands
   }, [
     terminals,
+    claimed,
     promotedCards,
     config,
     recentSessions,

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -19,6 +19,7 @@ import { FilesCard } from './FilesCard'
 import { EditorCard } from './EditorCard'
 import { BrowserCard } from './BrowserCard'
 import { DeviceCard } from './DeviceCard'
+import { TerminalsCard } from './TerminalsCard'
 import { parsePaneId } from '../lib/pane-id'
 import { isMac } from '../lib/platform'
 import { ArrowDown, FolderGit2, GitBranch, Minimize2, Pencil } from 'lucide-react'
@@ -67,6 +68,9 @@ export function FocusedTerminal() {
   const hasEditorPane = useAppStore((s) => (effectiveId ? s.editorPanes.has(effectiveId) : false))
   const hasBrowserPane = useAppStore((s) => (effectiveId ? s.browserPanes.has(effectiveId) : false))
   const hasDevicePane = useAppStore((s) => (effectiveId ? s.devicePanes.has(effectiveId) : false))
+  const hasTerminalsPane = useAppStore((s) =>
+    effectiveId ? s.terminalsPanes.has(effectiveId) : false
+  )
   // Shared with the card grid and tab view, so a new pane kind is added once.
   const hasAnyPane = useAppStore((s) => selectPaneFlags(s, effectiveId).any)
   // Maximize is session-scoped in the grid; expanded mode is that same session
@@ -89,7 +93,8 @@ export function FocusedTerminal() {
     (maximizedKind === 'files' && hasFilesPane) ||
     (maximizedKind === 'editor' && hasEditorPane) ||
     (maximizedKind === 'browser' && hasBrowserPane) ||
-    (maximizedKind === 'device' && hasDevicePane)
+    (maximizedKind === 'device' && hasDevicePane) ||
+    (maximizedKind === 'terminals' && hasTerminalsPane)
 
   const handleContract = (): void => {
     if (isPreview) {
@@ -310,6 +315,11 @@ export function FocusedTerminal() {
               {hasDevicePane && (
                 <PaneSlot hidden={hasMaximizedPane && maximizedKind !== 'device'}>
                   <DeviceCard sessionId={effectiveId} />
+                </PaneSlot>
+              )}
+              {hasTerminalsPane && (
+                <PaneSlot hidden={hasMaximizedPane && maximizedKind !== 'terminals'}>
+                  <TerminalsCard sessionId={effectiveId} />
                 </PaneSlot>
               )}
             </div>

--- a/src/renderer/components/PaneColumn.tsx
+++ b/src/renderer/components/PaneColumn.tsx
@@ -6,6 +6,7 @@ import { FilesCard } from './FilesCard'
 import { EditorCard } from './EditorCard'
 import { BrowserCard } from './BrowserCard'
 import { DeviceCard } from './DeviceCard'
+import { TerminalsCard } from './TerminalsCard'
 import { SplitDivider } from './SplitDivider'
 import { splitPaneWeights, resizePaneWeights } from '../lib/split-ratio'
 
@@ -57,6 +58,7 @@ export function PaneColumn({ sessionId }: { sessionId: string }): ReactNode {
     if (entry.kind === 'files') return <FilesCard sessionId={sessionId} />
     if (entry.kind === 'editor') return <EditorCard sessionId={sessionId} />
     if (entry.kind === 'browser') return <BrowserCard sessionId={sessionId} />
+    if (entry.kind === 'terminals') return <TerminalsCard sessionId={sessionId} />
     return <DeviceCard sessionId={sessionId} />
   }
 

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -23,7 +23,18 @@ import { buildTooltip } from '../lib/tab-tooltip'
 import { ConfirmPopover } from './ConfirmPopover'
 import { Tooltip } from './Tooltip'
 import { toast } from './Toast'
-import { ChevronDown, FolderOpen, Globe, GripVertical, Pencil, Plus, X } from 'lucide-react'
+import {
+  ChevronDown,
+  FolderOpen,
+  Globe,
+  GripVertical,
+  Pencil,
+  Plus,
+  SquareTerminal,
+  X
+} from 'lucide-react'
+import { toggleTerminalsPanel } from '../lib/session-utils'
+import { shouldOfferPane } from '../lib/pane-affordance'
 import { GridContextMenu } from './GridContextMenu'
 import { GridToolbar } from './GridToolbar'
 import { WindowControls } from './WindowControls'
@@ -158,6 +169,10 @@ export function TabView() {
   const reorderTerminals = useAppStore((s) => s.reorderTerminals)
   const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
   const toggleBrowserPane = useAppStore((s) => s.toggleBrowserPane)
+  // Only to answer "is this one already open" — a shell keeps the control for a
+  // pane it has, so the pane can still be closed.
+  const browserPanes = useAppStore((s) => s.browserPanes)
+  const terminalsPanes = useAppStore((s) => s.terminalsPanes)
   const tasks = useAppStore((s) => s.config?.tasks)
   const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
   const domBlocks = useAppStore((s) => s.config?.defaults.domBlockRendering ?? true)
@@ -452,11 +467,20 @@ export function TabView() {
                         icon={<FolderOpen size={13} />}
                         onClick={() => toggleFilesPane(id)}
                       />
-                      <TabIconButton
-                        label="Open browser"
-                        icon={<Globe size={13} />}
-                        onClick={() => toggleBrowserPane(id)}
-                      />
+                      {shouldOfferPane(terminal.session.agentType, terminalsPanes.has(id)) && (
+                        <TabIconButton
+                          label="Add a terminal"
+                          icon={<SquareTerminal size={13} />}
+                          onClick={() => void toggleTerminalsPanel(id)}
+                        />
+                      )}
+                      {shouldOfferPane(terminal.session.agentType, browserPanes.has(id)) && (
+                        <TabIconButton
+                          label="Open browser"
+                          icon={<Globe size={13} />}
+                          onClick={() => toggleBrowserPane(id)}
+                        />
+                      )}
                       <TabIconButton
                         label="Rename session"
                         icon={<Pencil size={13} />}

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -469,7 +469,7 @@ export function TabView() {
                       />
                       {shouldOfferPane(terminal.session.agentType, terminalsPanes.has(id)) && (
                         <TabIconButton
-                          label="Add a terminal"
+                          label={terminalsPanes.has(id) ? 'Close terminals' : 'Add a terminal'}
                           icon={<SquareTerminal size={13} />}
                           onClick={() => void toggleTerminalsPanel(id)}
                         />

--- a/src/renderer/components/TerminalsCard.tsx
+++ b/src/renderer/components/TerminalsCard.tsx
@@ -1,0 +1,180 @@
+import { memo, forwardRef, useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { Plus, SquareArrowOutUpRight, X } from 'lucide-react'
+import { useAppStore } from '../stores'
+import { PaneCard, PaneControls } from './PaneCard'
+import { TerminalPane } from './TerminalPane'
+import { PANE_SURFACE } from '../lib/pane-surface'
+import { terminalsPaneId } from '../lib/pane-id'
+import { getDisplayName } from '../lib/terminal-display'
+import { addTerminalToPanel } from '../lib/session-utils'
+import { closeTerminalSession } from '../lib/terminal-close'
+
+interface Props {
+  /** Session that owns this panel. */
+  sessionId: string
+  isDragTarget?: boolean
+  onDragStart?: (paneId: string, e: React.PointerEvent) => void
+  flexible?: boolean
+}
+
+/**
+ * The shells a session holds beside its agent.
+ *
+ * Tabbed rather than stacked: a shell needs width to be readable and this
+ * column is narrow, so three at once makes three unusable. Only the tab in
+ * front renders a `TerminalPane` — the others keep running and keep their
+ * scrollback, because the terminal registry owns the xterm and a slot is only
+ * where it is currently drawn.
+ *
+ * Every shell in here is a full session with its own pid. That is what makes
+ * the ↗ on each tab a one-line action: it removes the claim, and the terminal
+ * is immediately a grid cell, a tab, a sidebar row and a focus target, with no
+ * card machinery involved at all.
+ */
+export const TerminalsCard = memo(
+  forwardRef<HTMLDivElement, Props>(function TerminalsCard(
+    { sessionId, isDragTarget, onDragStart, flexible },
+    ref
+  ) {
+    // Everything selected here is either a primitive or a reference the store
+    // replaces only when it genuinely changes. Building the tab list inside the
+    // selector instead would hand `useShallow` a fresh array every call, so no
+    // two snapshots would ever compare equal and the component would re-render
+    // without end. Derive it in a memo below, not in the selector.
+    const { owner, pane, terminals, focusedId, setActive, extract, closePanel, domBlocks } =
+      useAppStore(
+        useShallow((s) => ({
+          owner: s.terminals.get(sessionId),
+          pane: s.terminalsPanes.get(sessionId) ?? null,
+          terminals: s.terminals,
+          focusedId: s.focusedTerminalId,
+          setActive: s.setActivePanelTerminal,
+          extract: s.extractPanelTerminal,
+          closePanel: s.closeTerminalsPane,
+          domBlocks: s.config?.defaults.domBlockRendering ?? true
+        }))
+      )
+
+    const held = pane?.terminals
+    const names = useMemo(
+      () =>
+        (held ?? []).map((id) => {
+          const t = terminals.get(id)
+          return { id, name: t ? getDisplayName(t.session) : id, agentType: t?.session.agentType }
+        }),
+      [held, terminals]
+    )
+
+    if (!owner || !pane || names.length === 0) return null
+
+    const active = names[Math.min(pane.activeTab, names.length - 1)]
+    const paneId = terminalsPaneId(sessionId)
+    const cwd = owner.session.worktreePath || owner.session.projectPath
+    const close = (): void => closePanel(sessionId)
+
+    return (
+      <PaneCard
+        ref={ref}
+        paneId={paneId}
+        title="Terminals"
+        onClose={close}
+        isDragTarget={isDragTarget}
+        onDragStart={onDragStart}
+        flexible={flexible}
+        // The tab strip is this pane's title bar, as the browser's is.
+        headerless
+      >
+        <div
+          className={`flex items-center gap-1 pl-1.5 pr-1 pt-1 shrink-0 ${
+            onDragStart || flexible ? 'drag-handle cursor-grab active:cursor-grabbing' : ''
+          }`}
+          onPointerDown={onDragStart ? (e) => onDragStart(paneId, e) : undefined}
+          data-testid={`terminals-pane-header-${sessionId}`}
+        >
+          <div
+            className="flex items-stretch gap-0.5 flex-1 min-w-0 overflow-x-auto"
+            role="tablist"
+            aria-label="Terminals"
+          >
+            {names.map((t, i) => {
+              const isActive = i === pane.activeTab
+              return (
+                <div
+                  key={t.id}
+                  role="tab"
+                  aria-selected={isActive}
+                  tabIndex={0}
+                  onClick={() => setActive(sessionId, i)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') setActive(sessionId, i)
+                  }}
+                  title={t.name}
+                  className={`group/tab flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-md max-w-[170px]
+                              cursor-default select-none transition-colors ${
+                                isActive
+                                  ? 'bg-white/[0.06] text-gray-200'
+                                  : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.03]'
+                              }`}
+                >
+                  <span className="text-[11px] truncate">{t.name}</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      extract(sessionId, t.id)
+                    }}
+                    aria-label={`Open ${t.name} as its own terminal`}
+                    title="Open as its own terminal"
+                    className="shrink-0 p-0.5 rounded text-gray-600 hover:text-white
+                               hover:bg-white/[0.08] transition-colors"
+                  >
+                    <SquareArrowOutUpRight size={10} strokeWidth={2.5} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      void closeTerminalSession(t.id)
+                    }}
+                    aria-label={`Close ${t.name}`}
+                    className="shrink-0 p-0.5 rounded text-gray-600 hover:text-white
+                               opacity-0 group-hover/tab:opacity-100 focus:opacity-100 transition-opacity"
+                  >
+                    <X size={10} strokeWidth={2.5} />
+                  </button>
+                </div>
+              )
+            })}
+            <button
+              type="button"
+              onClick={() => void addTerminalToPanel(sessionId, cwd)}
+              aria-label="New terminal in this session"
+              className="shrink-0 self-center ml-0.5 p-1 rounded-md text-gray-600 hover:text-gray-200
+                         hover:bg-white/[0.06] transition-colors"
+            >
+              <Plus size={13} strokeWidth={2} />
+            </button>
+          </div>
+
+          <PaneControls paneId={paneId} title="Terminals" onClose={close} className="shrink-0" />
+        </div>
+
+        {/* Only the tab in front is drawn. The rest keep running — the registry
+            holds the xterm and its scrollback, and a slot is only where a
+            terminal is currently shown. Rendering them all would also have two
+            slots claiming one terminal, which the registry resolves by
+            last-writer-wins: one of them would simply go blank. */}
+        <div className="flex-1 min-h-0 relative" style={{ background: PANE_SURFACE }}>
+          <TerminalPane
+            key={active.id}
+            terminalId={active.id}
+            agentType={active.agentType}
+            isFocused={focusedId === active.id}
+            domBlocks={domBlocks}
+          />
+        </div>
+      </PaneCard>
+    )
+  })
+)

--- a/src/renderer/components/TerminalsCard.tsx
+++ b/src/renderer/components/TerminalsCard.tsx
@@ -1,7 +1,8 @@
-import { memo, forwardRef, useMemo } from 'react'
+import { memo, forwardRef, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { Plus, SquareArrowOutUpRight, X } from 'lucide-react'
 import { useAppStore } from '../stores'
+import { activePanelIndex } from '../stores/types'
 import { PaneCard, PaneControls } from './PaneCard'
 import { TerminalPane } from './TerminalPane'
 import { IntentBar } from './IntentBar'
@@ -9,7 +10,7 @@ import { terminalsPaneId } from '../lib/pane-id'
 import { getDisplayName } from '../lib/terminal-display'
 import { terminalTextIndentPx } from '../lib/terminal-indent'
 import { addTerminalToPanel } from '../lib/session-utils'
-import { closeTerminalSession } from '../lib/terminal-close'
+import { closeTerminalSession, closeTerminalsPanel } from '../lib/terminal-close'
 
 interface Props {
   /** Session that owns this panel. */
@@ -43,19 +44,22 @@ export const TerminalsCard = memo(
     // selector instead would hand `useShallow` a fresh array every call, so no
     // two snapshots would ever compare equal and the component would re-render
     // without end. Derive it in a memo below, not in the selector.
-    const { owner, pane, terminals, focusedId, setActive, extract, closePanel, domBlocks } =
-      useAppStore(
-        useShallow((s) => ({
-          owner: s.terminals.get(sessionId),
-          pane: s.terminalsPanes.get(sessionId) ?? null,
-          terminals: s.terminals,
-          focusedId: s.focusedTerminalId,
-          setActive: s.setActivePanelTerminal,
-          extract: s.extractPanelTerminal,
-          closePanel: s.closeTerminalsPane,
-          domBlocks: s.config?.defaults.domBlockRendering ?? true
-        }))
-      )
+    const { owner, pane, terminals, setActive, extract, domBlocks } = useAppStore(
+      useShallow((s) => ({
+        owner: s.terminals.get(sessionId),
+        pane: s.terminalsPanes.get(sessionId) ?? null,
+        terminals: s.terminals,
+        setActive: s.setActivePanelTerminal,
+        extract: s.extractPanelTerminal,
+        domBlocks: s.config?.defaults.domBlockRendering ?? true
+      }))
+    )
+
+    // Which shell should hold the keyboard. It cannot be `focusedTerminalId`:
+    // a claimed shell is deliberately kept out of the focusable set, so that
+    // comparison is structurally always false and nothing ever put the caret in
+    // here — clicking a tab left you typing at the agent instead.
+    const [focusTarget, setFocusTarget] = useState<string | null>(null)
 
     const held = pane?.terminals
     const names = useMemo(
@@ -69,10 +73,9 @@ export const TerminalsCard = memo(
 
     if (!owner || !pane || names.length === 0) return null
 
-    const active = names[Math.min(pane.activeTab, names.length - 1)]
+    const active = names[activePanelIndex(pane)]
     const paneId = terminalsPaneId(sessionId)
-    const cwd = owner.session.worktreePath || owner.session.projectPath
-    const close = (): void => closePanel(sessionId)
+    const close = (): void => void closeTerminalsPanel(sessionId)
 
     return (
       <PaneCard
@@ -106,10 +109,19 @@ export const TerminalsCard = memo(
                   role="tab"
                   aria-selected={isActive}
                   tabIndex={0}
-                  onClick={() => setActive(sessionId, i)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') setActive(sessionId, i)
+                  onClick={() => {
+                    setActive(sessionId, i)
+                    setFocusTarget(t.id)
                   }}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return
+                    setActive(sessionId, i)
+                    setFocusTarget(t.id)
+                  }}
+                  // The card underneath selects its session on pointerdown and
+                  // then focuses that session's agent a frame later, which would
+                  // take the keyboard straight back off the shell.
+                  onPointerDown={(e) => e.stopPropagation()}
                   title={t.name}
                   className={`group/tab flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-md max-w-[170px]
                               cursor-default select-none transition-colors ${
@@ -149,7 +161,12 @@ export const TerminalsCard = memo(
             })}
             <button
               type="button"
-              onClick={() => void addTerminalToPanel(sessionId, cwd)}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={() => {
+                void addTerminalToPanel(sessionId).then((id) => {
+                  if (id) setFocusTarget(id)
+                })
+              }}
               aria-label="New terminal in this session"
               className="shrink-0 self-center ml-0.5 p-1 rounded-md text-gray-600 hover:text-gray-200
                          hover:bg-white/[0.06] transition-colors"
@@ -180,7 +197,7 @@ export const TerminalsCard = memo(
             key={active.id}
             terminalId={active.id}
             agentType={active.agentType}
-            isFocused={focusedId === active.id}
+            isFocused={focusTarget === active.id}
             flexible={flexible}
             domBlocks={domBlocks}
           />

--- a/src/renderer/components/TerminalsCard.tsx
+++ b/src/renderer/components/TerminalsCard.tsx
@@ -73,7 +73,8 @@ export const TerminalsCard = memo(
 
     if (!owner || !pane || names.length === 0) return null
 
-    const active = names[activePanelIndex(pane)]
+    const activeIndex = activePanelIndex(pane)
+    const active = names[activeIndex]
     const paneId = terminalsPaneId(sessionId)
     const close = (): void => void closeTerminalsPanel(sessionId)
 
@@ -102,7 +103,10 @@ export const TerminalsCard = memo(
             aria-label="Terminals"
           >
             {names.map((t, i) => {
-              const isActive = i === pane.activeTab
+              // The clamped index, the same one the body below is drawn from.
+              // Reading the raw value here would leave a stale one showing a
+              // terminal with no tab marked as its own.
+              const isActive = i === activeIndex
               return (
                 <div
                   key={t.id}

--- a/src/renderer/components/TerminalsCard.tsx
+++ b/src/renderer/components/TerminalsCard.tsx
@@ -4,9 +4,10 @@ import { Plus, SquareArrowOutUpRight, X } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { PaneCard, PaneControls } from './PaneCard'
 import { TerminalPane } from './TerminalPane'
-import { PANE_SURFACE } from '../lib/pane-surface'
+import { IntentBar } from './IntentBar'
 import { terminalsPaneId } from '../lib/pane-id'
 import { getDisplayName } from '../lib/terminal-display'
+import { terminalTextIndentPx } from '../lib/terminal-indent'
 import { addTerminalToPanel } from '../lib/session-utils'
 import { closeTerminalSession } from '../lib/terminal-close'
 
@@ -164,16 +165,32 @@ export const TerminalsCard = memo(
             holds the xterm and its scrollback, and a slot is only where a
             terminal is currently shown. Rendering them all would also have two
             slots claiming one terminal, which the registry resolves by
-            last-writer-wins: one of them would simply go blank. */}
-        <div className="flex-1 min-h-0 relative" style={{ background: PANE_SURFACE }}>
+            last-writer-wins: one of them would simply go blank.
+
+            Framed as a terminal, not as a pane: the sunken surface, the same
+            half-step of top padding, and the composer docked beneath. A shell
+            in here is the same kind of thing as a shell in the grid, and the
+            pane grey is for frames around someone else's content — which is
+            what the tab strip above is, and what the terminal below is not. */}
+        <div
+          className="flex-1 min-h-0 relative pt-0.5"
+          style={{ background: 'var(--color-surface-sunken)' }}
+        >
           <TerminalPane
             key={active.id}
             terminalId={active.id}
             agentType={active.agentType}
             isFocused={focusedId === active.id}
+            flexible={flexible}
             domBlocks={domBlocks}
           />
         </div>
+
+        <IntentBar
+          terminalId={active.id}
+          compact
+          indentPx={terminalTextIndentPx(active.agentType, domBlocks)}
+        />
       </PaneCard>
     )
   })

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -142,9 +142,11 @@ export function CardActionCluster({ terminalId, variant }: Props) {
   const agentType = terminal.session.agentType
   const showBrowser = shouldOfferPane(agentType, hasBrowserPane)
   const showTerminals = shouldOfferPane(agentType, hasTerminalsPane)
-  const showDevice =
-    shouldShowDeviceButton(mobileProjectCache.get(terminal.session.projectPath), hasDevicePane) &&
-    shouldOfferPane(agentType, hasDevicePane)
+  const showDevice = shouldShowDeviceButton(
+    mobileProjectCache.get(terminal.session.projectPath),
+    hasDevicePane,
+    agentType
+  )
 
   return (
     <div className="flex items-center gap-0.5 shrink-0">
@@ -175,7 +177,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
 
       {showTerminals && (
         <Tooltip
-          label={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+          label={hasTerminalsPane ? 'Close terminals' : 'Add a terminal'}
           position={tooltipPos}
         >
           <button
@@ -183,7 +185,7 @@ export function CardActionCluster({ terminalId, variant }: Props) {
             onClick={handleTerminals}
             onPointerDown={(e) => e.stopPropagation()}
             className={ICON_BUTTON}
-            aria-label={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+            aria-label={hasTerminalsPane ? 'Close terminals' : 'Add a terminal'}
           >
             <SquareTerminal size={ICON_BUTTON_SIZE} strokeWidth={2} />
           </button>

--- a/src/renderer/components/card/CardActionCluster.tsx
+++ b/src/renderer/components/card/CardActionCluster.tsx
@@ -7,6 +7,7 @@ import {
   Minus,
   MoreHorizontal,
   Smartphone,
+  SquareTerminal,
   X
 } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
@@ -17,11 +18,13 @@ import { Tooltip } from '../Tooltip'
 import { ConfirmPopover } from '../ConfirmPopover'
 import { CardContextMenu } from '../CardContextMenu'
 import { closeTerminalSession } from '../../lib/terminal-close'
+import { toggleTerminalsPanel } from '../../lib/session-utils'
 import { toast } from '../Toast'
 import { getDisplayName } from '../../lib/terminal-display'
 import { MOD } from '../../lib/platform'
 import { DevicePicker } from '../DevicePicker'
 import { shouldShowDeviceButton } from '../../lib/device-affordance'
+import { shouldOfferPane } from '../../lib/pane-affordance'
 
 export type CardVariant = 'mini' | 'focused'
 
@@ -37,6 +40,8 @@ export function CardActionCluster({ terminalId, variant }: Props) {
     toggleMinimized,
     toggleFilesPane,
     toggleBrowserPane,
+    hasTerminalsPane,
+    hasBrowserPane,
     hasDevicePane,
     claimAndOpenDevicePane,
     closeDevicePane,
@@ -49,6 +54,8 @@ export function CardActionCluster({ terminalId, variant }: Props) {
       toggleMinimized: s.toggleMinimized,
       toggleFilesPane: s.toggleFilesPane,
       toggleBrowserPane: s.toggleBrowserPane,
+      hasTerminalsPane: s.terminalsPanes.has(terminalId),
+      hasBrowserPane: s.browserPanes.has(terminalId),
       hasDevicePane: s.devicePanes.has(terminalId),
       claimAndOpenDevicePane: s.claimAndOpenDevicePane,
       closeDevicePane: s.closeDevicePane,
@@ -84,6 +91,11 @@ export function CardActionCluster({ terminalId, variant }: Props) {
   const handleOpenBrowser = (e: React.MouseEvent): void => {
     e.stopPropagation()
     toggleBrowserPane(terminalId)
+  }
+
+  const handleTerminals = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    void toggleTerminalsPanel(terminalId)
   }
 
   const handleMinimize = (e: React.MouseEvent): void => {
@@ -125,10 +137,14 @@ export function CardActionCluster({ terminalId, variant }: Props) {
   // tooltips get clipped off-screen. Drop them below the buttons instead.
   const tooltipPos = isFocused ? 'bottom' : 'top'
 
-  const showDevice = shouldShowDeviceButton(
-    mobileProjectCache.get(terminal.session.projectPath),
-    hasDevicePane
-  )
+  // A shell is offered none of the project panes it has no use for — unless one
+  // is already open, which keeps its own control so it can be closed.
+  const agentType = terminal.session.agentType
+  const showBrowser = shouldOfferPane(agentType, hasBrowserPane)
+  const showTerminals = shouldOfferPane(agentType, hasTerminalsPane)
+  const showDevice =
+    shouldShowDeviceButton(mobileProjectCache.get(terminal.session.projectPath), hasDevicePane) &&
+    shouldOfferPane(agentType, hasDevicePane)
 
   return (
     <div className="flex items-center gap-0.5 shrink-0">
@@ -157,17 +173,36 @@ export function CardActionCluster({ terminalId, variant }: Props) {
         </button>
       </Tooltip>
 
-      <Tooltip label="Open browser" position={tooltipPos}>
-        <button
-          type="button"
-          onClick={handleOpenBrowser}
-          onPointerDown={(e) => e.stopPropagation()}
-          className={ICON_BUTTON}
-          aria-label="Open browser"
+      {showTerminals && (
+        <Tooltip
+          label={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+          position={tooltipPos}
         >
-          <Globe size={ICON_BUTTON_SIZE} strokeWidth={2} />
-        </button>
-      </Tooltip>
+          <button
+            type="button"
+            onClick={handleTerminals}
+            onPointerDown={(e) => e.stopPropagation()}
+            className={ICON_BUTTON}
+            aria-label={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+          >
+            <SquareTerminal size={ICON_BUTTON_SIZE} strokeWidth={2} />
+          </button>
+        </Tooltip>
+      )}
+
+      {showBrowser && (
+        <Tooltip label="Open browser" position={tooltipPos}>
+          <button
+            type="button"
+            onClick={handleOpenBrowser}
+            onPointerDown={(e) => e.stopPropagation()}
+            className={ICON_BUTTON}
+            aria-label="Open browser"
+          >
+            <Globe size={ICON_BUTTON_SIZE} strokeWidth={2} />
+          </button>
+        </Tooltip>
+      )}
 
       {showDevice && (
         <Tooltip

--- a/src/renderer/components/project-sidebar/FlatSessionsSection.tsx
+++ b/src/renderer/components/project-sidebar/FlatSessionsSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useAppStore } from '../../stores'
+import { useClaimedTerminalIds } from '../../hooks/usePanelTerminals'
 import { SessionItem } from './SessionItem'
 import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
 import { getDisplayName } from '../../lib/terminal-display'
@@ -16,6 +17,8 @@ export function FlatSessionsSection({
   workspaceTerminalCount: number
 }) {
   const terminals = useAppStore((s) => s.terminals)
+  // Held by a terminals panel means drawn only there — see ProjectSidebar.
+  const claimed = useClaimedTerminalIds()
   const activeProject = useAppStore((s) => s.activeProject)
   const setActiveProject = useAppStore((s) => s.setActiveProject)
   const setFocusedTerminal = useAppStore((s) => s.setFocusedTerminal)
@@ -27,6 +30,7 @@ export function FlatSessionsSection({
       activeProject && workspaceProjectNames.has(activeProject) ? activeProject : null
     const list: (SidebarSessionInfo & { projectName: string; lastActivity: number })[] = []
     for (const [id, t] of terminals) {
+      if (claimed.has(id)) continue
       if (!workspaceProjectNames.has(t.session.projectName)) continue
       if (effectiveProject && t.session.projectName !== effectiveProject) continue
       list.push({
@@ -43,7 +47,7 @@ export function FlatSessionsSection({
     }
     list.sort((a, b) => b.lastActivity - a.lastActivity)
     return list
-  }, [terminals, workspaceProjectNames, activeProject])
+  }, [terminals, claimed, workspaceProjectNames, activeProject])
 
   return (
     <>

--- a/src/renderer/components/project-sidebar/ProjectSidebar.tsx
+++ b/src/renderer/components/project-sidebar/ProjectSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useAppStore } from '../../stores'
+import { useClaimedTerminalIds } from '../../hooks/usePanelTerminals'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { getDisplayName } from '../../lib/terminal-display'
 import { useSidebarResize } from './useSidebarResize'
@@ -14,6 +15,11 @@ import type { SidebarSessionInfo } from './types'
 export function ProjectSidebar() {
   const config = useAppStore((s) => s.config)
   const terminals = useAppStore((s) => s.terminals)
+  // A shell held by a session's terminals panel is drawn there and nowhere
+  // else. It is listed in `terminals` like any session, so every surface that
+  // walks that map has to drop it — a row here would focus a terminal the grid
+  // has no cell for.
+  const claimed = useClaimedTerminalIds()
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
   const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
   const toggleSidebar = useAppStore((s) => s.toggleSidebar)
@@ -58,6 +64,7 @@ export function ProjectSidebar() {
     const mainCounts = new Map<string, number>()
 
     for (const [id, t] of terminals) {
+      if (claimed.has(id)) continue
       const pName = t.session.projectName
       const info: SidebarSessionInfo = {
         id,
@@ -90,7 +97,7 @@ export function ProjectSidebar() {
       worktreeSessionCounts: wtCounts,
       mainRepoSessionCounts: mainCounts
     }
-  }, [terminals])
+  }, [terminals, claimed])
 
   const workspaceTerminalCount = useMemo(() => {
     let count = 0

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -3,11 +3,12 @@ import { X, FolderTree, Globe, Loader2, Smartphone, SquareTerminal } from 'lucid
 import { useAppStore } from '../../stores'
 import { AgentStatusIcon } from '../AgentStatusIcon'
 import { closeTerminalSession } from '../../lib/terminal-close'
-import { addTerminalToPanel } from '../../lib/session-utils'
+import { toggleTerminalsPanel } from '../../lib/session-utils'
 import { toast } from '../Toast'
 import { STATUS_LABEL } from '../../lib/status-colors'
 import { DevicePicker } from '../DevicePicker'
 import { shouldShowDeviceButton } from '../../lib/device-affordance'
+import { shouldOfferPane } from '../../lib/pane-affordance'
 import { PromotedCardItem } from './PromotedCardItem'
 import { usePromotedCardsFor } from '../../hooks/usePromotedCards'
 import type { SidebarSessionInfo } from './types'
@@ -33,11 +34,6 @@ export function SessionItem({
   const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
   const hasBrowserPane = useAppStore((s) => s.browserPanes.has(session.id))
   const hasTerminalsPane = useAppStore((s) => s.terminalsPanes.has(session.id))
-  const closeTerminalsPane = useAppStore((s) => s.closeTerminalsPane)
-  const sessionCwd = useAppStore((s) => {
-    const t = s.terminals.get(session.id)?.session
-    return t ? t.worktreePath || t.projectPath : ''
-  })
   const toggleBrowserPane = useAppStore((s) => s.toggleBrowserPane)
   const hasDevicePane = useAppStore((s) => s.devicePanes.has(session.id))
   const claimAndOpenDevicePane = useAppStore((s) => s.claimAndOpenDevicePane)
@@ -59,7 +55,13 @@ export function SessionItem({
     if (projectPath) void loadMobileProject(projectPath)
   }, [projectPath, loadMobileProject])
 
-  const showDevice = shouldShowDeviceButton(mobile, hasDevicePane)
+  // A shell has no use for a browser, a simulator, or a panel of further
+  // shells. An already-open pane keeps its control so it can still be closed.
+  const showBrowser = shouldOfferPane(session.agentType, hasBrowserPane)
+  const showTerminals = shouldOfferPane(session.agentType, hasTerminalsPane)
+  const showDevice =
+    shouldShowDeviceButton(mobile, hasDevicePane) &&
+    shouldOfferPane(session.agentType, hasDevicePane)
   const isActive =
     layoutMode === 'tabs' ? activeTabId === session.id : focusedTerminalId === session.id
   const isPreviewing = previewTerminalId === session.id
@@ -145,41 +147,42 @@ export function SessionItem({
         >
           <FolderTree size={12} strokeWidth={2} />
         </button>
-        <button
-          type="button"
-          aria-label={`${hasTerminalsPane ? 'Hide' : 'Show'} terminals for ${session.name}`}
-          title={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
-          onClick={(e) => {
-            e.stopPropagation()
-            // Opening with nothing in it would be an empty box taking up a
-            // pane, so the first shell is created as part of opening.
-            if (hasTerminalsPane) closeTerminalsPane(session.id)
-            else void addTerminalToPanel(session.id, sessionCwd)
-          }}
-          className={`${
-            hasTerminalsPane
-              ? 'opacity-100 text-ink'
-              : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
-          } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
-        >
-          <SquareTerminal size={12} strokeWidth={2} />
-        </button>
-        <button
-          type="button"
-          aria-label={`${hasBrowserPane ? 'Hide' : 'Show'} browser for ${session.name}`}
-          title={hasBrowserPane ? 'Hide browser' : 'Show browser'}
-          onClick={(e) => {
-            e.stopPropagation()
-            toggleBrowserPane(session.id)
-          }}
-          className={`${
-            hasBrowserPane
-              ? 'opacity-100 text-ink'
-              : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
-          } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
-        >
-          <Globe size={12} strokeWidth={2} />
-        </button>
+        {showTerminals && (
+          <button
+            type="button"
+            aria-label={`${hasTerminalsPane ? 'Hide' : 'Show'} terminals for ${session.name}`}
+            title={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+            onClick={(e) => {
+              e.stopPropagation()
+              void toggleTerminalsPanel(session.id)
+            }}
+            className={`${
+              hasTerminalsPane
+                ? 'opacity-100 text-ink'
+                : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
+            } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
+          >
+            <SquareTerminal size={12} strokeWidth={2} />
+          </button>
+        )}
+        {showBrowser && (
+          <button
+            type="button"
+            aria-label={`${hasBrowserPane ? 'Hide' : 'Show'} browser for ${session.name}`}
+            title={hasBrowserPane ? 'Hide browser' : 'Show browser'}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleBrowserPane(session.id)
+            }}
+            className={`${
+              hasBrowserPane
+                ? 'opacity-100 text-ink'
+                : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
+            } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
+          >
+            <Globe size={12} strokeWidth={2} />
+          </button>
+        )}
         {showDevice && (
           <button
             ref={deviceButtonRef}

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -1,8 +1,9 @@
 import { useRef, useCallback, useEffect, useState } from 'react'
-import { X, FolderTree, Globe, Loader2, Smartphone } from 'lucide-react'
+import { X, FolderTree, Globe, Loader2, Smartphone, SquareTerminal } from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { AgentStatusIcon } from '../AgentStatusIcon'
 import { closeTerminalSession } from '../../lib/terminal-close'
+import { addTerminalToPanel } from '../../lib/session-utils'
 import { toast } from '../Toast'
 import { STATUS_LABEL } from '../../lib/status-colors'
 import { DevicePicker } from '../DevicePicker'
@@ -31,6 +32,12 @@ export function SessionItem({
   const hasFilesPane = useAppStore((s) => s.filesPanes.has(session.id))
   const toggleFilesPane = useAppStore((s) => s.toggleFilesPane)
   const hasBrowserPane = useAppStore((s) => s.browserPanes.has(session.id))
+  const hasTerminalsPane = useAppStore((s) => s.terminalsPanes.has(session.id))
+  const closeTerminalsPane = useAppStore((s) => s.closeTerminalsPane)
+  const sessionCwd = useAppStore((s) => {
+    const t = s.terminals.get(session.id)?.session
+    return t ? t.worktreePath || t.projectPath : ''
+  })
   const toggleBrowserPane = useAppStore((s) => s.toggleBrowserPane)
   const hasDevicePane = useAppStore((s) => s.devicePanes.has(session.id))
   const claimAndOpenDevicePane = useAppStore((s) => s.claimAndOpenDevicePane)
@@ -137,6 +144,25 @@ export function SessionItem({
           } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
         >
           <FolderTree size={12} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          aria-label={`${hasTerminalsPane ? 'Hide' : 'Show'} terminals for ${session.name}`}
+          title={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+          onClick={(e) => {
+            e.stopPropagation()
+            // Opening with nothing in it would be an empty box taking up a
+            // pane, so the first shell is created as part of opening.
+            if (hasTerminalsPane) closeTerminalsPane(session.id)
+            else void addTerminalToPanel(session.id, sessionCwd)
+          }}
+          className={`${
+            hasTerminalsPane
+              ? 'opacity-100 text-ink'
+              : 'opacity-0 group-hover/session:opacity-100 text-gray-500'
+          } focus:opacity-100 hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0`}
+        >
+          <SquareTerminal size={12} strokeWidth={2} />
         </button>
         <button
           type="button"

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -59,9 +59,7 @@ export function SessionItem({
   // shells. An already-open pane keeps its control so it can still be closed.
   const showBrowser = shouldOfferPane(session.agentType, hasBrowserPane)
   const showTerminals = shouldOfferPane(session.agentType, hasTerminalsPane)
-  const showDevice =
-    shouldShowDeviceButton(mobile, hasDevicePane) &&
-    shouldOfferPane(session.agentType, hasDevicePane)
+  const showDevice = shouldShowDeviceButton(mobile, hasDevicePane, session.agentType)
   const isActive =
     layoutMode === 'tabs' ? activeTabId === session.id : focusedTerminalId === session.id
   const isPreviewing = previewTerminalId === session.id
@@ -150,8 +148,8 @@ export function SessionItem({
         {showTerminals && (
           <button
             type="button"
-            aria-label={`${hasTerminalsPane ? 'Hide' : 'Show'} terminals for ${session.name}`}
-            title={hasTerminalsPane ? 'Hide terminals' : 'Add a terminal'}
+            aria-label={`${hasTerminalsPane ? 'Close' : 'Show'} terminals for ${session.name}`}
+            title={hasTerminalsPane ? 'Close these terminals' : 'Add a terminal'}
             onClick={(e) => {
               e.stopPropagation()
               void toggleTerminalsPanel(session.id)

--- a/src/renderer/hooks/usePaneColumnEntries.ts
+++ b/src/renderer/hooks/usePaneColumnEntries.ts
@@ -28,12 +28,13 @@ export function usePaneColumnEntries(sessionId: string | null): ColumnEntry[] {
   // `editor:card:<id>` entry for a pane that does not exist. Harmless only
   // because today's callers happen to branch before reading it.
   const owner = sessionId !== null && !isPromotedCardId(sessionId) ? sessionId : null
-  const { hasFiles, hasEditor, hasBrowser, hasDevice } = useAppStore(
+  const { hasFiles, hasEditor, hasBrowser, hasDevice, hasTerminals } = useAppStore(
     useShallow((s) => ({
       hasFiles: owner ? s.filesPanes.has(owner) : false,
       hasEditor: owner ? s.editorPanes.has(owner) : false,
       hasBrowser: owner ? s.browserPanes.has(owner) : false,
-      hasDevice: owner ? s.devicePanes.has(owner) : false
+      hasDevice: owner ? s.devicePanes.has(owner) : false,
+      hasTerminals: owner ? s.terminalsPanes.has(owner) : false
     }))
   )
 
@@ -45,8 +46,9 @@ export function usePaneColumnEntries(sessionId: string | null): ColumnEntry[] {
       hasFiles ? ('files' as const) : null,
       hasEditor ? ('editor' as const) : null,
       hasBrowser ? ('browser' as const) : null,
-      hasDevice ? ('device' as const) : null
+      hasDevice ? ('device' as const) : null,
+      hasTerminals ? ('terminals' as const) : null
     ].filter((k): k is PaneChildKind => k !== null)
     return kinds.map((kind) => ({ id: paneIdFor(kind, owner), kind }))
-  }, [owner, hasFiles, hasEditor, hasBrowser, hasDevice])
+  }, [owner, hasFiles, hasEditor, hasBrowser, hasDevice, hasTerminals])
 }

--- a/src/renderer/hooks/usePanelTerminals.ts
+++ b/src/renderer/hooks/usePanelTerminals.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../stores'
+import type { AppStore } from '../stores/types'
+
+/** Stable empty, so "nothing claimed" does not invalidate every memo downstream. */
+const NONE = new Set<string>()
+
+/**
+ * Every terminal currently claimed by some session's panel.
+ *
+ * A claimed terminal is drawn in that panel and nowhere else — it is kept out
+ * of the grid, the tab strip, the sidebar, the dock and keyboard nav until it
+ * is extracted. That is not only tidiness: the terminal registry is
+ * last-writer-wins on a slot, so one terminal rendered in two places would have
+ * the two fighting over a single wrapper, and whichever lost would go blank.
+ *
+ * Derived rather than stored, the way a card is derived from a pane whose key
+ * is not its owner — so there is no second list to fall out of step with the
+ * panels themselves.
+ */
+export function claimedTerminalIds(state: Pick<AppStore, 'terminalsPanes'>): Set<string> {
+  if (state.terminalsPanes.size === 0) return NONE
+  const claimed = new Set<string>()
+  for (const pane of state.terminalsPanes.values()) {
+    for (const id of pane.terminals) claimed.add(id)
+  }
+  return claimed
+}
+
+export function useClaimedTerminalIds(): Set<string> {
+  const terminalsPanes = useAppStore((s) => s.terminalsPanes)
+  // Memoized on the map, which is replaced only when a panel actually changes —
+  // adding, extracting, closing, or switching which shell is in front.
+  return useMemo(() => claimedTerminalIds({ terminalsPanes }), [terminalsPanes])
+}

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL, type SortMode, type TerminalState } from '../stores/types'
 import { usePromotedCardsByOwner } from './usePromotedCards'
+import { useClaimedTerminalIds } from './usePanelTerminals'
 
 /**
  * Stable comparator for terminal ids under the active sortMode. Manual mode
@@ -74,6 +75,10 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
   // triggering a reconcile pass, for a list that had not changed. The grouping
   // is a stable empty when nothing is popped out, which is the common case.
   const cardsByOwner = usePromotedCardsByOwner()
+  // Terminals a session holds in its panel. They are drawn there and nowhere
+  // else, so they are not layout units, not focusable, and not dock entries —
+  // and the registry's one-slot-per-terminal rule depends on that staying true.
+  const claimedTerminals = useClaimedTerminalIds()
 
   const workspaceProjects = useMemo(() => {
     if (!projects) return null
@@ -91,7 +96,7 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     }
     const sortFn = ([aId]: [string, TerminalState], [bId]: [string, TerminalState]): number =>
       compareTerminalIds(aId, bId, terminals, sortMode, terminalOrder)
-    const all = Array.from(terminals.entries())
+    const all = Array.from(terminals.entries()).filter(([id]) => !claimedTerminals.has(id))
     const filtered = all
       .filter(([, t]) => {
         if (!inActiveScope(t)) return false
@@ -144,7 +149,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     sortMode,
     terminalOrder,
     minimizedTerminals,
-    cardsByOwner
+    cardsByOwner,
+    claimedTerminals
   ])
 
   useEffect(() => {

--- a/src/renderer/lib/device-affordance.ts
+++ b/src/renderer/lib/device-affordance.ts
@@ -1,4 +1,5 @@
-import type { DeviceInfo, MobileProject } from '../../shared/types'
+import type { AgentType, DeviceInfo, MobileProject } from '../../shared/types'
+import { shouldOfferPane } from './pane-affordance'
 
 /**
  * Whether to offer the device control for a session.
@@ -17,9 +18,13 @@ import type { DeviceInfo, MobileProject } from '../../shared/types'
  */
 export function shouldShowDeviceButton(
   mobile: MobileProject | undefined,
-  hasDevicePane: boolean
+  hasDevicePane: boolean,
+  agentType?: AgentType
 ): boolean {
   if (hasDevicePane) return true
+  // A simulator beside a plain shell is one of the project panes a shell has no
+  // use for; `shouldOfferPane` states that rule once for all of them.
+  if (!shouldOfferPane(agentType, hasDevicePane)) return false
   return mobile?.isMobile === true
 }
 

--- a/src/renderer/lib/pane-affordance.ts
+++ b/src/renderer/lib/pane-affordance.ts
@@ -1,0 +1,19 @@
+import { isShellSession, type AgentType } from '../../shared/types'
+
+/**
+ * Whether to offer a project pane — browser, device, terminals — on a session.
+ *
+ * These belong to a session that is driving a project. On a plain shell they
+ * are noise: a browser and a simulator beside a prompt nobody asked to drive
+ * from there, and a panel of shells inside what is already a shell.
+ *
+ * An open pane always keeps its control, the same exception
+ * `shouldShowDeviceButton` makes and for the same reason: hiding the control
+ * for a pane that is already on screen takes away the only way to close it.
+ *
+ * The file tree is deliberately not on this list. Looking at the files next to
+ * a shell is exactly as reasonable as looking at them next to an agent.
+ */
+export function shouldOfferPane(agentType: AgentType | undefined, isOpen: boolean): boolean {
+  return isOpen || !isShellSession(agentType)
+}

--- a/src/renderer/lib/pane-id.ts
+++ b/src/renderer/lib/pane-id.ts
@@ -12,7 +12,7 @@
  * untouched — only the components that *render* a pane need to branch on kind.
  */
 
-export type PaneKind = 'terminal' | 'files' | 'editor' | 'browser' | 'device' | 'card'
+export type PaneKind = 'terminal' | 'files' | 'editor' | 'browser' | 'device' | 'terminals' | 'card'
 
 /** Pane kinds a session stacks inside its own card, i.e. all but those two. */
 export type PaneChildKind = Exclude<PaneKind, 'terminal' | 'card'>
@@ -21,6 +21,7 @@ const FILES_PREFIX = 'files:'
 const EDITOR_PREFIX = 'editor:'
 const BROWSER_PREFIX = 'browser:'
 const DEVICE_PREFIX = 'device:'
+const TERMINALS_PREFIX = 'terminals:'
 const CARD_PREFIX = 'card:'
 
 /** Id of the file-tree pane owned by `sessionId`. */
@@ -36,6 +37,17 @@ export function editorPaneId(sessionId: string): string {
 /** Id of the browser pane owned by `sessionId`. */
 export function browserPaneId(sessionId: string): string {
   return `${BROWSER_PREFIX}${sessionId}`
+}
+
+/**
+ * Id of the terminals panel owned by `sessionId`.
+ *
+ * One panel per session holding any number of shells, so — like its browser —
+ * the owner id is enough to name it. Which shells, and which is in front, is
+ * the panel's own state.
+ */
+export function terminalsPaneId(sessionId: string): string {
+  return `${TERMINALS_PREFIX}${sessionId}`
 }
 
 /**
@@ -64,6 +76,8 @@ export function paneIdFor(kind: PaneChildKind, sessionId: string): string {
       return browserPaneId(sessionId)
     case 'device':
       return devicePaneId(sessionId)
+    case 'terminals':
+      return terminalsPaneId(sessionId)
   }
 }
 
@@ -127,6 +141,9 @@ export function parsePaneId(paneId: string): { kind: PaneKind; sessionId: string
   if (paneId.startsWith(DEVICE_PREFIX)) {
     return { kind: 'device', sessionId: paneId.slice(DEVICE_PREFIX.length) }
   }
+  if (paneId.startsWith(TERMINALS_PREFIX)) {
+    return { kind: 'terminals', sessionId: paneId.slice(TERMINALS_PREFIX.length) }
+  }
   return { kind: 'terminal', sessionId: paneId }
 }
 
@@ -137,6 +154,7 @@ export function paneKind(paneId: string): PaneKind {
   if (paneId.startsWith(EDITOR_PREFIX)) return 'editor'
   if (paneId.startsWith(BROWSER_PREFIX)) return 'browser'
   if (paneId.startsWith(DEVICE_PREFIX)) return 'device'
+  if (paneId.startsWith(TERMINALS_PREFIX)) return 'terminals'
   return 'terminal'
 }
 

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -208,6 +208,38 @@ export async function createSessionFromProject(
   state.addTerminal(session)
 }
 
+/**
+ * Start a shell inside a session's terminals panel.
+ *
+ * Same creation as `createShellInProject` — a shell terminal is a full session
+ * either way — differing only in where the new id is put. It must not become
+ * the active tab: a terminal claimed by a panel is deliberately absent from the
+ * tab strip, so activating one would select a tab that is not there.
+ */
+export async function addTerminalToPanel(sessionId: string, cwd: string): Promise<void> {
+  try {
+    const session = await window.api.createShellTerminal(cwd)
+    const state = useAppStore.getState()
+    const owner = state.terminals.get(sessionId)?.session
+    const enriched: TerminalSession = owner
+      ? {
+          ...session,
+          projectName: owner.projectName,
+          projectPath: owner.projectPath,
+          worktreePath: owner.worktreePath,
+          worktreeName: owner.worktreeName,
+          branch: owner.branch,
+          isWorktree: owner.isWorktree
+        }
+      : session
+    state.addTerminal(enriched)
+    state.openTerminalsPane(sessionId, enriched.id)
+  } catch (err) {
+    console.error('[addTerminalToPanel] failed:', err)
+    toast.error(`Failed to start terminal: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
 export async function createShellInProject(
   cwd?: string,
   context?: {

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -240,6 +240,26 @@ export async function addTerminalToPanel(sessionId: string, cwd: string): Promis
   }
 }
 
+/**
+ * Show or hide a session's terminals panel, from wherever it is asked for.
+ *
+ * Opening it with nothing in it would be an empty box holding a pane, so the
+ * first shell is created as part of opening — in the session's own directory,
+ * which is the point of the panel. The rule lives here rather than in each
+ * control because the sidebar row, the card header and the tab strip all offer
+ * it, and three copies would drift.
+ */
+export async function toggleTerminalsPanel(sessionId: string): Promise<void> {
+  const state = useAppStore.getState()
+  if (state.terminalsPanes.has(sessionId)) {
+    state.closeTerminalsPane(sessionId)
+    return
+  }
+  const owner = state.terminals.get(sessionId)?.session
+  if (!owner) return
+  await addTerminalToPanel(sessionId, owner.worktreePath || owner.projectPath)
+}
+
 export async function createShellInProject(
   cwd?: string,
   context?: {

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -9,6 +9,7 @@ import {
 } from '../../shared/types'
 import { useAppStore } from '../stores'
 import { toast } from '../components/Toast'
+import { closeTerminalsPanel } from './terminal-close'
 
 function normalizeComparablePath(p: string): string {
   const normalized = p.replace(/\\/g, '/').replace(/\/+$/, '')
@@ -216,27 +217,33 @@ export async function createSessionFromProject(
  * the active tab: a terminal claimed by a panel is deliberately absent from the
  * tab strip, so activating one would select a tab that is not there.
  */
-export async function addTerminalToPanel(sessionId: string, cwd: string): Promise<void> {
+export async function addTerminalToPanel(sessionId: string): Promise<string | null> {
+  // The owner answers both questions — where the shell starts and what it
+  // inherits — so it is read once here rather than each caller working out a
+  // cwd of its own and this function looking the same session up again.
+  const owner = useAppStore.getState().terminals.get(sessionId)?.session
+  if (!owner) return null
   try {
-    const session = await window.api.createShellTerminal(cwd)
+    const session = await window.api.createShellTerminal(owner.worktreePath || owner.projectPath)
     const state = useAppStore.getState()
-    const owner = state.terminals.get(sessionId)?.session
-    const enriched: TerminalSession = owner
-      ? {
-          ...session,
-          projectName: owner.projectName,
-          projectPath: owner.projectPath,
-          worktreePath: owner.worktreePath,
-          worktreeName: owner.worktreeName,
-          branch: owner.branch,
-          isWorktree: owner.isWorktree
-        }
-      : session
+    const enriched: TerminalSession = {
+      ...session,
+      projectName: owner.projectName,
+      projectPath: owner.projectPath,
+      worktreePath: owner.worktreePath,
+      worktreeName: owner.worktreeName,
+      branch: owner.branch,
+      isWorktree: owner.isWorktree
+    }
     state.addTerminal(enriched)
     state.openTerminalsPane(sessionId, enriched.id)
+    // Returned so the caller can put the keyboard in it — a new shell nobody
+    // is typing into is a shell you have to click before using.
+    return enriched.id
   } catch (err) {
     console.error('[addTerminalToPanel] failed:', err)
     toast.error(`Failed to start terminal: ${err instanceof Error ? err.message : String(err)}`)
+    return null
   }
 }
 
@@ -252,12 +259,13 @@ export async function addTerminalToPanel(sessionId: string, cwd: string): Promis
 export async function toggleTerminalsPanel(sessionId: string): Promise<void> {
   const state = useAppStore.getState()
   if (state.terminalsPanes.has(sessionId)) {
-    state.closeTerminalsPane(sessionId)
+    // The shells go with the panel. Merely dropping the claim would scatter
+    // them across the grid as top-level cards, and the next click here would
+    // add another shell beside them.
+    await closeTerminalsPanel(sessionId)
     return
   }
-  const owner = state.terminals.get(sessionId)?.session
-  if (!owner) return
-  await addTerminalToPanel(sessionId, owner.worktreePath || owner.projectPath)
+  await addTerminalToPanel(sessionId)
 }
 
 export async function createShellInProject(

--- a/src/renderer/lib/terminal-close.ts
+++ b/src/renderer/lib/terminal-close.ts
@@ -9,6 +9,40 @@ export function consumePendingTerminalClose(id: string): boolean {
   return pending
 }
 
+/**
+ * Close a session's terminals panel, and the shells it is holding.
+ *
+ * The shells go with it. They were created by the panel and are claimed by it,
+ * and that claim is the only thing keeping them off every other surface — so
+ * dropping the panel alone would leave live ptys scattered across the grid as
+ * top-level cards nobody asked for, and the next click on the same control
+ * would start yet another shell beside them.
+ *
+ * Each kill is independent, so one failure cannot strand the rest.
+ */
+export async function closeTerminalsPanel(sessionId: string): Promise<void> {
+  const state = useAppStore.getState()
+  const held = state.terminalsPanes.get(sessionId)?.terminals ?? []
+  for (const heldId of held) {
+    pendingTerminalCloses.add(heldId)
+    destroyTerminal(heldId)
+  }
+  // Closes the panel too: its last shell leaving is what shuts it, and
+  // `removeTerminal` releases each claim on the way through.
+  for (const heldId of held) state.removeTerminal(heldId)
+  state.closeTerminalsPane(sessionId)
+
+  await Promise.allSettled(
+    held.map(async (target) => {
+      try {
+        await window.api.killTerminal(target)
+      } catch (err) {
+        console.warn(`[terminal-close] killTerminal failed for ${target}:`, err)
+      }
+    })
+  )
+}
+
 export async function closeTerminalSession(id: string): Promise<void> {
   const state = useAppStore.getState()
 

--- a/src/renderer/lib/terminal-close.ts
+++ b/src/renderer/lib/terminal-close.ts
@@ -11,6 +11,19 @@ export function consumePendingTerminalClose(id: string): boolean {
 
 export async function closeTerminalSession(id: string): Promise<void> {
   const state = useAppStore.getState()
+
+  // Shells held in this session's panel go with it. Read before the store is
+  // touched — `removeTerminal` drops the panel, and after that there is nothing
+  // left to say which ptys these were, so they would keep running unreachable.
+  //
+  // Each kill is independent: a chain that aborted partway would leave some of
+  // them alive with no record of them anywhere.
+  const held = state.terminalsPanes.get(id)?.terminals ?? []
+  for (const heldId of held) {
+    pendingTerminalCloses.add(heldId)
+    destroyTerminal(heldId)
+  }
+
   pendingTerminalCloses.add(id)
   if (state.focusedTerminalId === id) state.setFocusedTerminal(null)
   if (state.selectedTerminalId === id) state.setSelectedTerminal(null)
@@ -18,9 +31,13 @@ export async function closeTerminalSession(id: string): Promise<void> {
   destroyTerminal(id)
   state.removeTerminal(id)
 
-  try {
-    await window.api.killTerminal(id)
-  } catch (err) {
-    console.warn(`[terminal-close] killTerminal failed for ${id}:`, err)
-  }
+  await Promise.allSettled(
+    [...held, id].map(async (target) => {
+      try {
+        await window.api.killTerminal(target)
+      } catch (err) {
+        console.warn(`[terminal-close] killTerminal failed for ${target}:`, err)
+      }
+    })
+  )
 }

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -33,9 +33,11 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
     set((state) => {
       const next = new Map(state.terminals)
       next.delete(id)
-      const order = state.terminalOrder.filter(
-        (tid) => tid !== id && !(state.terminalsPanes.get(id)?.terminals ?? []).includes(tid)
-      )
+      // The shells this session's panel is holding. Read once: the order filter
+      // below and the teardown further down have to name the same set, and the
+      // lookup was running per element of the whole session order.
+      const held = new Set(state.terminalsPanes.get(id)?.terminals ?? [])
+      const order = state.terminalOrder.filter((tid) => tid !== id && !held.has(tid))
       // A session owns its file-tree, editor, browser and device panes: they
       // die with it, and so does any maximized state pointing at them.
       const childIds = [filesPaneId(id), editorPaneId(id), browserPaneId(id), devicePaneId(id)]
@@ -78,9 +80,8 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       // from every other surface. Their ptys are killed by the caller, which
       // owns the async side; this is the record of them.
       let terminalsPanes = new Map(state.terminalsPanes)
-      const heldTerminals = terminalsPanes.get(id)?.terminals ?? []
       terminalsPanes.delete(id)
-      for (const heldId of heldTerminals) {
+      for (const heldId of held) {
         next.delete(heldId)
         minimized.delete(heldId)
         dying.add(heldId)
@@ -94,7 +95,7 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         terminalsPanes = released.panes
         for (const ownerId of released.emptied) dying.add(terminalsPaneId(ownerId))
       }
-      if (heldTerminals.length > 0 || released) saveTerminalPanels(terminalsPanes)
+      if (held.size > 0 || released) saveTerminalPanels(terminalsPanes)
       // The remembered tabs go with the session too. A recycled id would
       // otherwise reopen its browser onto a previous session's pages.
       const browserMemory = new Map(state.browserMemory)
@@ -111,7 +112,12 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       const gitDiffStats = new Map(state.gitDiffStats)
       gitDiffStats.delete(id)
       window.api.notifyWidgetStatus()
-      const extra = state.diffSidebarTerminalId === id ? { diffSidebarTerminalId: null } : {}
+      // Against the whole dying set, like every other field keyed by id below:
+      // the diff sidebar can be pointed at a shell this session was holding,
+      // and would then stay mounted against a session the store has dropped.
+      const extra = dying.has(state.diffSidebarTerminalId ?? '')
+        ? { diffSidebarTerminalId: null }
+        : {}
       const maxOwned = dying.has(state.maximizedPaneId ?? '')
       // Focus is the one that cannot be left dangling. The stage is chosen by
       // "is anything focused" and the app drops its titlebar while something

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -1,6 +1,13 @@
 import { StateCreator } from 'zustand'
 import { AppStore, TerminalsSlice, TerminalState } from './types'
-import { filesPaneId, editorPaneId, browserPaneId, devicePaneId } from '../lib/pane-id'
+import {
+  filesPaneId,
+  editorPaneId,
+  browserPaneId,
+  devicePaneId,
+  terminalsPaneId
+} from '../lib/pane-id'
+import { releaseFromPanels, saveTerminalPanels } from './ui-slice'
 import { clearDirty } from '../lib/editor-dirty'
 
 export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice> = (set) => ({
@@ -70,7 +77,7 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       // in their own right, and the list is the only thing that was hiding them
       // from every other surface. Their ptys are killed by the caller, which
       // owns the async side; this is the record of them.
-      const terminalsPanes = new Map(state.terminalsPanes)
+      let terminalsPanes = new Map(state.terminalsPanes)
       const heldTerminals = terminalsPanes.get(id)?.terminals ?? []
       terminalsPanes.delete(id)
       for (const heldId of heldTerminals) {
@@ -78,6 +85,16 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         minimized.delete(heldId)
         dying.add(heldId)
       }
+      // The other direction: this session may itself be a shell some panel is
+      // holding, closed from its own tab. Without releasing the claim the tab
+      // outlives the terminal — named after a raw id, drawing a pane for a
+      // session that is gone.
+      const released = releaseFromPanels(terminalsPanes, id)
+      if (released) {
+        terminalsPanes = released.panes
+        for (const ownerId of released.emptied) dying.add(terminalsPaneId(ownerId))
+      }
+      if (heldTerminals.length > 0 || released) saveTerminalPanels(terminalsPanes)
       // The remembered tabs go with the session too. A recycled id would
       // otherwise reopen its browser onto a previous session's pages.
       const browserMemory = new Map(state.browserMemory)

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -26,7 +26,9 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
     set((state) => {
       const next = new Map(state.terminals)
       next.delete(id)
-      const order = state.terminalOrder.filter((tid) => tid !== id)
+      const order = state.terminalOrder.filter(
+        (tid) => tid !== id && !(state.terminalsPanes.get(id)?.terminals ?? []).includes(tid)
+      )
       // A session owns its file-tree, editor, browser and device panes: they
       // die with it, and so does any maximized state pointing at them.
       const childIds = [filesPaneId(id), editorPaneId(id), browserPaneId(id), devicePaneId(id)]
@@ -64,6 +66,18 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         minimized.delete(paneId)
         dying.add(paneId)
       }
+      // The panel goes, and so do the shells it was holding — they are sessions
+      // in their own right, and the list is the only thing that was hiding them
+      // from every other surface. Their ptys are killed by the caller, which
+      // owns the async side; this is the record of them.
+      const terminalsPanes = new Map(state.terminalsPanes)
+      const heldTerminals = terminalsPanes.get(id)?.terminals ?? []
+      terminalsPanes.delete(id)
+      for (const heldId of heldTerminals) {
+        next.delete(heldId)
+        minimized.delete(heldId)
+        dying.add(heldId)
+      }
       // The remembered tabs go with the session too. A recycled id would
       // otherwise reopen its browser onto a previous session's pages.
       const browserMemory = new Map(state.browserMemory)
@@ -95,6 +109,7 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         terminals: next,
         terminalOrder: order,
         minimizedTerminals: minimized,
+        terminalsPanes,
         filesPanes,
         editorPanes,
         browserPanes,

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -105,6 +105,32 @@ export interface BrowserPaneState {
   sessionId: string
 }
 
+/**
+ * State of a session's terminals panel — the shells it holds beside its agent.
+ *
+ * Deliberately the same shape as `BrowserPaneState`, because it is the same
+ * problem: an ordered list with one of them in front, whose presence *is* the
+ * pane being open.
+ *
+ * What it holds are session ids. A shell terminal is already a full session
+ * with its own pid, so a panel needs no new entity — only a record of which
+ * session each shell hangs under, which is this list. Taking an id out of it is
+ * the whole of "extract this terminal": it is a session already, so it becomes
+ * a grid cell, a tab, a sidebar row and a focus target the moment it is no
+ * longer claimed here.
+ */
+export interface TerminalsPaneState {
+  /** Session ids of the shells in this panel. Never empty while it exists. */
+  terminals: string[]
+  /** Index into `terminals`. Always in range. */
+  activeTab: number
+}
+
+/** The terminal a panel is currently showing. */
+export function activePanelTerminalId(pane: TerminalsPaneState | undefined): string | null {
+  return pane ? (pane.terminals[pane.activeTab] ?? null) : null
+}
+
 /** The page a browser pane is currently showing. */
 export function activeBrowserUrl(pane: BrowserPaneState | undefined): string | null {
   return pane ? (pane.tabs[pane.activeTab] ?? null) : null
@@ -264,6 +290,16 @@ export interface UISlice {
   /** Session id → the simulator its device pane is showing. One device per session. */
   devicePanes: Map<string, DevicePaneState>
   /**
+   * Session id → the shells it holds beside its agent. One panel per session.
+   *
+   * A terminal listed here is claimed by that session: it is drawn in the panel
+   * and nowhere else, and is deliberately absent from the grid, the tab strip,
+   * the sidebar, the dock and keyboard nav until it is extracted. That hiding
+   * is what keeps a terminal to a single rendered slot — the registry is
+   * last-writer-wins, so two slots for one id would fight over the wrapper.
+   */
+  terminalsPanes: Map<string, TerminalsPaneState>
+  /**
    * Pane id currently maximized, or null. At most one app-wide. A maximized
    * pane covers only its owner session's footprint — other sessions are
    * unaffected, which is what makes it usable for side-by-side comparison.
@@ -378,6 +414,25 @@ export interface UISlice {
    */
   claimAndOpenDevicePane: (sessionId: string, device: DevicePaneState) => Promise<string | null>
   closeDevicePane: (sessionId: string) => void
+  /**
+   * Show the session's terminals panel, adding `terminalId` to it if given.
+   *
+   * Opening with nothing to show would be an empty box taking up a pane, so the
+   * caller creates a shell first and hands it here.
+   */
+  openTerminalsPane: (sessionId: string, terminalId: string) => void
+  /** Close the panel. The shells in it are the caller's to dispose of. */
+  closeTerminalsPane: (sessionId: string) => void
+  setActivePanelTerminal: (sessionId: string, index: number) => void
+  /**
+   * Take a terminal out of its session's panel and let it stand on its own.
+   *
+   * Only removes the claim — the terminal is already a session, so it has a
+   * grid cell, a tab, a sidebar row and a focus slot the moment nothing is
+   * hiding it. Taking the last one closes the panel, since a panel with no
+   * shells is a box taking up space.
+   */
+  extractPanelTerminal: (sessionId: string, terminalId: string) => void
   /** Maximize a pane over its owner session's footprint, or null to restore. */
   setMaximizedPane: (paneId: string | null) => void
   /**

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -126,9 +126,23 @@ export interface TerminalsPaneState {
   activeTab: number
 }
 
+/**
+ * Which tab a panel is showing, clamped into range.
+ *
+ * `activeTab` is kept in range by every action that writes it and by the
+ * persisted-state reader, so this is belt and braces — but it is the one place
+ * that answers the question, and the card indexes its tab list by it. Two
+ * answers, one clamped and one not, is how an out-of-range index reaches a
+ * dereference.
+ */
+export function activePanelIndex(pane: TerminalsPaneState | undefined): number {
+  if (!pane || pane.terminals.length === 0) return 0
+  return Math.min(Math.max(pane.activeTab, 0), pane.terminals.length - 1)
+}
+
 /** The terminal a panel is currently showing. */
 export function activePanelTerminalId(pane: TerminalsPaneState | undefined): string | null {
-  return pane ? (pane.terminals[pane.activeTab] ?? null) : null
+  return pane ? (pane.terminals[activePanelIndex(pane)] ?? null) : null
 }
 
 /** The page a browser pane is currently showing. */

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -9,6 +9,7 @@ import {
   EditorPaneState,
   BrowserPaneState,
   DevicePaneState,
+  TerminalsPaneState,
   CardSplit,
   isPromotedPane
 } from './types'
@@ -17,6 +18,7 @@ import {
   editorPaneId,
   browserPaneId,
   devicePaneId,
+  terminalsPaneId,
   isTerminalPane,
   paneOwnerId,
   promotedCardSeq,
@@ -41,6 +43,7 @@ const SIDEBAR_STORAGE_KEY = 'vorn:sidebarSettings'
 const FLEXIBLE_STORAGE_KEY = 'vorn:flexibleLayouts'
 const CARD_SPLITS_STORAGE_KEY = 'vorn:cardSplits'
 const PANES_STORAGE_KEY = 'vorn:panes'
+const TERMINAL_PANELS_STORAGE_KEY = 'vorn:terminalPanels'
 /**
  * Where a browser pane opened with no url starts. Deliberately blank: guessing
  * a page would be wrong more often than not, and the address bar is focused
@@ -254,6 +257,7 @@ function reconcilePanes(
   browserPanes: Map<string, BrowserPaneState>,
   browserMemory: Map<string, BrowserPaneState>,
   devicePanes: Map<string, DevicePaneState>,
+  terminalsPanes: Map<string, TerminalsPaneState>,
   cardSplits: Record<string, CardSplit>,
   liveSessionIds: Set<string>
 ): {
@@ -262,6 +266,7 @@ function reconcilePanes(
   browserPanes: Map<string, BrowserPaneState>
   browserMemory: Map<string, BrowserPaneState>
   devicePanes: Map<string, DevicePaneState>
+  terminalsPanes: Map<string, TerminalsPaneState>
   cardSplits: Record<string, CardSplit>
 } | null {
   const nextFiles = new Set([...filesPanes].filter((id) => liveSessionIds.has(id)))
@@ -278,6 +283,10 @@ function reconcilePanes(
   // card mounted against a device nobody can drive — the same leak, minus the
   // localStorage growth.
   const nextDevices = new Map([...devicePanes].filter(([id]) => liveSessionIds.has(id)))
+  // A panel goes with its owner, and its remaining shells go with it — they are
+  // sessions too, so a dead session's list would otherwise keep ids that hide
+  // terminals which no longer exist.
+  const nextPanels = new Map([...terminalsPanes].filter(([id]) => liveSessionIds.has(id)))
   const nextSplits = Object.fromEntries(
     Object.entries(cardSplits).filter(([id]) => liveSessionIds.has(id))
   )
@@ -288,18 +297,21 @@ function reconcilePanes(
     nextBrowsers.size === browserPanes.size &&
     nextMemory.size === browserMemory.size &&
     nextDevices.size === devicePanes.size &&
+    nextPanels.size === terminalsPanes.size &&
     !splitsChanged
   ) {
     return null
   }
   savePanes(nextFiles, nextEditors, nextBrowsers)
   if (splitsChanged) saveCardSplits(nextSplits)
+  if (nextPanels.size !== terminalsPanes.size) saveTerminalPanels(nextPanels)
   return {
     filesPanes: nextFiles,
     editorPanes: nextEditors,
     browserPanes: nextBrowsers,
     browserMemory: nextMemory,
     devicePanes: nextDevices,
+    terminalsPanes: nextPanels,
     cardSplits: nextSplits
   }
 }
@@ -383,6 +395,44 @@ function sameIds(a: readonly string[], b: readonly string[]): boolean {
   return true
 }
 
+/**
+ * Which shells each session holds, persisted so a reload keeps the arrangement.
+ *
+ * Shape: `{ [sessionId]: { terminals: sessionId[], activeTab: number } }`. An
+ * entry whose terminals are all gone is dropped on read: a panel listing shells
+ * that no longer exist would render an empty box, and its ids are how those
+ * shells stay hidden from every other surface.
+ */
+export function parsePersistedPanels(
+  parsed: Record<string, Partial<TerminalsPaneState>> | undefined
+): Map<string, TerminalsPaneState> {
+  const out = new Map<string, TerminalsPaneState>()
+  for (const [id, pane] of Object.entries(parsed ?? {})) {
+    const terminals = pane?.terminals?.filter((t) => typeof t === 'string') ?? []
+    if (terminals.length === 0) continue
+    const activeTab = Math.min(Math.max(pane?.activeTab ?? 0, 0), terminals.length - 1)
+    out.set(id, { terminals, activeTab })
+  }
+  return out
+}
+
+function loadTerminalPanels(): Map<string, TerminalsPaneState> {
+  try {
+    const raw = localStorage.getItem(TERMINAL_PANELS_STORAGE_KEY)
+    return raw ? parsePersistedPanels(JSON.parse(raw)) : new Map()
+  } catch {
+    return new Map()
+  }
+}
+
+function saveTerminalPanels(panels: Map<string, TerminalsPaneState>): void {
+  try {
+    localStorage.setItem(TERMINAL_PANELS_STORAGE_KEY, JSON.stringify(Object.fromEntries(panels)))
+  } catch {
+    /* ignore */
+  }
+}
+
 function loadSidebarSettings(): Record<string, string> {
   try {
     const raw = localStorage.getItem(SIDEBAR_STORAGE_KEY)
@@ -441,6 +491,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   // Not part of loadPanes: a claim lives in main and dies with the app, so a
   // device pane restored from disk would frame a simulator nobody holds.
   devicePanes: new Map(),
+  terminalsPanes: loadTerminalPanels(),
   maximizedPaneId: null,
   sessionDockCollapsed: false,
   isOnboardingOpen: false,
@@ -570,6 +621,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
               state.browserPanes,
               state.browserMemory,
               state.devicePanes,
+              state.terminalsPanes,
               state.cardSplits,
               live
             )
@@ -836,6 +888,85 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
         devicePanes: next,
         ...clearPlacement(state, devicePaneId(sessionId))
       }
+    }),
+
+  openTerminalsPane: (sessionId, terminalId) =>
+    set((state) => {
+      const next = new Map(state.terminalsPanes)
+      const existing = next.get(sessionId)
+      if (existing) {
+        // Already claimed — show it rather than listing it twice, which would
+        // put one terminal in two tabs fighting over a single rendered slot.
+        if (existing.terminals.includes(terminalId)) {
+          next.set(sessionId, {
+            ...existing,
+            activeTab: existing.terminals.indexOf(terminalId)
+          })
+        } else {
+          const terminals = [...existing.terminals, terminalId]
+          next.set(sessionId, { terminals, activeTab: terminals.length - 1 })
+        }
+      } else {
+        next.set(sessionId, { terminals: [terminalId], activeTab: 0 })
+      }
+      saveTerminalPanels(next)
+      return { terminalsPanes: next }
+    }),
+
+  closeTerminalsPane: (sessionId) =>
+    set((state) => {
+      if (!state.terminalsPanes.has(sessionId)) return {}
+      const next = new Map(state.terminalsPanes)
+      next.delete(sessionId)
+      saveTerminalPanels(next)
+      return {
+        terminalsPanes: next,
+        ...clearPlacement(state, terminalsPaneId(sessionId))
+      }
+    }),
+
+  setActivePanelTerminal: (sessionId, index) =>
+    set((state) => {
+      const pane = state.terminalsPanes.get(sessionId)
+      if (!pane || index < 0 || index >= pane.terminals.length) return {}
+      if (pane.activeTab === index) return {}
+      const next = new Map(state.terminalsPanes)
+      next.set(sessionId, { ...pane, activeTab: index })
+      saveTerminalPanels(next)
+      return { terminalsPanes: next }
+    }),
+
+  extractPanelTerminal: (sessionId, terminalId) =>
+    set((state) => {
+      const pane = state.terminalsPanes.get(sessionId)
+      if (!pane) return {}
+      const index = pane.terminals.indexOf(terminalId)
+      if (index === -1) return {}
+
+      const next = new Map(state.terminalsPanes)
+      const terminals = pane.terminals.filter((id) => id !== terminalId)
+      if (terminals.length === 0) {
+        // A panel with no shells is a box taking up a pane, the same rule the
+        // browser's last tab follows.
+        next.delete(sessionId)
+        saveTerminalPanels(next)
+        return {
+          terminalsPanes: next,
+          ...clearPlacement(state, terminalsPaneId(sessionId))
+        }
+      }
+      // Land on the neighbour rather than jumping to the far end, and shift
+      // when something ahead of the active one leaves.
+      const activeTab = Math.max(
+        0,
+        Math.min(
+          index <= pane.activeTab ? pane.activeTab - 1 : pane.activeTab,
+          terminals.length - 1
+        )
+      )
+      next.set(sessionId, { terminals, activeTab })
+      saveTerminalPanels(next)
+      return { terminalsPanes: next }
     }),
 
   setMaximizedPane: (paneId) =>
@@ -1197,12 +1328,30 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
  * say why. One selector, so a new kind is added once.
  */
 export function selectPaneFlags(
-  s: Pick<AppStore, 'filesPanes' | 'editorPanes' | 'browserPanes' | 'devicePanes'>,
+  s: Pick<
+    AppStore,
+    'filesPanes' | 'editorPanes' | 'browserPanes' | 'devicePanes' | 'terminalsPanes'
+  >,
   sessionId: string | null
-): { files: boolean; editor: boolean; browser: boolean; device: boolean; any: boolean } {
+): {
+  files: boolean
+  editor: boolean
+  browser: boolean
+  device: boolean
+  terminals: boolean
+  any: boolean
+} {
   const files = sessionId ? s.filesPanes.has(sessionId) : false
   const editor = sessionId ? s.editorPanes.has(sessionId) : false
   const browser = sessionId ? s.browserPanes.has(sessionId) : false
   const device = sessionId ? s.devicePanes.has(sessionId) : false
-  return { files, editor, browser, device, any: files || editor || browser || device }
+  const terminals = sessionId ? s.terminalsPanes.has(sessionId) : false
+  return {
+    files,
+    editor,
+    browser,
+    device,
+    terminals,
+    any: files || editor || browser || device || terminals
+  }
 }

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -286,7 +286,26 @@ function reconcilePanes(
   // A panel goes with its owner, and its remaining shells go with it — they are
   // sessions too, so a dead session's list would otherwise keep ids that hide
   // terminals which no longer exist.
-  const nextPanels = new Map([...terminalsPanes].filter(([id]) => liveSessionIds.has(id)))
+  //
+  // The shells are checked one by one for the same reason: a shell that never
+  // came back leaves its id in a panel whose owner did, and the tab would
+  // return after a restart named after the raw id with nothing behind it.
+  const nextPanels = new Map<string, TerminalsPaneState>()
+  let panelsChanged = false
+  for (const [id, pane] of terminalsPanes) {
+    if (!liveSessionIds.has(id)) {
+      panelsChanged = true
+      continue
+    }
+    const terminals = pane.terminals.filter((tid) => liveSessionIds.has(tid))
+    if (terminals.length === pane.terminals.length) {
+      nextPanels.set(id, pane)
+      continue
+    }
+    panelsChanged = true
+    if (terminals.length === 0) continue
+    nextPanels.set(id, { terminals, activeTab: Math.min(pane.activeTab, terminals.length - 1) })
+  }
   const nextSplits = Object.fromEntries(
     Object.entries(cardSplits).filter(([id]) => liveSessionIds.has(id))
   )
@@ -297,14 +316,14 @@ function reconcilePanes(
     nextBrowsers.size === browserPanes.size &&
     nextMemory.size === browserMemory.size &&
     nextDevices.size === devicePanes.size &&
-    nextPanels.size === terminalsPanes.size &&
+    !panelsChanged &&
     !splitsChanged
   ) {
     return null
   }
   savePanes(nextFiles, nextEditors, nextBrowsers)
   if (splitsChanged) saveCardSplits(nextSplits)
-  if (nextPanels.size !== terminalsPanes.size) saveTerminalPanels(nextPanels)
+  if (panelsChanged) saveTerminalPanels(nextPanels)
   return {
     filesPanes: nextFiles,
     editorPanes: nextEditors,
@@ -314,6 +333,51 @@ function reconcilePanes(
     terminalsPanes: nextPanels,
     cardSplits: nextSplits
   }
+}
+
+/**
+ * Let go of a terminal that a panel is holding.
+ *
+ * Extraction and closing both arrive here: one keeps the terminal alive and one
+ * kills it, but either way the panel has stopped claiming the id. A claim left
+ * behind outlives its terminal — the tab stays, falls back to naming itself
+ * after the raw id, and draws a pane for a session the store no longer has.
+ *
+ * Emptied panels are reported rather than quietly dropped, because a panel's
+ * pane id can be focused or maximized and that has to be released with it.
+ */
+export function releaseFromPanels(
+  panes: Map<string, TerminalsPaneState>,
+  terminalId: string
+): { panes: Map<string, TerminalsPaneState>; emptied: string[] } | null {
+  let next: Map<string, TerminalsPaneState> | null = null
+  const emptied: string[] = []
+  for (const [sessionId, pane] of panes) {
+    const index = pane.terminals.indexOf(terminalId)
+    if (index === -1) continue
+    next ??= new Map(panes)
+    const terminals = pane.terminals.filter((id) => id !== terminalId)
+    if (terminals.length === 0) {
+      // A panel with no shells is a box taking up a pane, the same rule the
+      // browser's last tab follows.
+      next.delete(sessionId)
+      emptied.push(sessionId)
+      continue
+    }
+    // Land on the neighbour rather than jumping to the far end, and shift when
+    // something ahead of the active one leaves.
+    next.set(sessionId, {
+      terminals,
+      activeTab: Math.max(
+        0,
+        Math.min(
+          index <= pane.activeTab ? pane.activeTab - 1 : pane.activeTab,
+          terminals.length - 1
+        )
+      )
+    })
+  }
+  return next ? { panes: next, emptied } : null
 }
 
 /**
@@ -425,7 +489,7 @@ function loadTerminalPanels(): Map<string, TerminalsPaneState> {
   }
 }
 
-function saveTerminalPanels(panels: Map<string, TerminalsPaneState>): void {
+export function saveTerminalPanels(panels: Map<string, TerminalsPaneState>): void {
   try {
     localStorage.setItem(TERMINAL_PANELS_STORAGE_KEY, JSON.stringify(Object.fromEntries(panels)))
   } catch {
@@ -938,35 +1002,17 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   extractPanelTerminal: (sessionId, terminalId) =>
     set((state) => {
-      const pane = state.terminalsPanes.get(sessionId)
-      if (!pane) return {}
-      const index = pane.terminals.indexOf(terminalId)
-      if (index === -1) return {}
-
-      const next = new Map(state.terminalsPanes)
-      const terminals = pane.terminals.filter((id) => id !== terminalId)
-      if (terminals.length === 0) {
-        // A panel with no shells is a box taking up a pane, the same rule the
-        // browser's last tab follows.
-        next.delete(sessionId)
-        saveTerminalPanels(next)
-        return {
-          terminalsPanes: next,
-          ...clearPlacement(state, terminalsPaneId(sessionId))
-        }
+      // Extraction is nothing but releasing the claim — the terminal was a
+      // session all along, and is now simply nobody's.
+      const released = releaseFromPanels(state.terminalsPanes, terminalId)
+      if (!released) return {}
+      saveTerminalPanels(released.panes)
+      return {
+        terminalsPanes: released.panes,
+        ...(released.emptied.includes(sessionId)
+          ? clearPlacement(state, terminalsPaneId(sessionId))
+          : {})
       }
-      // Land on the neighbour rather than jumping to the far end, and shift
-      // when something ahead of the active one leaves.
-      const activeTab = Math.max(
-        0,
-        Math.min(
-          index <= pane.activeTab ? pane.activeTab - 1 : pane.activeTab,
-          terminals.length - 1
-        )
-      )
-      next.set(sessionId, { terminals, activeTab })
-      saveTerminalPanels(next)
-      return { terminalsPanes: next }
     }),
 
   setMaximizedPane: (paneId) =>

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -474,7 +474,11 @@ export function parsePersistedPanels(
   for (const [id, pane] of Object.entries(parsed ?? {})) {
     const terminals = pane?.terminals?.filter((t) => typeof t === 'string') ?? []
     if (terminals.length === 0) continue
-    const activeTab = Math.min(Math.max(pane?.activeTab ?? 0, 0), terminals.length - 1)
+    // `?? 0` only catches null and undefined: a corrupted entry with a string
+    // or a NaN here propagates through Math.min as NaN, and the card indexes
+    // its tab list with it and dereferences undefined.
+    const saved = Number.isInteger(pane?.activeTab) ? (pane?.activeTab as number) : 0
+    const activeTab = Math.min(Math.max(saved, 0), terminals.length - 1)
     out.set(id, { terminals, activeTab })
   }
   return out
@@ -957,22 +961,11 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   openTerminalsPane: (sessionId, terminalId) =>
     set((state) => {
       const next = new Map(state.terminalsPanes)
-      const existing = next.get(sessionId)
-      if (existing) {
-        // Already claimed — show it rather than listing it twice, which would
-        // put one terminal in two tabs fighting over a single rendered slot.
-        if (existing.terminals.includes(terminalId)) {
-          next.set(sessionId, {
-            ...existing,
-            activeTab: existing.terminals.indexOf(terminalId)
-          })
-        } else {
-          const terminals = [...existing.terminals, terminalId]
-          next.set(sessionId, { terminals, activeTab: terminals.length - 1 })
-        }
-      } else {
-        next.set(sessionId, { terminals: [terminalId], activeTab: 0 })
-      }
+      const existing = next.get(sessionId)?.terminals ?? []
+      // Claimed already means show it, not list it twice: one terminal in two
+      // tabs is two slots fighting over a single rendered wrapper.
+      const terminals = existing.includes(terminalId) ? existing : [...existing, terminalId]
+      next.set(sessionId, { terminals, activeTab: terminals.indexOf(terminalId) })
       saveTerminalPanels(next)
       return { terminalsPanes: next }
     }),
@@ -1007,11 +1000,18 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
       const released = releaseFromPanels(state.terminalsPanes, terminalId)
       if (!released) return {}
       saveTerminalPanels(released.panes)
+      // Keyed off what was emptied, not off the caller's sessionId: those can
+      // disagree, and the panel that actually went would keep its focus and
+      // maximize pointing at a pane that no longer draws.
       return {
         terminalsPanes: released.panes,
-        ...(released.emptied.includes(sessionId)
-          ? clearPlacement(state, terminalsPaneId(sessionId))
-          : {})
+        ...released.emptied.reduce(
+          (cleared, ownerId) => ({
+            ...cleared,
+            ...clearPlacement(state, terminalsPaneId(ownerId))
+          }),
+          {}
+        )
       }
     }),
 

--- a/tests/card-action-cluster.test.tsx
+++ b/tests/card-action-cluster.test.tsx
@@ -113,6 +113,29 @@ describe('CardActionCluster — mini variant (grid, hover-revealed)', () => {
     expect(toggleFilesPane).toHaveBeenCalledWith('term-1')
   })
 
+  it('offers the terminals panel where the other panes are offered', async () => {
+    // The control has to be here, not only in the sidebar: this cluster is
+    // where someone reaches for a session's panes while working in the grid.
+    const createShellTerminal = vi.fn().mockResolvedValue({
+      id: 'sh1',
+      agentType: 'shell',
+      projectName: 'Vorn',
+      projectPath: '/tmp/vorn'
+    })
+    Object.assign((window as unknown as { api: Record<string, unknown> }).api, {
+      createShellTerminal,
+      notifyWidgetStatus: vi.fn()
+    })
+    act(() => useAppStore.setState({ terminalsPanes: new Map() }))
+    render(<CardActionCluster terminalId="term-1" variant="mini" />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add a terminal' }))
+    })
+
+    expect(useAppStore.getState().terminalsPanes.get('term-1')?.terminals).toEqual(['sh1'])
+  })
+
   it('Minimize toggles the minimized state for this terminal', () => {
     render(<CardActionCluster terminalId="term-1" variant="mini" />)
     fireEvent.click(screen.getByRole('button', { name: /Minimize/ }))

--- a/tests/command-palette-new-terminal.test.tsx
+++ b/tests/command-palette-new-terminal.test.tsx
@@ -64,6 +64,7 @@ beforeEach(() => {
     useAppStore.setState({
       isCommandPaletteOpen: true,
       terminals: new Map(),
+      terminalsPanes: new Map(),
       config: {
         version: 1,
         projects: [{ name: 'vorn', path: '/tmp/vorn', preferredAgents: ['claude'] }],
@@ -119,6 +120,37 @@ describe('CommandPalette — New Terminal Session action', () => {
       expect.objectContaining({ id: 'sh-42', projectName: 'vorn' })
     )
     expect(setActiveTabId).toHaveBeenCalledWith('sh-42')
+  })
+
+  it("leaves out a shell held by a session's terminals panel", () => {
+    const term = (id: string, name: string) => ({
+      id,
+      session: {
+        id,
+        projectName: 'vorn',
+        projectPath: '/tmp/vorn',
+        agentType: 'shell',
+        displayName: name
+      },
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    act(() => {
+      useAppStore.setState({
+        terminals: new Map([
+          ['agent', term('agent', 'Agent session')],
+          ['sh1', term('sh1', 'Held shell')]
+        ]) as never,
+        terminalsPanes: new Map([['agent', { terminals: ['sh1'], activeTab: 0 }]])
+      })
+    })
+
+    render(<CommandPalette />)
+
+    // Focusing a claimed shell from here would open a stage for a session the
+    // grid, the tab strip and the sidebar all agree is not there.
+    expect(screen.getByText('Agent session')).toBeInTheDocument()
+    expect(screen.queryByText('Held shell')).not.toBeInTheDocument()
   })
 
   it('does not expose "Toggle Terminal Panel" anymore', () => {

--- a/tests/flat-sessions-section.test.tsx
+++ b/tests/flat-sessions-section.test.tsx
@@ -5,6 +5,24 @@ import '@testing-library/jest-dom/vitest'
 
 const mockStore = {
   terminals: new Map(),
+  terminalsPanes: new Map(),
+  // A session row reads these; the rows are what this file renders.
+  filesPanes: new Set(),
+  editorPanes: new Map(),
+  browserPanes: new Map(),
+  devicePanes: new Map(),
+  mobileProjectCache: new Map(),
+  loadMobileProject: vi.fn(),
+  toggleFilesPane: vi.fn(),
+  toggleBrowserPane: vi.fn(),
+  claimAndOpenDevicePane: vi.fn(),
+  closeDevicePane: vi.fn(),
+  setActiveTabId: vi.fn(),
+  setPreviewTerminal: vi.fn(),
+  focusedTerminalId: null as string | null,
+  previewTerminalId: null as string | null,
+  activeTabId: null as string | null,
+  config: null,
   activeProject: null as string | null,
   setActiveProject: vi.fn(),
   setFocusedTerminal: vi.fn(),
@@ -29,6 +47,7 @@ const { FlatSessionsSection } =
 
 beforeEach(() => {
   mockStore.terminals.clear()
+  mockStore.terminalsPanes.clear()
   mockStore.activeProject = null
   mockStore.setActiveProject.mockReset()
   mockStore.setFocusedTerminal.mockReset()
@@ -71,6 +90,39 @@ describe('FlatSessionsSection', () => {
     fireEvent.click(screen.getByText('All Projects'))
     expect(mockStore.setActiveProject).toHaveBeenCalledWith(null)
     expect(mockStore.setFocusedTerminal).toHaveBeenCalledWith(null)
+  })
+
+  it("leaves out a shell held by a session's terminals panel", () => {
+    const term = (id: string, name: string) => ({
+      id,
+      session: {
+        id,
+        projectName: 'p1',
+        projectPath: '/p1',
+        agentType: 'shell',
+        displayName: name
+      },
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    mockStore.terminals.set('agent', term('agent', 'Agent'))
+    mockStore.terminals.set('sh1', term('sh1', 'Held shell'))
+    mockStore.terminalsPanes.set('agent', { terminals: ['sh1'], activeTab: 0 })
+
+    render(
+      <FlatSessionsSection
+        isCollapsed={false}
+        workspaceProjectNames={new Set(['p1'])}
+        workspaceTerminalCount={2}
+      />
+    )
+
+    // A claimed shell is drawn in its panel and nowhere else. A row here would
+    // focus a terminal that has no cell in the grid and no tab in the strip —
+    // and the sidebar builds its list straight off the terminals map, so it has
+    // to drop them itself.
+    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(screen.queryByText('Held shell')).not.toBeInTheDocument()
   })
 
   it('shows empty state when there are no sessions', () => {

--- a/tests/pane-affordance.test.ts
+++ b/tests/pane-affordance.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { shouldOfferPane } from '../src/renderer/lib/pane-affordance'
+
+/**
+ * Which project panes a session is offered. A browser, a simulator and a panel
+ * of shells belong to a session driving a project; beside a plain shell they
+ * are three controls nobody there is going to reach for.
+ */
+describe('shouldOfferPane', () => {
+  it('offers them to an agent session', () => {
+    expect(shouldOfferPane('claude', false)).toBe(true)
+    expect(shouldOfferPane('codex', false)).toBe(true)
+  })
+
+  it('withholds them from a shell', () => {
+    expect(shouldOfferPane('shell', false)).toBe(false)
+  })
+
+  it('keeps the control for a pane a shell already has open', () => {
+    // Hiding it would take away the only way to close what is on screen — the
+    // same exception the device button has always made.
+    expect(shouldOfferPane('shell', true)).toBe(true)
+  })
+
+  it('offers them while the session type is still unknown', () => {
+    // A row that renders before its terminal record arrives should not flash
+    // its controls in; erring towards showing matches every other gate here.
+    expect(shouldOfferPane(undefined, false)).toBe(true)
+  })
+})

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -82,6 +82,7 @@ function seed(ids = ['t1']): void {
       filesPanes: new Set(),
       editorPanes: new Map(),
       browserPanes: new Map(),
+      terminalsPanes: new Map(),
       minimizedTerminals: new Set(),
       maximizedPaneId: null,
       terminalOrder: ids
@@ -459,6 +460,20 @@ describe('panes travel with their session into focus mode', () => {
     )
     const paths = mockReadFileContent.mock.calls.map((c) => c[0])
     expect(paths).not.toContain('/repo/popped.ts')
+  })
+
+  it("carries the session's terminals panel in too", () => {
+    // Focus mode keeps its own copy of the pane stack, so a new kind has to be
+    // added there as well as to the column — leaving it out is how a pane
+    // silently vanishes on expand.
+    seed(['t1', 'sh1'])
+    act(() => {
+      useAppStore.setState({ focusedTerminalId: 't1' })
+      useAppStore.getState().openTerminalsPane('t1', 'sh1')
+    })
+    render(<FocusedTerminal />)
+
+    expect(screen.getByTestId('terminals-pane-header-t1')).toBeInTheDocument()
   })
 
   it("carries the session's browser into focus mode too", () => {

--- a/tests/pane-lib.test.ts
+++ b/tests/pane-lib.test.ts
@@ -5,6 +5,7 @@ import {
   editorPaneId,
   browserPaneId,
   devicePaneId,
+  terminalsPaneId,
   paneIdFor,
   promotedCardId,
   isPromotedCardId,
@@ -65,11 +66,12 @@ describe('pane-id', () => {
     // The pane column carries kinds, not ids, so it needs the inverse of
     // parsePaneId — and the two have to agree, or a promoted pane would be
     // skipped in the column under one id and drawn in the grid under another.
-    for (const kind of ['files', 'editor', 'browser', 'device'] as const) {
+    for (const kind of ['files', 'editor', 'browser', 'device', 'terminals'] as const) {
       const id = paneIdFor(kind, 'abc')
       expect(parsePaneId(id)).toEqual({ kind, sessionId: 'abc' })
     }
     expect(paneIdFor('device', 'abc')).toBe(devicePaneId('abc'))
+    expect(paneIdFor('terminals', 'abc')).toBe(terminalsPaneId('abc'))
   })
 
   it('reads a card id back to the session it was popped out of', () => {

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -206,6 +206,58 @@ describe('SessionItem device control', () => {
   })
 })
 
+describe('SessionItem terminals control', () => {
+  const seedApi = (createShellTerminal: unknown): void => {
+    Object.defineProperty(window, 'api', {
+      value: {
+        ...(window as unknown as { api?: object }).api,
+        createShellTerminal,
+        notifyWidgetStatus: vi.fn(),
+        reorderSessions: vi.fn()
+      },
+      writable: true,
+      configurable: true
+    })
+  }
+
+  it('opens the panel with a shell already in it', async () => {
+    const createShellTerminal = vi
+      .fn()
+      .mockResolvedValue({ id: 'sh1', agentType: 'shell', projectName: 'p', projectPath: '/proj' })
+    seedApi(createShellTerminal)
+    seedProject(WEB)
+    act(() => {
+      useAppStore.setState({ terminalsPanes: new Map() })
+    })
+
+    render(<SessionItem session={session} />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Show terminals for/ }))
+    })
+
+    // An empty panel is a box occupying a pane and showing nothing, so opening
+    // it and creating the first shell are one action.
+    expect(createShellTerminal).toHaveBeenCalledWith('/proj')
+    expect(useAppStore.getState().terminalsPanes.get(session.id)?.terminals).toEqual(['sh1'])
+  })
+
+  it('closes an open panel rather than adding another shell to it', () => {
+    const createShellTerminal = vi.fn()
+    seedApi(createShellTerminal)
+    seedProject(WEB)
+    act(() => {
+      useAppStore.setState({ terminalsPanes: new Map() })
+      useAppStore.getState().openTerminalsPane(session.id, 'sh1')
+    })
+
+    render(<SessionItem session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: /Hide terminals for/ }))
+
+    expect(useAppStore.getState().terminalsPanes.has(session.id)).toBe(false)
+    expect(createShellTerminal).not.toHaveBeenCalled()
+  })
+})
+
 /**
  * A session's popped-out cards are listed beneath its row, so the row is now a
  * fragment rather than a single button — and the rows below it have to be

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -269,12 +269,14 @@ describe('SessionItem terminals control', () => {
     render(<SessionItem session={{ ...session, agentType: 'shell' }} />)
 
     // Hiding it would leave the panel on screen with no way to close it.
-    expect(screen.getByRole('button', { name: /Hide terminals for/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Close terminals for/ })).toBeInTheDocument()
   })
 
-  it('closes an open panel rather than adding another shell to it', () => {
+  it('closes an open panel and the shells in it, rather than adding another', async () => {
     const createShellTerminal = vi.fn()
+    const killTerminal = vi.fn().mockResolvedValue(undefined)
     seedApi(createShellTerminal)
+    Object.assign((window as unknown as { api: Record<string, unknown> }).api, { killTerminal })
     seedProject(WEB)
     act(() => {
       useAppStore.setState({ terminalsPanes: new Map() })
@@ -282,9 +284,14 @@ describe('SessionItem terminals control', () => {
     })
 
     render(<SessionItem session={session} />)
-    fireEvent.click(screen.getByRole('button', { name: /Hide terminals for/ }))
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Close terminals for/ }))
+    })
 
+    // Dropping the claim alone would scatter live shells across the grid as
+    // top-level cards, and the next click here would add another beside them.
     expect(useAppStore.getState().terminalsPanes.has(session.id)).toBe(false)
+    expect(killTerminal).toHaveBeenCalledWith('sh1')
     expect(createShellTerminal).not.toHaveBeenCalled()
   })
 })

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -241,6 +241,37 @@ describe('SessionItem terminals control', () => {
     expect(useAppStore.getState().terminalsPanes.get(session.id)?.terminals).toEqual(['sh1'])
   })
 
+  it('offers a shell neither a panel nor a browser', () => {
+    seedApi(vi.fn())
+    seedProject(WEB)
+    act(() => {
+      useAppStore.setState({ terminalsPanes: new Map(), browserPanes: new Map() })
+    })
+
+    render(<SessionItem session={{ ...session, agentType: 'shell' }} />)
+
+    // A panel of shells inside a shell, and a browser beside a prompt nobody
+    // asked to drive from there. The file tree stays — looking at files next to
+    // a shell is as reasonable as next to an agent.
+    expect(screen.queryByRole('button', { name: /terminals for/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /browser for/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /files for/ })).toBeInTheDocument()
+  })
+
+  it('leaves a shell the control for a panel it already has', () => {
+    seedApi(vi.fn())
+    seedProject(WEB)
+    act(() => {
+      useAppStore.setState({ terminalsPanes: new Map() })
+      useAppStore.getState().openTerminalsPane(session.id, 'sh1')
+    })
+
+    render(<SessionItem session={{ ...session, agentType: 'shell' }} />)
+
+    // Hiding it would leave the panel on screen with no way to close it.
+    expect(screen.getByRole('button', { name: /Hide terminals for/ })).toBeInTheDocument()
+  })
+
   it('closes an open panel rather than adding another shell to it', () => {
     const createShellTerminal = vi.fn()
     seedApi(createShellTerminal)

--- a/tests/terminals-card.test.tsx
+++ b/tests/terminals-card.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  writable: true,
+  configurable: true
+})
+
+const createShellTerminal = vi.fn()
+const killTerminal = vi.fn().mockResolvedValue(undefined)
+Object.defineProperty(window, 'api', {
+  value: {
+    notifyWidgetStatus: vi.fn(),
+    reorderSessions: vi.fn(),
+    createShellTerminal: (...a: unknown[]) => createShellTerminal(...a),
+    killTerminal: (...a: unknown[]) => killTerminal(...a)
+  },
+  writable: true,
+  configurable: true
+})
+
+// The terminal body is the registry's business and has its own tests; this file
+// is about which shell the panel decides to draw and what its tabs do.
+vi.mock('../src/renderer/components/TerminalPane', () => ({
+  TerminalPane: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid={`terminal-body-${terminalId}`} />
+  )
+}))
+
+const { useAppStore } = await import('../src/renderer/stores')
+const { TerminalsCard } = await import('../src/renderer/components/TerminalsCard')
+
+const session = (id: string, displayName = id) =>
+  ({
+    id,
+    projectName: 'vorn',
+    projectPath: '/repo',
+    worktreePath: '/repo',
+    agentType: 'shell',
+    createdAt: 0,
+    displayName
+  }) as never
+
+beforeEach(() => {
+  localStorage.clear()
+  createShellTerminal.mockReset()
+  act(() => {
+    useAppStore.setState({
+      terminals: new Map([
+        [
+          'owner',
+          {
+            id: 'owner',
+            session: session('owner', 'agent'),
+            status: 'idle',
+            lastOutputTimestamp: 1
+          }
+        ],
+        [
+          'sh1',
+          { id: 'sh1', session: session('sh1', 'zsh'), status: 'idle', lastOutputTimestamp: 1 }
+        ],
+        [
+          'sh2',
+          { id: 'sh2', session: session('sh2', 'build'), status: 'idle', lastOutputTimestamp: 1 }
+        ]
+      ]) as never,
+      terminalOrder: ['owner', 'sh1', 'sh2'],
+      terminalsPanes: new Map(),
+      focusedTerminalId: null,
+      maximizedPaneId: null,
+      config: { defaults: { domBlockRendering: false } } as never
+    })
+  })
+})
+
+describe('TerminalsCard', () => {
+  const open = (): void => {
+    act(() => {
+      useAppStore.getState().openTerminalsPane('owner', 'sh1')
+      useAppStore.getState().openTerminalsPane('owner', 'sh2')
+    })
+  }
+
+  it('draws only the shell in front, and names the rest on tabs', () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    // Both are tabs; one is drawn. The others keep running — the registry owns
+    // the xterm, and a slot is only where a terminal is currently shown. Two
+    // slots for one id would fight over a single wrapper.
+    expect(screen.getByRole('tab', { name: /zsh/ })).toBeInTheDocument()
+    expect(screen.getByTestId('terminal-body-sh2')).toBeInTheDocument()
+    expect(screen.queryByTestId('terminal-body-sh1')).not.toBeInTheDocument()
+  })
+
+  it('switches which shell is drawn', () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /zsh/ }))
+    expect(screen.getByTestId('terminal-body-sh1')).toBeInTheDocument()
+    expect(screen.queryByTestId('terminal-body-sh2')).not.toBeInTheDocument()
+  })
+
+  it('switches from the keyboard too', () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: /zsh/ }), { key: 'Enter' })
+    expect(screen.getByTestId('terminal-body-sh1')).toBeInTheDocument()
+  })
+
+  it('extracts a shell from its tab', () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Open zsh as its own terminal/ }))
+
+    // Letting go of the claim is the whole action — the terminal was a session
+    // all along and is now simply nobody's.
+    expect(useAppStore.getState().terminalsPanes.get('owner')?.terminals).toEqual(['sh2'])
+    expect(useAppStore.getState().terminals.has('sh1')).toBe(true)
+  })
+
+  it('starts another shell in the session it belongs to', async () => {
+    createShellTerminal.mockResolvedValue({
+      id: 'sh3',
+      agentType: 'shell',
+      projectName: '',
+      projectPath: ''
+    })
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'New terminal in this session' }))
+    })
+
+    // In the session's own directory, not wherever the app happens to be.
+    expect(createShellTerminal).toHaveBeenCalledWith('/repo')
+    expect(useAppStore.getState().terminalsPanes.get('owner')?.terminals).toEqual([
+      'sh1',
+      'sh2',
+      'sh3'
+    ])
+  })
+
+  it('closes the panel from its controls', () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Terminals' }))
+    expect(useAppStore.getState().terminalsPanes.has('owner')).toBe(false)
+  })
+
+  it('closes a shell from its tab', async () => {
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Close zsh' }))
+    })
+
+    // Closing kills the pty; extraction does not. The two live side by side on
+    // the tab and must not be the same action.
+    expect(killTerminal).toHaveBeenCalledWith('sh1')
+  })
+
+  it('reports a shell that failed to start instead of opening an empty tab', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    createShellTerminal.mockRejectedValue(new Error('no pty'))
+    open()
+    render(<TerminalsCard sessionId="owner" />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'New terminal in this session' }))
+    })
+
+    expect(useAppStore.getState().terminalsPanes.get('owner')?.terminals).toEqual(['sh1', 'sh2'])
+    err.mockRestore()
+  })
+
+  it('hands the whole strip to the drag handler, not one tab', () => {
+    const onDragStart = vi.fn()
+    open()
+    render(<TerminalsCard sessionId="owner" onDragStart={onDragStart} />)
+
+    fireEvent.pointerDown(screen.getByTestId('terminals-pane-header-owner'))
+    // The pane moves as a unit, so what the grid is told to drag is the pane
+    // id — dragging a single tab out is the ↗ button's job.
+    expect(onDragStart).toHaveBeenCalledWith('terminals:owner', expect.anything())
+  })
+
+  it('renders nothing when the session holds no shells', () => {
+    const { container } = render(<TerminalsCard sessionId="owner" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('draws the first shell when the stored active index is stale', () => {
+    // Persisted state can name an index past the end after shells are closed
+    // elsewhere; an out-of-range read would draw nothing at all.
+    act(() => {
+      useAppStore.setState({
+        terminalsPanes: new Map([['owner', { terminals: ['sh1'], activeTab: 5 }]])
+      } as never)
+    })
+    render(<TerminalsCard sessionId="owner" />)
+
+    expect(screen.getByTestId('terminal-body-sh1')).toBeInTheDocument()
+  })
+})

--- a/tests/terminals-card.test.tsx
+++ b/tests/terminals-card.test.tsx
@@ -211,5 +211,8 @@ describe('TerminalsCard', () => {
     render(<TerminalsCard sessionId="owner" />)
 
     expect(screen.getByTestId('terminal-body-sh1')).toBeInTheDocument()
+    // And the strip agrees with the body: reading the raw index here would
+    // show a terminal with no tab marked as the one it belongs to.
+    expect(screen.getByRole('tab', { name: /zsh/ })).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/tests/terminals-panel.test.ts
+++ b/tests/terminals-panel.test.ts
@@ -129,6 +129,71 @@ describe('the terminals panel', () => {
     expect(s().terminalsPanes.has('owner')).toBe(false)
   })
 
+  it('lets go of a shell closed from its own tab', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+
+    act(() => s().removeTerminal('sh1'))
+
+    // Closing one is the other direction from closing the session: the panel
+    // survives and has to release the claim. Left behind, the tab outlives the
+    // terminal — falling back to its raw id for a name, with nothing to draw.
+    const pane = s().terminalsPanes.get('owner')!
+    expect(pane.terminals).toEqual(['sh2'])
+    expect(activePanelTerminalId(pane)).toBe('sh2')
+    expect(s().terminals.has('sh1')).toBe(false)
+  })
+
+  it('closes the panel when its last shell is closed from its tab', () => {
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+
+    act(() => s().removeTerminal('sh1'))
+    expect(s().terminalsPanes.has('owner')).toBe(false)
+    // And nothing may still be pointing at the pane that just went.
+    expect(s().maximizedPaneId).toBeNull()
+  })
+
+  it('releases a maximized panel when its last shell is closed', () => {
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+    act(() => s().setMaximizedPane('terminals:owner'))
+
+    act(() => s().removeTerminal('sh1'))
+    // A maximize pointing at a pane that no longer draws hides every sibling
+    // behind nothing at all.
+    expect(s().maximizedPaneId).toBeNull()
+  })
+
+  it('drops a shell that never came back, and keeps its panel for the rest', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+    // sh1 is gone from the live set — the restart-shaped version of the same
+    // bug, where there is no removal to hang the cleanup off.
+    act(() =>
+      useAppStore.setState({
+        terminals: new Map([...s().terminals].filter(([id]) => id !== 'sh1')) as never
+      })
+    )
+
+    act(() => s().setVisibleTerminalIds(['owner']))
+    expect(s().terminalsPanes.get('owner')?.terminals).toEqual(['sh2'])
+  })
+
+  it('drops a panel whose shells all failed to come back', () => {
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+    act(() =>
+      useAppStore.setState({
+        terminals: new Map([...s().terminals].filter(([id]) => id !== 'sh1')) as never
+      })
+    )
+
+    act(() => s().setVisibleTerminalIds(['owner']))
+    expect(s().terminalsPanes.has('owner')).toBe(false)
+  })
+
   it('takes its shells down with the session, and forgets the panel', () => {
     act(() => {
       s().openTerminalsPane('owner', 'sh1')

--- a/tests/terminals-panel.test.ts
+++ b/tests/terminals-panel.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act } from '@testing-library/react'
+import { useAppStore } from '../src/renderer/stores'
+import { claimedTerminalIds } from '../src/renderer/hooks/usePanelTerminals'
+import { activePanelTerminalId } from '../src/renderer/stores/types'
+
+const session = (id: string) =>
+  ({
+    id,
+    projectName: 'p',
+    projectPath: '/p',
+    agentType: 'claude',
+    createdAt: 0,
+    displayName: id
+  }) as never
+
+function seed(ids: string[]): void {
+  const terminals = new Map()
+  for (const id of ids) {
+    terminals.set(id, { id, session: session(id), status: 'idle', lastOutputTimestamp: 1 })
+  }
+  act(() => {
+    useAppStore.setState({
+      terminals: terminals as never,
+      terminalOrder: ids,
+      terminalsPanes: new Map(),
+      minimizedTerminals: new Set(),
+      maximizedPaneId: null,
+      focusedTerminalId: null,
+      previewTerminalId: null,
+      selectedTerminalId: null,
+      filesPanes: new Set(),
+      editorPanes: new Map(),
+      browserPanes: new Map(),
+      devicePanes: new Map()
+    })
+  })
+}
+
+/**
+ * A session can hold several shells beside its agent. They are sessions in
+ * their own right — the panel only records which ones it has claimed, and
+ * letting go of that claim is the whole of "extract this terminal".
+ */
+describe('the terminals panel', () => {
+  const s = () => useAppStore.getState()
+
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      ...(window as unknown as { api?: Record<string, unknown> }).api,
+      notifyWidgetStatus: vi.fn(),
+      reorderSessions: vi.fn()
+    }
+    seed(['owner', 'sh1', 'sh2', 'other'])
+  })
+
+  it('holds shells in order, with the newest in front', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+    const pane = s().terminalsPanes.get('owner')!
+
+    expect(pane.terminals).toEqual(['sh1', 'sh2'])
+    expect(activePanelTerminalId(pane)).toBe('sh2')
+  })
+
+  it('shows a shell it already holds rather than listing it twice', () => {
+    // Two tabs for one terminal would be two slots claiming one id, and the
+    // registry is last-writer-wins — one of them would simply go blank.
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+      s().openTerminalsPane('owner', 'sh1')
+    })
+    const pane = s().terminalsPanes.get('owner')!
+
+    expect(pane.terminals).toEqual(['sh1', 'sh2'])
+    expect(activePanelTerminalId(pane)).toBe('sh1')
+  })
+
+  it('hides every claimed shell, and only those', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+
+    const claimed = claimedTerminalIds({ terminalsPanes: s().terminalsPanes })
+    expect([...claimed].sort()).toEqual(['sh1', 'sh2'])
+    expect(claimed.has('owner')).toBe(false)
+    expect(claimed.has('other')).toBe(false)
+  })
+
+  it('lets go of a shell on extraction, keeping the rest', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+
+    act(() => s().extractPanelTerminal('owner', 'sh1'))
+    const pane = s().terminalsPanes.get('owner')!
+
+    // The terminal itself is untouched — it was a session all along, and is now
+    // simply no longer claimed.
+    expect(pane.terminals).toEqual(['sh2'])
+    expect(s().terminals.has('sh1')).toBe(true)
+    expect(claimedTerminalIds({ terminalsPanes: s().terminalsPanes }).has('sh1')).toBe(false)
+  })
+
+  it('lands on a neighbour when the shell in front is extracted', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+      s().setActivePanelTerminal('owner', 1)
+    })
+
+    act(() => s().extractPanelTerminal('owner', 'sh2'))
+    expect(activePanelTerminalId(s().terminalsPanes.get('owner')!)).toBe('sh1')
+  })
+
+  it('closes the panel when its last shell leaves', () => {
+    // A panel with no shells is a box taking up a pane — the same rule the
+    // browser's last tab follows.
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+
+    act(() => s().extractPanelTerminal('owner', 'sh1'))
+    expect(s().terminalsPanes.has('owner')).toBe(false)
+  })
+
+  it('takes its shells down with the session, and forgets the panel', () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+
+    act(() => s().removeTerminal('owner'))
+
+    // The shells are that session's, so they go with it — and nothing may be
+    // left claiming ids that no longer exist, or those terminals would be
+    // hidden from every surface with nothing left to un-hide them.
+    expect(s().terminalsPanes.has('owner')).toBe(false)
+    expect(s().terminals.has('sh1')).toBe(false)
+    expect(s().terminals.has('sh2')).toBe(false)
+    expect(s().terminalOrder).toEqual(['other'])
+  })
+
+  it('releases focus and selection pointing at a shell that went with its session', () => {
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+    act(() =>
+      useAppStore.setState({ focusedTerminalId: 'sh1', selectedTerminalId: 'sh1' } as never)
+    )
+
+    act(() => s().removeTerminal('owner'))
+    expect(s().focusedTerminalId).toBeNull()
+    expect(s().selectedTerminalId).toBeNull()
+  })
+
+  it("leaves another session's panel alone", () => {
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('other', 'sh2')
+    })
+
+    act(() => s().removeTerminal('owner'))
+    expect(s().terminalsPanes.get('other')?.terminals).toEqual(['sh2'])
+    expect(s().terminals.has('sh2')).toBe(true)
+  })
+
+  it('survives a reload with the same shells and the same one in front', async () => {
+    const { parsePersistedPanels } = await import('../src/renderer/stores/ui-slice')
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+      s().setActivePanelTerminal('owner', 0)
+    })
+
+    const restored = parsePersistedPanels(
+      JSON.parse(localStorage.getItem('vorn:terminalPanels') as string)
+    )
+    expect(restored.get('owner')).toEqual({ terminals: ['sh1', 'sh2'], activeTab: 0 })
+  })
+
+  it('drops a persisted panel that has no shells left', async () => {
+    const { parsePersistedPanels } = await import('../src/renderer/stores/ui-slice')
+    // Its ids are what hid those terminals; an empty one is a pane that would
+    // render nothing.
+    const restored = parsePersistedPanels({ owner: { terminals: [], activeTab: 0 } })
+    expect(restored.has('owner')).toBe(false)
+  })
+
+  it('clamps a persisted active tab that points past the end', async () => {
+    const { parsePersistedPanels } = await import('../src/renderer/stores/ui-slice')
+    const restored = parsePersistedPanels({ owner: { terminals: ['sh1'], activeTab: 7 } })
+    expect(restored.get('owner')?.activeTab).toBe(0)
+  })
+})

--- a/tests/terminals-panel.test.ts
+++ b/tests/terminals-panel.test.ts
@@ -194,6 +194,43 @@ describe('the terminals panel', () => {
     expect(s().terminalsPanes.has('owner')).toBe(false)
   })
 
+  it('takes its shells with it when the panel is closed', async () => {
+    const kill = vi.fn().mockResolvedValue(undefined)
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      ...(window as unknown as { api: Record<string, unknown> }).api,
+      killTerminal: kill
+    }
+    const { closeTerminalsPanel } = await import('../src/renderer/lib/terminal-close')
+    act(() => {
+      s().openTerminalsPane('owner', 'sh1')
+      s().openTerminalsPane('owner', 'sh2')
+    })
+
+    await act(async () => {
+      await closeTerminalsPanel('owner')
+    })
+
+    // Dropping the claim alone would leave two live ptys loose on the grid as
+    // top-level cards, and the control that made them would offer to make a
+    // third.
+    expect(s().terminalsPanes.has('owner')).toBe(false)
+    expect(s().terminals.has('sh1')).toBe(false)
+    expect(s().terminals.has('sh2')).toBe(false)
+    expect(kill.mock.calls.map((c) => c[0]).sort()).toEqual(['sh1', 'sh2'])
+    // The session that owned the panel is untouched — only its shells went.
+    expect(s().terminals.has('owner')).toBe(true)
+  })
+
+  it('reads a corrupted active tab as the first one', async () => {
+    const { parsePersistedPanels } = await import('../src/renderer/stores/ui-slice')
+    // `?? 0` only catches null and undefined. A string or a NaN here reaches
+    // the card as an index, which looks up undefined and is dereferenced.
+    const restored = parsePersistedPanels({
+      owner: { terminals: ['sh1'], activeTab: 'nope' as unknown as number }
+    })
+    expect(restored.get('owner')?.activeTab).toBe(0)
+  })
+
   it('takes its shells down with the session, and forgets the panel', () => {
     act(() => {
       s().openTerminalsPane('owner', 'sh1')

--- a/tests/visible-terminals-cards.test.tsx
+++ b/tests/visible-terminals-cards.test.tsx
@@ -29,6 +29,7 @@ function seed(ids: string[]): void {
       activeProject: null,
       activeWorktreePath: null,
       minimizedTerminals: new Set(),
+      terminalsPanes: new Map(),
       filesPanes: new Set(),
       editorPanes: new Map(),
       browserPanes: new Map(),
@@ -167,5 +168,60 @@ describe('useVisibleTerminals with popped-out cards', () => {
     const { result } = renderHook(() => useVisibleTerminals())
 
     expect(result.current.orderedIds).toEqual(['t1', a, b, 't2'])
+  })
+})
+
+/**
+ * A shell held in a session's panel is drawn there and nowhere else. That is
+ * not tidiness: the terminal registry is last-writer-wins on a slot, so one
+ * terminal rendered twice would have the two fighting over a single wrapper.
+ */
+describe('useVisibleTerminals with a terminals panel', () => {
+  beforeEach(() => {
+    ;(window as unknown as { api: Record<string, unknown> }).api = {
+      notifyWidgetStatus: vi.fn(),
+      reorderSessions: vi.fn()
+    }
+    seed(['t1', 't2'])
+  })
+
+  it('keeps a claimed shell out of the grid and out of keyboard nav', () => {
+    const { result, rerender } = renderHook(() => useVisibleTerminals())
+    expect(result.current.orderedIds).toEqual(['t1', 't2'])
+
+    act(() => useAppStore.getState().openTerminalsPane('t1', 't2'))
+    rerender()
+
+    // Out of the grid, and out of the ring — landing on it with Cmd+] would
+    // focus a terminal with nothing drawing it.
+    expect(result.current.orderedIds).toEqual(['t1'])
+    expect(useAppStore.getState().focusableTerminalIds).toEqual(['t1'])
+  })
+
+  it('keeps a claimed shell out of the dock, even when minimized', () => {
+    act(() => {
+      useAppStore.getState().toggleMinimized('t2')
+      useAppStore.getState().openTerminalsPane('t1', 't2')
+    })
+    const { result } = renderHook(() => useVisibleTerminals())
+
+    // A dock pill for it would restore a terminal into a grid that is not
+    // drawing it, which is the one-slot rule broken from the other side.
+    expect(result.current.minimizedIds).toEqual([])
+    expect(result.current.orderedIds).toEqual(['t1'])
+  })
+
+  it('gives it back the moment it is extracted', () => {
+    const { result, rerender } = renderHook(() => useVisibleTerminals())
+    act(() => useAppStore.getState().openTerminalsPane('t1', 't2'))
+    rerender()
+    expect(result.current.orderedIds).toEqual(['t1'])
+
+    act(() => useAppStore.getState().extractPanelTerminal('t1', 't2'))
+    rerender()
+
+    // Extraction is only letting go of the claim — the terminal was a session
+    // all along, so it is a cell again with nothing else to do.
+    expect(result.current.orderedIds).toEqual(['t1', 't2'])
   })
 })


### PR DESCRIPTION
A session could hold exactly one terminal. The only way to get a second shell beside your agent was to start a top-level session with no visible relationship to the work it belonged to.

It now holds as many as you like, in a tabbed panel beside its other panes, and the arrow on any tab makes that shell a top-level terminal.

## Why it's small

A shell terminal was already a full session with its own pid. The panel only records which ids it has claimed, so extraction is letting go of the claim — and the terminal is immediately a grid cell, a tab, a sidebar row, a dock pill and a focus target with no further machinery. `terminalsPanes: Map<sessionId, {terminals, activeTab}>` is deliberately the same shape as `BrowserPaneState`, because it is the same problem.

The claim is also what keeps a held shell out of every other surface. That is not tidiness: the terminal registry is last-writer-wins on a slot, so one terminal drawn in two places would have the two fighting over a single wrapper and one would go blank. That is why only the tab in front renders a pane, while the rest keep running and keep their scrollback.

## What the review changed

Six agents went over the branch; the ones that reported found real defects, each now fixed with a test that fails without the fix:

- **A held shell was still listed in the sidebar and the command palette.** One filter enforced the hiding rule and those two surfaces walked the terminals map themselves. Clicking such a row in tab mode snapped back to another session; hovering it in grid mode opened a focus stage on a terminal excluded from the focusable set, leaving Cmd+] landing somewhere unrelated.
- **Closing the panel orphaned its shells.** It dropped the claim and nothing else, so live ptys reappeared as top-level cards and the next click started another. Shells now close with the panel, each pty killed independently. Labels say "Close terminals", which is what happens.
- **Nothing ever put the keyboard in a panel shell** — it compared against `focusedTerminalId`, which a claimed shell is never allowed to be, so clicking a tab left you typing at the agent.
- **A corrupted `activeTab`** got past `?? 0` as NaN and took down the card tree; **the diff sidebar** was released only for the session, never for a shell it held.

## Verification

- 3460 tests pass; `tsc` clean on both projects; eslint 0 errors.
- Patch coverage 90% against the 80% gate.
- Every guard mutation-tested: the fix is reverted, the intended test must fail, and nothing else.

Manual passes still worth doing on a real build: extracting a shell and confirming it lands everywhere as a session, Cmd+] never stopping on a held shell, and closing a session killing both its shells.