### PR TITLE
Wait for what these two assertions look for

### DIFF
--- a/tests/network-settings.test.tsx
+++ b/tests/network-settings.test.tsx
@@ -414,7 +414,7 @@ describe('the device list', () => {
     await renderPanel()
 
     await user.click(screen.getByText('Add device'))
-    await user.click(screen.getByText('Pair manually instead'))
+    await user.click(await screen.findByText('Pair manually instead'))
     await user.type(screen.getByLabelText('What is this device?'), 'My phone')
     await user.click(screen.getByText('Create token'))
 
@@ -432,7 +432,7 @@ describe('the device list', () => {
     // No question first: showing a code is the answer almost every time.
     await waitFor(() => expect(screen.getByText('ABCD-EFGH')).toBeInTheDocument())
     expect(startPairing).toHaveBeenCalled()
-    expect(screen.getByAltText('Pairing code')).toBeInTheDocument()
+    expect(await screen.findByAltText('Pairing code')).toBeInTheDocument()
   })
 
   it('offers a code for each address, so a phone can be met on its own network', async () => {


### PR DESCRIPTION
Main is red from two tests I added in #484.

Both assert on things that arrive a tick later than the click that causes them: the QR is an `<img>` whose `src` is produced asynchronously, and the panel holding "Pair manually instead" does not exist until the code has been minted over a promise. Fast enough locally and on the branch run, not on a colder machine, so they went in green and turned main red on the squashed commit.

`findBy` rather than `getBy`, which is the query that waits. Ran the file three times in a row locally to check it settles.

