### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The first stable release of the 0.6 line, closing a beta that ran from beta.1 through beta.6. Version bump only — 0.6.0-beta.6 → 0.6.0 across the root and six workspace packages.

## What ships

A session is no longer only its terminals. It can hold a browser pane, a Files pane, an individual file, and an embedded iOS simulator — each a thing of its own, and the browser and the simulator drivable by the agent working in that session. Workflows gained per-node error policy and a way to stop a run, and a connector now reports its own readiness rather than assuming `gh` is installed.

The terminal hands the keyboard to the command that asked for it, so a prompt from `npm init` or vim can actually be answered. Updates moved into Settings and the app restarts when it says it will. Across every surface the palette is one palette, and a card is one shell.

## Blast radius

Tagging `v0.6.0` after merge is a one-way door:

- `@vornrun/mcp` and `@vornrun/connector-sdk` publish to npm under the `latest` dist-tag, moving it from 0.5.7 → 0.6.0. `npx @vornrun/mcp` starts serving the browser and device tools without an explicit `@beta`.
- `latest-mac.yml` / `latest.yml` / `latest-linux.yml` upload to the release, so every stable-channel user auto-updates off 0.5.7.

Not included: #464 (Phase 0 identity groundwork), still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)