### PR TITLE
Read a carriage return the way a terminal does

### DIFF
--- a/packages/server/src/ansi-strip.ts
+++ b/packages/server/src/ansi-strip.ts
@@ -40,20 +40,32 @@ const ESCAPES = new RegExp(
 )
 
 /**
- * Apply a carriage return the way a terminal does: by moving to the start of the
- * line, so what follows overwrites what came before.
+ * Apply a carriage return the way a terminal does: by moving the cursor to
+ * column 0, so what follows overwrites character by character.
  *
  * Deleting the `\r` instead — which is what this used to do — concatenates the
  * two, so an agent redrawing a spinner in place turned one line reading
  * `Working` into `WoWorkWorking`, and a progress bar became every frame it had
  * ever drawn, joined end to end.
  *
- * Only the text after the last `\r` survives, which is what the reader would
- * have seen on a real terminal.
+ * Overwriting rather than truncating, because a `\r` clears nothing: it only
+ * moves the cursor. A shorter repaint leaves the tail of the longer line behind,
+ * which is why `abc\rXX` reads `XXc` on a terminal and why a line ending in a
+ * bare `\r` still shows its text. Truncating loses output that was on screen.
  */
 function applyCarriageReturns(line: string): string {
-  const last = line.lastIndexOf('\r')
-  return last === -1 ? line : line.slice(last + 1)
+  if (!line.includes('\r')) return line
+  let out = ''
+  let col = 0
+  for (const ch of line) {
+    if (ch === '\r') {
+      col = 0
+      continue
+    }
+    out = out.slice(0, col) + ch + out.slice(col + 1)
+    col++
+  }
+  return out
 }
 
 export function stripAnsi(data: string): string {

--- a/packages/server/src/ansi-strip.ts
+++ b/packages/server/src/ansi-strip.ts
@@ -1,7 +1,70 @@
-// Strip ANSI escape sequences so stored output is plain text.
+/**
+ * Turn terminal output into the plain text a reader can act on.
+ *
+ * What comes out of a PTY is not text with some colour in it, it is a stream of
+ * drawing instructions. Storing it as-is gives a line buffer full of control
+ * sequences, and every consumer of that buffer — the status parser, agent
+ * history, and any client asking for a session's tail — reads noise.
+ */
+
+/**
+ * A CSI sequence is `ESC [`, then parameter bytes, then intermediate bytes, then
+ * one final byte. The parameter range is `0x30–0x3F`, which is the digits and
+ * `;` *and* `? < = >`.
+ *
+ * The previous pattern accepted only `[0-9;]`, so every private-mode sequence
+ * survived: `ESC[?25l` and `ESC[?25h`, which a TUI emits around each repaint to
+ * hide and show the cursor, appeared in stored output as a literal `[?25l`. The
+ * `ESC` is invisible when rendered, so the damage showed up as bracket noise
+ * scattered through otherwise readable text, which reads as a rendering bug
+ * rather than a stripping one.
+ */
 // eslint-disable-next-line no-control-regex
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)|\x1b[()][0-2B]|\x1b[=>]/g
+const CSI = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g
+
+/** OSC: `ESC ]` … terminated by BEL or ST. Window titles, hyperlinks. */
+// eslint-disable-next-line no-control-regex
+const OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g
+
+/** DCS, SOS, PM, APC: `ESC P/X/^/_` … ST. Rare, but unbounded if left in. */
+// eslint-disable-next-line no-control-regex
+const STRING_ESCAPES = /\x1b[P\x58\x5e\x5f][\s\S]*?(?:\x1b\\|\x07)/g
+
+/** Charset selection and the two-character escapes that carry no payload. */
+// eslint-disable-next-line no-control-regex
+const SHORT_ESCAPES = /\x1b[()][\x20-\x2f]*[\x30-\x7e]|\x1b[=><78Mc]/g
+
+const ESCAPES = new RegExp(
+  [CSI.source, OSC.source, STRING_ESCAPES.source, SHORT_ESCAPES.source].join('|'),
+  'g'
+)
+
+/**
+ * Apply a carriage return the way a terminal does: by moving to the start of the
+ * line, so what follows overwrites what came before.
+ *
+ * Deleting the `\r` instead — which is what this used to do — concatenates the
+ * two, so an agent redrawing a spinner in place turned one line reading
+ * `Working` into `WoWorkWorking`, and a progress bar became every frame it had
+ * ever drawn, joined end to end.
+ *
+ * Only the text after the last `\r` survives, which is what the reader would
+ * have seen on a real terminal.
+ */
+function applyCarriageReturns(line: string): string {
+  const last = line.lastIndexOf('\r')
+  return last === -1 ? line : line.slice(last + 1)
+}
 
 export function stripAnsi(data: string): string {
-  return data.replace(ANSI_RE, '').replace(/\r/g, '')
+  return (
+    data
+      .replace(ESCAPES, '')
+      // Before the rule below, or a CRLF line ending would be read as an
+      // overwrite and delete the line it terminates.
+      .replace(/\r\n/g, '\n')
+      .split('\n')
+      .map(applyCarriageReturns)
+      .join('\n')
+  )
 }

--- a/tests/ansi-strip.test.ts
+++ b/tests/ansi-strip.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { stripAnsi } from '../packages/server/src/ansi-strip'
+
+const ESC = '\x1b'
+
+/**
+ * A PTY emits drawing instructions, not text. Everything that reads the stored
+ * line buffer — the status parser, agent history, a client asking for a session's
+ * tail — reads whatever survives this function.
+ */
+describe('stripping escape sequences', () => {
+  it('removes colour', () => {
+    expect(stripAnsi(`${ESC}[31mred${ESC}[0m`)).toBe('red')
+  })
+
+  it('removes the cursor hide and show a TUI wraps every repaint in', () => {
+    // The pattern used to accept only digits and semicolons as parameters, so
+    // `?25l` never matched and a literal `[?25l` was stored. The ESC renders as
+    // nothing, so it surfaced as bracket noise through otherwise fine text.
+    expect(stripAnsi(`${ESC}[?25lWorking${ESC}[?25h`)).toBe('Working')
+  })
+
+  it.each([
+    ['bracketed paste on', `${ESC}[?2004h`],
+    ['bracketed paste off', `${ESC}[?2004l`],
+    ['alternate screen', `${ESC}[?1049h`],
+    ['mouse tracking', `${ESC}[?1000h`],
+    ['cursor position report', `${ESC}[6n`],
+    ['erase to end of line', `${ESC}[K`],
+    ['move cursor', `${ESC}[12;40H`],
+    ['scroll region', `${ESC}[1;24r`],
+    ['256 colour', `${ESC}[38;5;213m`],
+    ['soft reset', `${ESC}[!p`]
+  ])('removes %s', (_label, sequence) => {
+    expect(stripAnsi(`a${sequence}b`)).toBe('ab')
+  })
+
+  it('removes a window title, which carries text that would otherwise be kept', () => {
+    expect(stripAnsi(`${ESC}]0;some title\x07done`)).toBe('done')
+  })
+
+  it('removes a hyperlink wrapper but keeps the label', () => {
+    expect(stripAnsi(`${ESC}]8;;https://example.com\x07label${ESC}]8;;\x07`)).toBe('label')
+  })
+
+  it('removes charset selection and single-character escapes', () => {
+    expect(stripAnsi(`${ESC}(Bplain${ESC}=x${ESC}>y`)).toBe('plainxy')
+  })
+
+  it('leaves ordinary text alone, brackets included', () => {
+    expect(stripAnsi('a [not] an escape [?25l-ish')).toBe('a [not] an escape [?25l-ish')
+  })
+})
+
+/**
+ * The half that made stored output unreadable even where escapes were handled.
+ */
+describe('carriage returns', () => {
+  it('lets a redraw overwrite rather than concatenate', () => {
+    // Deleting the \r instead turned a spinner redrawing one line into
+    // `WoWorkWorking`, which is what a session tail actually looked like.
+    expect(stripAnsi('Wo\rWork\rWorking')).toBe('Working')
+  })
+
+  it('keeps a CRLF line ending intact', () => {
+    // Read as an overwrite, `abc\r\n` would delete the line it terminates.
+    expect(stripAnsi('abc\r\ndef\r\n')).toBe('abc\ndef\n')
+  })
+
+  it('applies the rule per line, not across the chunk', () => {
+    expect(stripAnsi('aa\rbb\ncc\rdd')).toBe('bb\ndd')
+  })
+
+  it('keeps a line with no carriage return in it', () => {
+    expect(stripAnsi('plain line')).toBe('plain line')
+  })
+
+  it('handles a progress bar redrawn many times', () => {
+    const frames = ['10%', '40%', '80%', '100%'].join('\r')
+    expect(stripAnsi(frames)).toBe('100%')
+  })
+
+  it('drops a line that was erased and not redrawn', () => {
+    // What the reader would see on a real terminal: nothing.
+    expect(stripAnsi('transient\r')).toBe('')
+  })
+})
+
+describe('the two together', () => {
+  it('reduces a real repaint to what a person would have read', () => {
+    const raw =
+      `${ESC}[?25l${ESC}[2K\rWo${ESC}[?25h` +
+      `${ESC}[?25l${ESC}[2K\rWork${ESC}[?25h` +
+      `${ESC}[?25l${ESC}[2K\rWorking${ESC}[?25h`
+    expect(stripAnsi(raw)).toBe('Working')
+  })
+})

--- a/tests/ansi-strip.test.ts
+++ b/tests/ansi-strip.test.ts
@@ -80,9 +80,17 @@ describe('carriage returns', () => {
     expect(stripAnsi(frames)).toBe('100%')
   })
 
-  it('drops a line that was erased and not redrawn', () => {
-    // What the reader would see on a real terminal: nothing.
-    expect(stripAnsi('transient\r')).toBe('')
+  it('keeps a line that a bare carriage return did not overwrite', () => {
+    // A `\r` moves the cursor; it erases nothing. The text is still on screen,
+    // and dropping it would lose output the reader saw.
+    expect(stripAnsi('transient\r')).toBe('transient')
+  })
+
+  it('leaves behind the tail of a longer line a shorter repaint did not cover', () => {
+    // The case that separates overwriting from truncating: a terminal shows
+    // `XXc`, because nothing cleared the `c`.
+    expect(stripAnsi('abc\rXX')).toBe('XXc')
+    expect(stripAnsi('abcdef\rXY')).toBe('XYcdef')
   })
 })
 


### PR DESCRIPTION
## Why

Two defects in `stripAnsi`, both visible as garbage in stored session output. Found while attaching a client to a live session, where the result is unreadable rather than merely untidy.

**Private-mode sequences survived.** A CSI sequence takes parameter bytes in `0x30–0x3f` — the digits and `;`, and also `? < = >`. The pattern accepted only `[0-9;]`, so `ESC[?25l` and `ESC[?25h`, which a TUI emits around every repaint to hide and show the cursor, were stored as a literal `[?25l`. The escape byte renders as nothing, so this surfaced as bracket noise scattered through otherwise fine text and reads as a rendering fault rather than a stripping one.

**`\r` was deleted rather than applied.** On a terminal it means return to the start of the line, so what follows overwrites what came before. Deleting it concatenates instead: an agent redrawing a spinner in place turned one line reading `Working` into `WoWorkWorking`, and a progress bar became every frame it had ever drawn, joined end to end.

## What changed

Full CSI, OSC, DCS and short-escape coverage, and `\r` applied as an overwrite. CRLF is normalised first, or a line ending would be read as an instruction to erase the line it terminates.

## Why it matters beyond display

This buffer is not only read by clients. `status-parser` matches `WAITING_PATTERNS` against its **last line** to decide whether an agent is waiting on a person — and a line ending in control bytes cannot match a prompt pattern. Stored agent history has the same problem.

## Tests

23 in `tests/ansi-strip.test.ts`. **11 fail against the previous implementation**, covering both defects separately and together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)