### PR TITLE
Hand out the plugin, not a bare mcp add

### DIFF
--- a/src/renderer/components/OnboardingModal.tsx
+++ b/src/renderer/components/OnboardingModal.tsx
@@ -227,7 +227,9 @@ function StepAgents() {
           className="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-white/[0.02] transition-colors"
         >
           <Plug size={13} className="text-bronzo" />
-          <span className="text-[12px] font-medium text-gray-200 flex-1">Connect MCP Server</span>
+          <span className="text-[12px] font-medium text-gray-200 flex-1">
+            Install skills &amp; MCP server
+          </span>
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded text-bronzo bg-bronzo/[0.08]">
             Recommended
           </span>

--- a/src/renderer/components/OnboardingModal.tsx
+++ b/src/renderer/components/OnboardingModal.tsx
@@ -258,24 +258,31 @@ function StepAgents() {
               )}
             </div>
 
-            <div className="space-y-1.5">
-              <div className="text-[10px] text-gray-600 uppercase tracking-wider font-medium">
-                Run in your terminal
-              </div>
-              {mcpToShow.map(({ agentType, command }) => {
+            <div className="space-y-2.5">
+              {mcpToShow.map(({ agentType, commands, inAgent, note }) => {
                 const def = AGENT_DEFINITIONS[agentType]
                 return (
-                  <div key={agentType} className="flex items-center gap-2">
-                    <div
-                      className="w-5 h-5 rounded flex items-center justify-center shrink-0"
-                      style={{ background: def.bgColor }}
-                    >
-                      <AgentIcon agentType={agentType} size={10} />
+                  <div key={agentType} className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-5 h-5 rounded flex items-center justify-center shrink-0"
+                        style={{ background: def.bgColor }}
+                      >
+                        <AgentIcon agentType={agentType} size={10} />
+                      </div>
+                      <span className="text-[10px] text-gray-600 uppercase tracking-wider font-medium">
+                        {inAgent ? `Run in ${def.displayName}` : 'Run in your terminal'}
+                      </span>
                     </div>
-                    <code className="flex-1 text-[11px] font-mono text-gray-400 truncate">
-                      {command}
-                    </code>
-                    <CopyBtn text={command} />
+                    {commands.map((command) => (
+                      <div key={command} className="flex items-center gap-2 pl-7">
+                        <code className="flex-1 text-[11px] font-mono text-gray-400 overflow-x-auto whitespace-nowrap">
+                          {command}
+                        </code>
+                        <CopyBtn text={command} />
+                      </div>
+                    ))}
+                    {note && <p className="pl-7 text-[10px] text-gray-600">{note}</p>}
                   </div>
                 )
               })}

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -155,7 +155,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
       },
       {
         key: 'mcp',
-        label: 'MCP',
+        label: 'Skills & MCP',
         icon: (
           <svg
             width="16"

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -26,14 +26,14 @@ function CopyButton({ text }: { text: string }) {
 export function McpSettings() {
   return (
     <div>
-      <h2 className="text-xl font-semibold text-white mb-1">MCP Integration</h2>
+      <h2 className="text-xl font-semibold text-white mb-1">Skills &amp; MCP</h2>
       <p className="text-sm text-gray-500 mb-6">
         Connect your coding agents to Vorn. The plugin installs the MCP server and the skills that
         explain what its tools are for.
       </p>
 
       {/* Per-agent commands */}
-      <h3 className="text-sm font-medium text-gray-200 mb-3">Agent Setup</h3>
+      <h3 className="text-sm font-medium text-gray-200 mb-3">Install the Vorn plugin</h3>
       <div className="space-y-3">
         {AGENT_MCP_SETUPS.map((setup) => {
           const agent = AGENT_DEFINITIONS[setup.agentType]

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -47,6 +47,9 @@ export function McpSettings() {
               <div className="flex items-center gap-3 mb-3">
                 <AgentIcon agentType={setup.agentType} size={20} />
                 <span className="text-sm font-medium text-gray-200">{agent.displayName}</span>
+                <span className="text-[11px] text-gray-500">
+                  {setup.inAgent ? `Run in ${agent.displayName}` : 'Run in your terminal'}
+                </span>
               </div>
               <div className="space-y-2">
                 {setup.commands.map((command) => (

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -28,12 +28,12 @@ export function McpSettings() {
     <div>
       <h2 className="text-xl font-semibold text-white mb-1">Skills &amp; MCP</h2>
       <p className="text-sm text-gray-500 mb-6">
-        Connect your coding agents to Vorn. The plugin installs the MCP server and the skills that
-        explain what its tools are for.
+        Connect your coding agents to Vorn. Each setup below installs the MCP server and the skills
+        that explain what its tools are for.
       </p>
 
       {/* Per-agent commands */}
-      <h3 className="text-sm font-medium text-gray-200 mb-3">Install the Vorn plugin</h3>
+      <h3 className="text-sm font-medium text-gray-200 mb-3">Set up an agent</h3>
       <div className="space-y-3">
         {AGENT_MCP_SETUPS.map((setup) => {
           const agent = AGENT_DEFINITIONS[setup.agentType]

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -27,7 +27,10 @@ export function McpSettings() {
   return (
     <div>
       <h2 className="text-xl font-semibold text-white mb-1">MCP Integration</h2>
-      <p className="text-sm text-gray-500 mb-6">Connect your coding agents to Vorn via MCP</p>
+      <p className="text-sm text-gray-500 mb-6">
+        Connect your coding agents to Vorn. The plugin installs the MCP server and the skills that
+        explain what its tools are for.
+      </p>
 
       {/* Per-agent commands */}
       <h3 className="text-sm font-medium text-gray-200 mb-3">Agent Setup</h3>
@@ -45,15 +48,20 @@ export function McpSettings() {
                 <AgentIcon agentType={setup.agentType} size={20} />
                 <span className="text-sm font-medium text-gray-200">{agent.displayName}</span>
               </div>
-              <div className="flex items-center gap-2">
-                <code
-                  className="flex-1 px-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-md
+              <div className="space-y-2">
+                {setup.commands.map((command) => (
+                  <div key={command} className="flex items-center gap-2">
+                    <code
+                      className="flex-1 px-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-md
                                text-xs text-gray-300 font-mono overflow-x-auto whitespace-nowrap"
-                >
-                  {setup.command}
-                </code>
-                <CopyButton text={setup.command} />
+                    >
+                      {command}
+                    </code>
+                    <CopyButton text={command} />
+                  </div>
+                ))}
               </div>
+              {setup.note && <p className="mt-2 text-[11px] text-gray-500">{setup.note}</p>}
             </div>
           )
         })}

--- a/src/renderer/components/settings/McpSettings.tsx
+++ b/src/renderer/components/settings/McpSettings.tsx
@@ -28,8 +28,8 @@ export function McpSettings() {
     <div>
       <h2 className="text-xl font-semibold text-white mb-1">Skills &amp; MCP</h2>
       <p className="text-sm text-gray-500 mb-6">
-        Connect your coding agents to Vorn. Each setup below installs the MCP server and the skills
-        that explain what its tools are for.
+        Connect your coding agents to Vorn. Each setup below installs the MCP server along with the
+        guidance that explains what its tools are for.
       </p>
 
       {/* Per-agent commands */}

--- a/src/renderer/lib/mcp-data.ts
+++ b/src/renderer/lib/mcp-data.ts
@@ -1,29 +1,79 @@
 import { AiAgentType } from '../../shared/types'
 
+/**
+ * How a person connects one agent to Vorn.
+ *
+ * The plugin rather than a bare `mcp add`, wherever the agent has a plugin
+ * system. Both install the same MCP server; the plugin also carries the skills
+ * that say what the tools are *for*. Agents defer tool descriptions, so a name
+ * like `browser_interact` otherwise arrives with no documentation and goes
+ * unused — the tools are present and invisible.
+ *
+ * Every command here was run against the real CLI. That is not ceremony: three
+ * of the five were wrong the first time they were written, in ways no amount of
+ * reading the docs would have caught.
+ */
+
 export interface AgentMcpSetup {
   agentType: AiAgentType
-  command: string
+  /**
+   * Ordered steps. More than one where the harness wants a marketplace
+   * registered before it will install from it.
+   */
+  commands: string[]
+  /**
+   * Typed inside the agent rather than in a shell. Claude's `/plugin` is a
+   * slash command, so telling someone to run it in a terminal sends them
+   * somewhere it does nothing.
+   */
+  inAgent?: boolean
+  /** For what a command line cannot express — see opencode. */
+  note?: string
 }
+
+/** The plugin's repo. Also the marketplace source, which is the same thing here. */
+export const VORN_PLUGIN_REPO = 'vorn-run/plugin'
+
+const PLUGIN_URL = `https://github.com/${VORN_PLUGIN_REPO}`
+
+/** The raw server, for agents with no plugin path and as the opencode first step. */
+const MCP_ONLY = `mcp add vorn -- npx -y @vornrun/mcp@latest`
 
 export const AGENT_MCP_SETUPS: AgentMcpSetup[] = [
   {
     agentType: 'claude',
-    command: 'claude mcp add vorn -- npx -y @vornrun/mcp@latest'
+    commands: [`/plugin marketplace add ${VORN_PLUGIN_REPO}`, '/plugin install vorn'],
+    inAgent: true
   },
   {
     agentType: 'copilot',
-    command: 'copilot mcp add vorn -- npx -y @vornrun/mcp@latest'
+    // `copilot plugin install vorn-run/plugin` also works, but installing
+    // straight from a repo is deprecated and warns that it will be removed.
+    commands: [
+      `copilot plugin marketplace add ${VORN_PLUGIN_REPO}`,
+      'copilot plugin install vorn@vorn'
+    ]
   },
   {
     agentType: 'codex',
-    command: 'codex mcp add vorn -- npx -y @vornrun/mcp@latest'
+    // Codex has no `plugin install` — only `plugin add`, and only from a
+    // registered marketplace. It rejects a bare name, wanting plugin@marketplace.
+    commands: [`codex plugin marketplace add ${VORN_PLUGIN_REPO}`, 'codex plugin add vorn@vorn'],
+    note: 'Restart, or start a fresh session — skills load at session start.'
   },
   {
     agentType: 'opencode',
-    command: 'opencode mcp add vorn -- npx -y @vornrun/mcp@latest'
+    // opencode reads SKILL.md natively through its own `skill` tool, so there is
+    // no plugin to install: the server and a path to the skills, separately. The
+    // second step is JSON config rather than a command, which is why it is a note.
+    commands: [`opencode ${MCP_ONLY}`, `git clone ${PLUGIN_URL} ~/.config/opencode/vorn`],
+    note: 'Then add "skills": { "paths": ["~/.config/opencode/vorn/skills"] } to ~/.config/opencode/opencode.jsonc'
   },
   {
     agentType: 'gemini',
-    command: 'gemini mcp add vorn -- npx -y @vornrun/mcp@latest'
+    // Gemini has no skills system, but its extensions carry both an MCP server
+    // and a context file — so one install still delivers both halves.
+    commands: [`gemini extensions install ${PLUGIN_URL}`],
+    note: 'Gemini disables MCP servers in a folder it does not trust, user-level ones included.'
   }
 ]

--- a/src/renderer/lib/onboarding-data.ts
+++ b/src/renderer/lib/onboarding-data.ts
@@ -9,7 +9,7 @@ export const ONBOARDING_STEPS: OnboardingStep[] = [
   {
     id: 'agents',
     title: 'Coding Agents',
-    subtitle: 'Detect agents & connect MCP',
+    subtitle: 'Detect agents & install skills',
     icon: 'Bot'
   },
   {

--- a/tests/mcp-data.test.ts
+++ b/tests/mcp-data.test.ts
@@ -1,29 +1,111 @@
 import { describe, it, expect } from 'vitest'
-import { AGENT_MCP_SETUPS } from '../src/renderer/lib/mcp-data'
+import { AGENT_MCP_SETUPS, VORN_PLUGIN_REPO } from '../src/renderer/lib/mcp-data'
 import { AGENT_LIST } from '../src/renderer/lib/agent-definitions'
+
+/**
+ * What a person is told to type.
+ *
+ * These strings are copied straight into a terminal, so a wrong one fails in
+ * front of someone on their first run. Three of the five were wrong when first
+ * written — each looked plausible and none had been executed. The assertions
+ * here are the shape checks that can be made without a CLI present; they cannot
+ * prove a command works, only that it has not silently reverted to a form we
+ * already know to be wrong.
+ */
 
 describe('AGENT_MCP_SETUPS', () => {
   it('has one setup per agent', () => {
     expect(AGENT_MCP_SETUPS).toHaveLength(AGENT_LIST.length)
   })
 
-  it('each setup has agentType and command', () => {
-    for (const setup of AGENT_MCP_SETUPS) {
-      expect(setup.agentType).toBeTruthy()
-      expect(setup.command).toBeTruthy()
-      expect(setup.command).toContain('mcp add vorn')
-    }
-  })
-
   it('covers all known agent types', () => {
     const setupTypes = AGENT_MCP_SETUPS.map((s) => s.agentType)
-    const agentTypes = AGENT_LIST.map((a) => a.type)
-    expect(setupTypes.sort()).toEqual(agentTypes.sort())
+    expect(setupTypes.sort()).toEqual(AGENT_LIST.map((a) => a.type).sort())
   })
 
-  it('each command starts with the agent name', () => {
+  it('gives every agent at least one command to run', () => {
     for (const setup of AGENT_MCP_SETUPS) {
-      expect(setup.command.startsWith(setup.agentType)).toBe(true)
+      expect({ [setup.agentType]: setup.commands.length > 0 }).toEqual({
+        [setup.agentType]: true
+      })
+      for (const c of setup.commands) expect(c.trim()).toBeTruthy()
     }
+  })
+
+  it('points every agent at the plugin, not just the bare server', () => {
+    // The reason this change exists: the raw `mcp add` gives an agent the tools
+    // with none of the skills that say what they are for.
+    for (const setup of AGENT_MCP_SETUPS) {
+      const all = setup.commands.join(' ')
+      expect({ [setup.agentType]: all.includes(VORN_PLUGIN_REPO) }).toEqual({
+        [setup.agentType]: true
+      })
+    }
+  })
+
+  describe('the forms verified against each CLI', () => {
+    const setupFor = (t: string) => AGENT_MCP_SETUPS.find((s) => s.agentType === t)!
+
+    it('types Claude’s commands in the agent, not a shell', () => {
+      // `/plugin` is a slash command. Told to run it in a terminal, a person
+      // gets "command not found" and no reason to think the docs are wrong.
+      const claude = setupFor('claude')
+      expect(claude.inAgent).toBe(true)
+      for (const c of claude.commands) expect(c.startsWith('/plugin')).toBe(true)
+    })
+
+    it('registers a marketplace before installing from it', () => {
+      // Copilot and Codex both refuse to install a plugin from a marketplace
+      // they have not been given.
+      for (const t of ['copilot', 'codex']) {
+        const { commands } = setupFor(t)
+        expect({ [t]: commands[0].includes('marketplace add') }).toEqual({ [t]: true })
+        expect({ [t]: commands.length > 1 }).toEqual({ [t]: true })
+      }
+    })
+
+    it('uses Codex’s `plugin add`, and qualifies the plugin with its marketplace', () => {
+      // Codex has no `plugin install`, and rejects a bare `vorn`.
+      const { commands } = setupFor('codex')
+      const install = commands[commands.length - 1]
+      expect(install).toContain('plugin add')
+      expect(install).not.toContain('plugin install')
+      expect(install).toContain('vorn@vorn')
+    })
+
+    it('avoids Copilot’s deprecated install-straight-from-a-repo form', () => {
+      // `copilot plugin install <owner>/<repo>` still works but warns it is
+      // going away; the marketplace form is the one that will survive.
+      const { commands } = setupFor('copilot')
+      const install = commands[commands.length - 1]
+      expect(install).toContain('vorn@vorn')
+      expect(install).not.toContain(VORN_PLUGIN_REPO)
+    })
+
+    it('installs Gemini as an extension, which carries the server and the context', () => {
+      // Gemini has no skills system and no plugin system — extensions are the
+      // only path, and one manifest holds both halves.
+      const { commands } = setupFor('gemini')
+      expect(commands).toHaveLength(1)
+      expect(commands[0]).toContain('extensions install')
+    })
+
+    it('gives opencode the server and the skills separately', () => {
+      // opencode reads SKILL.md natively, so there is no plugin to install.
+      const { commands, note } = setupFor('opencode')
+      expect(commands.join(' ')).toContain('mcp add vorn')
+      // The remaining step is JSON config, which no command line expresses.
+      expect(note).toContain('skills')
+    })
+
+    it('never claims opencode or Gemini install a plugin', () => {
+      // Both had a documented `plugin install` that could not work: opencode's
+      // pointed at an unpublished package, Gemini's at a system it does not have.
+      for (const t of ['opencode', 'gemini']) {
+        expect({ [t]: setupFor(t).commands.join(' ').includes('plugin install') }).toEqual({
+          [t]: false
+        })
+      }
+    })
   })
 })

--- a/tests/mcp-settings.test.tsx
+++ b/tests/mcp-settings.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import { McpSettings } from '../src/renderer/components/settings/McpSettings'
+import { AGENT_MCP_SETUPS } from '../src/renderer/lib/mcp-data'
+
+/**
+ * That the panel shows a whole install, not the first line of one.
+ *
+ * Most agents now need a marketplace registered before they will install from
+ * it, so a panel that renders `commands[0]` looks entirely correct and leaves
+ * the person one step short — with no error, because the step they were given
+ * succeeds on its own. The data tests cannot see this; only rendering can.
+ */
+
+describe('McpSettings', () => {
+  it('shows every command, not just the first', () => {
+    render(<McpSettings />)
+    for (const setup of AGENT_MCP_SETUPS) {
+      for (const command of setup.commands) {
+        expect(screen.getByText(command), `${setup.agentType}: ${command}`).toBeInTheDocument()
+      }
+    }
+  })
+
+  it('gives each command its own copy button', () => {
+    // One button per command. A single button for a two-step install would copy
+    // one of them and silently drop the other.
+    render(<McpSettings />)
+    const total = AGENT_MCP_SETUPS.reduce((n, s) => n + s.commands.length, 0)
+    expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(total)
+  })
+
+  it('shows the note for an agent whose setup a command line cannot express', () => {
+    // opencode's second half is JSON config; without the note the panel would
+    // imply the two commands finish the job.
+    render(<McpSettings />)
+    const opencode = AGENT_MCP_SETUPS.find((s) => s.agentType === 'opencode')!
+    expect(screen.getByText(opencode.note!)).toBeInTheDocument()
+  })
+
+  it('copies the command next to the button that was pressed', async () => {
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<McpSettings />)
+
+    const claude = AGENT_MCP_SETUPS.find((s) => s.agentType === 'claude')!
+    const second = claude.commands[1]
+    const row = screen.getByText(second).closest('div')!
+    fireEvent.click(within(row).getByRole('button', { name: 'Copy' }))
+
+    expect(writeText).toHaveBeenCalledWith(second)
+  })
+})

--- a/tests/mcp-settings.test.tsx
+++ b/tests/mcp-settings.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, within, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -14,6 +14,10 @@ import { AGENT_MCP_SETUPS } from '../src/renderer/lib/mcp-data'
  * the person one step short — with no error, because the step they were given
  * succeeds on its own. The data tests cannot see this; only rendering can.
  */
+
+// Stubbing the global rather than mutating `navigator`: the real object can be
+// non-configurable in jsdom, and a mutation would leak into later cases.
+afterEach(() => vi.unstubAllGlobals())
 
 describe('McpSettings', () => {
   it('shows every command, not just the first', () => {
@@ -33,6 +37,14 @@ describe('McpSettings', () => {
     expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(total)
   })
 
+  it('says where to run the commands, per agent', () => {
+    // The same trap onboarding has: Claude's `/plugin` is a slash command, and
+    // a panel that only names the agent leaves someone to assume a shell.
+    render(<McpSettings />)
+    expect(screen.getByText('Run in Claude Code')).toBeInTheDocument()
+    expect(screen.getAllByText('Run in your terminal').length).toBeGreaterThan(0)
+  })
+
   it('shows the note for an agent whose setup a command line cannot express', () => {
     // opencode's second half is JSON config; without the note the panel would
     // imply the two commands finish the job.
@@ -43,7 +55,7 @@ describe('McpSettings', () => {
 
   it('copies the command next to the button that was pressed', async () => {
     const writeText = vi.fn()
-    Object.assign(navigator, { clipboard: { writeText } })
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
     render(<McpSettings />)
 
     const claude = AGENT_MCP_SETUPS.find((s) => s.agentType === 'claude')!

--- a/tests/onboarding-mcp.test.tsx
+++ b/tests/onboarding-mcp.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import { AGENT_MCP_SETUPS } from '../src/renderer/lib/mcp-data'
+
+/**
+ * The install instructions a person meets first.
+ *
+ * Onboarding is where someone connects their agent before they have any feel
+ * for what is normal, so a wrong instruction here reads as "this app is broken"
+ * rather than "that line was out of date". The case that matters most is the
+ * heading: Claude's commands are typed in the agent, and under "Run in your
+ * terminal" they produce "command not found" with nothing pointing at the real
+ * cause.
+ */
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'api', {
+    value: {
+      detectInstalledAgents: () => Promise.resolve(['claude', 'opencode']),
+      listDir: () => Promise.resolve([])
+    },
+    writable: true
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+})
+
+// Detection reaches out to the host, so pin it: these cases are about what the
+// step renders for a given set of agents, not about finding them.
+vi.mock('../src/renderer/hooks/useAgentInstallStatus', () => ({
+  useAgentInstallStatus: () => ({
+    status: { claude: true, opencode: true, copilot: false, codex: false, gemini: false },
+    loading: false,
+    refresh: () => Promise.resolve()
+  })
+}))
+
+import { OnboardingModal } from '../src/renderer/components/OnboardingModal'
+import { useAppStore } from '../src/renderer/stores'
+
+const claude = AGENT_MCP_SETUPS.find((s) => s.agentType === 'claude')!
+const opencode = AGENT_MCP_SETUPS.find((s) => s.agentType === 'opencode')!
+
+/** The commands sit behind a disclosure that starts closed. */
+function openMcpSection(): void {
+  render(<OnboardingModal />)
+  fireEvent.click(screen.getByText(/Connect MCP Server/i))
+}
+
+beforeEach(() => {
+  cleanup()
+  useAppStore.setState({ isOnboardingOpen: true })
+})
+
+describe('onboarding — connecting an agent', () => {
+  it('shows every step of a multi-step install', () => {
+    // Claude needs the marketplace registered before the install will resolve.
+    // Showing only the first line leaves someone with a step that succeeds and
+    // an agent that never gains the tools.
+    openMcpSection()
+    for (const command of claude.commands) {
+      expect(screen.getByText(command)).toBeInTheDocument()
+    }
+  })
+
+  it('says to type Claude’s commands in Claude, not a terminal', () => {
+    openMcpSection()
+    expect(screen.getByText(/Run in Claude Code/i)).toBeInTheDocument()
+  })
+
+  it('still says terminal for an agent whose commands are shell commands', () => {
+    openMcpSection()
+    expect(screen.getByText(/Run in your terminal/i)).toBeInTheDocument()
+  })
+
+  it('shows the note for a setup a command line cannot finish', () => {
+    // opencode's remaining step is JSON config; without it the two commands
+    // read as the whole job.
+    openMcpSection()
+    expect(screen.getByText(opencode.note!)).toBeInTheDocument()
+  })
+
+  it('gives each command its own copy button', () => {
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+    openMcpSection()
+
+    const second = claude.commands[1]
+    const row = screen.getByText(second).closest('div')!
+    fireEvent.click(within(row).getByRole('button'))
+
+    expect(writeText).toHaveBeenCalledWith(second)
+  })
+
+  it('offers only the agents that are actually installed', () => {
+    // Copilot is not installed here, so its commands would be noise.
+    openMcpSection()
+    const copilot = AGENT_MCP_SETUPS.find((s) => s.agentType === 'copilot')!
+    expect(screen.queryByText(copilot.commands[0])).not.toBeInTheDocument()
+  })
+})

--- a/tests/onboarding-mcp.test.tsx
+++ b/tests/onboarding-mcp.test.tsx
@@ -49,7 +49,7 @@ const opencode = AGENT_MCP_SETUPS.find((s) => s.agentType === 'opencode')!
 /** The commands sit behind a disclosure that starts closed. */
 function openMcpSection(): void {
   render(<OnboardingModal />)
-  fireEvent.click(screen.getByText(/Connect MCP Server/i))
+  fireEvent.click(screen.getByText(/Install skills & MCP server/i))
 }
 
 afterEach(() => vi.unstubAllGlobals())

--- a/tests/onboarding-mcp.test.tsx
+++ b/tests/onboarding-mcp.test.tsx
@@ -22,11 +22,15 @@ vi.hoisted(() => {
       detectInstalledAgents: () => Promise.resolve(['claude', 'opencode']),
       listDir: () => Promise.resolve([])
     },
-    writable: true
+    writable: true,
+    // Configurable so a later test file can redefine it — many re-stub `window.api`,
+    // and a non-configurable stub here would make them throw.
+    configurable: true
   })
   Object.defineProperty(window, 'matchMedia', {
     value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
-    writable: true
+    writable: true,
+    configurable: true
   })
 })
 

--- a/tests/onboarding-mcp.test.tsx
+++ b/tests/onboarding-mcp.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -52,6 +52,8 @@ function openMcpSection(): void {
   fireEvent.click(screen.getByText(/Connect MCP Server/i))
 }
 
+afterEach(() => vi.unstubAllGlobals())
+
 beforeEach(() => {
   cleanup()
   useAppStore.setState({ isOnboardingOpen: true })
@@ -87,7 +89,7 @@ describe('onboarding — connecting an agent', () => {
 
   it('gives each command its own copy button', () => {
     const writeText = vi.fn()
-    Object.assign(navigator, { clipboard: { writeText } })
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
     openMcpSection()
 
     const second = claude.commands[1]


### PR DESCRIPTION
Settings → MCP and onboarding step 1 both told a person to run `<agent> mcp add vorn -- npx -y @vornrun/mcp@latest`. That installs the 67 tools and nothing that explains them — agents defer tool descriptions, so a name like `browser_interact` arrives with no documentation and goes unused. `vorn-run/plugin` installs the same server *plus* the four skills, so both surfaces now recommend it.

Four of the five installs need more than one step, since most harnesses want a marketplace registered before installing from it. A setup is therefore a list of commands rather than one string, each with its own copy button — a single button on a two-step install copies one line and drops the other, and the step you do get succeeds on its own, so nothing appears broken.

Two things a command string could not carry:
- **`inAgent`** — Claude's `/plugin` is typed in the agent. Under the old "Run in your terminal" heading it yields "command not found".
- **`note`** — opencode's second half is JSON config no command line expresses.

**Every command was run against its real CLI**, which is how the previously-documented ones turned out wrong: Codex has no `plugin install` (it's `plugin add`, needing `vorn@vorn`), Gemini rejects the `--` separator, and opencode's plugin package was never published (404).

Tests: 11 data assertions pinning the forms already known to be wrong, plus 4 component assertions. Verified the component test fails (3 of 4) when only `commands[0]` renders — the exact bug it exists to catch. Full suite 3975 passing.