### PR TITLE
chore(release): 0.6.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — 0.6.0 → 0.6.1-beta.1 across the root and six workspace packages.

## Why this should not wait

**Vorn had no authentication.** Any process on the machine could drive the server, and because browsers apply neither CORS nor same-origin policy to a WebSocket upgrade, so could any website you happened to visit. An unauthenticated socket reaches `terminal:create` and `script:execute`.

Everyone on 0.6.0 — currently npm `latest` and the stable auto-update target — is running without that fix.

## What ships

- **#464** — identity and device tokens, authentication at the socket boundary, a protocol version and capability handshake, a `vorn-server` CLI, a device list in Settings, host mode, and MCP routed over the socket. Reachability is a deliberate setting rather than a side effect of Tailscale running; the origin rule is same-origin plus a requirement that the origin be unrebindable.
- **#467** — the browser pane's answers are honest: a ref click scrolls its target into view (so `ok` means the element was hit, not that the call was accepted), the tab strip names the page the guest is actually on, tabs can be listed rather than guessed at by index, back/forward are reachable, and a pane can open files inside its own session's worktree — bounded by a request filter on the session partition rather than by a check on the one url an agent happened to ask for.

## Blast radius

Beta only. The tag publishes `@vornrun/mcp` and `@vornrun/connector-sdk` under the **`beta`** dist-tag and uploads `beta-mac.yml` / `beta.yml` / `beta-linux.yml`, so:

- `npx @vornrun/mcp` (which resolves `latest`) stays on 0.6.0
- Stable-channel users are not auto-updated
- Only the beta channel picks this up

Promoting to stable is a separate `v0.6.1` tag once it has been tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)