### PR TITLE
chore(release): 0.6.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0-beta.4",
+  "version": "0.6.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Two things that were one thing can now be several.

**A file or a browser tab can leave its session** (#458) and become a card of its own — its own grid cell, its own tab in the strip, its own focus stage, sidebar row, dock pill and slot in Cmd+]/Cmd+1-9. Each carries its owner's project, worktree and branch.

**A session can hold as many shells as you like** (#461), in a tabbed panel beside its agent, and any of them can be pulled out to stand on its own. A shell was already a full session with its own pid, so the panel only records which ones it has claimed — extraction is letting go of the claim.

Also in this build:

- **Restart Now actually restarts** on macOS (#460). It used to hide the app, and the update landed whenever you next quit by hand. Updates also moved into Settings.
- **The open dependency security alerts are closed** (#459), including three high-severity Electron ones: a sandboxed-iframe popup bypass, a contextBridge context-isolation bypass, and a custom-protocol CORS read.

Version bump only — 7 package.json files, no source changes. `main` at the time of the bump: 3511 tests passing, `tsc` clean on both projects, eslint 0 errors.