### PR TITLE
chore(release): 0.7.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
A minor, not a patch: the phone stops being a thing you configure by hand
and becomes a thing you pair.

Pairing is a code on the desktop that the phone reads. What the screen
shows is deliberately not a token -- a device token never expires and
authorises running terminals, so a QR carrying one leaves a permanent key
on screen for anyone who photographs the monitor. The code lives five
minutes, buys exactly one exchange, and is held in memory so a restart
forgets it.

Underneath that, three things a phone needed and the server did not have.
Raw PTY bytes are kept alongside the line buffer, because the line buffer
has every escape sequence stripped out of it and that is precisely what a
terminal emulator needs to draw -- attaching used to show a blank screen
until the program next repainted, which for an idle agent is never. A
socket may now declare which notifications it wants, since terminal:data
alone is every byte of every PTY on the machine and a phone renders none
of it. And carriage returns are read the way a terminal reads them, so a
spinner redrawing in place stops being stored as WoWorkWorking.

Setup hands out the plugin now rather than a bare mcp add, which gave an
agent 67 undocumented tools.

Beta only: this publishes under the beta dist-tag and beta-*.yml, so the
stable channel stays on 0.6.1 until it has been tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)