### PR TITLE
Let a design look like one in the tab strip

### DIFF
--- a/src/main/browser-registry.ts
+++ b/src/main/browser-registry.ts
@@ -697,6 +697,12 @@ export async function readManifest(params: { sessionId: string }): Promise<{
     expression: `(() => {
       const el = document.getElementById('artifact')
       const declared = el && el.textContent ? el.textContent : ''
+      // Tell the page a pane is driving it. A design that carries its own
+      // controls for the standalone case needs to stand them down here, or it
+      // sits under an identical row in the pane's header — and it cannot work
+      // this out for itself: this read happens after its script has run, so
+      // there is nothing yet to detect.
+      window.__artifactHost = 'vorn'
       let live = null
       try {
         const t = window.__artifact && window.__artifact.tweaks

--- a/src/renderer/components/BrowserCard.tsx
+++ b/src/renderer/components/BrowserCard.tsx
@@ -1,6 +1,6 @@
 import { memo, forwardRef, useState, useRef, useEffect, useCallback } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { MousePointerClick, Pencil, Plus, SquareArrowOutUpRight, X } from 'lucide-react'
+import { MousePointerClick, Pencil, Plus, Shapes, SquareArrowOutUpRight, X } from 'lucide-react'
 import { useAppStore } from '../stores'
 import { tabUrl } from '../stores/types'
 import { browserPartition } from '../../shared/types'
@@ -581,7 +581,17 @@ export const BrowserCard = memo(
                                   : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.03]'
                               }`}
                 >
-                  <span className="text-[11px] truncate">{displayHost(shown)}</span>
+                  {/* A design is marked, because a tab that is a file in the
+                      repo behaves differently from a web page — it repaints when
+                      the file changes, and its header holds controls rather than
+                      an address. Only the active tab's manifest is known, so the
+                      mark appears where the claim has actually been read. */}
+                  {active && manifest && (
+                    <Shapes size={11} strokeWidth={2} className="shrink-0 text-bronzo" />
+                  )}
+                  <span className="text-[11px] truncate">
+                    {(active && manifest?.title) || displayHost(shown)}
+                  </span>
                   {/* A card already holds exactly one page — popping its tab out
                       again would swap one card for another. */}
                   {!isCard && (
@@ -657,11 +667,9 @@ export const BrowserCard = memo(
         <div className="flex items-center gap-0.5 px-1.5 py-1 shrink-0">
           {manifest ? (
             <>
-              {manifest.title && (
-                <span className="text-[11px] text-ink font-medium px-1 shrink-0 truncate max-w-[38%]">
-                  {manifest.title}
-                </span>
-              )}
+              {/* Controls only. The name lives on the tab, where every other
+                  page's name lives — repeating it here would spend header
+                  width on something already on screen. */}
               <TweakBar manifest={manifest} values={tweakValues} onChange={applyTweak} />
               <span className="flex-1" />
             </>

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -133,7 +133,15 @@ export function displayHost(url: string): string {
     // identifies the file off the end. The filename is what a person calls it.
     if (parsed.protocol === 'file:') {
       const name = parsed.pathname.split('/').filter(Boolean).pop()
-      return name ? decodeURIComponent(name) : url
+      if (!name) return url
+      try {
+        return decodeURIComponent(name)
+      } catch {
+        // A stray `%` is a legal filename character and a malformed escape.
+        // Caught here rather than left to the outer handler, which would fall
+        // back to the whole url — the unreadable label this exists to avoid.
+        return name
+      }
     }
     // Other schemes without a hostname parse cleanly but have nothing to show;
     // an empty header is worse than showing the url itself.

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -128,6 +128,13 @@ export function displayHost(url: string): string {
   if (url === 'about:blank') return 'New tab'
   try {
     const parsed = new URL(url)
+    // A local file has no host, and its path is the whole of it — a tab is a
+    // few characters wide, so the leading directories push the only part that
+    // identifies the file off the end. The filename is what a person calls it.
+    if (parsed.protocol === 'file:') {
+      const name = parsed.pathname.split('/').filter(Boolean).pop()
+      return name ? decodeURIComponent(name) : url
+    }
     // Other schemes without a hostname parse cleanly but have nothing to show;
     // an empty header is worse than showing the url itself.
     if (!parsed.hostname) return url

--- a/tests/artifact-manifest.test.ts
+++ b/tests/artifact-manifest.test.ts
@@ -266,11 +266,27 @@ describe('what the injected snippet does inside the guest', () => {
    * snippet out of the source and executes it against a stand-in guest — the
    * only way to cover the half of this feature that never runs in this process.
    */
+  const START = 'expression: `(() => {'
+  const END = '`,\n    returnByValue'
+
+  /** The cap the snippet is built with, read from source so the test cannot drift. */
+  const maxTweaks = (): number => {
+    const m = readFileSync('src/main/browser-registry.ts', 'utf8').match(/const MAX_TWEAKS = (\d+)/)
+    if (!m) throw new Error('Could not read MAX_TWEAKS from browser-registry.ts')
+    return Number(m[1])
+  }
+
   const snippet = (): string => {
     const src = readFileSync('src/main/browser-registry.ts', 'utf8')
-    const from = src.indexOf('expression: `(() => {')
+    const from = src.indexOf(START)
+    // Guarded rather than sliced blindly: a moved or reworded snippet would
+    // otherwise yield garbage, and `new Function` would fail with a syntax
+    // error pointing at nothing. This says which end went missing.
+    if (from === -1) throw new Error(`Could not find the injected snippet (${START})`)
     const body = src.slice(from + 'expression: `'.length)
-    return body.slice(0, body.indexOf('`,\n    returnByValue')).replace(/\$\{MAX_TWEAKS\}/g, '24')
+    const to = body.indexOf(END)
+    if (to === -1) throw new Error('Found the injected snippet start but not its end')
+    return body.slice(0, to).replace(/\$\{MAX_TWEAKS\}/g, String(maxTweaks()))
   }
 
   const run = (
@@ -334,7 +350,7 @@ describe('what the injected snippet does inside the guest', () => {
     const tweaks = Object.fromEntries(Array.from({ length: 200 }, (_, i) => [`k${i}`, i]))
     const win: Record<string, unknown> = { __artifact: { tweaks } }
     const { live } = run(win, { kind: 'design' })
-    expect(Object.keys(live ?? {})).toHaveLength(24)
+    expect(Object.keys(live ?? {})).toHaveLength(maxTweaks())
   })
 
   it('survives a page that put something else on __artifact', () => {

--- a/tests/artifact-manifest.test.ts
+++ b/tests/artifact-manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 /** What the guest answers when asked to evaluate something. */
 const guest = {
@@ -267,26 +268,31 @@ describe('what the injected snippet does inside the guest', () => {
    * only way to cover the half of this feature that never runs in this process.
    */
   const START = 'expression: `(() => {'
-  const END = '`,\n    returnByValue'
+  // Regex rather than a literal, so reindentation or CRLF does not move the
+  // marker out from under the search.
+  const END = /`,\s*\n\s*returnByValue/
+  // Anchored to this file, not the working directory — the convention the
+  // other source-reading tests already follow.
+  const REGISTRY = join(__dirname, '..', 'src', 'main', 'browser-registry.ts')
 
   /** The cap the snippet is built with, read from source so the test cannot drift. */
   const maxTweaks = (): number => {
-    const m = readFileSync('src/main/browser-registry.ts', 'utf8').match(/const MAX_TWEAKS = (\d+)/)
+    const m = readFileSync(REGISTRY, 'utf8').match(/const MAX_TWEAKS = (\d+)/)
     if (!m) throw new Error('Could not read MAX_TWEAKS from browser-registry.ts')
     return Number(m[1])
   }
 
   const snippet = (): string => {
-    const src = readFileSync('src/main/browser-registry.ts', 'utf8')
+    const src = readFileSync(REGISTRY, 'utf8')
     const from = src.indexOf(START)
     // Guarded rather than sliced blindly: a moved or reworded snippet would
     // otherwise yield garbage, and `new Function` would fail with a syntax
     // error pointing at nothing. This says which end went missing.
     if (from === -1) throw new Error(`Could not find the injected snippet (${START})`)
     const body = src.slice(from + 'expression: `'.length)
-    const to = body.indexOf(END)
-    if (to === -1) throw new Error('Found the injected snippet start but not its end')
-    return body.slice(0, to).replace(/\$\{MAX_TWEAKS\}/g, String(maxTweaks()))
+    const end = body.match(END)
+    if (!end?.index) throw new Error('Found the injected snippet start but not its end')
+    return body.slice(0, end.index).replace(/\$\{MAX_TWEAKS\}/g, String(maxTweaks()))
   }
 
   const run = (

--- a/tests/artifact-manifest.test.ts
+++ b/tests/artifact-manifest.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
 
 /** What the guest answers when asked to evaluate something. */
 const guest = {
@@ -255,5 +256,90 @@ describe('what a page read tells an agent about a design', () => {
     const read = await readPage({ sessionId: 'sess-read' })
     expect(read.url).toBe('file:///repo/budget.dc.html')
     expect(read.artifact).toBeUndefined()
+  })
+})
+
+describe('what the injected snippet does inside the guest', () => {
+  /**
+   * The mock above answers `Runtime.evaluate` with a canned value, so it proves
+   * nothing about the code that actually runs in the page. This reads the real
+   * snippet out of the source and executes it against a stand-in guest — the
+   * only way to cover the half of this feature that never runs in this process.
+   */
+  const snippet = (): string => {
+    const src = readFileSync('src/main/browser-registry.ts', 'utf8')
+    const from = src.indexOf('expression: `(() => {')
+    const body = src.slice(from + 'expression: `'.length)
+    return body.slice(0, body.indexOf('`,\n    returnByValue')).replace(/\$\{MAX_TWEAKS\}/g, '24')
+  }
+
+  const run = (
+    win: Record<string, unknown>,
+    declared: unknown
+  ): { declared: string; live: Record<string, unknown> | null } => {
+    const doc = {
+      getElementById: () => (declared === null ? null : { textContent: JSON.stringify(declared) })
+    }
+    const out = new Function('window', 'document', `return ${snippet()}`)(win, doc)
+    return JSON.parse(out as string)
+  }
+
+  it('tells the page a pane is driving it', () => {
+    // A design that carries its own controls for the standalone case has to
+    // stand them down, and it cannot work this out for itself: the manifest is
+    // read after the page's script has already run, so there is nothing there
+    // to detect at first paint. Vorn has to say so.
+    const win: Record<string, unknown> = {}
+    run(win, { kind: 'design' })
+    expect(win.__artifactHost).toBe('vorn')
+  })
+
+  it('says so even for a page that declares nothing', () => {
+    // Cheap and unconditional. A page checking the flag must not have to also
+    // know whether its own manifest parsed.
+    const win: Record<string, unknown> = {}
+    run(win, null)
+    expect(win.__artifactHost).toBe('vorn')
+  })
+
+  it('takes only scalars, and only short ones', () => {
+    const win: Record<string, unknown> = {
+      __artifact: {
+        tweaks: {
+          n: 42,
+          b: true,
+          short: 'ok',
+          long: 'x'.repeat(500),
+          obj: { nested: true },
+          fn: () => {}
+        }
+      }
+    }
+    const { live } = run(win, { kind: 'design' })
+    expect(live).toEqual({ n: 42, b: true, short: 'ok' })
+  })
+
+  it('drops a non-finite number at the source', () => {
+    // These become null crossing JSON and fail the type check downstream, so
+    // the outcome was already right — but by accident of the transport.
+    const win: Record<string, unknown> = { __artifact: { tweaks: { a: NaN, b: Infinity, c: 1 } } }
+    const { live } = run(win, { kind: 'design' })
+    expect(live).toEqual({ c: 1 })
+  })
+
+  it('caps how many keys a page can put on the way out', () => {
+    // The filter that keeps only declared names runs in main, after this has
+    // crossed CDP — so a page hanging thousands of keys here would have all of
+    // them built and shipped first.
+    const tweaks = Object.fromEntries(Array.from({ length: 200 }, (_, i) => [`k${i}`, i]))
+    const win: Record<string, unknown> = { __artifact: { tweaks } }
+    const { live } = run(win, { kind: 'design' })
+    expect(Object.keys(live ?? {})).toHaveLength(24)
+  })
+
+  it('survives a page that put something else on __artifact', () => {
+    const win: Record<string, unknown> = { __artifact: 'not an object' }
+    const { live } = run(win, { kind: 'design' })
+    expect(live).toBeNull()
   })
 })

--- a/tests/browser-url.test.ts
+++ b/tests/browser-url.test.ts
@@ -114,6 +114,13 @@ describe('displayHost', () => {
     expect(displayHost('file:///repo/a%20b.dc.html')).toBe('a b.dc.html')
   })
 
+  it('keeps the filename when its escaping is malformed', () => {
+    // A stray `%` is a legal filename character and an invalid escape, so
+    // decoding throws. Falling through to the outer handler would return the
+    // whole url — the unreadable label this fix exists to remove.
+    expect(displayHost('file:///repo/%ZZ.dc.html')).toBe('%ZZ.dc.html')
+  })
+
   it('names a blank page "New tab" rather than showing the scheme', () => {
     // `about:blank` parses cleanly but has an empty hostname, and the raw
     // string is jargon — a tab you have not navigated yet should read as a

--- a/tests/browser-url.test.ts
+++ b/tests/browser-url.test.ts
@@ -104,6 +104,16 @@ describe('displayHost', () => {
     expect(displayHost('https://example.com/a/b')).toBe('example.com')
   })
 
+  it('names a local file by its filename, not its whole path', () => {
+    // A tab is a few characters wide. The leading directories push the only
+    // part that identifies the file off the end, so a design in a repo showed
+    // as an unreadable run of path with the name invisible.
+    expect(displayHost('file:///Users/j/dev/vorn/design/true-black.dc.html')).toBe(
+      'true-black.dc.html'
+    )
+    expect(displayHost('file:///repo/a%20b.dc.html')).toBe('a b.dc.html')
+  })
+
   it('names a blank page "New tab" rather than showing the scheme', () => {
     // `about:blank` parses cleanly but has an empty hostname, and the raw
     // string is jargon — a tab you have not navigated yet should read as a

--- a/tests/pane-components.test.tsx
+++ b/tests/pane-components.test.tsx
@@ -946,6 +946,50 @@ describe('BrowserCard', () => {
     expect(mockReadManifest).not.toHaveBeenCalled()
   })
 
+  it('names a design by its title on the tab, and not twice', async () => {
+    // The name belongs where every other page's name is. Repeating it beside
+    // the controls spends header width on something already on screen.
+    mockReadManifest.mockResolvedValue({
+      manifest: {
+        kind: 'design',
+        title: 'True Black',
+        tweaks: { lift: { type: 'number', default: 6 } }
+      }
+    })
+    act(() =>
+      useAppStore
+        .getState()
+        .openBrowserPane('t1', 'file:///repo/true-black.dc.html', { trusted: true })
+    )
+    render(<BrowserCard sessionId="t1" />)
+    act(
+      () =>
+        void (document.querySelector('webview') as HTMLElement).dispatchEvent(
+          new Event('did-stop-loading')
+        )
+    )
+
+    // Once, on the tab — not again in the control row.
+    await waitFor(() => expect(screen.getAllByText('True Black')).toHaveLength(1))
+    expect(screen.getByRole('tab')).toHaveTextContent('True Black')
+  })
+
+  it('falls back to the filename for a file that declares no title', async () => {
+    mockReadManifest.mockResolvedValue({ manifest: { kind: 'design' } })
+    act(() =>
+      useAppStore.getState().openBrowserPane('t1', 'file:///repo/sketch.dc.html', { trusted: true })
+    )
+    render(<BrowserCard sessionId="t1" />)
+    act(
+      () =>
+        void (document.querySelector('webview') as HTMLElement).dispatchEvent(
+          new Event('did-stop-loading')
+        )
+    )
+
+    await waitFor(() => expect(screen.getByRole('tab')).toHaveTextContent('sketch.dc.html'))
+  })
+
   it('ignores a subframe navigating, which is not where the person is', () => {
     // Ads, embedded docs and OAuth widgets route in place constantly. Taking a
     // subframe's url would have the strip, the address bar and `browser_tabs


### PR DESCRIPTION
Follow-up to #472. Three things a design pane got wrong, all visible the moment one is open, plus the contract underneath them.

## What you see

**The tab showed the whole path.** `displayHost` falls back to the raw url when there is no hostname, so a design tab read `file:///Users/javier/dev/vorn/design/true-black.dc.html` — a run of path in a strip a few characters wide, with the only identifying part pushed off the end.

| Tab now shows | When |
|---|---|
| **True Black** | the design declares a title |
| `true-black.dc.html` | a file with no title — filename, not path |
| `example.com` | a web page, unchanged |

**The title also sat in the control row**, repeating what the tab already said and spending header width to do it. The row holds controls now.

**A design tab carries a mark**, because it is a different kind of thing: it repaints when its file changes, and its header holds controls rather than an address. Only the active tab gets it — the others are urls until something loads them, and marking one a design would be a guess.

## The contract underneath

A page that carries its own controls for the standalone case has to stand them down when a pane is drawing them, or it sits under an identical row. **It cannot work this out for itself:** the manifest is read on `did-stop-loading`, after the page's script has already run, so there is nothing to detect at first paint.

Inferring it from `__artifactRender` does not work either — a pane only writes values that *differ* from what the page holds, so a design opened at its declared defaults is never written to and never rendered. Both of those were wrong turns I took before finding it.

Vorn sets `window.__artifactHost = 'vorn'` when it reads a manifest, and the page can ask.

## Tests for code that never runs here

The injected snippet is read out of the source and executed against a stand-in page. The existing mock answers `Runtime.evaluate` with a canned value, so it proved nothing about the code that actually ships — this covers the host signal, the scalar-only filter, the length and key caps, and the non-finite guard.

## Verification

**3963 tests pass**, typecheck and lint clean. The host-signal tests fail without the one line that sets it, verified by removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)