### PR TITLE
chore(release): 0.6.1-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — 0.6.1-beta.1 → 0.6.1-beta.2 across the root and six workspace packages.

## What's new since beta.1

**#472 — a design file that repaints itself.** An HTML file in a session's worktree declares what it is in a `<script id="artifact">` block; the browser pane reads that and swaps its address bar for the controls the design declared. Turn a value without spending an agent turn. The pane repaints when the file changes and puts your adjustments back, and `read_page` now tells the agent what is on screen rather than what is written in the file.

No new pane kind and no new MCP tool — the browser pane already had the guest, the CDP driving, element picking and the `file:` scoping from #467.

Also still in this beta from beta.1: **#464**, which is the reason this line matters — Vorn had no authentication before it, and an unauthenticated WebSocket reaches `terminal:create`.

## Blast radius

Beta only. The tag publishes `@vornrun/mcp` and `@vornrun/connector-sdk` under the **`beta`** dist-tag and uploads `beta-*.yml`, so `npx @vornrun/mcp` stays on 0.6.0 and stable-channel users are not auto-updated.

## Trying the new part

Open a session on a repo, put a `.dc.html` in it, and navigate the pane to it with a `file://` url. The gesture that shows the whole loop: set a tweak to a new value, then edit the file from a terminal — the pane repaints *with your value still set*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)