### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.1-beta.3",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Promotes 0.6.1 to stable after three betas. Version bump only — seven package.json files in lockstep.

Shipped since 0.6.0: every server connection now authenticates and the port is opened deliberately rather than by accident (#464); the browser pane answers honestly about what it can see and can reach the session's own files (#467); a design file reopens itself when it changes on disk, with your adjustments surviving the repaint (#472); and a design shows its title in the tab strip instead of a raw file path (#474).

Note for anyone pinning `@vornrun/mcp@latest`: the auth work in #464 means a 0.6.0 client cannot talk to a 0.6.1 app — it has no auth code and fails every tool with "Not authenticated". Moving `latest` to 0.6.1 resolves it, but a client pinned to the old exact version will need updating.