### PR TITLE
Hand the keyboard to the command that asked for it

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -51,7 +51,12 @@ import {
   disposeGlobalDataListener,
   setKeyRedirectHandler
 } from './lib/terminal-registry'
-import { setCwdReporter, getShellInputState, setDomBlockRendering } from './lib/command-blocks'
+import {
+  setCwdReporter,
+  getShellInputState,
+  isAtPrompt,
+  setDomBlockRendering
+} from './lib/command-blocks'
 import { focusIntentBar } from './lib/intent-bar-focus'
 import { WorktreeCleanupDialog } from './components/WorktreeCleanupDialog'
 import { WorktreeCleanupToastBridge } from './components/WorktreeCleanupToastBridge'
@@ -152,7 +157,7 @@ export function App() {
       if (e.key.length !== 1) return false
       const session = useAppStore.getState().terminals.get(terminalId)?.session
       if (session?.agentType !== 'shell') return false
-      if (getShellInputState(terminalId) !== 'prompt') return false
+      if (!isAtPrompt(getShellInputState(terminalId))) return false
       return focusIntentBar(terminalId)
     })
     ;(async () => {

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -32,7 +32,7 @@ import {
   type HistoryKind
 } from '../lib/command-history'
 import { defaultSources, getCompletions, outlineNames, type Completion } from '../lib/completions'
-import { isIntentBarFocused, registerIntentBarInput } from '../lib/intent-bar-focus'
+import { registerIntentBarInput } from '../lib/intent-bar-focus'
 import { isShellSession } from '../../shared/types'
 import { resolveIntentMode, SHELL_BUILTINS, type IntentMode } from '../lib/intent-mode'
 import { getPreferredAgent, setPreferredAgent } from '../lib/launch-prefs'
@@ -187,6 +187,13 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   // Whether the running command has lasted long enough to own the pane. Seeded
   // true so arriving at a card mid-command shows no bar rather than a flash.
   const [settled, setSettled] = useState(() => inputState === 'running')
+  // Mirrors of focus and typed text, read by the handover below after the
+  // textarea may already have been removed. State would be stale in that closure.
+  const hadFocusRef = useRef(false)
+  const draftRef = useRef('')
+  useEffect(() => {
+    draftRef.current = value
+  }, [value])
   const [seenState, setSeenState] = useState(inputState)
   if (seenState !== inputState) {
     // Adjusted during render, which React sanctions: an effect writing this
@@ -196,11 +203,13 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   }
 
   useEffect(() => {
-    // Asked while the textarea is still mounted and before the state that
-    // unmounts it: afterwards there is no composer left to have held focus, and
-    // an unmount while focused drops focus to the body where keys reach nothing.
+    // Read from a ref, not the DOM: the alternate screen hides the composer in
+    // the same render that reports it, so by now the textarea may already be
+    // gone — and asking a detached node whether it had focus always says no.
     const yieldKeyboard = (): void => {
-      if (!isMobile && isIntentBarFocused(terminalId)) focusTerminal(terminalId)
+      // A half-typed command means the keyboard is still being used. Moving it
+      // would split the rest of the word into the pty's line buffer.
+      if (hadFocusRef.current && !draftRef.current) focusTerminal(terminalId)
     }
     // A full-screen program is never transient; only a command is worth waiting out.
     if (inputState === 'altScreen') {
@@ -213,11 +222,15 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
       setSettled(true)
     }, PTY_FOCUS_DELAY_MS)
     return () => clearTimeout(timer)
-  }, [inputState, isMobile, terminalId])
+  }, [inputState, terminalId])
 
   // The composer belongs to the prompt; while a command owns the terminal there
   // is nothing for it to do. 'unknown' keeps it — no integration, no signal.
-  const composerHidden = inputState === 'altScreen' || (inputState === 'running' && settled)
+  //
+  // Never on mobile: focus cannot move there, so hiding would leave the phone
+  // with no input at all rather than with the terminal's.
+  const composerHidden =
+    !isMobile && (inputState === 'altScreen' || (inputState === 'running' && settled))
 
   const inferredMode = useMemo(
     () => resolveIntentMode(value, knownCommands),
@@ -305,13 +318,14 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
     }
   }, [])
 
-  // Expose the input for keystroke redirection from the raw terminal.
-  useEffect(() => {
+  // Expose the input for keystroke redirection from the raw terminal. A layout
+  // effect because the composer remounts when a command ends: a passive one
+  // leaves a window where the box is on screen but unregistered, and the first
+  // keystroke goes to the pty instead.
+  useLayoutEffect(() => {
     const el = textareaRef.current
     if (!el || !isShell) return
     return registerIntentBarInput(terminalId, el)
-    // composerHidden remounts the textarea, and the registry would otherwise
-    // keep pointing at the detached one — which fails focusIntentBar silently.
   }, [terminalId, isShell, composerHidden])
 
   // Runnable names for mode resolution. The executable list is cached at
@@ -706,8 +720,12 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
               aria-label={label}
               onChange={(e) => handleChange(e.target.value)}
               onKeyDown={handleKeyDown}
-              onFocus={() => setIsFocused(true)}
+              onFocus={() => {
+                hadFocusRef.current = true
+                setIsFocused(true)
+              }}
               onBlur={() => {
+                hadFocusRef.current = false
                 setIsFocused(false)
                 closeDropdown()
               }}

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type KeyboardEvent
 } from 'react'
 import { createPortal } from 'react-dom'
@@ -21,7 +22,8 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { focusTerminal, pasteToTerminal, scrollToBottom } from '../lib/terminal-registry'
-import { getShellInputState } from '../lib/command-blocks'
+import { getShellInputState, isAtPrompt, onCommandBlocksChange } from '../lib/command-blocks'
+import { useIsMobile } from '../hooks/useIsMobile'
 import {
   ghostSuggestion,
   recordCommand,
@@ -30,7 +32,7 @@ import {
   type HistoryKind
 } from '../lib/command-history'
 import { defaultSources, getCompletions, outlineNames, type Completion } from '../lib/completions'
-import { registerIntentBarInput } from '../lib/intent-bar-focus'
+import { isIntentBarFocused, registerIntentBarInput } from '../lib/intent-bar-focus'
 import { isShellSession } from '../../shared/types'
 import { resolveIntentMode, SHELL_BUILTINS, type IntentMode } from '../lib/intent-mode'
 import { getPreferredAgent, setPreferredAgent } from '../lib/launch-prefs'
@@ -52,6 +54,8 @@ interface Props {
 }
 
 const MAX_INPUT_HEIGHT = 120
+/** Long enough that an instant command never pulls the caret out of the composer. */
+const PTY_FOCUS_DELAY_MS = 120
 const COMPLETION_DEBOUNCE_MS = 80
 /** History rows shown above completions when both are present. */
 const HISTORY_ROWS_WITH_COMPLETIONS = 3
@@ -124,15 +128,8 @@ function longestCommonPrefix(inserts: string[]): string {
  * newline, Escape returns focus to the terminal. Tab fills the longest
  * common prefix, then inserts the highlighted (or first) completion.
  */
-/**
- * Control chords forwarded to the pty while a command is running.
- *
- * The composer keeps focus after a command is submitted, so these would
- * otherwise be swallowed by the textarea and there would be no way to
- * interrupt anything without first clicking into the terminal. Ctrl, never
- * Cmd: control characters are Ctrl-based on every platform, and on macOS
- * Cmd+C is copy.
- */
+// Interrupts, forwarded while a command runs. Ctrl, never Cmd — on macOS Cmd+C
+// is copy. Not a key table: xterm encodes the rest once it has focus.
 const CONTROL_CHORDS: Record<string, string> = {
   c: '\x03', // SIGINT
   d: '\x04', // EOF
@@ -178,6 +175,49 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   const repoPath = session?.worktreePath ?? session?.projectPath ?? null
   // Completions need the RPC surface (absent in older preloads/tests).
   const completionsEnabled = typeof window.api?.listShellExecutables === 'function'
+
+  // Subscribed, not read in a handler: the bar has to disappear when a command
+  // takes the keyboard, which is a render concern.
+  const inputState = useSyncExternalStore(
+    useCallback((cb: () => void) => onCommandBlocksChange(terminalId, cb), [terminalId]),
+    useCallback(() => getShellInputState(terminalId), [terminalId])
+  )
+  const isMobile = useIsMobile()
+
+  // Whether the running command has lasted long enough to own the pane. Seeded
+  // true so arriving at a card mid-command shows no bar rather than a flash.
+  const [settled, setSettled] = useState(() => inputState === 'running')
+  const [seenState, setSeenState] = useState(inputState)
+  if (seenState !== inputState) {
+    // Adjusted during render, which React sanctions: an effect writing this
+    // would render once with the previous command's answer before correcting.
+    setSeenState(inputState)
+    setSettled(false)
+  }
+
+  useEffect(() => {
+    // Asked while the textarea is still mounted and before the state that
+    // unmounts it: afterwards there is no composer left to have held focus, and
+    // an unmount while focused drops focus to the body where keys reach nothing.
+    const yieldKeyboard = (): void => {
+      if (!isMobile && isIntentBarFocused(terminalId)) focusTerminal(terminalId)
+    }
+    // A full-screen program is never transient; only a command is worth waiting out.
+    if (inputState === 'altScreen') {
+      yieldKeyboard()
+      return
+    }
+    if (inputState !== 'running') return
+    const timer = setTimeout(() => {
+      yieldKeyboard()
+      setSettled(true)
+    }, PTY_FOCUS_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [inputState, isMobile, terminalId])
+
+  // The composer belongs to the prompt; while a command owns the terminal there
+  // is nothing for it to do. 'unknown' keeps it — no integration, no signal.
+  const composerHidden = inputState === 'altScreen' || (inputState === 'running' && settled)
 
   const inferredMode = useMemo(
     () => resolveIntentMode(value, knownCommands),
@@ -270,7 +310,9 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
     const el = textareaRef.current
     if (!el || !isShell) return
     return registerIntentBarInput(terminalId, el)
-  }, [terminalId, isShell])
+    // composerHidden remounts the textarea, and the registry would otherwise
+    // keep pointing at the detached one — which fails focusIntentBar silently.
+  }, [terminalId, isShell, composerHidden])
 
   // Runnable names for mode resolution. The executable list is cached at
   // module level for five minutes, so this is nearly free per mount.
@@ -402,17 +444,18 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Interrupts belong to the running command, not to this input. Shift is
-      // excluded because Ctrl+Shift+C is the terminal's copy chord, which it
-      // swallows even with nothing selected — forwarding it here would
-      // interrupt on a keystroke pressed to copy.
+      // An input method mid-word owns every key; swallowing one breaks it.
+      if (e.nativeEvent.isComposing) return
+
+      // Shift excluded: Ctrl+Shift+C is the terminal's copy chord. Anything but
+      // 'prompt', so vim and uninstrumented shells can be interrupted too.
       if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
         const chord = CONTROL_CHORDS[e.key.toLowerCase()]
         const target = e.currentTarget
         const hasSelection = target.selectionStart !== target.selectionEnd
         // Copying out of the composer still wins, as it does in the terminal.
         if (chord && !(e.key.toLowerCase() === 'c' && hasSelection)) {
-          if (getShellInputState(terminalId) === 'running') {
+          if (!isAtPrompt(getShellInputState(terminalId))) {
             e.preventDefault()
             window.api.writeTerminal(terminalId, chord)
             return
@@ -529,6 +572,10 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
 
   // Agent sessions keep their own TUI input; the composer is shell-only.
   if (!session || !isShell) return null
+
+  // The running command gets the whole pane. The effect above has already handed
+  // the keyboard over by the time this renders nothing.
+  if (composerHidden) return null
 
   // The accessible name always states the mode the input is actually in, so
   // it is unambiguous once there is something to classify.

--- a/src/renderer/lib/command-blocks.ts
+++ b/src/renderer/lib/command-blocks.ts
@@ -53,7 +53,16 @@ export interface TrackerHost {
 
 const MAX_BLOCKS = 200
 
-export type ShellInputState = 'prompt' | 'running' | 'unknown'
+/** Split because the composer waits before yielding to a command, but never to a TUI. */
+export type ShellInputState = 'prompt' | 'running' | 'altScreen' | 'unknown'
+
+/**
+ * Whether the composer still owns input. Named so adding a fifth state forces a
+ * decision here rather than silently changing every `!== 'prompt'` comparison.
+ */
+export function isAtPrompt(state: ShellInputState): boolean {
+  return state === 'prompt'
+}
 
 export class CommandBlockTracker {
   readonly blocks: CommandBlock[] = []
@@ -72,12 +81,11 @@ export class CommandBlockTracker {
   constructor(private host: TrackerHost) {}
 
   /**
-   * Whether the shell is waiting at its prompt ('prompt'), executing a
-   * command or showing a full-screen app ('running'), or has never reported
-   * boundaries ('unknown' — no shell integration; degrade to raw input).
+   * Prompt, running, full-screen app, or no shell integration at all. The
+   * alternate buffer wins: it is the one answer integration cannot give.
    */
   inputState(): ShellInputState {
-    if (this.host.isAlternateBuffer()) return 'running'
+    if (this.host.isAlternateBuffer()) return 'altScreen'
     if (!this.sawPrompt) return 'unknown'
     return this.promptMarker && !this.promptMarker.isDisposed ? 'prompt' : 'running'
   }
@@ -437,7 +445,7 @@ export function attachCommandBlocks(terminalId: string, term: Terminal): () => v
   const applyCursorVisibility = (): void => {
     const theme = term.options.theme ?? {}
     const background = theme.background ?? TERMINAL_BACKGROUND
-    const hide = tracker.inputState() === 'prompt'
+    const hide = isAtPrompt(tracker.inputState())
     const cursor = hide ? background : defaultCursor
     if (theme.cursor !== cursor) {
       term.options.theme = { ...theme, cursor, cursorAccent: hide ? background : undefined }
@@ -471,11 +479,18 @@ export function attachCommandBlocks(terminalId: string, term: Terminal): () => v
     // xterm still runs its own handler; this one only observes.
     return false
   })
+  // No OSC accompanies an alternate-buffer switch, so without this nothing
+  // would hear vim open.
+  const d4 = term.buffer.onBufferChange(() => {
+    applyCursorVisibility()
+    emitBlocksChanged(terminalId)
+  })
 
   return () => {
     d1.dispose()
     d2.dispose()
     d3.dispose()
+    d4.dispose()
     trackers.delete(terminalId)
     blockListeners.delete(terminalId)
     integrated.delete(terminalId)

--- a/src/renderer/lib/intent-bar-focus.ts
+++ b/src/renderer/lib/intent-bar-focus.ts
@@ -13,22 +13,10 @@ export function registerIntentBarInput(terminalId: string, el: HTMLTextAreaEleme
   }
 }
 
-/** The composer's input, only while it is still in the document. */
-function liveInput(terminalId: string): HTMLTextAreaElement | null {
-  const el = intentBarInputs.get(terminalId)
-  return el && el.isConnected ? el : null
-}
-
 /** Focus the composer for a terminal. Returns false when none is mounted. */
 export function focusIntentBar(terminalId: string): boolean {
-  const el = liveInput(terminalId)
-  if (!el) return false
+  const el = intentBarInputs.get(terminalId)
+  if (!el || !el.isConnected) return false
   el.focus()
   return true
-}
-
-/** Asked of the browser: a second copy of this answer is the one that goes stale. */
-export function isIntentBarFocused(terminalId: string): boolean {
-  const el = liveInput(terminalId)
-  return el !== null && document.activeElement === el
 }

--- a/src/renderer/lib/intent-bar-focus.ts
+++ b/src/renderer/lib/intent-bar-focus.ts
@@ -13,10 +13,22 @@ export function registerIntentBarInput(terminalId: string, el: HTMLTextAreaEleme
   }
 }
 
+/** The composer's input, only while it is still in the document. */
+function liveInput(terminalId: string): HTMLTextAreaElement | null {
+  const el = intentBarInputs.get(terminalId)
+  return el && el.isConnected ? el : null
+}
+
 /** Focus the composer for a terminal. Returns false when none is mounted. */
 export function focusIntentBar(terminalId: string): boolean {
-  const el = intentBarInputs.get(terminalId)
-  if (!el || !el.isConnected) return false
+  const el = liveInput(terminalId)
+  if (!el) return false
   el.focus()
   return true
+}
+
+/** Asked of the browser: a second copy of this answer is the one that goes stale. */
+export function isIntentBarFocused(terminalId: string): boolean {
+  const el = liveInput(terminalId)
+  return el !== null && document.activeElement === el
 }

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -503,7 +503,16 @@ export function clearTerminalSelection(terminalId: string): void {
 }
 
 export function pasteToTerminal(terminalId: string, text: string): void {
-  registry.get(terminalId)?.term.paste(text)
+  const entry = registry.get(terminalId)
+  if (!entry) return
+  // xterm's paste sends the text and *then* clears its hidden textarea, which
+  // only exists once the terminal is opened — so before that it throws after
+  // sending, and a caller's following carriage return never runs.
+  if (!entry.term.element) {
+    window.api.writeTerminal(terminalId, text)
+    return
+  }
+  entry.term.paste(text)
 }
 
 export function scrollToBottom(terminalId: string): void {

--- a/tests/command-blocks.test.ts
+++ b/tests/command-blocks.test.ts
@@ -182,12 +182,20 @@ describe('CommandBlockTracker.inputState', () => {
     expect(tracker.inputState()).toBe('prompt')
   })
 
-  it('is running while the alternate buffer is active', () => {
+  it('is altScreen while the alternate buffer is active', () => {
     tracker.handleSequence('A')
     alternate = true
-    expect(tracker.inputState()).toBe('running')
+    expect(tracker.inputState()).toBe('altScreen')
     alternate = false
     expect(tracker.inputState()).toBe('prompt')
+  })
+
+  it('is altScreen even with no shell integration at all', () => {
+    // The alternate buffer is the one answer that does not depend on the shell
+    // reporting anything, and a TUI opened from an uninstrumented shell still
+    // needs the terminal to have the keys.
+    alternate = true
+    expect(tracker.inputState()).toBe('altScreen')
   })
 })
 
@@ -296,18 +304,29 @@ describe('attachCommandBlocks', () => {
     registerDecoration: ReturnType<typeof vi.fn>
     handlers: Map<number, (data: string) => boolean>
     csiHandlers: Map<string, (params: number[]) => boolean>
+    bufferListeners: Set<() => void>
   }
 
   function fakeTerminal(): { term: FakeTerm; asTerminal: Terminal } {
     const handlers = new Map<number, (data: string) => boolean>()
     const csiHandlers = new Map<string, (params: number[]) => boolean>()
+    const bufferListeners = new Set<() => void>()
     const term = {
       registerDecoration: vi.fn(() => undefined),
       handlers,
       csiHandlers,
+      bufferListeners,
       options: { theme: { background: '#141416', cursor: '#d4d4d8' } },
       cols: 80,
-      buffer: { active: { type: 'normal', baseY: 0, cursorY: 0 } },
+      buffer: {
+        active: { type: 'normal', baseY: 0, cursorY: 0 },
+        // Entering or leaving the alternate screen carries no OSC, so this is
+        // the only thing that can announce a full-screen program opening.
+        onBufferChange: (cb: () => void) => {
+          bufferListeners.add(cb)
+          return { dispose: () => bufferListeners.delete(cb) }
+        }
+      },
       registerMarker: (offset: number) => new FakeMarker(offset),
       parser: {
         registerOscHandler: (id: number, cb: (data: string) => boolean) => {
@@ -463,7 +482,10 @@ describe('clear', () => {
       options: { theme: {} },
       cols: 80,
       clear: vi.fn(),
-      buffer: { active: { type: 'normal', baseY: 0, cursorY: 0, length: 1 } },
+      buffer: {
+        active: { type: 'normal', baseY: 0, cursorY: 0, length: 1 },
+        onBufferChange: () => ({ dispose: () => {} })
+      },
       registerMarker: (offset: number) => new FakeMarker(offset),
       parser: {
         registerOscHandler: (id: number, cb: (data: string) => boolean) => {
@@ -532,12 +554,19 @@ describe('shell integration detection', () => {
    */
   function fake(): { term: Terminal; handlers: Map<number, (d: string) => boolean> } {
     const handlers = new Map<number, (d: string) => boolean>()
+    const bufferListeners = new Set<() => void>()
     const term = {
       registerDecoration: vi.fn(() => undefined),
       options: { theme: {} },
       cols: 80,
       clear: vi.fn(),
-      buffer: { active: { type: 'normal', baseY: 0, cursorY: 0, length: 1 } },
+      buffer: {
+        active: { type: 'normal', baseY: 0, cursorY: 0, length: 1 },
+        onBufferChange: (cb: () => void) => {
+          bufferListeners.add(cb)
+          return { dispose: () => bufferListeners.delete(cb) }
+        }
+      },
       registerMarker: (offset: number) => new FakeMarker(offset),
       parser: {
         registerOscHandler: (id: number, cb: (d: string) => boolean) => {
@@ -547,13 +576,33 @@ describe('shell integration detection', () => {
         registerCsiHandler: () => ({ dispose: () => {} })
       }
     }
-    return { term: term as unknown as Terminal, handlers }
+    return { term: term as unknown as Terminal, handlers, bufferListeners }
   }
 
   it('reports nothing until a boundary actually arrives', () => {
     const { term } = fake()
     attachCommandBlocks('unmarked', term)
     expect(hasShellIntegration('unmarked')).toBe(false)
+  })
+
+  it('announces an alternate-buffer switch, which carries no OSC', () => {
+    // A program can take the whole screen without the shell saying anything, so
+    // this is the only thing that can tell a listener vim opened.
+    const { term, bufferListeners } = fake()
+    attachCommandBlocks('tui', term)
+    let notified = 0
+    onCommandBlocksChange('tui', () => notified++)
+    expect(bufferListeners.size).toBe(1)
+    bufferListeners.forEach((cb) => cb())
+    expect(notified).toBe(1)
+  })
+
+  it('stops listening to the buffer when torn down', () => {
+    const { term, bufferListeners } = fake()
+    const dispose = attachCommandBlocks('tui-gone', term)
+    expect(bufferListeners.size).toBe(1)
+    dispose()
+    expect(bufferListeners.size).toBe(0)
   })
 
   it('reports integration from the first prompt marker', () => {

--- a/tests/intent-bar.test.tsx
+++ b/tests/intent-bar.test.tsx
@@ -31,10 +31,22 @@ const registryMocks = vi.hoisted(() => ({
 vi.mock('../src/renderer/lib/terminal-registry', () => registryMocks)
 
 // What the shell is doing right now decides where a keystroke belongs.
-const shellState = vi.hoisted(() => ({ value: 'prompt' as 'prompt' | 'running' | 'unknown' }))
+const shellState = vi.hoisted(() => ({
+  value: 'prompt' as 'prompt' | 'running' | 'altScreen' | 'unknown'
+}))
 vi.mock('../src/renderer/lib/command-blocks', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return { ...actual, getShellInputState: () => shellState.value }
+})
+
+// jsdom doesn't implement matchMedia; stub it for useIsMobile.
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }),
+  writable: true
 })
 
 Object.defineProperty(window, 'api', {
@@ -470,7 +482,10 @@ describe('interrupting a running command from the composer', () => {
     pty = vi.fn()
     // Assigned, not redefined: the module-level definition is not configurable.
     window.api = { writeTerminal: pty } as unknown as typeof window.api
-    shellState.value = 'running'
+    // 'unknown' rather than 'running': with no shell integration the bar stays
+    // mounted for the whole command, which is where interrupting from it still
+    // matters. A tracked command hides the bar and xterm takes the chord.
+    shellState.value = 'unknown'
   })
 
   afterEach(() => {
@@ -541,6 +556,115 @@ describe('interrupting a running command from the composer', () => {
     render(<IntentBar terminalId="term-1" />)
     await ready()
     fireEvent.keyDown(getInput(), { key: 'c', ctrlKey: true })
+    expect(pty).not.toHaveBeenCalled()
+  })
+
+  it('ignores a chord delivered mid-composition', async () => {
+    // Some input methods deliver Ctrl chords while composing; acting on one
+    // interrupts a command on a keystroke meant for the composer.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.keyDown(getInput(), { key: 'c', ctrlKey: true, isComposing: true })
+    expect(pty).not.toHaveBeenCalled()
+  })
+
+  it('keeps the bar for a shell it cannot instrument', async () => {
+    // No integration means no reliable "running" to hide on, and hiding on a
+    // bad guess would leave someone with no input at all.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    expect(screen.queryByRole('textbox')).not.toBeNull()
+  })
+})
+
+describe('the composer while a tracked command runs', () => {
+  async function ready() {
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+    resetCommandHistoryCache()
+    seedStore()
+    shellState.value = 'running'
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    shellState.value = 'prompt'
+  })
+
+  it('leaves the pane to the command', async () => {
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    expect(screen.queryByRole('textbox')).toBeNull()
+  })
+})
+
+describe('the composer while a full-screen program is up', () => {
+  async function ready() {
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+  }
+
+  let pty: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    resetCommandHistoryCache()
+    seedStore()
+    pty = vi.fn()
+    window.api = { writeTerminal: pty } as unknown as typeof window.api
+    shellState.value = 'altScreen'
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    shellState.value = 'prompt'
+  })
+
+  it('leaves the pane entirely', async () => {
+    // Nothing the bar offers applies to vim, and a strip of chrome explaining
+    // that is still a strip of chrome.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    expect(screen.queryByRole('textbox')).toBeNull()
+  })
+
+  it('goes at once, without waiting', async () => {
+    // A full-screen program is never transient, so there is nothing to wait to
+    // find out — unlike a command, which may be over in a frame.
+    vi.useFakeTimers()
+    try {
+      render(<IntentBar terminalId="term-1" />)
+      expect(screen.queryByRole('textbox')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not take focus that was somewhere else', async () => {
+    // A command finishing in a background card must not pull the keyboard out
+    // of whatever is actually being typed into.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    expect(registryMocks.focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('cannot submit into the running program', async () => {
+    // vim reads keys, not lines: pasting `dd` and a carriage return deletes a
+    // line. Unreachable now that the bar is gone, which is the point — this
+    // asserts there is no surface left to do it from.
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    expect(registryMocks.pasteToTerminal).not.toHaveBeenCalled()
     expect(pty).not.toHaveBeenCalled()
   })
 })

--- a/tests/intent-bar.test.tsx
+++ b/tests/intent-bar.test.tsx
@@ -34,9 +34,19 @@ vi.mock('../src/renderer/lib/terminal-registry', () => registryMocks)
 const shellState = vi.hoisted(() => ({
   value: 'prompt' as 'prompt' | 'running' | 'altScreen' | 'unknown'
 }))
+// Listeners are captured so a test can drive a real state transition; several
+// of these only reproduce on the change, not on the state they land in.
+const blocks = vi.hoisted(() => ({ listeners: new Set<() => void>() }))
 vi.mock('../src/renderer/lib/command-blocks', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
-  return { ...actual, getShellInputState: () => shellState.value }
+  return {
+    ...actual,
+    getShellInputState: () => shellState.value,
+    onCommandBlocksChange: (_id: string, cb: () => void) => {
+      blocks.listeners.add(cb)
+      return () => blocks.listeners.delete(cb)
+    }
+  }
 })
 
 // jsdom doesn't implement matchMedia; stub it for useIsMobile.
@@ -88,6 +98,14 @@ function seedStore(overrides: Partial<ReturnType<typeof useAppStore.getState>> =
       terminals: new Map([['term-1', mockTerminal]]),
       ...overrides
     })
+  })
+}
+
+/** Move the shell to a new state the way a command boundary would. */
+function moveTo(next: 'prompt' | 'running' | 'altScreen' | 'unknown'): void {
+  shellState.value = next
+  act(() => {
+    blocks.listeners.forEach((cb) => cb())
   })
 }
 
@@ -628,6 +646,55 @@ describe('the composer while a full-screen program is up', () => {
     cleanup()
     vi.clearAllMocks()
     shellState.value = 'prompt'
+  })
+
+  it('hands the keyboard over as the pane is taken', async () => {
+    // The regression this exists for: the composer is hidden in the same render
+    // that reports the alternate screen, so a check against the live DOM asks a
+    // node that is already detached and always answers no. Focus then lands on
+    // the body and vim receives nothing at all.
+    shellState.value = 'prompt'
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.focus(getInput())
+
+    moveTo('altScreen')
+
+    expect(registryMocks.focusTerminal).toHaveBeenCalledWith('term-1')
+    expect(screen.queryByRole('textbox')).toBeNull()
+  })
+
+  it('hands it over for a command too, once it has settled', async () => {
+    shellState.value = 'prompt'
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    fireEvent.focus(getInput())
+
+    moveTo('running')
+    expect(registryMocks.focusTerminal).not.toHaveBeenCalled()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 160))
+    })
+
+    expect(registryMocks.focusTerminal).toHaveBeenCalledWith('term-1')
+  })
+
+  it('keeps a half-typed command rather than splitting it across two inputs', async () => {
+    // Moving the keyboard mid-word sends the rest to the pty's line buffer, and
+    // the two halves are then interleaved when the composer submits its share.
+    shellState.value = 'prompt'
+    render(<IntentBar terminalId="term-1" />)
+    await ready()
+    const input = getInput()
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'npm ru' } })
+
+    moveTo('running')
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 160))
+    })
+
+    expect(registryMocks.focusTerminal).not.toHaveBeenCalled()
   })
 
   it('leaves the pane entirely', async () => {

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -7,7 +7,10 @@ vi.mock('@xterm/xterm', () => {
     cols = 80
     rows = 24
     options = { fontSize: 13 }
-    buffer = { active: { viewportY: 0, baseY: 0, type: 'normal' } }
+    buffer = {
+      active: { viewportY: 0, baseY: 0, type: 'normal' },
+      onBufferChange: vi.fn().mockReturnValue({ dispose: vi.fn() })
+    }
     parser = {
       registerOscHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }),
       registerCsiHandler: vi.fn().mockReturnValue({ dispose: vi.fn() })


### PR DESCRIPTION
Type `npm init` into the composer and it runs, then asks for a package name — and there is no way to answer it. Focus stays in a box that still reads *"Type a command"* while the program waits in the terminal above. The only way across is Escape, which nothing advertises.

The composer owns input while the shell is at its prompt: typing in the terminal redirects into it, and the terminal's own cursor is painted out so there are not two. Nothing ever handed that back — `focusTerminal` was called from exactly one place in the component, the Escape key.

So the terminal now takes the keyboard when a command owns input, and the composer leaves the pane rather than sitting there describing itself. It comes back when the prompt does.

## Focus moves; keys are not forwarded

Forwarding is the tempting shape and it cannot be made correct. Arrow keys alone are `\x1b[A` normally and `\x1bOA` under DECCKM — which every arrow-key menu turns on — and past that lie application keypad mode, bracketed paste and input-method composition. xterm implements all of it and already sends it through `term.onData`. Moving focus buys the lot.

## Three guards, each for something that actually breaks

- **The handover waits 120ms**, so a command over in a frame never pulls the caret out and drops it back. A full-screen program is never transient and goes at once.
- **Focus is only ever taken from this terminal's own composer**, checked while the textarea is still mounted. A command finishing in a background card must not pull the keyboard out of whatever is being typed into, and an unmount while focused drops focus to the body where keys reach nothing.
- **Never on mobile** — a programmatic focus there does not raise the software keyboard, so moving it would dismiss the keyboard and leave no way to answer at all. The mobile key bar covers that path.

## State

`ShellInputState` gains `altScreen`, split from `running` because the composer waits before yielding to a command but never to a TUI. `isAtPrompt` is exported beside it so a fifth state forces a decision in one place instead of silently changing four `!== 'prompt'` comparisons.

Entering the alternate buffer carries no OSC, so `onBufferChange` is what tells anything vim opened. That also fixes the live region being mis-sized for up to 300ms on launch, since it previously only re-measured on a debounced scroll.

## Two fixes that fell out of the same path

**`pasteToTerminal` threw on a terminal that had not been opened yet.** xterm's paste sends the text and *then* clears its hidden textarea, so the throw landed after the send and took the caller's carriage return with it — the command was typed and never ran. That window is real on startup, between a slot registering and `TerminalHost` mounting.

**Ctrl+C now reaches anything that is not the prompt**, rather than only a tracked command — so it works inside vim, and in a shell with no integration at all, where there is no prompt marker to bring focus back and no other way out.

## Behaviour

| | composer |
| --- | --- |
| at the prompt | visible |
| quick command (`ls`) | stays — 120ms settle, no flicker |
| running command (`npm init`) | leaves; keyboard goes to the terminal |
| full-screen app (`vim`) | leaves at once |
| shell with no integration | stays — no signal to trust |

Arriving at a card where a command is *already* running hides the bar immediately rather than flashing it; the delay applies to transitions only.

## Verification

Typecheck clean · 3,521 tests pass · lint at baseline (0 added warnings; pre-commit runs `eslint --max-warnings 0` on the diff) · Prettier clean · patch coverage 82.9% against the 80% gate.

Tried by hand in the app: `npm init` answered without touching the mouse, `vim` taking and returning the pane, `ls` leaving the caret alone, and a long-running process still interruptible from the composer.