### PR TITLE
What a phone needs from the server

### DIFF
--- a/packages/server/src/broadcast.ts
+++ b/packages/server/src/broadcast.ts
@@ -13,10 +13,15 @@ import log from './logger'
  * Absent means everything, so nothing that exists today has to opt in and no
  * behaviour changes for a client that never asks.
  *
- * An entry is either an exact notification name (`config:changed`) or a namespace
- * wildcard (`session:*`). The wildcard is what keeps a shipped client correct:
- * a phone that asked for `session:*` also receives whatever is added to that
- * namespace after it was built.
+ * An entry is an exact notification name (`config:changed`), a namespace wildcard
+ * (`session:*`), or one instance of a notification (`terminal:data#<id>`). The
+ * wildcard is what keeps a shipped client correct: a phone that asked for
+ * `session:*` also receives whatever is added to that namespace after it was
+ * built.
+ *
+ * The instance form exists for `terminal:data`, where subscribing by name is
+ * useless on a phone: it means every byte of every terminal on the machine when
+ * what is wanted is the one on screen.
  */
 export type TopicFilter = readonly string[] | undefined
 
@@ -31,8 +36,11 @@ class Subscription {
     }
   }
 
-  wants(method: string): boolean {
+  wants(method: string, scope: string | undefined): boolean {
+    // The bare name still means every instance, so a desktop asking for
+    // `terminal:data` is unaffected by the instance form existing.
     if (this.exact.has(method)) return true
+    if (scope !== undefined && this.exact.has(`${method}#${scope}`)) return true
     for (const prefix of this.prefixes) if (method.startsWith(prefix)) return true
     return false
   }
@@ -102,14 +110,19 @@ export class ClientRegistry {
     this.clients.set(ws, subscriptionFrom(topics))
   }
 
-  broadcast(method: string, params: unknown): void {
+  /**
+   * `scope` names which instance of `method` this is, for notifications that
+   * have instances. Derived by the caller rather than dug out of `params` here,
+   * so the registry keeps knowing nothing about any particular payload shape.
+   */
+  broadcast(method: string, params: unknown, scope?: string): void {
     // Serialised on the first socket that actually wants it. With only a
     // filtered client attached, an unwanted notification now costs a map walk
     // instead of a full JSON encode of the payload.
     let msg: string | undefined
     for (const [ws, subscription] of this.clients) {
       if (ws.readyState !== ws.OPEN) continue
-      if (subscription && !subscription.wants(method)) continue
+      if (subscription && !subscription.wants(method, scope)) continue
       msg ??= JSON.stringify(createNotification(method, params))
       ws.send(msg)
     }

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -37,6 +37,7 @@ import {
 import { getShellIntegration } from './shell-integration'
 import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
+import { appendScrollback, clearScrollback } from './terminal-scrollback'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 
 const MAX_OUTPUT_LINES = 1000
@@ -600,6 +601,10 @@ class PtyManager extends EventEmitter {
     ptyProcess.onData((data: string) => {
       this.bufferData(id, data)
       this.appendOutput(id, data)
+      // Kept unstripped, and deliberately alongside `appendOutput` rather than
+      // instead of it: one answers what the agent said, the other what a
+      // terminal should draw, and neither can be derived from the other.
+      appendScrollback(id, data)
     })
 
     ptyProcess.onExit(({ exitCode }) => {
@@ -612,6 +617,7 @@ class PtyManager extends EventEmitter {
       this.clearBuffer(id)
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
+      clearScrollback(id)
       this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
 
       this.ptys.delete(id)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -92,7 +92,9 @@ import {
   dbInsertWorkflow,
   dbDeleteWorkflow,
   dbGetWorkflow,
-  dbListWorkflows
+  dbListWorkflows,
+  dbListTasks,
+  dbGetTask
 } from './database'
 import {
   connectorRegistry,
@@ -295,6 +297,53 @@ export function registerAllMethods(): void {
     sessionManager.scheduleSave()
     broadcastWidgetUpdate()
   })
+  /**
+   * The board without the rest of the configuration around it.
+   *
+   * `config:load` carries every task inline, so a client that wants the board
+   * pulls roughly a hundred kilobytes and a client that moves one card sends all
+   * of it back. The database already stores tasks individually; only the wire
+   * treated them as one object.
+   */
+  registerMethod('task:list', (params) => {
+    const filter = (params ?? {}) as {
+      projectName?: string
+      status?: TaskStatus
+      includeDescription?: boolean
+    }
+    const tasks = dbListTasks(filter.projectName, filter.status)
+    if (filter.includeDescription) return tasks
+    // A board renders titles. Descriptions are most of the bytes and none of
+    // what is drawn, so they are left out until something asks for one task.
+    return tasks.map((task) => ({ ...task, description: '' }))
+  })
+
+  registerMethod('workflow:resolveGate', ({ runId, nodeId, decision }) => {
+    // Broadcast rather than claimed, for the same reason stopping a run is: the
+    // client that answers is not necessarily the one holding the run, and on a
+    // phone it never is.
+    log.info({ runId, nodeId, decision }, '[workflow] broadcasting a gate decision')
+    clientRegistry.broadcast(IPC.WORKFLOW_GATE_RESOLVED, { runId, nodeId, decision })
+    return { accepted: true }
+  })
+
+  registerMethod(
+    'workflow:get',
+    ({ id }) => configManager.loadConfig().workflows?.find((w) => w.id === id) ?? null
+  )
+
+  registerMethod('task:get', ({ id }) => dbGetTask(id))
+
+  registerMethod('task:setStatus', ({ id, status }) => {
+    if (!dbGetTask(id)) return { ok: false }
+    dbUpdateTask(id, { status })
+    // Everything else reads the board through the cached config, so a direct
+    // row write has to invalidate it. This also broadcasts `config:changed`,
+    // which is how other clients learn the card moved.
+    configManager.notifyChanged()
+    return { ok: true }
+  })
+
   registerMethod('terminal:readScrollback', ({ id }) => ({ data: readScrollback(id) }))
   registerMethod('terminal:readOutput', ({ id, lines }) => ptyManager.getOutput(id, lines))
   registerMethod('shell:create', (cwd) => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -12,6 +12,7 @@ import { detectIDEs, openInIDE } from './ide-detector'
 import { detectMobileProject } from './mobile-detector'
 import { detectInstalledAgents, clearAgentDetectionCache } from './agent-detector'
 import { clientRegistry } from './broadcast'
+import { readScrollback } from './terminal-scrollback'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
 import { hookStatusMapper } from './hook-status-mapper'
@@ -294,6 +295,7 @@ export function registerAllMethods(): void {
     sessionManager.scheduleSave()
     broadcastWidgetUpdate()
   })
+  registerMethod('terminal:readScrollback', ({ id }) => ({ data: readScrollback(id) }))
   registerMethod('terminal:readOutput', ({ id, lines }) => ptyManager.getOutput(id, lines))
   registerMethod('shell:create', (cwd) => {
     const session = ptyManager.createShellPty(cwd)
@@ -1209,16 +1211,32 @@ export function registerAllMethods(): void {
   registerMethod('device:logs', (p) => browserBridge.request('device:logs', p))
   registerMethod('device:openPane', (p) => browserBridge.request('device:openPane', p))
 
+  /**
+   * Which instance a manager notification is about, or nothing.
+   *
+   * `terminal:data` and its siblings all carry the terminal's id, and a client
+   * that only wants one terminal's output subscribes to `terminal:data#<id>`.
+   * Payloads without an `id` simply have no instance, and match by name alone.
+   */
+  const terminalScope = (payload: unknown): string | undefined => {
+    const id = (payload as { id?: unknown } | null)?.id
+    return typeof id === 'string' ? id : undefined
+  }
+
   // Wire manager events → broadcast to WS clients
   ptyManager.on('client-message', (channel: string, payload: unknown) => {
-    clientRegistry.broadcast(channel, payload)
+    // A payload's `id` is the instance this notification is about, which lets a
+    // client subscribe to one terminal rather than to all of them. Read
+    // generically rather than per channel: every id-bearing payload here means
+    // the same thing by it.
+    clientRegistry.broadcast(channel, payload, terminalScope(payload))
     if (channel === IPC.TERMINAL_EXIT) {
       const p = payload as { id: string; exitCode: number }
       logSessionEvent(p.id, 'exited', { exitCode: p.exitCode })
     }
   })
   headlessManager.on('client-message', (channel: string, payload: unknown) => {
-    clientRegistry.broadcast(channel, payload)
+    clientRegistry.broadcast(channel, payload, terminalScope(payload))
     if (channel === IPC.HEADLESS_EXIT) {
       const p = payload as { id: string; exitCode: number }
       logSessionEvent(p.id, 'exited', { exitCode: p.exitCode })

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -332,6 +332,8 @@ export function registerAllMethods(): void {
     ({ id }) => configManager.loadConfig().workflows?.find((w) => w.id === id) ?? null
   )
 
+  registerMethod('project:list', () => configManager.loadConfig().projects ?? [])
+
   registerMethod('task:get', ({ id }) => dbGetTask(id))
 
   registerMethod('task:setStatus', ({ id, status }) => {

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -1,0 +1,63 @@
+/**
+ * The bytes a terminal emitted, kept as they were emitted.
+ *
+ * Separate from the line buffer in `pty-manager`, which stores the same output
+ * with every escape sequence removed. That buffer answers "what did this agent
+ * say", and stripping is what makes it answerable. This one answers "what should
+ * a terminal draw", and stripping destroys exactly the information needed:
+ * colour, cursor movement, the alternate screen, the repaint a TUI performs on
+ * every keystroke.
+ *
+ * A client attaching to a live session gets this first, feeds it to its terminal
+ * emulator, and only then starts applying live output. Without it, attaching
+ * shows a blank screen until the program next decides to redraw, which for an
+ * idle agent may be never.
+ */
+
+/**
+ * How much to keep per terminal.
+ *
+ * Enough to redraw a full-screen application several times over, and small
+ * enough that a hundred idle sessions do not add up to something worth
+ * worrying about. This is bytes, not lines, because the cost being bounded is
+ * memory and the thing being stored is a byte stream.
+ */
+const MAX_BYTES = 256 * 1024
+
+const buffers = new Map<string, string>()
+
+/**
+ * Trim from the front, at a line boundary where there is one nearby.
+ *
+ * Cutting mid-sequence would hand the client half an escape sequence, and a
+ * terminal emulator fed a truncated sequence will either swallow the text that
+ * follows it or render it as literal characters. A newline is a safe cut: no
+ * escape sequence spans one.
+ *
+ * When there is no newline in the trimmed region — a single enormous line, which
+ * a progress bar redrawing without newlines produces — the cut is taken as-is.
+ * Losing the head of one line is better than growing without bound.
+ */
+function trim(data: string): string {
+  if (data.length <= MAX_BYTES) return data
+  const cut = data.length - MAX_BYTES
+  const boundary = data.indexOf('\n', cut)
+  return boundary === -1 ? data.slice(cut) : data.slice(boundary + 1)
+}
+
+export function appendScrollback(id: string, data: string): void {
+  buffers.set(id, trim((buffers.get(id) ?? '') + data))
+}
+
+export function readScrollback(id: string): string {
+  return buffers.get(id) ?? ''
+}
+
+export function clearScrollback(id: string): void {
+  buffers.delete(id)
+}
+
+/** Only for tests, which would otherwise leak state between cases. */
+export function resetScrollback(): void {
+  buffers.clear()
+}

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -19,10 +19,16 @@
  *
  * Enough to redraw a full-screen application several times over, and small
  * enough that a hundred idle sessions do not add up to something worth
- * worrying about. This is bytes, not lines, because the cost being bounded is
- * memory and the thing being stored is a byte stream.
+ * worrying about. A length, not a line count, because the cost being bounded is
+ * memory and the thing being stored is a stream.
+ *
+ * Counted in UTF-16 code units — what `String.length` returns — rather than
+ * encoded bytes. For ASCII, which terminal output overwhelmingly is, they are
+ * the same; CJK runs at three bytes per unit, so a buffer of entirely CJK output
+ * costs about three times this. That is an acceptable ceiling, and measuring it
+ * exactly would mean encoding every write to count it.
  */
-const MAX_BYTES = 256 * 1024
+const MAX_UNITS = 256 * 1024
 
 const buffers = new Map<string, string>()
 
@@ -39,8 +45,8 @@ const buffers = new Map<string, string>()
  * Losing the head of one line is better than growing without bound.
  */
 function trim(data: string): string {
-  if (data.length <= MAX_BYTES) return data
-  const cut = data.length - MAX_BYTES
+  if (data.length <= MAX_UNITS) return data
+  const cut = data.length - MAX_UNITS
   const boundary = data.indexOf('\n', cut)
   return boundary === -1 ? data.slice(cut) : data.slice(boundary + 1)
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowExecution,
   ScriptConfig,
   ScheduleLogEntry,
+  ProjectConfig,
   RecentSession,
   PermissionRequestInfo,
   WidgetAgentInfo,
@@ -233,6 +234,15 @@ export interface RequestMethods {
     result: TaskConfig[]
   }
   'task:setStatus': { params: { id: string; status: TaskStatus }; result: { ok: boolean } }
+  /**
+   * The projects a session can be launched into.
+   *
+   * Small, and inside the configuration with everything else — so asking for it
+   * alone costs a few hundred bytes rather than the hundred kilobytes that
+   * carrying the task board along with it does.
+   */
+  'project:list': { params: void; result: ProjectConfig[] }
+
   /** One task, description included. The listing omits descriptions. */
   'task:get': { params: { id: string }; result: TaskConfig | null }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -7,6 +7,7 @@ import type {
   FileEntry,
   GitDiffStat,
   GitDiffResult,
+  WorkflowDefinition,
   WorkflowExecution,
   ScriptConfig,
   ScheduleLogEntry,
@@ -21,6 +22,7 @@ import type {
   TaskSourceLink,
   ConnectorManifest,
   ConnectorItemContext,
+  TaskConfig,
   TaskStatus,
   WorktreeInventory,
   WorktreeActionResult,
@@ -218,6 +220,48 @@ export interface RequestMethods {
   'tailscale:status': { params: void; result: TailscaleStatus }
 
   // Task images and UI
+  /**
+   * The task board on its own, rather than as part of the whole configuration.
+   *
+   * Tasks live in `AppConfig.tasks`, so reading the board has meant loading the
+   * entire config and changing one status has meant sending all of it back. On
+   * a real board that is around 95 KB of a 104 KB payload, which is invisible on
+   * a desk and the difference between usable and not on a phone.
+   */
+  'task:list': {
+    params: { projectName?: string; status?: TaskStatus; includeDescription?: boolean } | void
+    result: TaskConfig[]
+  }
+  'task:setStatus': { params: { id: string; status: TaskStatus }; result: { ok: boolean } }
+  /** One task, description included. The listing omits descriptions. */
+  'task:get': { params: { id: string }; result: TaskConfig | null }
+
+  /**
+   * One workflow's definition.
+   *
+   * A run records node ids and their outcome, not what the nodes are called, so
+   * anything drawing a trace needs the definition beside it. `config:load`
+   * carries every workflow, and on a phone that is a hundred kilobytes to label
+   * a handful of rows
+   */
+  'workflow:get': { params: { id: string }; result: WorkflowDefinition | null }
+
+  /**
+   * Answer a run that is parked on an approval gate.
+   *
+   * The decision is recorded by whichever instance is holding the run, not here:
+   * resuming means re-entering the execution engine, and that lives in a desktop
+   * window rather than in this process. So this broadcasts and returns, the same
+   * way stopping a run does — every instance hears it and only the owner acts.
+   *
+   * `accepted` says the message went out, not that a run resumed. If no desktop
+   * is open there is nothing to act on it, and the gate stays open until one is.
+   */
+  'workflow:resolveGate': {
+    params: { runId: string; nodeId: string; decision: 'approve' | 'reject' }
+    result: { accepted: boolean }
+  }
+
   'task:imageUpload': {
     params: { taskId: string; base64: string; filename: string }
     result: string
@@ -762,6 +806,8 @@ export interface ServerNotifications {
     missedAt: string
   }>
   'workflow:executionComplete': WorkflowExecution
+  /** A person answered a gate. Only the instance holding the run acts on it. */
+  'workflow:gateResolved': { runId: string; nodeId: string; decision: 'approve' | 'reject' }
   'session-exit': TerminalSession
   'database:corruption-recovered': { message: string }
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -230,6 +230,16 @@ export interface RequestMethods {
   'terminal:rename': { params: { id: string; displayName: string }; result: void }
   'terminal:reorder': { params: string[]; result: void }
   'terminal:readOutput': { params: { id: string; lines?: number }; result: string[] }
+  /**
+   * The terminal's output as it was emitted, escape sequences intact.
+   *
+   * `terminal:readOutput` is the same output with every sequence removed, which
+   * is right for reading and useless for drawing. A client attaching a terminal
+   * emulator feeds this in first, then applies live `terminal:data`; without it
+   * the screen stays blank until the program next repaints, which for an idle
+   * agent may be never.
+   */
+  'terminal:readScrollback': { params: { id: string }; result: { data: string } }
   'shell:create': { params: string | undefined; result: TerminalSession }
   'config:load': { params: void; result: AppConfig }
   'config:save': { params: AppConfig; result: void }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1386,6 +1386,7 @@ export const IPC = {
   SCHEDULER_GET_LOG: 'scheduler:getLog',
   SCHEDULER_GET_NEXT_RUN: 'scheduler:getNextRun',
   WORKFLOW_EXECUTION_COMPLETE: 'workflow:executionComplete',
+  WORKFLOW_GATE_RESOLVED: 'workflow:gateResolved',
   WINDOW_MINIMIZE: 'window:minimize',
   WINDOW_MAXIMIZE: 'window:maximize',
   WINDOW_CLOSE: 'window:close',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -550,6 +550,9 @@ export function createApiShim(wsUrl: string) {
     ) => rpc.on('scheduler:execute', callback as (p: unknown) => void),
     onSchedulerStopRun: (callback: (event: { runId: string }) => void) =>
       rpc.on('scheduler:stopRun', callback as (p: unknown) => void),
+    onWorkflowGateResolved: (
+      callback: (event: { runId: string; nodeId: string; decision: 'approve' | 'reject' }) => void
+    ) => rpc.on('workflow:gateResolved', callback as (p: unknown) => void),
     onSchedulerMissed: (callback: (missed: unknown[]) => void) =>
       rpc.on('scheduler:missed', callback as (p: unknown) => void),
     completeConnectorInbox: (params: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -244,6 +244,7 @@ function wireServerNotifications(bridge: ServerBridge): void {
       case IPC.SCHEDULER_STOP_RUN:
       case IPC.SCHEDULER_MISSED:
       case IPC.WORKFLOW_EXECUTION_COMPLETE:
+      case IPC.WORKFLOW_GATE_RESOLVED:
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send(method, params)
         }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -446,6 +446,16 @@ const api = {
       ipcRenderer.removeListener(IPC.SCHEDULER_STOP_RUN, listener)
     }
   },
+  onWorkflowGateResolved: (
+    callback: (event: { runId: string; nodeId: string; decision: 'approve' | 'reject' }) => void
+  ) => {
+    const listener = (
+      _e: unknown,
+      event: { runId: string; nodeId: string; decision: 'approve' | 'reject' }
+    ) => callback(event)
+    ipcRenderer.on(IPC.WORKFLOW_GATE_RESOLVED, listener)
+    return () => ipcRenderer.removeListener(IPC.WORKFLOW_GATE_RESOLVED, listener)
+  },
 
   onSchedulerMissed: (
     callback: (missed: { workflow: { id: string; name: string }; scheduledFor: string }[]) => void

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,7 +23,8 @@ import {
   executeWorkflow as runWorkflow,
   rescheduleWaitingGateTimers,
   reconcileRunningExecutions,
-  stopWorkflowRun
+  stopWorkflowRun,
+  applyGateDecision
 } from './lib/workflow-execution'
 import type { WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
@@ -367,6 +368,15 @@ export function App() {
       )
     })
 
+    // A gate answered elsewhere — a phone, or another window. Broadcast for the
+    // same reason a stop is: whoever answered is usually not who is holding the
+    // run. applyGateDecision no-ops unless this instance is.
+    const removeGateListener = window.api.onWorkflowGateResolved(({ runId, nodeId, decision }) => {
+      void applyGateDecision(runId, nodeId, decision).catch((err) =>
+        console.warn(`[workflow] gate decision for ${runId} failed:`, err)
+      )
+    })
+
     // Seed from main first: the events fire once, and a window opened after
     // one has already passed would otherwise sit on 'unsupported' forever.
     useAppStore.getState().setAppUpdateStatus(window.api.getUpdateStatus())
@@ -513,6 +523,7 @@ export function App() {
       removeHeadlessExitListener()
       removeHeadlessDataListener()
       removeStopRunListener()
+      removeGateListener()
       clearInterval(headlessPollInterval)
       clearInterval(pruneInterval)
     }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1504,12 +1504,6 @@ function latestRunForWorkflow(workflowId: string): WorkflowExecution | undefined
 }
 
 /**
- * Stop a run: kill the agents it launched, then close it as `cancelled`.
- *
- * Worktrees are deliberately left on disk. A stopped run has usually done
- * partial work, and discarding it silently is not something the user can undo.
- */
-/**
  * Apply a gate decision that came from somewhere else.
  *
  * Someone answered a gate on another client — a phone, or a second window — and
@@ -1539,6 +1533,12 @@ export async function applyGateDecision(
   else await rejectWorkflowGate(execution, nodeId)
 }
 
+/**
+ * Stop a run: kill the agents it launched, then close it as `cancelled`.
+ *
+ * Worktrees are deliberately left on disk. A stopped run has usually done
+ * partial work, and discarding it silently is not something the user can undo.
+ */
 export async function stopWorkflowRun(runId: string): Promise<void> {
   const handle = activeRuns.get(runId)
   // Prefer the live object over the store's copy so the run the engine is

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1509,6 +1509,36 @@ function latestRunForWorkflow(workflowId: string): WorkflowExecution | undefined
  * Worktrees are deliberately left on disk. A stopped run has usually done
  * partial work, and discarding it silently is not something the user can undo.
  */
+/**
+ * Apply a gate decision that came from somewhere else.
+ *
+ * Someone answered a gate on another client — a phone, or a second window — and
+ * the server broadcast it to everyone. Only the instance actually holding the
+ * run can resume it, so every other instance no-ops, exactly as it does for a
+ * stop request.
+ *
+ * The run is looked up in the store as well as in `activeRuns`, because an
+ * instance that reloaded while a run was parked has the execution rehydrated
+ * but no in-memory handle, and it is still the one that should pick it up.
+ */
+export async function applyGateDecision(
+  runId: string,
+  nodeId: string,
+  decision: 'approve' | 'reject'
+): Promise<void> {
+  const execution =
+    activeRuns.get(runId)?.execution ?? useAppStore.getState().workflowExecutions.get(runId)
+  if (!execution) return
+
+  const node = execution.nodeStates.find((state) => state.nodeId === nodeId)
+  // Already answered, by this instance or by a broadcast that arrived twice.
+  // Re-approving would restart the branch below the gate.
+  if (node?.status !== 'waiting') return
+
+  if (decision === 'approve') await approveWorkflowGate(execution, nodeId)
+  else await rejectWorkflowGate(execution, nodeId)
+}
+
 export async function stopWorkflowRun(runId: string): Promise<void> {
   const handle = activeRuns.get(runId)
   // Prefer the live object over the store's copy so the run the engine is

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -207,3 +207,71 @@ describe('the topic list on the socket URL', () => {
     expect(parseTopics(query)).toBeUndefined()
   })
 })
+
+/**
+ * Subscribing to `terminal:data` by name means every byte of every terminal on
+ * the machine. On a phone showing one session that is the wrong unit entirely.
+ */
+describe('subscribing to one terminal', () => {
+  const sentMethods = (ws: import('ws').WebSocket): string[] =>
+    (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => JSON.parse(c[0] as string).method
+    )
+
+  it('delivers the terminal that was asked for', () => {
+    const reg = new ClientRegistry()
+    const phone = mockWs()
+    reg.add(phone, ['terminal:data#term-1'])
+
+    reg.broadcast('terminal:data', { id: 'term-1', data: 'x' }, 'term-1')
+
+    expect(sentMethods(phone)).toEqual(['terminal:data'])
+  })
+
+  it('withholds every other terminal', () => {
+    const reg = new ClientRegistry()
+    const phone = mockWs()
+    reg.add(phone, ['terminal:data#term-1'])
+
+    reg.broadcast('terminal:data', { id: 'term-2', data: 'x' }, 'term-2')
+
+    expect(sentMethods(phone)).toEqual([])
+  })
+
+  it('still gives every terminal to a client that asked by name', () => {
+    // A desktop renders all of them, and must not be narrowed by the instance
+    // form existing.
+    const reg = new ClientRegistry()
+    const desktop = mockWs()
+    reg.add(desktop, ['terminal:data'])
+
+    reg.broadcast('terminal:data', { id: 'term-1', data: 'x' }, 'term-1')
+    reg.broadcast('terminal:data', { id: 'term-2', data: 'y' }, 'term-2')
+
+    expect(sentMethods(desktop)).toEqual(['terminal:data', 'terminal:data'])
+  })
+
+  it('does not match an instance subscription against a scopeless broadcast', () => {
+    const reg = new ClientRegistry()
+    const phone = mockWs()
+    reg.add(phone, ['terminal:data#term-1'])
+
+    reg.broadcast('terminal:data', { data: 'x' })
+
+    expect(sentMethods(phone)).toEqual([])
+  })
+
+  it('lets one client follow a terminal while another follows nothing', () => {
+    const reg = new ClientRegistry()
+    const watching = mockWs()
+    const listing = mockWs()
+    reg.add(watching, ['session:*', 'terminal:data#term-1'])
+    reg.add(listing, ['session:*'])
+
+    reg.broadcast('terminal:data', { id: 'term-1', data: 'x' }, 'term-1')
+    reg.broadcast('session:updated', { id: 'term-1' }, 'term-1')
+
+    expect(sentMethods(watching)).toEqual(['terminal:data', 'session:updated'])
+    expect(sentMethods(listing)).toEqual(['session:updated'])
+  })
+})

--- a/tests/terminal-scrollback.test.ts
+++ b/tests/terminal-scrollback.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  appendScrollback,
+  clearScrollback,
+  readScrollback,
+  resetScrollback
+} from '../packages/server/src/terminal-scrollback'
+
+const ESC = '\x1b'
+
+beforeEach(resetScrollback)
+
+/**
+ * A client attaching a terminal emulator to a live session needs the bytes as
+ * they were emitted. The stripped line buffer cannot serve that: it answers what
+ * an agent said, and the escape sequences it removes are exactly what a terminal
+ * needs in order to draw.
+ */
+describe('what a terminal needs on attach', () => {
+  it('keeps escape sequences, which the stripped buffer removes', () => {
+    appendScrollback('a', `${ESC}[31mred${ESC}[0m`)
+
+    expect(readScrollback('a')).toBe(`${ESC}[31mred${ESC}[0m`)
+  })
+
+  it('keeps carriage returns, so a repaint still repaints', () => {
+    appendScrollback('a', 'Wo\rWork\rWorking')
+
+    expect(readScrollback('a')).toBe('Wo\rWork\rWorking')
+  })
+
+  it('joins chunks in the order they arrived', () => {
+    appendScrollback('a', 'one ')
+    appendScrollback('a', 'two')
+
+    expect(readScrollback('a')).toBe('one two')
+  })
+
+  it('keeps terminals apart', () => {
+    appendScrollback('a', 'first')
+    appendScrollback('b', 'second')
+
+    expect(readScrollback('a')).toBe('first')
+    expect(readScrollback('b')).toBe('second')
+  })
+
+  it('reads a terminal that has produced nothing as empty', () => {
+    expect(readScrollback('never-seen')).toBe('')
+  })
+
+  it('forgets a terminal that exited', () => {
+    // Or a long-lived server accumulates a buffer per session it ever ran.
+    appendScrollback('a', 'output')
+
+    clearScrollback('a')
+
+    expect(readScrollback('a')).toBe('')
+  })
+})
+
+describe('staying bounded', () => {
+  it('drops the oldest output rather than growing', () => {
+    appendScrollback('a', 'x'.repeat(400_000))
+
+    expect(readScrollback('a').length).toBeLessThanOrEqual(256 * 1024)
+  })
+
+  it('keeps the most recent output, which is the part being drawn', () => {
+    appendScrollback('a', `${'x'.repeat(400_000)}\nthe latest line`)
+
+    expect(readScrollback('a').endsWith('the latest line')).toBe(true)
+  })
+
+  it('cuts at a line boundary so no escape sequence is severed', () => {
+    // Half a sequence makes an emulator swallow the text after it or print the
+    // sequence as literal characters, which is worse than losing the text.
+    appendScrollback('a', `${'x'.repeat(300_000)}\n${ESC}[31mred${ESC}[0m\n`)
+    const kept = readScrollback('a')
+
+    expect(kept.startsWith(ESC)).toBe(true)
+    expect(kept).toContain(`${ESC}[31mred${ESC}[0m`)
+  })
+
+  it('still bounds a single line with no boundary to cut at', () => {
+    // A progress bar redrawing with carriage returns and never a newline.
+    appendScrollback('a', 'y'.repeat(400_000))
+
+    expect(readScrollback('a').length).toBe(256 * 1024)
+  })
+
+  it('bounds across many small appends, not just one large one', () => {
+    for (let i = 0; i < 1000; i++) appendScrollback('a', 'z'.repeat(1000))
+
+    expect(readScrollback('a').length).toBeLessThanOrEqual(256 * 1024)
+  })
+})

--- a/tests/workflow-gate-decision.test.ts
+++ b/tests/workflow-gate-decision.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WorkflowExecution } from '../packages/shared/src/types'
+
+/**
+ * A gate answered somewhere else.
+ *
+ * The decision is broadcast to every connected client, because whoever answered
+ * is usually not the instance holding the run — from a phone it never is. So
+ * every instance receives it and all but one must do nothing. That is the part
+ * worth pinning: a second instance acting would run the branch below the gate
+ * a second time.
+ */
+
+const executions = new Map<string, WorkflowExecution>()
+const saved: WorkflowExecution[] = []
+
+// The module imports from the barrel, not the slice. Mocking the slice looks
+// right and applies to nothing, which makes every no-op assertion pass for the
+// wrong reason: the real store is empty, so no run is ever found.
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: {
+    getState: () => ({
+      workflowExecutions: executions,
+      config: { workflows: [{ id: 'wf-1', name: 'W', nodes: [], edges: [] }] },
+      setWorkflowExecution: (_runId: string, execution: WorkflowExecution) => saved.push(execution)
+    })
+  }
+}))
+
+vi.mock('../src/renderer/lib/notifications', () => ({
+  notifyWorkflowGate: vi.fn(),
+  notifyAgentStatus: vi.fn()
+}))
+
+function parkedRun(
+  nodeStatus: WorkflowExecution['nodeStates'][number]['status']
+): WorkflowExecution {
+  return {
+    runId: 'run-1',
+    workflowId: 'wf-1',
+    startedAt: new Date(0).toISOString(),
+    status: 'running',
+    nodeStates: [{ nodeId: 'gate-1', status: nodeStatus }]
+  } as WorkflowExecution
+}
+
+let applyGateDecision: typeof import('../src/renderer/lib/workflow-execution').applyGateDecision
+
+beforeEach(async () => {
+  // This module runs in a renderer. Only the two calls this path makes are
+  // stubbed; anything else it reaches for should fail loudly rather than be
+  // quietly satisfied by a permissive stub.
+  vi.stubGlobal('window', {
+    api: {
+      saveWorkflowRun: vi.fn(async () => {}),
+      launchHeadlessAgent: vi.fn(async () => ({}))
+    }
+  })
+  executions.clear()
+  saved.length = 0
+  vi.resetModules()
+  ;({ applyGateDecision } = await import('../src/renderer/lib/workflow-execution'))
+})
+
+describe('acting on a gate decision from another client', () => {
+  it('does nothing for a run this instance has never heard of', async () => {
+    // The ordinary case: the broadcast reaches every window, and only one of
+    // them — sometimes none — is holding the run.
+    await applyGateDecision('run-nobody-has', 'gate-1', 'approve')
+
+    expect(saved).toHaveLength(0)
+  })
+
+  it('does nothing for a node that has already resolved', async () => {
+    // A duplicate broadcast, or two people answering at once. Approving a gate
+    // that is no longer waiting would resume the branch below it twice.
+    executions.set('run-1', parkedRun('success'))
+
+    await applyGateDecision('run-1', 'gate-1', 'approve')
+
+    expect(saved).toHaveLength(0)
+  })
+
+  it('drops a duplicate quietly, rather than through the layer below', async () => {
+    // The gate resolver underneath also refuses a node that is not waiting, so
+    // the outcome is the same either way — but it warns when it does, and a
+    // broadcast reaching every window would put that warning in every console
+    // on every duplicate. Checking for silence is what distinguishes the two.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    executions.set('run-1', parkedRun('success'))
+
+    await applyGateDecision('run-1', 'gate-1', 'approve')
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('does nothing for a node id the run does not contain', async () => {
+    executions.set('run-1', parkedRun('waiting'))
+
+    await applyGateDecision('run-1', 'a-node-from-another-workflow', 'approve')
+
+    expect(saved).toHaveLength(0)
+  })
+
+  it('acts when this instance is holding a run parked on that gate', async () => {
+    executions.set('run-1', parkedRun('waiting'))
+
+    // Resumption is deliberately allowed to fail here. Approving records the
+    // decision and then hands the run back to the execution engine, which wants
+    // a whole renderer around it; stubbing enough of one to let it proceed would
+    // make this a test of the engine rather than of the decision. What matters
+    // is that the decision was taken and written down.
+    await applyGateDecision('run-1', 'gate-1', 'approve').catch(() => {})
+    expect(saved.length).toBeGreaterThan(0)
+    expect(saved[0]?.nodeStates.find((n) => n.nodeId === 'gate-1')?.status).toBe('success')
+  })
+})

--- a/tests/workflow-gate-decision.test.ts
+++ b/tests/workflow-gate-decision.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { WorkflowExecution } from '../packages/shared/src/types'
 
 /**
@@ -45,6 +45,10 @@ function parkedRun(
 }
 
 let applyGateDecision: typeof import('../src/renderer/lib/workflow-execution').applyGateDecision
+
+// `window` is stubbed per case, so put it back afterwards: a stubbed global left
+// standing leaks into whatever else this worker runs.
+afterEach(() => vi.unstubAllGlobals())
 
 beforeEach(async () => {
   // This module runs in a renderer. Only the two calls this path makes are


### PR DESCRIPTION
Reopens #471, which GitHub auto-closed when its base branch (#469) was deleted on merge. Same three commits, rebased onto main — the branch was never lost.

Note #471 never ran CI: the workflow triggers only on PRs targeting `main`, and it was stacked on #469's branch. Now that it targets main, CI runs for the first time. Locally: 4050 tests passing, typecheck clean.

## Raw scrollback for an attaching terminal
Keeps what a terminal needs to draw, not only what an agent said.

## A gate answered from somewhere that cannot resume it
Lets an approval be decided from a client that has no workflow runtime.

## Projects without the rest of the configuration
A phone asking for the project list should not be handed every setting on the machine.