### PR TITLE
Let a client say which pushes it wants

### DIFF
--- a/packages/server/src/broadcast.ts
+++ b/packages/server/src/broadcast.ts
@@ -2,11 +2,84 @@ import type { WebSocket } from 'ws'
 import { createNotification } from '@vornrun/shared/protocol'
 import log from './logger'
 
-export class ClientRegistry {
-  private clients = new Set<WebSocket>()
+/**
+ * Which pushes a socket wants.
+ *
+ * Every client used to get every notification, because the registry was a bare
+ * set of sockets with nothing attached to them. That is right for a desktop, which
+ * renders all of it, and wrong for a phone: `terminal:data` alone is every byte of
+ * every PTY on the machine, and a phone renders none of it.
+ *
+ * Absent means everything, so nothing that exists today has to opt in and no
+ * behaviour changes for a client that never asks.
+ *
+ * An entry is either an exact notification name (`config:changed`) or a namespace
+ * wildcard (`session:*`). The wildcard is what keeps a shipped client correct:
+ * a phone that asked for `session:*` also receives whatever is added to that
+ * namespace after it was built.
+ */
+export type TopicFilter = readonly string[] | undefined
 
-  add(ws: WebSocket): void {
-    this.clients.add(ws)
+class Subscription {
+  private readonly exact = new Set<string>()
+  private readonly prefixes: string[] = []
+
+  constructor(topics: readonly string[]) {
+    for (const topic of topics) {
+      if (topic.endsWith('*')) this.prefixes.push(topic.slice(0, -1))
+      else this.exact.add(topic)
+    }
+  }
+
+  wants(method: string): boolean {
+    if (this.exact.has(method)) return true
+    for (const prefix of this.prefixes) if (method.startsWith(prefix)) return true
+    return false
+  }
+}
+
+/**
+ * A filter, or `null` for "send everything".
+ *
+ * Malformed input reads as no filter rather than an empty one. Failing open costs
+ * bandwidth; failing closed would silence a client completely, which looks like a
+ * broken app rather than a bad parameter and is far harder to diagnose from the
+ * other end of a phone.
+ */
+function subscriptionFrom(topics: TopicFilter): Subscription | null {
+  if (topics === undefined) return null
+  if (!Array.isArray(topics) || topics.some((t) => typeof t !== 'string')) {
+    log.warn('[ws] ignoring a malformed topic list; this client will receive everything')
+    return null
+  }
+  if (topics.length === 0) return null
+  return new Subscription(topics)
+}
+
+/**
+ * The filter a client declares on the socket URL, as
+ * `?topics=session:*,config:changed`.
+ *
+ * On the upgrade rather than in a frame because a filter that arrives later is a
+ * filter that arrives too late: the socket is already in the broadcast set, and
+ * on a busy machine that gap is enough PTY output to matter on a phone. It
+ * happens on every reconnect, which on a mobile network is often.
+ */
+export function parseTopics(query: unknown): readonly string[] | undefined {
+  const raw = (query as { topics?: unknown } | undefined)?.topics
+  if (typeof raw !== 'string') return undefined
+  const topics = raw
+    .split(',')
+    .map((topic) => topic.trim())
+    .filter(Boolean)
+  return topics.length > 0 ? topics : undefined
+}
+
+export class ClientRegistry {
+  private clients = new Map<WebSocket, Subscription | null>()
+
+  add(ws: WebSocket, topics?: TopicFilter): void {
+    this.clients.set(ws, subscriptionFrom(topics))
     log.info(`[ws] client connected (total: ${this.clients.size})`)
   }
 
@@ -15,12 +88,27 @@ export class ClientRegistry {
     log.info(`[ws] client disconnected (total: ${this.clients.size})`)
   }
 
+  /**
+   * Narrow or widen what an already-connected socket receives.
+   *
+   * Ignored for a socket that was never admitted, so this cannot be used to add
+   * an unauthenticated connection to the broadcast set.
+   */
+  setTopics(ws: WebSocket, topics: TopicFilter): void {
+    if (!this.clients.has(ws)) return
+    this.clients.set(ws, subscriptionFrom(topics))
+  }
+
   broadcast(method: string, params: unknown): void {
-    const msg = JSON.stringify(createNotification(method, params))
-    for (const ws of this.clients) {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(msg)
-      }
+    // Serialised on the first socket that actually wants it. With only a
+    // filtered client attached, an unwanted notification now costs a map walk
+    // instead of a full JSON encode of the payload.
+    let msg: string | undefined
+    for (const [ws, subscription] of this.clients) {
+      if (ws.readyState !== ws.OPEN) continue
+      if (subscription && !subscription.wants(method)) continue
+      msg ??= JSON.stringify(createNotification(method, params))
+      ws.send(msg)
     }
   }
 

--- a/packages/server/src/broadcast.ts
+++ b/packages/server/src/broadcast.ts
@@ -52,6 +52,9 @@ function subscriptionFrom(topics: TopicFilter): Subscription | null {
     log.warn('[ws] ignoring a malformed topic list; this client will receive everything')
     return null
   }
+  // An empty list widens to everything rather than narrowing to nothing, for
+  // the same reason malformed input does. There is deliberately no way to
+  // subscribe to nothing: a client that wants nothing can close the socket.
   if (topics.length === 0) return null
   return new Subscription(topics)
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(pro
 import websocket from '@fastify/websocket'
 import fastifyStatic from '@fastify/static'
 import { handleConnection, registerMethod } from './ws-handler'
+import { parseTopics } from './broadcast'
 import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
@@ -111,7 +112,7 @@ export async function startServer(
       }
     },
     (socket, req) => {
-      handleConnection(socket, bearerFrom(req.headers.authorization))
+      handleConnection(socket, bearerFrom(req.headers.authorization), parseTopics(req.query))
       scheduler.deliverPendingConnectorInbox()
     }
   )

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -54,6 +54,11 @@ const handlers = new Map<string, Handler>()
 
 registerCapability('auth', 1)
 
+// Declared so a client knows the server will honour a topic list before it sends
+// one. Without the check, an older server silently drops `subscribe:set` and the
+// client believes it is filtered while receiving everything.
+registerCapability('subscribe', 1)
+
 /**
  * Register a method handler. Called during server startup to wire up
  * manager methods to the WS protocol.
@@ -156,7 +161,11 @@ export function resetTokenTracking(): void {
   pendingSockets = 0
 }
 
-export function handleConnection(ws: WebSocket, credential?: string): void {
+export function handleConnection(
+  ws: WebSocket,
+  credential?: string,
+  initialTopics?: readonly string[]
+): void {
   // Announce the contract first, so a client that has to authenticate by message
   // knows that it must before it is refused for not having.
   ws.send(helloFrame())
@@ -177,7 +186,11 @@ export function handleConnection(ws: WebSocket, credential?: string): void {
   /** Admit the socket: only from here does it receive broadcasts. */
   const admit = (result: Authenticated): void => {
     session = result
-    clientRegistry.add(ws)
+    // Topics from the upgrade rather than a later frame, so a filtered client is
+    // never briefly unfiltered. `subscribe:set` can only run after admission, and
+    // in that gap a busy machine can push a lot of PTY output at a phone that
+    // asked for none — on every reconnect, which on a mobile network is often.
+    clientRegistry.add(ws, initialTopics)
     if (result.tokenId) trackToken(result.tokenId, ws)
     if (authTimer) {
       clearTimeout(authTimer)
@@ -299,6 +312,18 @@ export function handleConnection(ws: WebSocket, credential?: string): void {
       }
       if (id !== undefined && id !== null) {
         ws.send(JSON.stringify(createResponse(id, { ok: claimed })))
+      }
+      return
+    }
+
+    // Changing what this socket receives. Handled here rather than through
+    // `registerNotification` because it is the socket that is being configured,
+    // and a registered handler is given only its params.
+    if (method === 'subscribe:set') {
+      const topics = (params as { topics?: readonly string[] } | undefined)?.topics
+      clientRegistry.setTopics(ws, topics)
+      if (id !== undefined && id !== null) {
+        ws.send(JSON.stringify(createResponse(id, { ok: true })))
       }
       return
     }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -761,6 +761,18 @@ export interface ServerNotifications {
 export interface ClientNotifications {
   'terminal:write': { id: string; data: string }
   'terminal:resize': ResizePayload
+  /**
+   * Narrow which server notifications this socket receives.
+   *
+   * An entry is an exact name (`config:changed`) or a namespace wildcard
+   * (`session:*`). Omitting `topics` restores everything, which is also the
+   * default, so a client that never sends this is unaffected.
+   *
+   * Only honoured when `server:hello` advertised the `subscribe` capability.
+   * Prefer the `topics` query parameter on the socket URL for the initial set:
+   * this message can only take effect after the socket is already receiving.
+   */
+  'subscribe:set': { topics?: readonly string[] }
 }
 
 // ─── Typed helpers ──────────────────────────────────────────────

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -766,7 +766,10 @@ export interface ClientNotifications {
    *
    * An entry is an exact name (`config:changed`) or a namespace wildcard
    * (`session:*`). Omitting `topics` restores everything, which is also the
-   * default, so a client that never sends this is unaffected.
+   * default, so a client that never sends this is unaffected. An empty list
+   * does the same rather than silencing the socket: there is no way to ask for
+   * nothing, because a client that wants nothing can close, whereas one that
+   * sent `[]` by accident would look broken with no signal saying why.
    *
    * Only honoured when `server:hello` advertised the `subscribe` capability.
    * Prefer the `topics` query parameter on the socket URL for the initial set:

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -4,7 +4,7 @@ vi.mock('../packages/server/src/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }))
 
-import { ClientRegistry } from '../packages/server/src/broadcast'
+import { ClientRegistry, parseTopics } from '../packages/server/src/broadcast'
 
 function mockWs(open = true) {
   const ws = {
@@ -58,5 +58,152 @@ describe('ClientRegistry', () => {
   it('broadcast on empty registry does nothing', () => {
     const reg = new ClientRegistry()
     expect(() => reg.broadcast('test:event', {})).not.toThrow()
+  })
+})
+
+/**
+ * Every client used to receive every notification. That is right for a desktop and
+ * wrong for a phone: `terminal:data` alone is every byte of every PTY on the
+ * machine, over cellular, to a client that renders none of it.
+ */
+describe('what one client wants', () => {
+  const sentMethods = (ws: import('ws').WebSocket): string[] =>
+    (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => JSON.parse(c[0] as string).method
+    )
+
+  it('sends everything to a client that asked for nothing', () => {
+    // The default, and what every client shipped before this existed relies on.
+    const reg = new ClientRegistry()
+    const ws = mockWs()
+    reg.add(ws)
+
+    reg.broadcast('terminal:data', { id: 'a', data: 'x' })
+    reg.broadcast('config:changed', {})
+
+    expect(sentMethods(ws)).toEqual(['terminal:data', 'config:changed'])
+  })
+
+  it('withholds a notification outside the list', () => {
+    const reg = new ClientRegistry()
+    const phone = mockWs()
+    reg.add(phone, ['session:*', 'config:changed'])
+
+    reg.broadcast('session:updated', {})
+    reg.broadcast('terminal:data', { id: 'a', data: 'x' })
+    reg.broadcast('config:changed', {})
+
+    expect(sentMethods(phone)).toEqual(['session:updated', 'config:changed'])
+  })
+
+  it('lets a wildcard cover a notification added later', () => {
+    // The point of a namespace over a list of names: a client already on a phone
+    // keeps working when the namespace grows.
+    const reg = new ClientRegistry()
+    const ws = mockWs()
+    reg.add(ws, ['session:*'])
+
+    reg.broadcast('session:somethingAddedNextYear', {})
+
+    expect(sentMethods(ws)).toEqual(['session:somethingAddedNextYear'])
+  })
+
+  it('does not let an exact name match by prefix', () => {
+    const reg = new ClientRegistry()
+    const ws = mockWs()
+    reg.add(ws, ['session:updated'])
+
+    reg.broadcast('session:updatedSomethingElse', {})
+
+    expect(sentMethods(ws)).toEqual([])
+  })
+
+  it('filters each client independently', () => {
+    const reg = new ClientRegistry()
+    const desktop = mockWs()
+    const phone = mockWs()
+    reg.add(desktop)
+    reg.add(phone, ['session:*'])
+
+    reg.broadcast('terminal:data', { id: 'a', data: 'x' })
+
+    expect(sentMethods(desktop)).toEqual(['terminal:data'])
+    expect(sentMethods(phone)).toEqual([])
+  })
+
+  it('serialises nothing when no one wants it', () => {
+    // Not a micro-optimisation: with only a phone attached, this is the whole PTY
+    // firehose that no longer gets JSON-encoded.
+    const reg = new ClientRegistry()
+    reg.add(mockWs(), ['session:*'])
+    const payload = { id: 'a' }
+    const toJSON = vi.fn(() => ({}))
+
+    reg.broadcast('terminal:data', Object.assign(payload, { toJSON }))
+
+    expect(toJSON).not.toHaveBeenCalled()
+  })
+
+  it('widens back to everything when the list is cleared', () => {
+    const reg = new ClientRegistry()
+    const ws = mockWs()
+    reg.add(ws, ['session:*'])
+
+    reg.setTopics(ws, undefined)
+    reg.broadcast('terminal:data', {})
+
+    expect(sentMethods(ws)).toEqual(['terminal:data'])
+  })
+
+  it('ignores a topic list for a socket that was never admitted', () => {
+    // Or `setTopics` would be a way for an unauthenticated socket to add itself.
+    const reg = new ClientRegistry()
+    const stranger = mockWs()
+
+    reg.setTopics(stranger, ['session:*'])
+    reg.broadcast('session:updated', {})
+
+    expect(stranger.send).not.toHaveBeenCalled()
+    expect(reg.size).toBe(0)
+  })
+
+  it('falls back to everything on a malformed list', () => {
+    // Failing open costs bandwidth. Failing closed silences the client, which
+    // reads as a broken app rather than a bad parameter.
+    const reg = new ClientRegistry()
+    const ws = mockWs()
+    reg.add(ws, [42 as unknown as string])
+
+    reg.broadcast('terminal:data', {})
+
+    expect(sentMethods(ws)).toEqual(['terminal:data'])
+  })
+})
+
+describe('the topic list on the socket URL', () => {
+  it('splits a comma-separated list', () => {
+    expect(parseTopics({ topics: 'session:*,config:changed' })).toEqual([
+      'session:*',
+      'config:changed'
+    ])
+  })
+
+  it('tolerates spacing around the commas', () => {
+    expect(parseTopics({ topics: ' session:* , config:changed ' })).toEqual([
+      'session:*',
+      'config:changed'
+    ])
+  })
+
+  it.each([
+    ['no query at all', undefined],
+    ['no topics parameter', {}],
+    ['an empty value', { topics: '' }],
+    ['only separators', { topics: ',,' }],
+    ['a repeated parameter, which Fastify gives as an array', { topics: ['a', 'b'] }]
+  ])('reads %s as no filter', (_label, query) => {
+    // Undefined means everything, so an unparseable list leaves the client exactly
+    // as it was before this feature existed rather than silencing it.
+    expect(parseTopics(query)).toBeUndefined()
   })
 })

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -179,7 +179,7 @@ describe('server integration', () => {
       })
 
       expect(JSON.parse(first).method).toBe('server:hello')
-      expect(JSON.parse(first).params.capabilities).toEqual({ auth: 1 })
+      expect(JSON.parse(first).params.capabilities).toEqual({ auth: 1, subscribe: 1 })
       ws.close()
     })
 
@@ -233,6 +233,43 @@ describe('server integration', () => {
       })
       expect(ws.readyState).toBe(WebSocket.OPEN)
       ws.close()
+    })
+  })
+
+  /**
+   * A phone connects over cellular and renders no terminals, but the registry
+   * used to hand every socket every notification — including every byte of every
+   * PTY on the machine.
+   */
+  describe('a socket that asked for less', () => {
+    /** Collect notifications until the server has plainly finished sending. */
+    async function notificationsFor(query: string): Promise<string[]> {
+      const ws = new WebSocket(`ws://127.0.0.1:${serverPort}/ws${query}`, authOptions())
+      const methods: string[] = []
+      ws.on('message', (raw) => {
+        const frame = JSON.parse(raw.toString())
+        if (frame.method && frame.method !== 'server:hello') methods.push(frame.method)
+      })
+      await new Promise<void>((r) => ws.on('open', r))
+
+      const { clientRegistry } = await import('../packages/server/src/broadcast')
+      clientRegistry.broadcast('terminal:data', { id: 'a', data: 'x' })
+      clientRegistry.broadcast('session:updated', { id: 'a' })
+
+      await new Promise((r) => setTimeout(r, 100))
+      ws.close()
+      return methods
+    }
+
+    it('still receives everything when it asks for nothing', async () => {
+      expect(await notificationsFor('')).toEqual(['terminal:data', 'session:updated'])
+    })
+
+    it('receives only what the URL asked for', async () => {
+      // On the URL rather than in a later frame: by the time a frame could arrive
+      // the socket is already in the broadcast set, and that gap repeats on every
+      // reconnect.
+      expect(await notificationsFor('?topics=session:*')).toEqual(['session:updated'])
     })
   })
 

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -242,13 +242,30 @@ describe('server integration', () => {
    * PTY on the machine.
    */
   describe('a socket that asked for less', () => {
-    /** Collect notifications until the server has plainly finished sending. */
+    /**
+     * Collect notifications until the server has plainly finished sending.
+     *
+     * Idle-based rather than a fixed sleep: the assertion is partly that certain
+     * frames never arrive, and a fixed wait either ends before a slow one lands —
+     * passing for the wrong reason on a loaded machine — or pads every run to be
+     * sure. Each frame restarts the clock, so this settles as fast as the server
+     * allows and still waits when the server is slow.
+     */
     async function notificationsFor(query: string): Promise<string[]> {
       const ws = new WebSocket(`ws://127.0.0.1:${serverPort}/ws${query}`, authOptions())
       const methods: string[] = []
-      ws.on('message', (raw) => {
-        const frame = JSON.parse(raw.toString())
-        if (frame.method && frame.method !== 'server:hello') methods.push(frame.method)
+      let idle: ReturnType<typeof setTimeout>
+      const settled = new Promise<void>((resolve) => {
+        const restart = (): void => {
+          clearTimeout(idle)
+          idle = setTimeout(resolve, 60)
+        }
+        ws.on('message', (raw) => {
+          const frame = JSON.parse(raw.toString())
+          if (frame.method && frame.method !== 'server:hello') methods.push(frame.method)
+          restart()
+        })
+        restart()
       })
       await new Promise<void>((r) => ws.on('open', r))
 
@@ -256,7 +273,8 @@ describe('server integration', () => {
       clientRegistry.broadcast('terminal:data', { id: 'a', data: 'x' })
       clientRegistry.broadcast('session:updated', { id: 'a' })
 
-      await new Promise((r) => setTimeout(r, 100))
+      await settled
+      clearTimeout(idle)
       ws.close()
       return methods
     }

--- a/tests/ws-handler.test.ts
+++ b/tests/ws-handler.test.ts
@@ -10,7 +10,7 @@ const CLOSE_UNAUTHENTICATED = 4001
 const CLOSE_CREDENTIAL_REJECTED = 4002
 
 vi.mock('../packages/server/src/broadcast', () => ({
-  clientRegistry: { add: vi.fn(), remove: vi.fn() }
+  clientRegistry: { add: vi.fn(), remove: vi.fn(), setTopics: vi.fn() }
 }))
 vi.mock('../packages/server/src/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -89,7 +89,7 @@ describe('handleConnection', () => {
   it('adds client to registry on connect', () => {
     const ws = createMockWs()
     connectAuthed(ws)
-    expect(clientRegistry.add).toHaveBeenCalledWith(ws)
+    expect(clientRegistry.add).toHaveBeenCalledWith(ws, undefined)
   })
 
   it('removes client on close', () => {
@@ -179,7 +179,7 @@ describe('handshake', () => {
 
     // Declared by the code that enforces it, so the advertisement cannot drift
     // from the behaviour. Pass A shipped this empty because nothing was true yet.
-    expect(sentFrames(ws)[0].params?.capabilities).toEqual({ auth: 1 })
+    expect(sentFrames(ws)[0].params?.capabilities).toEqual({ auth: 1, subscribe: 1 })
   })
 
   it('greets every connection, not just the first', () => {
@@ -305,7 +305,7 @@ describe('authentication', () => {
     handleConnection(ws)
     sendMessage(ws, { jsonrpc: '2.0', method: 'auth:authenticate', params: { token: GOOD_TOKEN } })
 
-    await vi.waitFor(() => expect(clientRegistry.add).toHaveBeenCalledWith(ws))
+    await vi.waitFor(() => expect(clientRegistry.add).toHaveBeenCalledWith(ws, undefined))
     expect(replies(ws).some((f) => f.method === 'auth:ok')).toBe(true)
     expect(ws.close).not.toHaveBeenCalled()
   })
@@ -316,7 +316,7 @@ describe('authentication', () => {
 
     // MCP opens a fresh connection per RPC call, so a mandatory round-trip here
     // would tax every one of them.
-    expect(clientRegistry.add).toHaveBeenCalledWith(ws)
+    expect(clientRegistry.add).toHaveBeenCalledWith(ws, undefined)
     expect(replies(ws)).toHaveLength(0)
   })
 
@@ -586,5 +586,64 @@ describe('sockets that connect and say nothing', () => {
     handleConnection(next)
 
     expect(next.close).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * A phone wants the session and workflow pushes and none of the PTY output. The
+ * socket carries that preference, so it is set here rather than in a handler,
+ * which only ever sees its own params.
+ */
+describe('narrowing what a socket receives', () => {
+  it('takes the initial list from the upgrade', () => {
+    // On the upgrade, not a later frame: `subscribe:set` can only arrive after the
+    // socket is already in the broadcast set, and that gap is enough PTY output to
+    // matter on a phone — on every reconnect.
+    const ws = createMockWs()
+    handleConnection(ws, GOOD_TOKEN, ['session:*'])
+
+    expect(clientRegistry.add).toHaveBeenCalledWith(ws, ['session:*'])
+  })
+
+  it('changes the list on request', () => {
+    const ws = createMockWs()
+    connectAuthed(ws)
+
+    sendMessage(ws, { jsonrpc: '2.0', method: 'subscribe:set', params: { topics: ['session:*'] } })
+
+    expect(clientRegistry.setTopics).toHaveBeenCalledWith(ws, ['session:*'])
+  })
+
+  it('acknowledges when asked with an id', async () => {
+    const ws = createMockWs()
+    connectAuthed(ws)
+
+    sendMessage(ws, { jsonrpc: '2.0', id: 7, method: 'subscribe:set', params: { topics: [] } })
+
+    await vi.waitFor(() => expect(replies(ws).length).toBeGreaterThan(0))
+    expect(replies(ws)[0]).toMatchObject({ id: 7, result: { ok: true } })
+  })
+
+  it('does not answer -32601 for a subscribe it handled', async () => {
+    // It is dispatched before the handler map, so it must not fall through to the
+    // unknown-method branch.
+    const ws = createMockWs()
+    connectAuthed(ws)
+
+    sendMessage(ws, { jsonrpc: '2.0', id: 8, method: 'subscribe:set', params: { topics: ['a'] } })
+
+    await vi.waitFor(() => expect(replies(ws).length).toBeGreaterThan(0))
+    expect(replies(ws)[0].error).toBeUndefined()
+  })
+
+  it('refuses one from a socket that has not authenticated', () => {
+    // Everything past the credential check requires a session; a filter is not an
+    // exception just because it only narrows.
+    const ws = createMockWs()
+    handleConnection(ws)
+
+    sendMessage(ws, { jsonrpc: '2.0', method: 'subscribe:set', params: { topics: ['session:*'] } })
+
+    expect(clientRegistry.setTopics).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Why

Every authenticated socket received every notification. `ClientRegistry` held a bare `Set<WebSocket>` with no identity attached, no topics and no filter, so `broadcast` fanned everything to everyone.

That is right for a desktop, which renders all of it. It is wrong for a phone: `terminal:data` alone is every byte of every PTY on the machine, sent over cellular to a client that renders none of it.

This is the first piece of Phase 1 groundwork, and the one everything else waits on.

## What changed

A socket may declare which notifications it wants. An entry is either an exact name (`config:changed`) or a namespace wildcard (`session:*`) — the wildcard is what keeps a shipped phone client correct when a namespace grows.

**Absent means everything.** No existing client opts in, and none change behaviour.

Two ways to set it:

- `?topics=session:*,config:changed` on the socket URL, which is the one that matters. A filter that arrives in a frame arrives too late: the socket is already in the broadcast set by then, and on a busy machine that gap is enough output to matter. It repeats on every reconnect, which on a mobile network is often.
- `subscribe:set` afterwards, for changing it while connected.

Advertised as `subscribe: 1` in `server:hello`, so a client knows the server will honour a list before sending one. Without that check an older server drops the message silently and the client believes it is filtered while receiving everything.

Two smaller things fall out:

- `broadcast` now serialises on the first socket that actually wants the message. With only a filtered client attached, an unwanted notification costs a map walk instead of a full JSON encode of the payload.
- Malformed input reads as no filter rather than an empty one. Failing open costs bandwidth; failing closed silences the client, which looks like a broken app rather than a bad parameter and is far harder to diagnose from the other end of a phone.

## Tests

21 in `broadcast.test.ts`, 5 in `ws-handler.test.ts`, 2 end-to-end in `server-integration.test.ts` over a real socket against the real route.

Each was checked against a mutant rather than only against green:

| mutation | caught by |
|---|---|
| filter check removed from `broadcast` | 4 unit + 1 integration |
| `setTopics` call dropped | `changes the list on request` |
| `subscribe:set` hoisted above the auth gate | `refuses one from a socket that has not authenticated` |

## Notes

- `tests/pty-session-id.test.ts` fails on this branch and on `main`. It is caused by an uncommitted local `node-pty` alias in `vitest.config.ts`, not by this change.
- Repo-wide `yarn lint` cannot parse anything right now: two stale worktrees under `.claude/worktrees/` make `tsconfigRootDir` ambiguous. The changed files lint and format clean when pointed at an absolute root, and lint-staged passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)