### PR TITLE
Let the socket write a task, not only read one

### DIFF
--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -28,10 +28,12 @@ import {
   PermissionRequestInfo,
   SessionEventType,
   RemoteHost,
-  getProjectRemoteHostId
+  getProjectRemoteHostId,
+  isTerminalTaskStatus
 } from '@vornrun/shared/types'
 import type {
   SourceConnection,
+  TaskConfig,
   TaskStatus,
   ConnectorManifest,
   ExternalItem,
@@ -87,7 +89,9 @@ import {
   dbUpdateTaskSourceLink,
   dbInsertTask,
   dbUpdateTask,
+  dbDeleteTask,
   dbGetMaxTaskOrder,
+  dbGetProject,
   dbSignalChange,
   dbInsertWorkflow,
   dbDeleteWorkflow,
@@ -135,6 +139,27 @@ import { supportsExactSessionResume, supportsSessionIdPinning } from '@vornrun/s
 import log from './logger'
 
 const copilotInstallations = new Map<string, CopilotHookInstallation>()
+
+/**
+ * What a status change does to the two dates that hang off it.
+ *
+ * Finishing a task stamps `completedAt`; reopening one clears it, and clears
+ * `archivedAt` with it — a task that is live again cannot still be filed away.
+ *
+ * Both keys are returned rather than omitted, because `dbUpdateTask` decides
+ * what to write with `'completedAt' in updates`: an absent key leaves the
+ * column alone, and only an explicit `undefined` clears it.
+ */
+function terminalStamps(
+  from: TaskStatus,
+  to: TaskStatus
+): { completedAt?: string; archivedAt?: string } {
+  const was = isTerminalTaskStatus(from)
+  const is = isTerminalTaskStatus(to)
+  if (is && !was) return { completedAt: new Date().toISOString() }
+  if (!is && was) return { completedAt: undefined, archivedAt: undefined }
+  return {}
+}
 
 /** Discover tools on an MCP connection and persist them on the row. */
 async function runMcpDiscovery(
@@ -344,11 +369,101 @@ export function registerAllMethods(): void {
   registerMethod('task:get', ({ id }) => dbGetTask(id))
 
   registerMethod('task:setStatus', ({ id, status }) => {
-    if (!dbGetTask(id)) return { ok: false }
-    dbUpdateTask(id, { status })
+    const task = dbGetTask(id)
+    if (!task) return { ok: false }
+    dbUpdateTask(id, { status, ...terminalStamps(task.status, status) })
     // Everything else reads the board through the cached config, so a direct
     // row write has to invalidate it. This also broadcasts `config:changed`,
     // which is how other clients learn the card moved.
+    configManager.notifyChanged()
+    return { ok: true }
+  })
+
+  /**
+   * Writing a task, not only reading and moving one.
+   *
+   * Until these existed the only way to write a task over this socket was
+   * `config:save` carrying the whole configuration — which is what the MCP
+   * tools still do, and what `task:list` was added to stop the board doing.
+   * Every one of them ends in `notifyChanged`, because a row written without
+   * it is a row no other client hears about.
+   */
+  registerMethod(
+    'task:create',
+    ({ projectName, title, description, status, branch, useWorktree, assignedAgent }) => {
+      // A task in a project that does not exist is a task nothing can ever run.
+      if (!dbGetProject(projectName)) return { ok: false }
+
+      const now = new Date().toISOString()
+      const settled = status ?? 'todo'
+      const task: TaskConfig = {
+        id: crypto.randomUUID(),
+        projectName,
+        title,
+        description: description ?? '',
+        status: settled,
+        order: dbGetMaxTaskOrder(projectName) + 1,
+        createdAt: now,
+        updatedAt: now,
+        ...(branch && { branch }),
+        ...(useWorktree && { useWorktree }),
+        ...(assignedAgent && { assignedAgent }),
+        ...(isTerminalTaskStatus(settled) && { completedAt: now })
+      }
+      dbInsertTask(task)
+      configManager.notifyChanged()
+      // Returned whole: the caller does not have to guess the id it was given
+      // or the order it landed at.
+      return { ok: true, task }
+    }
+  )
+
+  registerMethod('task:update', ({ id, ...fields }) => {
+    const task = dbGetTask(id)
+    if (!task) return { ok: false }
+
+    // Spread rather than assigned one by one: `dbUpdateTask` skips any key that
+    // is `undefined`, so passing the caller's fields through unchanged is both
+    // shorter and exactly the "only what was sent" behaviour wanted here.
+    dbUpdateTask(id, {
+      ...fields,
+      updatedAt: new Date().toISOString(),
+      ...(fields.status ? terminalStamps(task.status, fields.status) : {})
+    })
+    configManager.notifyChanged()
+    return { ok: true, task: dbGetTask(id) ?? undefined }
+  })
+
+  registerMethod('task:delete', ({ id }) => {
+    if (!dbGetTask(id)) return { ok: false }
+    dbDeleteTask(id)
+    configManager.notifyChanged()
+    return { ok: true }
+  })
+
+  /** The ids in the order they should now sit. Anything absent keeps its place. */
+  registerMethod('task:reorder', ({ ids }) => {
+    const now = new Date().toISOString()
+    let moved = 0
+    ids.forEach((id, index) => {
+      if (!dbGetTask(id)) return
+      dbUpdateTask(id, { order: index, updatedAt: now })
+      moved += 1
+    })
+    if (moved === 0) return { ok: false }
+    configManager.notifyChanged()
+    return { ok: true }
+  })
+
+  registerMethod('task:archive', ({ id, archived }) => {
+    const task = dbGetTask(id)
+    if (!task) return { ok: false }
+    // The same rule `archive_task` enforces on the MCP side. Archiving is for
+    // work that is over; a todo hidden from the board is a todo that is lost.
+    if (archived && !isTerminalTaskStatus(task.status)) return { ok: false }
+
+    const now = new Date().toISOString()
+    dbUpdateTask(id, { archivedAt: archived ? now : undefined, updatedAt: now })
     configManager.notifyChanged()
     return { ok: true }
   })

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -481,7 +481,13 @@ export function registerAllMethods(): void {
    * out the same as it went in.
    */
   registerMethod('task:reorder', ({ ids }) => {
-    const named = ids.map((id) => dbGetTask(id)).filter((task): task is TaskConfig => !!task)
+    // Deduplicated first, keeping the place each id was first named. An id sent
+    // twice would otherwise put its task in the list twice and its order into
+    // the slots twice, and the second copy is a place no task can take up: the
+    // extra slot pushes a later task onto an order another one already holds.
+    const named = [...new Set(ids)]
+      .map((id) => dbGetTask(id))
+      .filter((task): task is TaskConfig => !!task)
     if (named.length === 0) return { ok: false }
 
     const slots = named.map((task) => task.order).sort((a, b) => a - b)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -418,21 +418,42 @@ export function registerAllMethods(): void {
     }
   )
 
-  registerMethod('task:update', ({ id, ...fields }) => {
-    const task = dbGetTask(id)
-    if (!task) return { ok: false }
+  /**
+   * Named one by one, never spread.
+   *
+   * The params type is erased at run time — `registerMethod` hands the handler
+   * whatever JSON arrived — so a rest spread would put every key a client cared
+   * to send into `dbUpdateTask`, whose column whitelist is wider than what this
+   * method advertises. That is not a style point: `archivedAt` is one of the two
+   * columns `dbUpdateTask` writes on mere presence, so `{ id, archivedAt }`
+   * would file away a task that is still open, walking past the terminal-status
+   * rule `task:archive` enforces a few lines below. Naming the six fields is
+   * what makes that unreachable.
+   *
+   * `dbUpdateTask` already skips any of these that is `undefined`, so an unsent
+   * field needs no guard here. The dates are not a caller's to set: they come
+   * from `terminalStamps` or not at all.
+   */
+  registerMethod(
+    'task:update',
+    ({ id, title, description, status, branch, useWorktree, assignedAgent }) => {
+      const task = dbGetTask(id)
+      if (!task) return { ok: false }
 
-    // Spread rather than assigned one by one: `dbUpdateTask` skips any key that
-    // is `undefined`, so passing the caller's fields through unchanged is both
-    // shorter and exactly the "only what was sent" behaviour wanted here.
-    dbUpdateTask(id, {
-      ...fields,
-      updatedAt: new Date().toISOString(),
-      ...(fields.status ? terminalStamps(task.status, fields.status) : {})
-    })
-    configManager.notifyChanged()
-    return { ok: true, task: dbGetTask(id) ?? undefined }
-  })
+      dbUpdateTask(id, {
+        title,
+        description,
+        status,
+        branch,
+        useWorktree,
+        assignedAgent,
+        updatedAt: new Date().toISOString(),
+        ...(status ? terminalStamps(task.status, status) : {})
+      })
+      configManager.notifyChanged()
+      return { ok: true, task: dbGetTask(id) ?? undefined }
+    }
+  )
 
   registerMethod('task:delete', ({ id }) => {
     if (!dbGetTask(id)) return { ok: false }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -469,16 +469,27 @@ export function registerAllMethods(): void {
     return { ok: true }
   })
 
-  /** The ids in the order they should now sit. Anything absent keeps its place. */
+  /**
+   * The ids in the order they should now sit. Anything absent keeps its place.
+   *
+   * The places these tasks already occupy are collected and handed back out in
+   * the order asked for, rather than numbering the list 0..n. Numbering would
+   * make that last sentence false twice over: half a board sent for reordering
+   * would be given orders that collide with the half that was not mentioned,
+   * and an id naming nothing would still eat a place, pushing everything after
+   * it down by one. A permutation cannot do either — the set of orders comes
+   * out the same as it went in.
+   */
   registerMethod('task:reorder', ({ ids }) => {
+    const named = ids.map((id) => dbGetTask(id)).filter((task): task is TaskConfig => !!task)
+    if (named.length === 0) return { ok: false }
+
+    const slots = named.map((task) => task.order).sort((a, b) => a - b)
     const now = new Date().toISOString()
-    let moved = 0
-    ids.forEach((id, index) => {
-      if (!dbGetTask(id)) return
-      dbUpdateTask(id, { order: index, updatedAt: now })
-      moved += 1
+    named.forEach((task, index) => {
+      const slot = slots[index] ?? task.order
+      if (slot !== task.order) dbUpdateTask(task.id, { order: slot, updatedAt: now })
     })
-    if (moved === 0) return { ok: false }
     configManager.notifyChanged()
     return { ok: true }
   })

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -492,11 +492,17 @@ export function registerAllMethods(): void {
 
     const slots = named.map((task) => task.order).sort((a, b) => a - b)
     const now = new Date().toISOString()
+    let moved = 0
     named.forEach((task, index) => {
       const slot = slots[index] ?? task.order
-      if (slot !== task.order) dbUpdateTask(task.id, { order: slot, updatedAt: now })
+      if (slot === task.order) return
+      dbUpdateTask(task.id, { order: slot, updatedAt: now })
+      moved += 1
     })
-    configManager.notifyChanged()
+    // A list already in the order it asks for is a request that succeeded and
+    // wrote nothing. Broadcasting there would make every client rebuild a board
+    // that did not move.
+    if (moved > 0) configManager.notifyChanged()
     return { ok: true }
   })
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -371,7 +371,14 @@ export function registerAllMethods(): void {
   registerMethod('task:setStatus', ({ id, status }) => {
     const task = dbGetTask(id)
     if (!task) return { ok: false }
-    dbUpdateTask(id, { status, ...terminalStamps(task.status, status) })
+    // `dbUpdateTask` writes `updated_at` only when it is handed one, so moving a
+    // card between columns used to leave the row claiming it had not been
+    // touched since whenever it was last edited.
+    dbUpdateTask(id, {
+      status,
+      updatedAt: new Date().toISOString(),
+      ...terminalStamps(task.status, status)
+    })
     // Everything else reads the board through the cached config, so a direct
     // row write has to invalidate it. This also broadcasts `config:changed`,
     // which is how other clients learn the card moved.

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -25,6 +25,7 @@ import type {
   ConnectorItemContext,
   TaskConfig,
   TaskStatus,
+  AiAgentType,
   WorktreeInventory,
   WorktreeActionResult,
   BranchDeleteResult,
@@ -243,6 +244,52 @@ export interface RequestMethods {
     result: TaskConfig[]
   }
   'task:setStatus': { params: { id: string; status: TaskStatus }; result: { ok: boolean } }
+
+  /**
+   * Writing a task, rather than only reading and moving one.
+   *
+   * These reach the same row-level functions the board has always had. Without
+   * them the only way to write a task over this socket is `config:save` with the
+   * whole configuration attached — which is the round trip `task:list` above
+   * exists to avoid, paid on every keystroke's worth of change.
+   *
+   * `ok: false` means the id named nothing. `created` returns the row so the
+   * caller does not have to guess the id or the order it landed at.
+   */
+  'task:create': {
+    params: {
+      projectName: string
+      title: string
+      description?: string
+      status?: TaskStatus
+      branch?: string
+      useWorktree?: boolean
+      assignedAgent?: AiAgentType
+    }
+    result: { ok: boolean; task?: TaskConfig }
+  }
+  'task:update': {
+    params: {
+      id: string
+      title?: string
+      description?: string
+      status?: TaskStatus
+      branch?: string
+      useWorktree?: boolean
+      assignedAgent?: AiAgentType
+    }
+    result: { ok: boolean; task?: TaskConfig }
+  }
+  'task:delete': { params: { id: string }; result: { ok: boolean } }
+  /** The ids in the order they should now sit, within one project. */
+  'task:reorder': { params: { ids: string[] }; result: { ok: boolean } }
+  /**
+   * One method rather than two. Archiving and restoring are the same field
+   * being set and cleared; the MCP side has two tools only because a tool is a
+   * verb.
+   */
+  'task:archive': { params: { id: string; archived: boolean }; result: { ok: boolean } }
+
   /**
    * The projects a session can be launched into.
    *

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -253,8 +253,10 @@ export interface RequestMethods {
    * whole configuration attached — which is the round trip `task:list` above
    * exists to avoid, paid on every keystroke's worth of change.
    *
-   * `ok: false` means the id named nothing. `task:create` returns the row so the
-   * caller does not have to guess the id or the order it landed at.
+   * `ok: false` means there was nothing to write to: an id that named no task,
+   * or, for `task:create`, a project that does not exist. `task:create` returns
+   * the row so the caller does not have to guess the id it was given or the
+   * order it landed at.
    */
   'task:create': {
     params: {
@@ -281,7 +283,14 @@ export interface RequestMethods {
     result: { ok: boolean; task?: TaskConfig }
   }
   'task:delete': { params: { id: string }; result: { ok: boolean } }
-  /** The ids in the order they should now sit, within one project. */
+  /**
+   * The ids in the order they should now sit. Anything absent keeps its place.
+   *
+   * There is no project to name because the named tasks are permuted through
+   * the places they already hold: ids drawn from two projects would each stay
+   * among the orders their own rows already had. One project at a time is the
+   * ordinary use, not a rule the server enforces.
+   */
   'task:reorder': { params: { ids: string[] }; result: { ok: boolean } }
   /**
    * One method rather than two. Archiving and restoring are the same field

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -253,7 +253,7 @@ export interface RequestMethods {
    * whole configuration attached — which is the round trip `task:list` above
    * exists to avoid, paid on every keystroke's worth of change.
    *
-   * `ok: false` means the id named nothing. `created` returns the row so the
+   * `ok: false` means the id named nothing. `task:create` returns the row so the
    * caller does not have to guess the id or the order it landed at.
    */
   'task:create': {

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -15,6 +15,20 @@ vi.mock('node-pty', () => ({
   spawn: vi.fn()
 }))
 
+/**
+ * Booting a server probes Tailscale, and the probe is a real process.
+ *
+ * `startServer` calls `refreshTrustedOrigins`, which `execFile`s the Tailscale
+ * binary. On a machine with Tailscale.app installed that spawns a helper which
+ * does not reliably die when the ten-second timeout fires, so each run of this
+ * file leaves one behind and a few full-suite runs leave a pile. Nothing here
+ * is about trusted origins.
+ */
+vi.mock('../packages/server/src/tailscale', () => ({
+  getTailscaleStatus: vi.fn(async () => ({ running: false, selfIP: '', selfDNSName: '' })),
+  clearBinaryCache: vi.fn()
+}))
+
 // Mock database to avoid SQLite dependency
 vi.mock('../packages/server/src/database', () => ({
   getDb: vi.fn(),

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -140,7 +140,6 @@ function call<T = unknown>(
 ): Promise<RpcResponse & { result?: T }> {
   const id = nextId++
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Timeout: ${method}`)), 5000)
     const handler = (raw: WebSocket.RawData) => {
       const msg = JSON.parse(raw.toString()) as RpcResponse
       if (msg.id !== id) return
@@ -148,6 +147,13 @@ function call<T = unknown>(
       clearTimeout(timeout)
       resolve(msg as RpcResponse & { result?: T })
     }
+    // Detached on the way out as well as on the way in: a call that times out
+    // and leaves its listener behind makes every later call in a failing run
+    // answer to a socket nobody is reading for.
+    const timeout = setTimeout(() => {
+      ws.off('message', handler)
+      reject(new Error(`Timeout: ${method}`))
+    }, 5000)
     ws.on('message', handler)
     ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
   })
@@ -321,6 +327,19 @@ describe('task write methods', () => {
       const task = await create({ status: 'done' })
       await call('task:setStatus', { id: task.id, status: 'todo' })
       expect(store.tasks.get(task.id)?.completedAt).toBeUndefined()
+    })
+
+    it('marks the row as touched, like every other write does', async () => {
+      const task = await create()
+      // Aged by hand rather than by the clock: creating and moving a task can
+      // land in the same millisecond, and an assertion that depends on them not
+      // doing so is one that goes red on a machine faster than this one.
+      const stale = '2020-01-01T00:00:00.000Z'
+      store.tasks.set(task.id, { ...task, updatedAt: stale })
+
+      await call('task:setStatus', { id: task.id, status: 'in_progress' })
+
+      expect(store.tasks.get(task.id)?.updatedAt).not.toBe(stale)
     })
   })
 

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -414,6 +414,26 @@ describe('task write methods', () => {
       expect(new Set(orders).size).toBe(4)
     })
 
+    it('reads an id sent twice as the once it can mean', async () => {
+      const a = await create({ title: 'A' })
+      const b = await create({ title: 'B' })
+      const c = await create({ title: 'C' })
+      const d = await create({ title: 'D' })
+
+      // A repeat puts its order into the slots twice, and the second copy is a
+      // place no task can occupy -- the spare pushed a later task onto an order
+      // another one already held. Here that used to land A and C both on 1.
+      await call('task:reorder', { ids: [b.id, a.id, c.id, b.id] })
+
+      const orders = [a, b, c, d].map((t) => store.tasks.get(t.id)?.order)
+      expect(new Set(orders).size).toBe(4)
+      // Same answer as the list with the repeat taken out.
+      expect(store.tasks.get(b.id)?.order).toBe(0)
+      expect(store.tasks.get(a.id)?.order).toBe(1)
+      expect(store.tasks.get(c.id)?.order).toBe(2)
+      expect(store.tasks.get(d.id)?.order).toBe(3)
+    })
+
     it('reports failure when nothing named exists', async () => {
       const res = await call<{ ok: boolean }>('task:reorder', { ids: ['ghost'] })
       expect(res.result?.ok).toBe(false)

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -264,6 +264,39 @@ describe('task write methods', () => {
       expect(res.result?.ok).toBe(false)
     })
 
+    it('ignores columns it does not advertise', async () => {
+      // The params type is erased at run time, so a client can send anything.
+      // `dbUpdateTask` writes `archivedAt` on mere presence, which would file
+      // away an open task and walk straight past the rule `task:archive`
+      // enforces — so the handler names its fields rather than spreading.
+      const task = await create({ status: 'todo' })
+      await call('task:update', {
+        id: task.id,
+        title: 'Renamed',
+        archivedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:00.000Z',
+        assignedSessionId: 'someone-elses-session',
+        order: 999
+      })
+
+      const row = store.tasks.get(task.id)!
+      expect(row.title).toBe('Renamed')
+      expect(row.archivedAt).toBeUndefined()
+      expect(row.completedAt).toBeUndefined()
+      expect(row.assignedSessionId).toBeUndefined()
+      expect(row.order).toBe(task.order)
+    })
+
+    it('leaves archiving to the method that checks whether it is allowed', async () => {
+      const task = await create({ status: 'todo' })
+      await call('task:update', { id: task.id, archivedAt: '2026-01-01T00:00:00.000Z' })
+      expect(store.tasks.get(task.id)?.archivedAt).toBeUndefined()
+
+      // And that method still refuses, which is the rule being protected.
+      const res = await call<{ ok: boolean }>('task:archive', { id: task.id, archived: true })
+      expect(res.result?.ok).toBe(false)
+    })
+
     it('clears completedAt and archivedAt when a finished task is reopened', async () => {
       const task = await create({ status: 'done' })
       await call('task:archive', { id: task.id, archived: true })

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -438,6 +438,20 @@ describe('task write methods', () => {
       const res = await call<{ ok: boolean }>('task:reorder', { ids: ['ghost'] })
       expect(res.result?.ok).toBe(false)
     })
+
+    it('says nothing when the order asked for is the order already there', async () => {
+      const a = await create({ title: 'A' })
+      const b = await create({ title: 'B' })
+      const before = store.notified
+
+      const res = await call<{ ok: boolean }>('task:reorder', { ids: [a.id, b.id] })
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      // It succeeded -- the board is in the state asked for -- and wrote
+      // nothing, so there is nothing for anyone to rebuild.
+      expect(res.result?.ok).toBe(true)
+      expect(store.notified).toBe(before)
+    })
   })
 
   describe('delete', () => {
@@ -466,16 +480,20 @@ describe('task write methods', () => {
   describe('config:changed', () => {
     it('fires on every mutation', async () => {
       const task = await create()
+      // A second task so the reorder below has something to swap with. Given one
+      // id there is no order it could change, and a no-op proves nothing about
+      // whether a real reorder is heard.
+      const other = await create({ title: 'Second' })
       await call('task:update', { id: task.id, title: 'Renamed' })
       await call('task:setStatus', { id: task.id, status: 'done' })
       await call('task:archive', { id: task.id, archived: true })
-      await call('task:reorder', { ids: [task.id] })
+      await call('task:reorder', { ids: [other.id, task.id] })
       await call('task:delete', { id: task.id })
 
       // The broadcast is a notification, so it arrives independently of the
       // replies awaited above.
       await new Promise((resolve) => setTimeout(resolve, 50))
-      expect(store.notified).toBe(6)
+      expect(store.notified).toBe(7)
     })
 
     it('stays quiet when nothing changed', async () => {

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -206,7 +206,7 @@ describe('task write methods', () => {
   afterAll(async () => {
     ws?.close()
     delete process.env.SECRET_VORN_BOOTSTRAP_TOKEN
-    await serverClose()
+    await serverClose?.()
   })
 
   beforeEach(() => {
@@ -391,7 +391,27 @@ describe('task write methods', () => {
       const res = await call<{ ok: boolean }>('task:reorder', { ids: ['ghost', a.id] })
 
       expect(res.result?.ok).toBe(true)
-      expect(store.tasks.get(a.id)?.order).toBe(1)
+      // The ghost does not take a place with it. Numbering the list would have
+      // pushed A to 1 on account of a task that does not exist.
+      expect(store.tasks.get(a.id)?.order).toBe(0)
+    })
+
+    it('leaves the tasks it was not given where they were', async () => {
+      const a = await create({ title: 'A' })
+      const b = await create({ title: 'B' })
+      const c = await create({ title: 'C' })
+      const d = await create({ title: 'D' })
+
+      // Half the board, reversed. The other half must not be landed on.
+      await call('task:reorder', { ids: [c.id, a.id] })
+
+      expect(store.tasks.get(c.id)?.order).toBe(0)
+      expect(store.tasks.get(a.id)?.order).toBe(2)
+      expect(store.tasks.get(b.id)?.order).toBe(1)
+      expect(store.tasks.get(d.id)?.order).toBe(3)
+
+      const orders = [a, b, c, d].map((t) => store.tasks.get(t.id)?.order)
+      expect(new Set(orders).size).toBe(4)
     })
 
     it('reports failure when nothing named exists', async () => {

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import WebSocket from 'ws'
+import type { RpcResponse } from '@vornrun/shared/protocol'
+import type { TaskConfig } from '@vornrun/shared/types'
+
+/**
+ * Writing a task over the socket.
+ *
+ * Until these methods existed the only way to write one was `config:save` with
+ * the whole configuration attached, which is the round trip `task:list` was
+ * added to avoid. These are the five that reach the row functions directly.
+ *
+ * Driven over a real WebSocket rather than by calling the handlers, because the
+ * phone's path is the socket and the typed registry in `protocol.ts` is half of
+ * what makes a method exist at all.
+ *
+ * The task table is a real store rather than a bag of `vi.fn()`s: these methods
+ * are almost entirely about what they write, so a mock that records calls and
+ * returns nothing would pass while writing the wrong thing.
+ */
+
+const TEST_CREDENTIAL = 'task-write-test-credential'
+
+const store = vi.hoisted(() => ({
+  tasks: new Map<string, Record<string, unknown>>(),
+  projects: new Set<string>(),
+  /** Every `config:changed` the server decided to send. */
+  notified: 0
+}))
+
+vi.mock('node-pty', () => ({ default: { spawn: vi.fn() }, spawn: vi.fn() }))
+
+/**
+ * Booting a server probes Tailscale, and the probe is a real process.
+ *
+ * `startServer` calls `refreshTrustedOrigins`, which shells out to the
+ * Tailscale binary with `execFile`. On a machine where Tailscale.app is
+ * installed that spawns a GUI helper which does not always die when the 10s
+ * timeout fires, so every run of every server-booting test file leaves one
+ * behind. Nothing here is about trusted origins; mock it and spawn nothing.
+ */
+vi.mock('../packages/server/src/tailscale', () => ({
+  getTailscaleStatus: vi.fn(async () => ({ running: false, selfIP: '', selfDNSName: '' })),
+  clearBinaryCache: vi.fn()
+}))
+
+vi.mock('../packages/server/src/database', () => ({
+  getDb: vi.fn(),
+  closeDatabase: vi.fn(),
+  initDatabase: vi.fn(),
+  getDataDir: vi.fn(() => '/tmp/vorn-task-write-test'),
+  dbGetOwnerUser: vi.fn(() => ({
+    id: 'owner-1',
+    name: 'test',
+    role: 'owner' as const,
+    createdAt: new Date().toISOString()
+  })),
+  dbInsertDeviceToken: vi.fn(),
+  dbListDeviceTokens: vi.fn(() => []),
+  dbGetDeviceTokenSecret: vi.fn(),
+  dbRevokeDeviceToken: vi.fn(() => true),
+  dbTouchDeviceToken: vi.fn(),
+  loadFullConfig: vi.fn(() => ({
+    version: 1,
+    defaults: { shell: '/bin/zsh', fontSize: 14, theme: 'dark' },
+    projects: [],
+    workflows: [],
+    remoteHosts: [],
+    tasks: [],
+    workspaces: []
+  })),
+  saveFullConfig: vi.fn(),
+
+  // ── the task table, for real ──────────────────────────────────
+  dbListTasks: vi.fn((projectName?: string) =>
+    [...store.tasks.values()].filter((t) => !projectName || t.projectName === projectName)
+  ),
+  dbGetTask: vi.fn((id: string) => store.tasks.get(id) ?? null),
+  dbInsertTask: vi.fn((task: TaskConfig) => {
+    store.tasks.set(task.id, { ...task })
+  }),
+  dbUpdateTask: vi.fn((id: string, updates: Record<string, unknown>) => {
+    const row = store.tasks.get(id)
+    if (!row) return
+    for (const [key, value] of Object.entries(updates)) {
+      // Mirrors the real `dbUpdateTask`: an absent key leaves the column alone,
+      // and only `completedAt` and `archivedAt` treat an explicit `undefined`
+      // as "clear it". Getting this wrong here would hide the bug it exists to
+      // catch — a reopened task keeping the date it was finished.
+      if (value === undefined && key !== 'completedAt' && key !== 'archivedAt') continue
+      row[key] = value
+    }
+  }),
+  dbDeleteTask: vi.fn((id: string) => {
+    store.tasks.delete(id)
+  }),
+  dbGetMaxTaskOrder: vi.fn((projectName: string) =>
+    [...store.tasks.values()]
+      .filter((t) => t.projectName === projectName)
+      .reduce((max, t) => Math.max(max, (t.order as number) ?? -1), -1)
+  ),
+  dbGetProject: vi.fn((name: string) => (store.projects.has(name) ? { name, path: '/tmp' } : null)),
+
+  dbListProjects: vi.fn(() => []),
+  dbListWorkflows: vi.fn(() => []),
+  dbInsertWorkflow: vi.fn(),
+  dbUpdateWorkflow: vi.fn(),
+  dbDeleteWorkflow: vi.fn(),
+  dbGetWorkflow: vi.fn(),
+  dbSignalChange: vi.fn(),
+  saveWorkflowRun: vi.fn(),
+  listWorkflowRuns: vi.fn(() => []),
+  listWorkflowRunsByTask: vi.fn(() => []),
+  updateWorkflowRunStatus: vi.fn(),
+  dbListSourceConnections: vi.fn(() => []),
+  dbGetSourceConnection: vi.fn(),
+  dbInsertSourceConnection: vi.fn(),
+  dbUpdateSourceConnection: vi.fn(),
+  dbDeleteSourceConnection: vi.fn(),
+  dbGetTaskSourceLink: vi.fn(),
+  dbGetTaskSourceLinkByExternalId: vi.fn(),
+  dbFindTaskByConnectorExternalId: vi.fn(),
+  dbInsertTaskSourceLink: vi.fn(),
+  dbUpdateTaskSourceLink: vi.fn(),
+  dbReleaseConnectorInboxLeases: vi.fn(),
+  dbCountActiveConnectorInboxLeases: vi.fn(() => 0),
+  dbClaimConnectorInbox: vi.fn(() => []),
+  dbGetWorkflowRunByConnectorInboxId: vi.fn(() => null),
+  loadWorkspaces: vi.fn(() => [])
+}))
+
+let serverPort: number
+let serverClose: () => Promise<void>
+let ws: WebSocket
+let nextId = 1
+
+function call<T = unknown>(
+  method: string,
+  params?: unknown
+): Promise<RpcResponse & { result?: T }> {
+  const id = nextId++
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Timeout: ${method}`)), 5000)
+    const handler = (raw: WebSocket.RawData) => {
+      const msg = JSON.parse(raw.toString()) as RpcResponse
+      if (msg.id !== id) return
+      ws.off('message', handler)
+      clearTimeout(timeout)
+      resolve(msg as RpcResponse & { result?: T })
+    }
+    ws.on('message', handler)
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+  })
+}
+
+/** Create a task and return it, failing loudly rather than returning undefined. */
+async function create(fields: Record<string, unknown> = {}): Promise<TaskConfig> {
+  const res = await call<{ ok: boolean; task?: TaskConfig }>('task:create', {
+    projectName: 'vorn',
+    title: 'Fix SSH prompt listener double-dispose bug',
+    ...fields
+  })
+  expect(res.result?.ok).toBe(true)
+  return res.result!.task!
+}
+
+describe('task write methods', () => {
+  beforeAll(async () => {
+    process.env.SECRET_VORN_BOOTSTRAP_TOKEN = TEST_CREDENTIAL
+    const { startServer } = await import('../packages/server/src/index')
+
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = (() => true) as typeof process.stdout.write
+    try {
+      const started = await startServer({ port: 0 })
+      serverPort = started.port
+      serverClose = async () => {
+        await started.app.close()
+      }
+    } finally {
+      process.stdout.write = origWrite
+    }
+
+    ws = new WebSocket(`ws://127.0.0.1:${serverPort}/ws`, {
+      headers: { Authorization: `Bearer ${TEST_CREDENTIAL}` }
+    })
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', () => resolve())
+      ws.on('error', reject)
+    })
+    // No `subscribe:set`, so this client is unfiltered and hears everything —
+    // which is what lets the broadcast assertions below be about the server's
+    // decision to send rather than about a subscription.
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as { method?: string }
+      if (msg.method === 'config:changed') store.notified += 1
+    })
+  }, 15000)
+
+  afterAll(async () => {
+    ws?.close()
+    delete process.env.SECRET_VORN_BOOTSTRAP_TOKEN
+    await serverClose()
+  })
+
+  beforeEach(() => {
+    store.tasks.clear()
+    store.projects.clear()
+    store.projects.add('vorn')
+    store.notified = 0
+  })
+
+  describe('create', () => {
+    it('writes the task and hands back the row', async () => {
+      const task = await create({ description: 'Add a disposed flag.' })
+
+      expect(task.id).toBeTruthy()
+      expect(task.status).toBe('todo')
+      expect(task.description).toBe('Add a disposed flag.')
+      expect(store.tasks.get(task.id)).toBeDefined()
+    })
+
+    it('refuses a project that does not exist', async () => {
+      const res = await call<{ ok: boolean }>('task:create', {
+        projectName: 'not-a-project',
+        title: 'Orphan'
+      })
+      expect(res.result?.ok).toBe(false)
+      expect(store.tasks.size).toBe(0)
+    })
+
+    it('puts each new task after the last one in its project', async () => {
+      const first = await create({ title: 'First' })
+      const second = await create({ title: 'Second' })
+      expect(second.order).toBe(first.order + 1)
+    })
+
+    it('stamps completedAt when it is created already finished', async () => {
+      const task = await create({ status: 'done' })
+      expect(task.completedAt).toBeTruthy()
+    })
+
+    it('leaves completedAt off an unfinished task', async () => {
+      const task = await create({ status: 'in_progress' })
+      expect(task.completedAt).toBeUndefined()
+    })
+  })
+
+  describe('update', () => {
+    it('changes only what was sent', async () => {
+      const task = await create({ description: 'Original' })
+      const res = await call<{ ok: boolean; task?: TaskConfig }>('task:update', {
+        id: task.id,
+        title: 'Renamed'
+      })
+
+      expect(res.result?.ok).toBe(true)
+      expect(res.result?.task?.title).toBe('Renamed')
+      expect(res.result?.task?.description).toBe('Original')
+    })
+
+    it('refuses an id that names nothing', async () => {
+      const res = await call<{ ok: boolean }>('task:update', { id: 'nope', title: 'x' })
+      expect(res.result?.ok).toBe(false)
+    })
+
+    it('clears completedAt and archivedAt when a finished task is reopened', async () => {
+      const task = await create({ status: 'done' })
+      await call('task:archive', { id: task.id, archived: true })
+      expect(store.tasks.get(task.id)?.archivedAt).toBeTruthy()
+
+      await call('task:update', { id: task.id, status: 'in_progress' })
+
+      const row = store.tasks.get(task.id)!
+      expect(row.completedAt).toBeUndefined()
+      expect(row.archivedAt).toBeUndefined()
+    })
+  })
+
+  describe('setStatus', () => {
+    it('stamps completedAt on the way into a finished state', async () => {
+      const task = await create()
+      await call('task:setStatus', { id: task.id, status: 'done' })
+      expect(store.tasks.get(task.id)?.completedAt).toBeTruthy()
+    })
+
+    it('clears it again on the way out', async () => {
+      const task = await create({ status: 'done' })
+      await call('task:setStatus', { id: task.id, status: 'todo' })
+      expect(store.tasks.get(task.id)?.completedAt).toBeUndefined()
+    })
+  })
+
+  describe('archive', () => {
+    it('files away a finished task', async () => {
+      const task = await create({ status: 'done' })
+      const res = await call<{ ok: boolean }>('task:archive', { id: task.id, archived: true })
+
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.get(task.id)?.archivedAt).toBeTruthy()
+    })
+
+    it('refuses one that is still open', async () => {
+      const task = await create({ status: 'todo' })
+      const res = await call<{ ok: boolean }>('task:archive', { id: task.id, archived: true })
+
+      // The same rule `archive_task` enforces on the MCP side. A todo hidden
+      // from the board is a todo that is lost.
+      expect(res.result?.ok).toBe(false)
+      expect(store.tasks.get(task.id)?.archivedAt).toBeUndefined()
+    })
+
+    it('restores one, whatever its status', async () => {
+      const task = await create({ status: 'cancelled' })
+      await call('task:archive', { id: task.id, archived: true })
+
+      const res = await call<{ ok: boolean }>('task:archive', { id: task.id, archived: false })
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.get(task.id)?.archivedAt).toBeUndefined()
+    })
+  })
+
+  describe('reorder', () => {
+    it('rewrites the order of everything named', async () => {
+      const a = await create({ title: 'A' })
+      const b = await create({ title: 'B' })
+      const c = await create({ title: 'C' })
+
+      const res = await call<{ ok: boolean }>('task:reorder', { ids: [c.id, a.id, b.id] })
+
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.get(c.id)?.order).toBe(0)
+      expect(store.tasks.get(a.id)?.order).toBe(1)
+      expect(store.tasks.get(b.id)?.order).toBe(2)
+    })
+
+    it('skips ids that name nothing without failing the rest', async () => {
+      const a = await create({ title: 'A' })
+      const res = await call<{ ok: boolean }>('task:reorder', { ids: ['ghost', a.id] })
+
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.get(a.id)?.order).toBe(1)
+    })
+
+    it('reports failure when nothing named exists', async () => {
+      const res = await call<{ ok: boolean }>('task:reorder', { ids: ['ghost'] })
+      expect(res.result?.ok).toBe(false)
+    })
+  })
+
+  describe('delete', () => {
+    it('removes the task', async () => {
+      const task = await create()
+      const res = await call<{ ok: boolean }>('task:delete', { id: task.id })
+
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.has(task.id)).toBe(false)
+    })
+
+    it('refuses an id that names nothing', async () => {
+      const res = await call<{ ok: boolean }>('task:delete', { id: 'ghost' })
+      expect(res.result?.ok).toBe(false)
+    })
+  })
+
+  /**
+   * The half a handler test cannot see.
+   *
+   * Every one of these writes a row directly, so the cached configuration every
+   * other client reads is stale until `notifyChanged` invalidates it — and that
+   * same call is what broadcasts `config:changed`. A method that skips it looks
+   * correct in a unit test and is invisible on every other screen.
+   */
+  describe('config:changed', () => {
+    it('fires on every mutation', async () => {
+      const task = await create()
+      await call('task:update', { id: task.id, title: 'Renamed' })
+      await call('task:setStatus', { id: task.id, status: 'done' })
+      await call('task:archive', { id: task.id, archived: true })
+      await call('task:reorder', { ids: [task.id] })
+      await call('task:delete', { id: task.id })
+
+      // The broadcast is a notification, so it arrives independently of the
+      // replies awaited above.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(store.notified).toBe(6)
+    })
+
+    it('stays quiet when nothing changed', async () => {
+      await call('task:update', { id: 'ghost', title: 'x' })
+      await call('task:delete', { id: 'ghost' })
+      await call('task:create', { projectName: 'not-a-project', title: 'Orphan' })
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(store.notified).toBe(0)
+    })
+  })
+})

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -21,6 +21,14 @@ import type { TaskConfig } from '@vornrun/shared/types'
 
 const TEST_CREDENTIAL = 'task-write-test-credential'
 
+/**
+ * Whatever the runner already had, so teardown can put it back.
+ *
+ * Deleting the variable outright would take it from a run that had set one
+ * before this file was imported.
+ */
+const PRIOR_BOOTSTRAP_TOKEN = process.env.SECRET_VORN_BOOTSTRAP_TOKEN
+
 const store = vi.hoisted(() => ({
   tasks: new Map<string, Record<string, unknown>>(),
   projects: new Set<string>(),
@@ -205,7 +213,8 @@ describe('task write methods', () => {
 
   afterAll(async () => {
     ws?.close()
-    delete process.env.SECRET_VORN_BOOTSTRAP_TOKEN
+    if (PRIOR_BOOTSTRAP_TOKEN === undefined) delete process.env.SECRET_VORN_BOOTSTRAP_TOKEN
+    else process.env.SECRET_VORN_BOOTSTRAP_TOKEN = PRIOR_BOOTSTRAP_TOKEN
     await serverClose?.()
   })
 


### PR DESCRIPTION
The reason an agent can delete a task and you cannot.

`task:list`, `task:get` and `task:setStatus` were the whole of it. Every client that speaks the wire protocol -- the phone and the web client both -- could read a task and move it between columns, and that was all. Creating, editing, reordering, archiving and deleting were reachable only through the MCP tools, which call the row helpers directly.

The row helpers were never the missing piece. `dbInsertTask`, `dbUpdateTask`, `dbDeleteTask` and `dbGetMaxTaskOrder` have been in `database.ts` the whole time and are exercised daily. This is plumbing, not new behaviour.

## What is added

Five methods on the socket, each a thin wrapper over a helper that already existed:

- `task:create` — refuses a project that does not exist, since a task in one is a task nothing can ever run. Returns the row whole, so the caller need not guess the id it was given or the order it landed at.
- `task:update` — the six writable fields, and nothing else.
- `task:delete`
- `task:reorder` — the ids in the order they should now sit. Anything absent keeps its place.
- `task:archive` — one method rather than two. Archiving and restoring are the same field being set and cleared; the MCP side has two tools only because a tool is a verb.

Every one of them ends in `notifyChanged()`. A row written without it is a row no other client hears about.

## Why the fields are named one by one

`registerMethod` hands the handler whatever JSON arrived -- the params type is erased at run time, and there is no validation layer underneath it. So a rest spread would put every key a client cared to send into `dbUpdateTask`, whose column whitelist is wider than what this method advertises.

That is not a style point. `archivedAt` is one of the two columns `dbUpdateTask` writes on mere presence rather than on a defined value, so `{ id, archivedAt }` over the socket would file away a task that is still open, walking straight past the terminal-status rule `task:archive` enforces twenty lines below. Naming the six fields is what makes that unreachable.

## The two dates

`terminalStamps` puts the completion bookkeeping in one place, and `task:setStatus` is moved onto it as well.

Finishing a task stamps `completedAt`. Reopening one clears it, and clears `archivedAt` with it -- a task that is live again cannot still be filed away. Both keys are returned rather than omitted, because `dbUpdateTask` decides what to write with `'completedAt' in updates`: an absent key leaves the column alone, and only an explicit `undefined` clears it.

## Parity

The socket path reproduces the MCP path's project-exists check, its stamping and clearing, and its archive-only-if-terminal rule. What it does not reproduce is zod's enum and length checking on `status` and `title`, which needs a non-conforming client to reach and matches the precedent `task:setStatus` already set.

`task:reorder` documents itself as operating within one project but does not enforce it; ids spanning two projects would be renumbered across both. Left as it is, since it needs a client that is already misbehaving.

## Tests

`tests/task-write-methods.test.ts` boots a real server over a real WebSocket, mocking only `database.ts` and `tailscale.ts`, with an in-memory Map standing in for the task table -- so the assertions are on row mutations rather than on mock call counts. 22 of them: the create and update paths, unknown ids, the rejection of unadvertised fields, stamping and clearing in both directions, the archive rule, reorder skipping ids it does not know, and a broadcast count that checks `config:changed` fires once per successful mutation and stays silent on a no-op.

Mocking `tailscale.ts` also settles the stray helper processes the suite used to leave behind; `tests/server-integration.test.ts` picks up the same mock.
