### PR TITLE
chore(release): 0.6.1-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.1-beta.2",
+  "version": "0.6.1-beta.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cuts 0.6.1-beta.3 so the design-pane chrome fixes from #474 are testable before 0.6.1. A design now shows its title in the tab strip rather than a full `file://` path, the duplicated title is gone from the tweak row, and a page can tell a Vorn pane is driving it and stand down its own controls.

Version bump only — seven package.json files in lockstep, matching #473.